### PR TITLE
feat(chatgpt-oauth): add gpt-5.3-codex-spark model (131k context)

### DIFF
--- a/code_puppy/plugins/chatgpt_oauth/test_plugin.py
+++ b/code_puppy/plugins/chatgpt_oauth/test_plugin.py
@@ -268,8 +268,10 @@ def test_fetch_chatgpt_models_fallback(mock_get):
     models = utils.fetch_chatgpt_models("test_access_token", "test_account_id")
     assert models is not None
     # Should return default models
+    assert "gpt-5.3-codex-spark" in models
+    assert "gpt-5.3-codex" in models
+    assert "gpt-5.2-codex" in models
     assert "gpt-5.2" in models
-    assert "gpt-4o" in models
 
 
 def test_add_models_to_chatgpt_config(tmp_path):

--- a/code_puppy/plugins/chatgpt_oauth/utils.py
+++ b/code_puppy/plugins/chatgpt_oauth/utils.py
@@ -344,10 +344,17 @@ def exchange_code_for_tokens(
 # These are the known models that work with ChatGPT OAuth tokens
 # Based on codex-rs CLI and shell-scripts/codex-call.sh
 DEFAULT_CODEX_MODELS = [
+    "gpt-5.3-codex-spark",
     "gpt-5.3-codex",
     "gpt-5.2-codex",
     "gpt-5.2",
 ]
+
+# Per-model context length overrides (tokens).
+# Models not listed here use CHATGPT_OAUTH_CONFIG["default_context_length"] (272,000).
+CODEX_MODEL_CONTEXT_LENGTHS = {
+    "gpt-5.3-codex-spark": 131000,
+}
 
 
 def fetch_chatgpt_models(access_token: str, account_id: str) -> Optional[List[str]]:
@@ -457,7 +464,9 @@ def add_models_to_extra_config(models: List[str]) -> bool:
                     # Codex API uses chatgpt.com/backend-api/codex, not api.openai.com
                     "url": CHATGPT_OAUTH_CONFIG["api_base_url"],
                 },
-                "context_length": CHATGPT_OAUTH_CONFIG["default_context_length"],
+                "context_length": CODEX_MODEL_CONTEXT_LENGTHS.get(
+                    model_name, CHATGPT_OAUTH_CONFIG["default_context_length"]
+                ),
                 "oauth_source": "chatgpt-oauth-plugin",
                 "supported_settings": supported_settings,
                 "supports_xhigh_reasoning": is_codex,

--- a/tests/plugins/test_chatgpt_oauth_integration.py
+++ b/tests/plugins/test_chatgpt_oauth_integration.py
@@ -13,6 +13,7 @@ from unittest.mock import Mock, patch
 
 import requests
 
+from code_puppy.plugins.chatgpt_oauth import config
 from code_puppy.plugins.chatgpt_oauth.config import (
     CHATGPT_OAUTH_CONFIG,
     get_chatgpt_models_path,
@@ -110,6 +111,24 @@ class TestModelManagement:
         )
         assert "supported_settings" in model_config
         assert "oauth_source" in model_config
+
+    def test_add_models_spark_context_length(self, tmp_path):
+        """Test that gpt-5.3-codex-spark gets its custom 131k context length."""
+        with patch.object(
+            config,
+            "get_chatgpt_models_path",
+            return_value=tmp_path / "chatgpt_models.json",
+        ):
+            with patch(
+                "code_puppy.plugins.chatgpt_oauth.utils.get_chatgpt_models_path",
+                return_value=tmp_path / "chatgpt_models.json",
+            ):
+                result = add_models_to_extra_config(["gpt-5.3-codex-spark"])
+                assert result is True
+                models = load_chatgpt_models()
+                spark_config = models["chatgpt-gpt-5.3-codex-spark"]
+                assert spark_config["context_length"] == 131000
+                assert spark_config["supports_xhigh_reasoning"] is True
 
     @patch("code_puppy.plugins.chatgpt_oauth.utils.get_chatgpt_models_path")
     def test_remove_chatgpt_models(self, mock_path, tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -487,8 +487,8 @@ class TestModelName:
         def get_section_or_create(name):
             if name == DEFAULT_SECTION_NAME:
                 # Ensure subsequent checks for section existence pass
-                mock_parser_instance.__contains__ = (
-                    lambda s_name: s_name == DEFAULT_SECTION_NAME
+                mock_parser_instance.__contains__ = lambda s_name: (
+                    s_name == DEFAULT_SECTION_NAME
                 )
                 return section_dict
             raise KeyError(name)


### PR DESCRIPTION
- Add gpt-5.3-codex-spark to DEFAULT_CODEX_MODELS
- Add CODEX_MODEL_CONTEXT_LENGTHS for per-model context length overrides
- Update add_models_to_extra_config() to use model-specific context lengths
- Fix pre-existing test_fetch_chatgpt_models_fallback assertions
- Add test for spark model 131k context length

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three new AI model variants to the available model list (including gpt-5.3-codex-spark).
  * Extended context length support (131,000 tokens) for gpt-5.3-codex-spark.
  * Enabled extended reasoning support on the new models.

* **Tests**
  * Updated and added tests to verify model availability, context length, and reasoning feature flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->