### PR TITLE
Add pup alias for code-puppy command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ HomePage = "https://github.com/mpfaffenberger/code_puppy"
 
 [project.scripts]
 code-puppy = "code_puppy.main:main_entry"
+pup = "code_puppy.main:main_entry"
 
 [tool.logfire]
 ignore_no_config = true


### PR DESCRIPTION
## Summary
• Adds "pup" as a shorter alias for the code-puppy command
• Both commands will point to the same entry point function

## Test plan
- [ ] Install package locally and verify both `code-puppy` and `pup` commands work
- [x] Confirm no conflicts with existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)