### PR TITLE
fix: allow Ctrl+C interrupt during agent thinking phase

### DIFF
--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -788,6 +788,12 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
 
                 time.sleep(0.1)  # Brief pause to ensure all messages are rendered
 
+            except KeyboardInterrupt:
+                # Force-quit from second Ctrl+C — return gracefully to prompt
+                from code_puppy.messaging import emit_info
+
+                emit_info("Interrupted")
+                continue
             except Exception:
                 from code_puppy.messaging.queue_console import get_queue_console
 


### PR DESCRIPTION
## Problem

Users cannot interrupt Code Puppy with Ctrl+C during the "thinking" phase — the period between submitting a prompt and when the LLM starts streaming back tokens. Pressing Ctrl+C during this window either crashes the program entirely or is silently ignored.

## Root Cause

The custom SIGINT handler that enables graceful cancellation was installed **deep inside** `run_with_mcp()` in `base_agent.py`, only after significant setup work:
- Prompt sanitization & model prompt preparation
- Attachment building
- Inner task creation
- Plugin hook firing (`on_agent_run_start`)

During this entire setup window, asyncio's default SIGINT handler was active, which raises a raw `KeyboardInterrupt` instead of gracefully cancelling the task. This `KeyboardInterrupt` would bubble up to `main_entry()` and crash the program with a traceback.

Additionally, the main `while True` loop only had `except Exception:` around agent execution — but `KeyboardInterrupt` is a `BaseException`, not an `Exception`, so it was never caught gracefully at that level.

## Fix

### 1. Early SIGINT handler in `run_prompt_with_attachments()`
Install a preliminary SIGINT handler immediately after creating the outer agent task, **before** `run_with_mcp` starts executing. This handler cancels the outer task via `loop.call_soon_threadsafe(agent_task.cancel)`. When `run_with_mcp` eventually installs its own, more granular handler, it naturally supersedes this one. The `finally` block cleans up if `run_with_mcp` never got a chance to install its own.

### 2. `KeyboardInterrupt` guard in main loop
Added `except KeyboardInterrupt` around agent execution so any stray interrupts gracefully return to the prompt with a friendly message instead of crashing.

## Testing
- All 35 `test_cli_runner.py` tests pass ✅
- All 15 `test_base_agent_key_listeners.py` tests pass ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ctrl+C handling across interactive sessions and agent operations: first interrupt now cancels gracefully and returns to the prompt with a clear "Interrupted" message; a second interrupt forces immediate termination.
  * Ensures spinner/terminal state is restored and messages are reliably displayed during cancellation to avoid deadlocks and messy terminal output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->