### PR TITLE
Add spinner elapsed time display and optional alert bell

### DIFF
--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -277,6 +277,8 @@ def get_config_keys():
     plus certain preset expected keys (e.g. "yolo_mode", "model", "compaction_strategy", "message_limit", "allow_recursion").
     """
     default_keys = [
+        "alert_bell_enabled",
+        "alert_bell_threshold",
         "yolo_mode",
         "model",
         "compaction_strategy",
@@ -1710,3 +1712,53 @@ def get_frontend_emitter_queue_size() -> int:
         return int(val)
     except ValueError:
         return 100
+
+
+# --- ALERT BELL CONFIGURATION ---
+def get_alert_bell_enabled() -> bool:
+    """Check if the alert bell feature is enabled.
+
+    When enabled, a system bell will ring after the spinner has been
+    running for longer than the configured threshold, prompting the
+    user to check back on their terminal.
+
+    Returns:
+        bool: True if alert bell is enabled, False otherwise (default: False)
+    """
+    val = get_value("alert_bell_enabled")
+    if val is None:
+        return False  # Disabled by default
+    return val.lower() in ("true", "1", "yes", "on")
+
+
+def set_alert_bell_enabled(enabled: bool) -> None:
+    """Enable or disable the alert bell feature.
+
+    Args:
+        enabled: True to enable the alert bell, False to disable
+    """
+    set_config_value("alert_bell_enabled", "true" if enabled else "false")
+
+
+def get_alert_bell_threshold() -> int:
+    """Get the threshold in seconds before the alert bell rings.
+
+    Returns:
+        int: Threshold in seconds (default: 30, minimum: 1)
+    """
+    val = get_value("alert_bell_threshold")
+    if val is None:
+        return 30  # Default to 30 seconds
+    try:
+        return max(1, int(val))  # Minimum 1 second
+    except ValueError:
+        return 30
+
+
+def set_alert_bell_threshold(seconds: int) -> None:
+    """Set the threshold in seconds before the alert bell rings.
+
+    Args:
+        seconds: Threshold in seconds (minimum: 1)
+    """
+    set_config_value("alert_bell_threshold", str(max(1, seconds)))

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -1728,7 +1728,7 @@ def get_alert_bell_enabled() -> bool:
     val = get_value("alert_bell_enabled")
     if val is None:
         return False  # Disabled by default
-    return val.lower() in ("true", "1", "yes", "on")
+    return str(val).strip().lower() in {"1", "true", "yes", "on"}
 
 
 def set_alert_bell_enabled(enabled: bool) -> None:

--- a/tests/messaging/spinner/test_console_spinner_elapsed.py
+++ b/tests/messaging/spinner/test_console_spinner_elapsed.py
@@ -6,12 +6,14 @@ from code_puppy.messaging.spinner.console_spinner import ConsoleSpinner
 
 
 def test_get_elapsed_str_empty_when_not_started():
+    """Test that elapsed string is empty when spinner hasn't started."""
     spinner = ConsoleSpinner()
     spinner._start_time = None
     assert spinner._get_elapsed_str() == ""
 
 
 def test_get_elapsed_str_formats_seconds_under_minute():
+    """Test elapsed time formatting for durations under one minute."""
     spinner = ConsoleSpinner()
     spinner._start_time = 0
     with patch("code_puppy.messaging.spinner.console_spinner.time.time", return_value=45):
@@ -19,6 +21,7 @@ def test_get_elapsed_str_formats_seconds_under_minute():
 
 
 def test_get_elapsed_str_formats_minutes_and_seconds():
+    """Test elapsed time formatting for durations with minutes and seconds."""
     spinner = ConsoleSpinner()
     spinner._start_time = 0
     with patch("code_puppy.messaging.spinner.console_spinner.time.time", return_value=125):
@@ -26,6 +29,7 @@ def test_get_elapsed_str_formats_minutes_and_seconds():
 
 
 def test_get_elapsed_str_formats_hours_minutes_seconds():
