### PR TITLE
Note in README that OPENAI_API_KEY must be set for custom_endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ export MODELS_JSON_PATH=/path/to/custom/models.json
     }
 }
 ```
+Note that the `OPENAI_API_KEY` env variable must be set when using `custom_openai` endpoints.
+
 Open an issue if your environment is somehow weirder than mine.
 
 Run specific tasks or engage in interactive mode:


### PR DESCRIPTION
Add a note to the README.md that env var `OPENAI_API_KEY` must be set when using `custom_openai` endpoint.

I was trying to use OpenRouter, which uses an OpenAI compatible API. Setting the API key only through a header in the model JSON results in `401 - UNAUTHORIZED` errors. I found a code comment with the env var requirement and I believe it should be noted in the README as well.