### PR TITLE
fix: improve model error surfacing and Z.ai response handling

### DIFF
--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -776,18 +776,25 @@ class BaseAgent(ABC):
             return model, requested_model_name
         except ValueError as exc:
             available_models = list(models_config.keys())
-            available_str = (
-                ", ".join(sorted(available_models))
-                if available_models
-                else "no configured models"
-            )
-            emit_warning(
-                (
-                    f"[yellow]Model '{requested_model_name}' not found. "
-                    f"Available models: {available_str}[/yellow]"
-                ),
-                message_group=message_group,
-            )
+
+            if requested_model_name in available_models:
+                emit_error(
+                    f"[bold red]Failed to load model '{requested_model_name}': {exc}[/bold red]",
+                    message_group=message_group,
+                )
+            else:
+                available_str = (
+                    ", ".join(sorted(available_models))
+                    if available_models
+                    else "no configured models"
+                )
+                emit_warning(
+                    (
+                        f"[yellow]Model '{requested_model_name}' not found. "
+                        f"Available models: {available_str}[/yellow]"
+                    ),
+                    message_group=message_group,
+                )
 
             fallback_candidates: List[str] = []
             global_candidate = get_global_model_name()

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -241,7 +241,14 @@ class ModelFactory:
                 provider_args["api_key"] = api_key
             provider = OpenAIProvider(**provider_args)
 
-            model = OpenAIChatModel(model_name=model_config["name"], provider=provider)
+            # Z.ai has two OpenAI-compatible APIs: the common PAYGO endpoint and
+            # the coding plan endpoint. Both need the ZaiChatModel shim to
+            # normalize responses to "chat.completion".
+            if url and "api.z.ai" in url.lower():
+                model = ZaiChatModel(model_name=model_config["name"], provider=provider)
+            else:
+                model = OpenAIChatModel(model_name=model_config["name"], provider=provider)
+
             setattr(model, "provider", provider)
             return model
         elif model_type == "zai_coding":


### PR DESCRIPTION
fix: improve model error surfacing and Z.ai response handling

 - Surface the original `ModelFactory.get_model()` exception when a configured model fails to load so users see credential/config issues instead of a generic “model not found” warning (`code_puppy/agents/base_agent.py`).
 - Apply the `ZaiChatModel` shim automatically for any custom OpenAI endpoint under `api.z.ai`, ensuring both PAYGO and Coding plan GLM APIs normalize their non‑standard responses while leaving other providers on `OpenAIChatModel` (`code_puppy/model_factory.py`).