+    """Test elapsed time formatting for durations exceeding one hour."""
     spinner = ConsoleSpinner()
     spinner._start_time = 0
     with patch("code_puppy.messaging.spinner.console_spinner.time.time", return_value=3725):
@@ -33,6 +37,7 @@ def test_get_elapsed_str_formats_hours_minutes_seconds():
 
 
 def test_check_bell_alert_does_nothing_when_disabled():
+    """Test that bell alert does not trigger when feature is disabled."""
     spinner = ConsoleSpinner()
     spinner._start_time = 0
     spinner._bell_triggered = False
@@ -45,6 +50,7 @@ def test_check_bell_alert_does_nothing_when_disabled():
 
 
 def test_check_bell_alert_does_nothing_before_threshold():
+    """Test that bell alert does not trigger before threshold is reached."""
     spinner = ConsoleSpinner()
     spinner._start_time = 0
     spinner._bell_triggered = False
@@ -59,6 +65,7 @@ def test_check_bell_alert_does_nothing_before_threshold():
 
 
 def test_check_bell_alert_rings_once_after_threshold():
+    """Test that bell alert triggers exactly once when threshold is reached."""
     spinner = ConsoleSpinner()
     spinner._start_time = 0
     spinner._bell_triggered = False
@@ -74,6 +81,7 @@ def test_check_bell_alert_rings_once_after_threshold():
 
 
 def test_check_bell_alert_only_triggers_once_per_session():
+    """Test that bell alert only triggers once per spinner session."""
     spinner = ConsoleSpinner()
     spinner._start_time = 0
     spinner._bell_triggered = False

--- a/tests/messaging/spinner/test_console_spinner_elapsed.py
+++ b/tests/messaging/spinner/test_console_spinner_elapsed.py
@@ -16,7 +16,9 @@ def test_get_elapsed_str_formats_seconds_under_minute():
     """Test elapsed time formatting for durations under one minute."""
     spinner = ConsoleSpinner()
     spinner._start_time = 0
-    with patch("code_puppy.messaging.spinner.console_spinner.time.time", return_value=45):
+    with patch(
+        "code_puppy.messaging.spinner.console_spinner.time.time", return_value=45
+    ):
         assert spinner._get_elapsed_str() == "[0:45]"
 
 
@@ -24,7 +26,9 @@ def test_get_elapsed_str_formats_minutes_and_seconds():
     """Test elapsed time formatting for durations with minutes and seconds."""
     spinner = ConsoleSpinner()
     spinner._start_time = 0
-    with patch("code_puppy.messaging.spinner.console_spinner.time.time", return_value=125):
+    with patch(
+        "code_puppy.messaging.spinner.console_spinner.time.time", return_value=125
+    ):
         assert spinner._get_elapsed_str() == "[2:05]"
 
 
@@ -32,7 +36,9 @@ def test_get_elapsed_str_formats_hours_minutes_seconds():
     """Test elapsed time formatting for durations exceeding one hour."""
     spinner = ConsoleSpinner()
     spinner._start_time = 0
-    with patch("code_puppy.messaging.spinner.console_spinner.time.time", return_value=3725):
+    with patch(
+        "code_puppy.messaging.spinner.console_spinner.time.time", return_value=3725
+    ):
         assert spinner._get_elapsed_str() == "[1:02:05]"
 
 
@@ -57,7 +63,10 @@ def test_check_bell_alert_does_nothing_before_threshold():
 
     with patch("code_puppy.config.get_alert_bell_enabled", return_value=True):
         with patch("code_puppy.config.get_alert_bell_threshold", return_value=30):
-            with patch("code_puppy.messaging.spinner.console_spinner.time.time", return_value=29):
+            with patch(
+                "code_puppy.messaging.spinner.console_spinner.time.time",
+                return_value=29,
+            ):
                 with patch("sys.stdout") as mock_stdout:
                     spinner._check_bell_alert()
                     mock_stdout.write.assert_not_called()
