### PR TITLE
Update badges to latest versions and add Discord badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Build Status](https://img.shields.io/badge/Build-Passing-brightgreen?style=for-the-badge&logo=github)](https://github.com/mpfaffenberger/code_puppy/actions)
 [![Tests](https://img.shields.io/badge/Tests-Passing-success?style=for-the-badge&logo=pytest)](https://github.com/mpfaffenberger/code_puppy/tests)
 
-[![OpenAI](https://img.shields.io/badge/OpenAI-GPT--5-orange?style=flat-square&logo=openai)](https://openai.com)
+[![OpenAI](https://img.shields.io/badge/OpenAI-GPT--5.2--Codex-orange?style=flat-square&logo=openai)](https://openai.com)
 [![Gemini](https://img.shields.io/badge/Google-Gemini-blue?style=flat-square&logo=google)](https://ai.google.dev/)
 [![Anthropic](https://img.shields.io/badge/Anthropic-Claude-orange?style=flat-square&logo=anthropic)](https://anthropic.com)
 [![Cerebras](https://img.shields.io/badge/Cerebras-GLM%204.7-red?style=flat-square)](https://cerebras.ai)


### PR DESCRIPTION
This PR updates the badges in the README to reflect the latest model versions and adds a Discord badge for the community.

## Changes
- Updated GLM badges (Cerebras and Z.AI) from 4.6 to 4.7
- Updated MiniMax badge from M2 to M2.1
- Added a new Discord badge linking to https://discord.gg/SqYAaXVy

All badges now show the most recent version numbers!