### PR TITLE
Fix: Slash command completions reappear after backspace

### DIFF
--- a/code_puppy/command_line/prompt_toolkit_completion.py
+++ b/code_puppy/command_line/prompt_toolkit_completion.py
@@ -648,6 +648,30 @@ async def get_input_with_combined_completion(
         else:
             event.current_buffer.validate_and_handle()
 
+    # Backspace/Delete: trigger completions after deletion
+    # By default, complete_while_typing only triggers on character insertion,
+    # not deletion. This fixes completions not reappearing after backspace.
+    @bindings.add("c-h", eager=True)  # Backspace (Ctrl+H)
+    @bindings.add("backspace", eager=True)
+    def handle_backspace_with_completion(event):
+        buffer = event.app.current_buffer
+        # Perform the deletion first
+        buffer.delete_before_cursor(count=1)
+        # Then trigger completion if text starts with '/'
+        text = buffer.text.lstrip()
+        if text.startswith("/"):
+            buffer.start_completion(select_first=False)
+
+    @bindings.add("delete", eager=True)
+    def handle_delete_with_completion(event):
+        buffer = event.app.current_buffer
+        # Perform the deletion first
+        buffer.delete(count=1)
+        # Then trigger completion if text starts with '/'
+        text = buffer.text.lstrip()
+        if text.startswith("/"):
+            buffer.start_completion(select_first=False)
+
     # Handle bracketed paste - smart detection for text vs images.
     # Most terminals (Windows included!) send Ctrl+V through bracketed paste.
     # - If there's meaningful text content → paste as text (drag-and-drop file paths, copied text)


### PR DESCRIPTION
## Fix: Slash command completions reappear after backspace

Fixes #175 

### Problem
Completions disappear after backspace and don't reappear.

### Solution
Added custom key bindings for backspace/delete that trigger `start_completion()` after deletion when text starts with `/`.

### Changes
- `code_puppy/command_line/prompt_toolkit_completion.py`

### Testing
- Type `/agent`, backspace to `/a` → completions now reappear 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed autocomplete completions to properly reappear after deleting characters in the command line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->