@@ -72,7 +81,10 @@ def test_check_bell_alert_rings_once_after_threshold():
 
     with patch("code_puppy.config.get_alert_bell_enabled", return_value=True):
         with patch("code_puppy.config.get_alert_bell_threshold", return_value=30):
-            with patch("code_puppy.messaging.spinner.console_spinner.time.time", return_value=30):
+            with patch(
+                "code_puppy.messaging.spinner.console_spinner.time.time",
+                return_value=30,
+            ):
                 with patch("sys.stdout") as mock_stdout:
                     spinner._check_bell_alert()
                     mock_stdout.write.assert_called_once_with("\a")
@@ -88,7 +100,10 @@ def test_check_bell_alert_only_triggers_once_per_session():
 
     with patch("code_puppy.config.get_alert_bell_enabled", return_value=True):
         with patch("code_puppy.config.get_alert_bell_threshold", return_value=30):
-            with patch("code_puppy.messaging.spinner.console_spinner.time.time", return_value=35):
+            with patch(
+                "code_puppy.messaging.spinner.console_spinner.time.time",
+                return_value=35,
+            ):
                 with patch("sys.stdout") as mock_stdout:
                     spinner._check_bell_alert()
                     spinner._check_bell_alert()

--- a/tests/messaging/spinner/test_console_spinner_elapsed.py
+++ b/tests/messaging/spinner/test_console_spinner_elapsed.py
@@ -1,0 +1,89 @@
+"""Unit tests for ConsoleSpinner elapsed time and bell alert behavior."""
+
+from unittest.mock import patch
+
+from code_puppy.messaging.spinner.console_spinner import ConsoleSpinner
+
+
+def test_get_elapsed_str_empty_when_not_started():
+    spinner = ConsoleSpinner()
+    spinner._start_time = None
+    assert spinner._get_elapsed_str() == ""
+
+
+def test_get_elapsed_str_formats_seconds_under_minute():
+    spinner = ConsoleSpinner()
+    spinner._start_time = 0
+    with patch("code_puppy.messaging.spinner.console_spinner.time.time", return_value=45):
+        assert spinner._get_elapsed_str() == "[0:45]"
+
+
+def test_get_elapsed_str_formats_minutes_and_seconds():
+    spinner = ConsoleSpinner()
+    spinner._start_time = 0
+    with patch("code_puppy.messaging.spinner.console_spinner.time.time", return_value=125):
+        assert spinner._get_elapsed_str() == "[2:05]"
+
+
+def test_get_elapsed_str_formats_hours_minutes_seconds():
+    spinner = ConsoleSpinner()
+    spinner._start_time = 0
+    with patch("code_puppy.messaging.spinner.console_spinner.time.time", return_value=3725):
+        assert spinner._get_elapsed_str() == "[1:02:05]"
+
+
+def test_check_bell_alert_does_nothing_when_disabled():
+    spinner = ConsoleSpinner()
+    spinner._start_time = 0
+    spinner._bell_triggered = False
+
+    with patch("code_puppy.config.get_alert_bell_enabled", return_value=False):
+        with patch("sys.stdout") as mock_stdout:
+            spinner._check_bell_alert()
+            mock_stdout.write.assert_not_called()
+            assert spinner._bell_triggered is False
+
+
+def test_check_bell_alert_does_nothing_before_threshold():
+    spinner = ConsoleSpinner()
+    spinner._start_time = 0
+    spinner._bell_triggered = False
+
+    with patch("code_puppy.config.get_alert_bell_enabled", return_value=True):
+        with patch("code_puppy.config.get_alert_bell_threshold", return_value=30):
+            with patch("code_puppy.messaging.spinner.console_spinner.time.time", return_value=29):
+                with patch("sys.stdout") as mock_stdout:
+                    spinner._check_bell_alert()
+                    mock_stdout.write.assert_not_called()
+                    assert spinner._bell_triggered is False
+
+
+def test_check_bell_alert_rings_once_after_threshold():
+    spinner = ConsoleSpinner()
+    spinner._start_time = 0
+    spinner._bell_triggered = False
+
+    with patch("code_puppy.config.get_alert_bell_enabled", return_value=True):
+        with patch("code_puppy.config.get_alert_bell_threshold", return_value=30):
+            with patch("code_puppy.messaging.spinner.console_spinner.time.time", return_value=30):
+                with patch("sys.stdout") as mock_stdout:
+                    spinner._check_bell_alert()
+                    mock_stdout.write.assert_called_once_with("\a")
+                    mock_stdout.flush.assert_called_once()
+                    assert spinner._bell_triggered is True
+
+
+def test_check_bell_alert_only_triggers_once_per_session():
+    spinner = ConsoleSpinner()
+    spinner._start_time = 0
+    spinner._bell_triggered = False
+
+    with patch("code_puppy.config.get_alert_bell_enabled", return_value=True):
+        with patch("code_puppy.config.get_alert_bell_threshold", return_value=30):
+            with patch("code_puppy.messaging.spinner.console_spinner.time.time", return_value=35):
+                with patch("sys.stdout") as mock_stdout:
+                    spinner._check_bell_alert()
+                    spinner._check_bell_alert()
+
+                    mock_stdout.write.assert_called_once_with("\a")
+                    assert spinner._bell_triggered is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -283,6 +283,8 @@ class TestGetConfigKeys:
         mock_parser_instance.read.assert_called_once_with(mock_cfg_file)
         assert keys == sorted(
             [
+                "alert_bell_enabled",
+                "alert_bell_threshold",
                 "allow_recursion",
                 "auto_save_session",
                 "banner_color_agent_reasoning",
@@ -336,6 +338,8 @@ class TestGetConfigKeys:
         keys = cp_config.get_config_keys()
         assert keys == sorted(
             [
+                "alert_bell_enabled",
+                "alert_bell_threshold",
                 "allow_recursion",
                 "auto_save_session",
                 "banner_color_agent_reasoning",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -491,8 +491,8 @@ class TestModelName:
         def get_section_or_create(name):
             if name == DEFAULT_SECTION_NAME:
                 # Ensure subsequent checks for section existence pass
-                mock_parser_instance.__contains__ = (
-                    lambda s_name: s_name == DEFAULT_SECTION_NAME
+                mock_parser_instance.__contains__ = lambda s_name: (
+                    s_name == DEFAULT_SECTION_NAME
                 )
                 return section_dict
             raise KeyError(name)


### PR DESCRIPTION
This PR adds two features to the console spinner:

## Features

### 1. Elapsed Time Display
Shows how long the spinner has been running in the format `[M:SS]` or `[H:MM:SS]` for longer operations. This helps users understand how long they've been waiting.

### 2. Optional Alert Bell
When enabled via config, rings the system bell after a configurable threshold (default 30 seconds) to alert users that a long-running task needs attention. The bell only rings once per spinner session.

## Configuration

```
/set alert_bell_enabled=true
/set alert_bell_threshold=30
```

## Changes
- `code_puppy/config.py`: Added config keys and getter/setter functions
- `code_puppy/messaging/spinner/console_spinner.py`: Added elapsed time display and bell alert logic
- `tests/messaging/spinner/test_console_spinner_elapsed.py`: Added unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable alert bell notifications with enable/disable and adjustable threshold (default 30s).
  * Real-time elapsed-time display in [M:SS] or [H:MM:SS] during long-running operations.
  * Bell emits at most once per operation when enabled and threshold is exceeded.

* **Tests**
  * Added unit tests for elapsed-time formatting and bell alert behavior (thresholding, single-alert, disabled state).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->