### PR TITLE
feat: add direct session resume by name

### DIFF
--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -653,8 +653,14 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
                         from code_puppy.messaging import emit_error, emit_success
                         from code_puppy.session_storage import load_session
 
-                        base_dir = Path(AUTOSAVE_DIR)
-                        session_path = base_dir / f"{session_name}.pkl"
+                        base_dir = Path(AUTOSAVE_DIR).resolve()
+                        session_path = (base_dir / f"{session_name}.pkl").resolve()
+
+                        # Security: Prevent path traversal attacks
+                        if base_dir not in session_path.parents and session_path.parent != base_dir:
+                            emit_error(f"❌ Invalid session name: {session_name}")
+                            emit_info("💡 Use /resume to open the session picker.")
+                            continue
 
                         # Check if session exists
                         if not session_path.exists():

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -642,8 +642,51 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
             if command_result is True:
                 continue
             elif isinstance(command_result, str):
-                if command_result == "__AUTOSAVE_LOAD__":
-                    # Handle async autosave loading
+                if command_result.startswith("__AUTOSAVE_LOAD_DIRECT__:"):
+                    # Handle direct session load by name
+                    session_name = command_result.split(":", 1)[1]
+                    try:
+                        from code_puppy.agents.agent_manager import get_current_agent
+                        from code_puppy.config import (
+                            set_current_autosave_from_session_name,
+                        )
+                        from code_puppy.messaging import emit_error, emit_success
+                        from code_puppy.session_storage import load_session
+
+                        base_dir = Path(AUTOSAVE_DIR)
+                        session_path = base_dir / f"{session_name}.pkl"
+
+                        # Check if session exists
+                        if not session_path.exists():
+                            emit_error(f"❌ Session not found: {session_name}")
+                            emit_info("💡 Use /resume to open the session picker.")
+                            continue
+
+                        # Load the session
+                        history = load_session(session_name, base_dir)
+
+                        agent = get_current_agent()
+                        agent.set_message_history(history)
+
+                        # Set current autosave session
+                        set_current_autosave_from_session_name(session_name)
+
+                        total_tokens = sum(
+                            agent.estimate_tokens_for_message(msg) for msg in history
+                        )
+
+                        emit_success(
+                            f"✅ Resumed: {session_name}\n"
+                            f"📊 {len(history)} messages ({total_tokens:,} tokens)"
+                        )
+                    except Exception as e:
+                        from code_puppy.messaging import emit_error
+
+                        emit_error(f"Failed to load session: {e}")
+                        emit_info("💡 Use /resume to open the session picker.")
+                    continue
+                elif command_result == "__AUTOSAVE_LOAD__":
+                    # Handle async autosave loading (interactive picker)
                     try:
                         # Check if we're in a real interactive terminal
                         # (not pexpect/tests) - interactive picker requires proper TTY

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -657,7 +657,10 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
                         session_path = (base_dir / f"{session_name}.pkl").resolve()
 
                         # Security: Prevent path traversal attacks
-                        if base_dir not in session_path.parents and session_path.parent != base_dir:
+                        if (
+                            base_dir not in session_path.parents
+                            and session_path.parent != base_dir
+                        ):
                             emit_error(f"❌ Invalid session name: {session_name}")
                             emit_info("💡 Use /resume to open the session picker.")
                             continue

--- a/code_puppy/command_line/session_commands.py
+++ b/code_puppy/command_line/session_commands.py
@@ -200,11 +200,14 @@ def handle_truncate_command(command: str) -> bool:
       /resume auto_session_20260214_175543
     """,
 )
-def handle_autosave_load_command(command: str) -> bool:
+def handle_autosave_load_command(command: str) -> "bool | str":
     """Load an autosave session.
 
     If no session name is provided, opens interactive picker.
     If session name is provided, loads that session directly.
+
+    Returns:
+        "__AUTOSAVE_LOAD__" for picker, "__AUTOSAVE_LOAD_DIRECT__:<name>" for direct load.
     """
     tokens = command.split()
 

--- a/code_puppy/command_line/session_commands.py
+++ b/code_puppy/command_line/session_commands.py
@@ -184,15 +184,37 @@ def handle_truncate_command(command: str) -> bool:
 
 @register_command(
     name="autosave_load",
-    description="Load an autosave session interactively",
-    usage="/autosave_load",
+    description="Load an autosave session interactively, or by name",
+    usage="/autosave_load [session_name]",
     aliases=["resume"],
     category="session",
+    detailed_help="""
+    Load an autosave session.
+
+    Commands:
+      /resume                    Open interactive session picker
+      /resume <session_name>     Load session directly by name
+
+    Examples:
+      /resume
+      /resume auto_session_20260214_175543
+    """,
 )
 def handle_autosave_load_command(command: str) -> bool:
-    """Load an autosave session."""
-    # Return a special marker to indicate we need to run async autosave loading
-    return "__AUTOSAVE_LOAD__"
+    """Load an autosave session.
+
+    If no session name is provided, opens interactive picker.
+    If session name is provided, loads that session directly.
+    """
+    tokens = command.split()
+
+    if len(tokens) == 1:
+        # No argument = open picker
+        return "__AUTOSAVE_LOAD__"
+
+    # Session name provided = load directly
+    session_name = tokens[1]
+    return f"__AUTOSAVE_LOAD_DIRECT__:{session_name}"
 
 
 @register_command(


### PR DESCRIPTION
## Summary

Allow users to resume a session directly by name instead of always opening the interactive picker:

```bash
/resume                              # Opens picker (unchanged)
/resume auto_session_20260214_175543 # Loads directly (NEW)
```

## Problem

Users kept getting told they could use `/resume <session_name>` but it didn't actually work - it just opened the picker regardless.

## Changes

| File | Changes |
|------|---------|
| `session_commands.py` | Parse optional session_name argument, return direct load marker |
| `cli_runner.py` | Handle `__AUTOSAVE_LOAD_DIRECT__` marker with session lookup |

## User Experience

**Success:**
```
✅ Resumed: auto_session_20260214_175543
📊 47 messages (12,345 tokens)
```

**Error:**
```
❌ Session not found: invalid_session_name
💡 Use /resume to open the session picker.
```

## Testing

- All existing session tests pass ✅
- Manual testing confirms both picker and direct load work

---

*Ported from Walmart internal implementation*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Session loading now supports direct load by session name in addition to interactive selection.
  * Enhanced error handling for session loading with helpful error messages and recovery guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->