### PR TITLE
Add configurable reasoning_effort for OpenAI-compatible models

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ Then just use /model and tab to select your round-robin model!
 
 The `rotate_every` parameter controls how many requests are made to each model before rotating to the next one. In this example, the round-robin model will use each Qwen model for 5 consecutive requests before moving to the next model in the sequence.
 
+### Reasoning Effort Overrides
+- Add an optional `reasoning_effort` key (`low`, `medium`, `high`) to any OpenAI-compatible model in `extra_models.json` when you need to tune thoughtful modes.
+- The loader automatically normalizes whitespace/casing and falls back to `medium` if you skip the field or pass an invalid value.
+- OpenAI, Azure OpenAI, custom OpenAI backends, and OpenRouter models receive the value; other providers ignore it.
+
 ---
 
 ## Create your own Agent!!!

--- a/tests/test_agent_reasoning_settings.py
+++ b/tests/test_agent_reasoning_settings.py
@@ -1,0 +1,150 @@
+"""Tests for reasoning_effort wiring in BaseAgent reload."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from code_puppy.agents.agent_code_puppy import CodePuppyAgent
+from code_puppy.model_factory import (
+    DEFAULT_REASONING_EFFORT,
+    _normalize_reasoning_effort,
+)
+
+
+@dataclass
+class FakeModelSettings:
+    kwargs: Dict[str, Any]
+
+
+@dataclass
+class FakeOpenAIModelSettings:
+    kwargs: Dict[str, Any]
+
+
+class FakePydanticAgent:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        FakePydanticAgent.instances.append(self)
+
+
+FakePydanticAgent.instances: List[FakePydanticAgent] = []
+
+
+def _run_reload(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    model_type: str,
+    reasoning_effort: Optional[str],
+) -> Dict[str, Any]:
+    FakePydanticAgent.instances.clear()
+
+    def fake_load_config() -> Dict[str, Dict[str, Any]]:
+        model_config: Dict[str, Any] = {"type": model_type}
+        if reasoning_effort is not None:
+            model_config["reasoning_effort"] = reasoning_effort
+        model_config["reasoning_effort"] = _normalize_reasoning_effort(
+            "test-model",
+            model_config,
+        )
+        return {"test-model": model_config}
+
+    def fake_get_model(*_args: Any, **_kwargs: Any) -> object:
+        return object()
+
+    fake_model_settings_calls: List[FakeModelSettings] = []
+    fake_openai_settings_calls: List[FakeOpenAIModelSettings] = []
+
+    def fake_model_settings(**kwargs: Any) -> FakeModelSettings:
+        call = FakeModelSettings(kwargs)
+        fake_model_settings_calls.append(call)
+        return call
+
+    def fake_openai_settings(**kwargs: Any) -> FakeOpenAIModelSettings:
+        call = FakeOpenAIModelSettings(kwargs)
+        fake_openai_settings_calls.append(call)
+        return call
+
+    def fake_register_tools(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "code_puppy.agents.base_agent.ModelFactory.load_config",
+        staticmethod(fake_load_config),
+    )
+    monkeypatch.setattr(
+        "code_puppy.agents.base_agent.ModelFactory.get_model",
+        staticmethod(fake_get_model),
+    )
+    monkeypatch.setattr(
+        "code_puppy.agents.base_agent.ModelSettings", fake_model_settings
+    )
+    monkeypatch.setattr(
+        "code_puppy.agents.base_agent.OpenAIModelSettings", fake_openai_settings
+    )
+    monkeypatch.setattr(
+        "code_puppy.agents.base_agent.PydanticAgent", FakePydanticAgent
+    )
+    monkeypatch.setattr(
+        "code_puppy.agents.base_agent.BaseAgent.get_model_context_length",
+        lambda self: 100_000,
+    )
+    monkeypatch.setattr(
+        "code_puppy.agents.base_agent.BaseAgent.load_mcp_servers", lambda self: []
+    )
+    monkeypatch.setattr(
+        "code_puppy.agents.base_agent.BaseAgent.load_puppy_rules", lambda self: None
+    )
+    monkeypatch.setattr(CodePuppyAgent, "get_model_name", lambda self: "test-model")
+    monkeypatch.setattr(CodePuppyAgent, "get_system_prompt", lambda self: "prompt")
+    monkeypatch.setattr(
+        "code_puppy.agents.base_agent.console.print", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "code_puppy.tools.register_tools_for_agent", fake_register_tools
+    )
+
+    agent = CodePuppyAgent()
+    agent.reload_code_generation_agent()
+
+    result = {
+        "openai_calls": fake_openai_settings_calls,
+        "model_calls": fake_model_settings_calls,
+        "agent_instances": FakePydanticAgent.instances.copy(),
+    }
+    return result
+
+
+@pytest.mark.parametrize(
+    "model_type,reasoning,expected",
+    [
+        ("openrouter", "high", "high"),
+        ("custom_openai", "weird", DEFAULT_REASONING_EFFORT),
+    ],
+)
+def test_openai_compatible_models_apply_reasoning(
+    monkeypatch: pytest.MonkeyPatch,
+    model_type: str,
+    reasoning: Optional[str],
+    expected: str,
+) -> None:
+    outcome = _run_reload(monkeypatch, model_type=model_type, reasoning_effort=reasoning)
+
+    assert len(outcome["openai_calls"]) == 1
+    assert outcome["model_calls"] == []
+    call_kwargs = outcome["openai_calls"][0].kwargs
+    assert call_kwargs["openai_reasoning_effort"] == expected
+
+
+def test_non_openai_models_skip_reasoning(monkeypatch: pytest.MonkeyPatch) -> None:
+    outcome = _run_reload(
+        monkeypatch,
+        model_type="anthropic",
+        reasoning_effort="high",
+    )
+
+    assert outcome["openai_calls"] == []
+    assert len(outcome["model_calls"]) == 1
+    assert "openai_reasoning_effort" not in outcome["model_calls"][0].kwargs

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -2,7 +2,11 @@ import os
 
 import pytest
 
-from code_puppy.model_factory import ModelFactory
+from code_puppy.model_factory import (
+    DEFAULT_REASONING_EFFORT,
+    ModelFactory,
+    _normalize_reasoning_effort,
+)
 
 TEST_CONFIG_PATH = os.path.join(os.path.dirname(__file__), "../code_puppy/models.json")
 
@@ -190,7 +194,11 @@ def test_extra_models_json_decode_error(tmp_path, monkeypatch):
     extra_models_file.write_text("{ invalid json content }")
 
     # Patch the EXTRA_MODELS_FILE path to point to our temporary file
-    from code_puppy.model_factory import ModelFactory
+    from code_puppy.model_factory import (
+    DEFAULT_REASONING_EFFORT,
+    ModelFactory,
+    _normalize_reasoning_effort,
+)
 
     monkeypatch.setattr(
         "code_puppy.model_factory.EXTRA_MODELS_FILE", str(extra_models_file)
@@ -211,7 +219,11 @@ def test_extra_models_exception_handling(tmp_path, monkeypatch, caplog):
     extra_models_file.mkdir()
 
     # Patch the EXTRA_MODELS_FILE path
-    from code_puppy.model_factory import ModelFactory
+    from code_puppy.model_factory import (
+    DEFAULT_REASONING_EFFORT,
+    ModelFactory,
+    _normalize_reasoning_effort,
+)
 
     monkeypatch.setattr(
         "code_puppy.model_factory.EXTRA_MODELS_FILE", str(extra_models_file)
@@ -227,3 +239,13 @@ def test_extra_models_exception_handling(tmp_path, monkeypatch, caplog):
 
     # Check that warning was logged
     assert "Failed to load extra models config" in caplog.text
+
+
+def test_normalize_reasoning_effort_invalid_defaults():
+    value = _normalize_reasoning_effort("test", {"reasoning_effort": "invalid"})
+    assert value == DEFAULT_REASONING_EFFORT
+
+
+def test_normalize_reasoning_effort_coerces_case():
+    value = _normalize_reasoning_effort("test", {"reasoning_effort": " HIGH "})
+    assert value == "high"


### PR DESCRIPTION
Add configurable reasoning_effort for OpenAI-compatible models
- normalize optional reasoning_effort from extra_models.json and default it to medium
- plumb sanitized effort through BaseAgent reload and drop the hard-coded off setting
- document the option and cover it with unit tests