### PR TITLE
build: remove pnpm check from pre-commit hook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -35,12 +35,6 @@ pre-commit:
           ruff check --fix {staged_files}
         fi
       stage_fixed: true
-    pnpm-check:
-      run: |
-        if command -v pnpm >/dev/null 2>&1; then
-          pnpm check
-        else
-          echo "pnpm not found, skipping pnpm check"
-        fi
+
 
 # pre-push hook removed - tests run in CI only


### PR DESCRIPTION
- Eliminated pnpm-check command from lefthook pre-commit configuration
- This change streamlines the pre-commit process by removing an optional dependency check
- Tests are now handled exclusively in CI, as noted in the existing comment