### PR TITLE
Add session_id tracking to messages for multi-agent support

### DIFF
--- a/code_puppy/messaging/__init__.py
+++ b/code_puppy/messaging/__init__.py
@@ -45,7 +45,9 @@ from .bus import emit_success as bus_emit_success
 from .bus import emit_warning as bus_emit_warning
 from .bus import (
     get_message_bus,
+    get_session_context,
     reset_message_bus,
+    set_session_context,
 )
 
 # Command types (UI -> Agent)
@@ -201,6 +203,9 @@ __all__ = [
     "MessageBus",
     "get_message_bus",
     "reset_message_bus",
+    # Session context
+    "set_session_context",
+    "get_session_context",
     # New API convenience functions (prefixed to avoid collision)
     "bus_emit",
     "bus_emit_info",

--- a/code_puppy/messaging/messages.py
+++ b/code_puppy/messaging/messages.py
@@ -56,6 +56,10 @@ class BaseMessage(BaseModel):
     category: MessageCategory = Field(
         description="Category for routing and rendering decisions"
     )
+    session_id: Optional[str] = Field(
+        default=None,
+        description="Session ID of the agent that emitted this message (for multi-agent tracking)",
+    )
 
     model_config = {"frozen": False, "extra": "forbid"}
 

--- a/code_puppy/tools/agent_tools.py
+++ b/code_puppy/tools/agent_tools.py
@@ -29,6 +29,8 @@ from code_puppy.messaging import (
     emit_info,
     emit_system_message,
     get_message_bus,
+    get_session_context,
+    set_session_context,
 )
 from code_puppy.model_factory import ModelFactory, make_model_settings
 from code_puppy.tools.common import generate_group_id
@@ -407,6 +409,10 @@ def register_invoke_agent(agent):
             )
         )
 
+        # Save current session context and set the new one for this sub-agent
+        previous_session_id = get_session_context()
+        set_session_context(session_id)
+
         try:
             # Load the specified agent config
             agent_config = load_agent(agent_name)
@@ -542,5 +548,9 @@ def register_invoke_agent(agent):
                 session_id=session_id,
                 error=error_msg,
             )
+
+        finally:
+            # Restore the previous session context
+            set_session_context(previous_session_id)
 
     return invoke_agent


### PR DESCRIPTION
This enables GUI clients to identify which agent emitted each message, solving the issue of interleaved messages when multiple sub-agents run in parallel.

Changes:
- Add optional session_id field to BaseMessage (backward compatible)
- Add set_session_context/get_session_context to MessageBus
- Auto-tag messages with current session_id in emit()
- Set/restore session context in invoke_agent tool

When an agent invokes a sub-agent, the session_id is set as the current context. All messages emitted during that sub-agent's execution are automatically tagged. The previous context is restored when the sub-agent completes.