### PR TITLE
feat: add support for Google Gemini models

### DIFF
--- a/code_puppy/models.json
+++ b/code_puppy/models.json
@@ -160,5 +160,20 @@
     "type": "zai_api",
     "name": "glm-4.6",
     "context_length": 200000
+  },
+  "gemini-3-pro-preview": {
+    "type": "gemini",
+    "name": "gemini-3-pro-preview",
+    "context_length": 1048576
+  },
+  "gemini-2.5-flash": {
+    "type": "gemini",
+    "name": "gemini-2.5-flash",
+    "context_length": 1048576
+  },
+  "gemini-2.5-pro": {
+    "type": "gemini",
+    "name": "gemini-2.5-pro",
+    "context_length": 1048576
   }
 }


### PR DESCRIPTION
- Add gemini-3-pro-preview model with 1048576 context length
- Add gemini-2.5-flash model with 1048576 context length
- Add gemini-2.5-pro model with 1048576 context length
- All new models use the gemini API type