### PR TITLE
fix: prioritize exact matches and longest prefix in /m and /model commands

### DIFF
--- a/code_puppy/command_line/model_picker_completion.py
+++ b/code_puppy/command_line/model_picker_completion.py
@@ -101,7 +101,7 @@ def _find_matching_model(rest: str, model_names: list[str]) -> Optional[str]:
 
     # Check for prefix match
     for model in sorted_models:
-        if rest_lower.startswith(model.lower()):
+        if model.lower().startswith(rest_lower):
             return model
 
     return None


### PR DESCRIPTION
Summary
───────
Fixes a bug where typing a longer model name that contains a shorter model name as a prefix would incorrectly match the shorter one.

Problem
───────
When using /m or /model commands with model names like:
• synthetic-Kimi-K2.5-Thinking (INT4)
• synthetic-Kimi-K2.5-Thinking-NVFP4 (NVFP4)

Typing /m synthetic-Kimi-K2.5-Thinking-NVFP4 would incorrectly select the INT4 variant because:
• The code iterated through models in arbitrary order
• It used rest.startswith(model) which matched the shorter prefix first

Solution
────────
Added _find_matching_model() helper with two-tier matching:

• Exact match (case-insensitive) - highest priority
• Prefix match sorted by length (longest first) - ensures most specific match wins

Changes
• New _find_matching_model(rest: str, model_names: list[str]) -> Optional[str] function
• Centralized matching logic used by both /model and /m commands (DRY)
• Removed duplicate matching code

Testing
───────
• ✅ /m synthetic-Kimi-K2.5-Thinking-NVFP4 → selects NVFP4
• ✅ /m synthetic-Kimi-K2.5-Thinking → selects INT4
• ✅ /m synthetic → prefix matching with completion support
• ✅ All existing model-related tests pass

Files Changed
─────────────
• code_puppy/command_line/model_picker_completion.py (+65 lines, -39 lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization for model matching in /model and /m commands with a streamlined internal helper function, reducing code duplication while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->