### PR TITLE
feat: upgrade zai GLM models - remove 4.6, add 5

### DIFF
--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -487,8 +487,10 @@ def model_supports_setting(model_name: str, setting: str) -> bool:
         True if the model supports the setting, False otherwise.
         Defaults to True for backwards compatibility if model config doesn't specify.
     """
-    # GLM-4.7 models always support clear_thinking setting
-    if setting == "clear_thinking" and "glm-4.7" in model_name.lower():
+    # GLM-4.7 and GLM-5 models always support clear_thinking setting
+    if setting == "clear_thinking" and (
+        "glm-4.7" in model_name.lower() or "glm-5" in model_name.lower()
+    ):
         return True
 
     try:

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -146,8 +146,8 @@ def make_model_settings(
     if not get_yolo_mode():
         model_settings_dict["parallel_tool_calls"] = False
 
-    # Default to clear_thinking=False for GLM-4.7 models (preserved thinking)
-    if "glm-4.7" in model_name.lower():
+    # Default to clear_thinking=False for GLM-4.7 and GLM-5 models (preserved thinking)
+    if "glm-4.7" in model_name.lower() or "glm-5" in model_name.lower():
         clear_thinking = effective_settings.get("clear_thinking", False)
         model_settings_dict["thinking"] = {
             "type": "enabled",

--- a/code_puppy/models.json
+++ b/code_puppy/models.json
@@ -93,18 +93,6 @@
     "context_length": 200000,
     "supported_settings": ["temperature", "extended_thinking", "budget_tokens", "interleaved_thinking"]
   },
-  "zai-glm-4.6-coding": {
-    "type": "zai_coding",
-    "name": "glm-4.6",
-    "context_length": 200000,
-    "supported_settings": ["temperature", "top_p"]
-  },
-  "zai-glm-4.6-api": {
-    "type": "zai_api",
-    "name": "glm-4.6",
-    "context_length": 200000,
-    "supported_settings": ["temperature", "top_p"]
-  },
   "zai-glm-4.7-coding": {
     "type": "zai_coding",
     "name": "glm-4.7",
@@ -114,6 +102,18 @@
   "zai-glm-4.7-api": {
     "type": "zai_api",
     "name": "glm-4.7",
+    "context_length": 200000,
+    "supported_settings": ["temperature", "top_p"]
+  },
+  "zai-glm-5-coding": {
+    "type": "zai_coding",
+    "name": "glm-5",
+    "context_length": 200000,
+    "supported_settings": ["temperature", "top_p"]
+  },
+  "zai-glm-5-api": {
+    "type": "zai_api",
+    "name": "glm-5",
     "context_length": 200000,
     "supported_settings": ["temperature", "top_p"]
   }


### PR DESCRIPTION
- Remove zai-glm-4.6-coding and zai-glm-4.6-api
- Add zai-glm-5-coding and zai-glm-5-api models
- Update config.py to support clear_thinking for GLM-5
- Update model_factory.py for GLM-5 thinking configuration

GLM 5 is now the latest available zai model!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GLM-5 models with coding and API variants.
  * Extended clear thinking feature support to GLM-5 models.

* **Updates**
  * Updated model configurations; GLM-4.6 entries upgraded to GLM-4.7.
  * Expanded default thinking behavior to GLM-5 models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->