### PR TITLE
TUI: Interactive /model picker + border fix

### DIFF
--- a/code_puppy/tui/components/input_area.py
+++ b/code_puppy/tui/components/input_area.py
@@ -44,12 +44,12 @@ class SubmitCancelButton(Button):
     """
 
     def __init__(self, **kwargs):
-        super().__init__("▶️", **kwargs)
+        super().__init__("▶", **kwargs)
         self.id = "submit-cancel-button"
 
     def watch_is_cancel_mode(self, is_cancel: bool) -> None:
         """Update the button label when cancel mode changes."""
-        self.label = "⏹️" if is_cancel else "▶️"
+        self.label = "■" if is_cancel else "▶"
 
     def on_click(self) -> None:
         """Handle click event and bubble it up to parent."""
@@ -97,7 +97,7 @@ class InputArea(Container):
     #input-field {
         height: 5;
         width: 1fr;
-        border: round $primary;
+        border: solid $primary;
         background: $surface;
     }
 

--- a/code_puppy/tui/screens/__init__.py
+++ b/code_puppy/tui/screens/__init__.py
@@ -7,6 +7,7 @@ from .mcp_install_wizard import MCPInstallWizardScreen
 from .settings import SettingsScreen
 from .tools import ToolsScreen
 from .autosave_picker import AutosavePicker
+from .model_picker import ModelPicker
 
 __all__ = [
     "HelpScreen",
@@ -14,4 +15,5 @@ __all__ = [
     "ToolsScreen",
     "MCPInstallWizardScreen",
     "AutosavePicker",
+    "ModelPicker",
 ]

--- a/code_puppy/tui/screens/model_picker.py
+++ b/code_puppy/tui/screens/model_picker.py
@@ -1,0 +1,125 @@
+"""
+Model Picker modal for TUI.
+Lists available models and lets the user select one.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Container, Horizontal
+from textual.screen import ModalScreen
+from textual.widgets import Button, Label, ListItem, ListView, Static
+
+from code_puppy.command_line.model_picker_completion import (
+    get_active_model,
+    load_model_names,
+)
+
+
+class ModelPicker(ModalScreen):
+    """Modal to present available models for selection."""
+
+    DEFAULT_CSS = """
+    ModelPicker {
+        align: center middle;
+    }
+
+    #modal-container {
+        width: 80%;
+        max-width: 100;
+        height: 24;
+        min-height: 18;
+        background: $surface;
+        border: solid $primary;
+        padding: 1 2;
+        layout: vertical;
+    }
+
+    #list-label {
+        width: 100%;
+        height: 1;
+        color: $text;
+        text-align: left;
+    }
+
+    #model-list {
+        height: 1fr;
+        overflow: auto;
+        border: solid $primary-darken-2;
+        background: $surface-darken-1;
+        margin: 1 0;
+    }
+
+    .button-row {
+        height: 3;
+        align-horizontal: right;
+        margin-top: 1;
+    }
+
+    #cancel-button { background: $primary-darken-1; }
+    #select-button { background: $success; }
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.model_names: List[str] = []
+        self.list_view: Optional[ListView] = None
+
+    def on_mount(self) -> None:
+        self.model_names = load_model_names()
+        current_model = get_active_model()
+
+        # Populate the ListView
+        if self.list_view is None:
+            try:
+                self.list_view = self.query_one("#model-list", ListView)
+            except Exception:
+                self.list_view = None
+
+        if self.list_view is not None:
+            try:
+                self.list_view.clear()
+            except Exception:
+                self.list_view.children.clear()  # type: ignore
+            selected_index = 0
+            for i, name in enumerate(self.model_names):
+                if name == current_model:
+                    label = f"{name} [green]\u2190 current[/green]"
+                    selected_index = i
+                else:
+                    label = name
+                self.list_view.append(ListItem(Static(label)))
+
+            if self.model_names:
+                self.list_view.index = selected_index
+                self.list_view.focus()
+
+    def compose(self) -> ComposeResult:
+        with Container(id="modal-container"):
+            yield Label("Select a model (Esc to cancel)", id="list-label")
+            self.list_view = ListView(id="model-list")
+            yield self.list_view
+            with Horizontal(classes="button-row"):
+                yield Button("Cancel", id="cancel-button")
+                yield Button("Select", id="select-button", variant="primary")
+
+    @on(Button.Pressed, "#cancel-button")
+    def cancel(self) -> None:
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#select-button")
+    def select_model(self) -> None:
+        if not self.list_view or not self.model_names:
+            self.dismiss(None)
+            return
+        idx = self.list_view.index if self.list_view.index is not None else 0
+        if 0 <= idx < len(self.model_names):
+            self.dismiss(self.model_names[idx])
+        else:
+            self.dismiss(None)
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:  # type: ignore
+        self.select_model()


### PR DESCRIPTION
Implements a /model command that opens a modal window, allowing users to select from a list of live models directly in the interface.

Replace emoji icons with single width glyphs use "▶" and "■" instead of "▶️" and "⏹️".
Switch the input field border from “round” to “solid”.
These two changes eliminate width/rounding artifacts that caused the jagged edges.

New /model Selector Modal
<img width="1070" height="457" alt="image" src="https://github.com/user-attachments/assets/5cc42cf1-4333-4466-b9b5-2e4034a08ce8" />

Before (Old Jagged Edges issue)
<img width="1035" height="143" alt="image" src="https://github.com/user-attachments/assets/2d74ffec-73b1-4ce8-b653-cee7b13dc561" />

After (Fixed Edges)
<img width="1069" height="197" alt="image" src="https://github.com/user-attachments/assets/9583abd2-0622-4923-9d9d-8801b18865a2" />
