### PR TITLE
feat: add --agent CLI option for startup agent selection

### DIFF
--- a/code_puppy/main.py
+++ b/code_puppy/main.py
@@ -65,6 +65,12 @@ async def main():
         help="Execute a single prompt and exit (no interactive mode)",
     )
     parser.add_argument(
+        "--agent",
+        "-a",
+        type=str,
+        help="Specify which agent to use (e.g., --agent code-puppy)",
+    )
+    parser.add_argument(
         "command", nargs="*", help="Run a single command (deprecated, use -p instead)"
     )
     args = parser.parse_args()
@@ -164,6 +170,27 @@ async def main():
         return
 
     ensure_config_exists()
+
+    # Handle agent selection from command line
+    if args.agent:
+        from code_puppy.agents.agent_manager import set_current_agent, get_available_agents
+
+        agent_name = args.agent.lower()
+        try:
+            # First check if the agent exists by getting available agents
+            available_agents = get_available_agents()
+            if agent_name not in available_agents:
+                emit_system_message(f"[bold red]Error:[/bold red] Agent '{agent_name}' not found")
+                emit_system_message(f"Available agents: {', '.join(available_agents.keys())}")
+                sys.exit(1)
+
+            # Agent exists, set it
+            set_current_agent(agent_name)
+            emit_system_message(f"🤖 Using agent: {agent_name}")
+        except Exception as e:
+            emit_system_message(f"[bold red]Error setting agent:[/bold red] {str(e)}")
+            sys.exit(1)
+            
     current_version = __version__
 
     no_version_update = os.getenv("NO_VERSION_UPDATE", "").lower() in (


### PR DESCRIPTION
Add support for specifying which agent to use directly from the command line, enabling better automation and non-interactive usage patterns.

## What's Added
- New --agent/-a command line argument
- Agent validation with helpful error messages
- Support for all existing modes (interactive, TUI, non-interactive)

## Why This Matters
- **Automation**: Perfect for CI/CD pipelines and scripts
- **Non-interactive mode**: No need to switch agents during runtime
- **Developer experience**: Faster workflow when you know which agent you need
- **Scripting**: Enables predictable agent behavior in automated environments

## Usage Examples

### Non-interactive mode with specific agent:
python -m code_puppy --prompt 'Create a hello world script' --agent code-puppy

### Interactive mode with pre-selected agent:
python -m code_puppy --interactive --agent agent-creator

### TUI mode with specific agent:
python -m code_puppy --tui --agent ld-expert

### Short form syntax:
python -m code_puppy -p 'hello world' -a code-puppy

## Error Handling
- Validates agent exists before startup
- Shows clear error messages for invalid agents
- Lists available agents when errors occur
- Proper exit codes for automation (exit 1 on error)

## Available Agents
- code-puppy: Main coding assistance agent
- agent-creator: Helps create new JSON agent configurations
- ld-expert: Living Design expert for Walmart design system

## Technical Implementation
- Added argparse argument parsing for --agent/-a
- Early validation in startup flow before agent initialization
- Integrated with existing agent_manager infrastructure
- Maintains backward compatibility (no breaking changes)

This feature significantly improves the developer experience for automation, scripting, and situations where you know exactly which agent you need upfront.