### PR TITLE
feat: Add Synthetic provider status commands and quota client

### DIFF
--- a/code_puppy/plugins/synthetic_status/__init__.py
+++ b/code_puppy/plugins/synthetic_status/__init__.py
@@ -1,0 +1,2 @@
+"""Synthetic provider status plugin."""
+

--- a/code_puppy/plugins/synthetic_status/register_callbacks.py
+++ b/code_puppy/plugins/synthetic_status/register_callbacks.py
@@ -1,0 +1,134 @@
+"""Slash commands for Synthetic provider subscription status."""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+from rich.panel import Panel
+
+from code_puppy.callbacks import register_callback
+from code_puppy.messaging import emit_error, emit_info, emit_warning
+from code_puppy.model_factory import get_api_key
+
+from .status_api import fetch_synthetic_quota, resolve_syn_api_key
+
+_PROVIDER_ENV_KEYS = {
+    "synthetic": "SYN_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "cerebras": "CEREBRAS_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+    "zai": "ZAI_API_KEY",
+    "azure_openai": "AZURE_OPENAI_API_KEY",
+}
+
+
+def _custom_help() -> List[Tuple[str, str]]:
+    return [
+        ("synthetic-status", "Check Synthetic subscription quota and renewal time"),
+        ("provider", "Provider utilities (usage: /provider synthetic status)"),
+        (
+            "status",
+            "Show provider status when only Synthetic appears configured",
+        ),
+    ]
+
+
+def _format_amount(value: float) -> str:
+    rounded = round(value)
+    if abs(value - rounded) < 1e-9:
+        return str(int(rounded))
+    return f"{value:.2f}".rstrip("0").rstrip(".")
+
+
+def _render_synthetic_status_panel(
+    limit: float,
+    used: float,
+    renews_at_utc: str,
+) -> Panel:
+    remaining = max(limit - used, 0.0)
+    body = "\n".join(
+        [
+            "Provider      : Synthetic",
+            f"Requests used : {_format_amount(used)} / {_format_amount(limit)}",
+            f"Requests left : {_format_amount(remaining)}",
+            f"Renews at     : {renews_at_utc}",
+        ]
+    )
+    return Panel(body, border_style="cyan")
+
+
+def _handle_synthetic_status() -> None:
+    api_key = resolve_syn_api_key()
+    if not api_key:
+        emit_error(
+            "SYN_API_KEY is not configured. Set it with /set syn_api_key <key>."
+        )
+        return
+
+    result = fetch_synthetic_quota(api_key=api_key)
+    if not result.ok or not result.quota:
+        emit_warning(result.error or "Failed to fetch Synthetic quota status.")
+        return
+
+    renews_at_str = result.quota.renews_at_utc.strftime("%Y-%m-%d %H:%M UTC")
+    panel = _render_synthetic_status_panel(
+        limit=result.quota.limit,
+        used=result.quota.requests_used,
+        renews_at_utc=renews_at_str,
+    )
+    emit_info(panel)
+
+
+def _is_synthetic_only_provider_configured() -> bool:
+    configured = {
+        provider
+        for provider, env_name in _PROVIDER_ENV_KEYS.items()
+        if get_api_key(env_name)
+    }
+    return configured == {"synthetic"}
+
+
+def _handle_provider_command(command: str) -> Optional[bool]:
+    tokens = command.strip().split()
+    if len(tokens) < 2:
+        return None
+
+    provider = tokens[1].lower()
+    if provider != "synthetic":
+        return None
+
+    if len(tokens) == 3 and tokens[2].lower() == "status":
+        _handle_synthetic_status()
+        return True
+
+    emit_info("Usage: /provider synthetic status")
+    return True
+
+
+def _handle_custom_command(command: str, name: str) -> Optional[bool]:
+    if not name:
+        return None
+
+    if name == "synthetic-status":
+        _handle_synthetic_status()
+        return True
+
+    if name == "provider":
+        return _handle_provider_command(command)
+
+    if name == "status":
+        if _is_synthetic_only_provider_configured():
+            _handle_synthetic_status()
+        else:
+            emit_warning(
+                "Multiple providers appear configured. Use /provider synthetic status."
+            )
+        return True
+
+    return None
+
+
+register_callback("custom_command_help", _custom_help)
+register_callback("custom_command", _handle_custom_command)

--- a/code_puppy/plugins/synthetic_status/status_api.py
+++ b/code_puppy/plugins/synthetic_status/status_api.py
@@ -1,0 +1,147 @@
+"""HTTP helpers for Synthetic quota status."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import requests
+
+from code_puppy.model_factory import get_api_key
+
+SYNTHETIC_QUOTAS_URL = "https://api.synthetic.new/v2/quotas"
+
+
+@dataclass
+class SyntheticQuota:
+    """Parsed Synthetic subscription quota values."""
+
+    limit: float
+    requests_used: float
+    renews_at_utc: datetime
+
+
+@dataclass
+class SyntheticQuotaResult:
+    """Result wrapper for Synthetic quota fetches."""
+
+    quota: SyntheticQuota | None = None
+    error: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.quota is not None and self.error is None
+
+
+def resolve_syn_api_key() -> str | None:
+    """Resolve SYN_API_KEY from config/environment."""
+    value = get_api_key("SYN_API_KEY")
+    if not value:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _parse_renews_at(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+
+    normalized = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def fetch_synthetic_quota(
+    api_key: str,
+    timeout_seconds: float = 15.0,
+) -> SyntheticQuotaResult:
+    """Fetch and validate Synthetic subscription quota status."""
+    if not api_key:
+        return SyntheticQuotaResult(error="SYN_API_KEY is not configured.")
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+    }
+
+    try:
+        response = requests.get(
+            SYNTHETIC_QUOTAS_URL,
+            headers=headers,
+            timeout=timeout_seconds,
+        )
+    except requests.Timeout:
+        return SyntheticQuotaResult(error="Synthetic API request timed out.")
+    except requests.ConnectionError:
+        return SyntheticQuotaResult(
+            error="Could not connect to the Synthetic API endpoint."
+        )
+    except requests.RequestException as exc:
+        return SyntheticQuotaResult(error=f"Synthetic API request failed: {exc}")
+
+    if response.status_code in (401, 403):
+        return SyntheticQuotaResult(
+            error="Synthetic API authentication failed. Check SYN_API_KEY."
+        )
+    if response.status_code == 429:
+        return SyntheticQuotaResult(
+            error="Synthetic API rate limited this request (HTTP 429)."
+        )
+    if response.status_code >= 500:
+        return SyntheticQuotaResult(
+            error=f"Synthetic API server error (HTTP {response.status_code})."
+        )
+    if response.status_code != 200:
+        detail = response.text.strip()
+        if len(detail) > 200:
+            detail = f"{detail[:200]}..."
+        suffix = f": {detail}" if detail else ""
+        return SyntheticQuotaResult(
+            error=f"Synthetic API returned HTTP {response.status_code}{suffix}"
+        )
+
+    try:
+        payload = response.json()
+    except ValueError:
+        return SyntheticQuotaResult(
+            error="Synthetic API returned invalid JSON for /v2/quotas."
+        )
+
+    if not isinstance(payload, dict):
+        return SyntheticQuotaResult(
+            error="Synthetic API response payload is not an object."
+        )
+
+    subscription = payload.get("subscription")
+    if not isinstance(subscription, dict):
+        return SyntheticQuotaResult(
+            error="Synthetic API response is missing 'subscription'."
+        )
+
+    try:
+        limit = float(subscription.get("limit"))
+        requests_used = float(subscription.get("requests"))
+    except (TypeError, ValueError):
+        return SyntheticQuotaResult(
+            error="Synthetic API response has invalid numeric quota values."
+        )
+
+    renews_at = _parse_renews_at(subscription.get("renewsAt"))
+    if renews_at is None:
+        return SyntheticQuotaResult(
+            error="Synthetic API response has an invalid 'renewsAt' timestamp."
+        )
+
+    return SyntheticQuotaResult(
+        quota=SyntheticQuota(
+            limit=limit,
+            requests_used=requests_used,
+            renews_at_utc=renews_at,
+        )
+    )

--- a/tests/plugins/test_synthetic_status_plugin.py
+++ b/tests/plugins/test_synthetic_status_plugin.py
@@ -1,0 +1,160 @@
+"""Tests for Synthetic status plugin command handling and API parsing."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from code_puppy.plugins.synthetic_status import status_api
+from code_puppy.plugins.synthetic_status.register_callbacks import (
+    _custom_help,
+    _handle_custom_command,
+    _is_synthetic_only_provider_configured,
+)
+from code_puppy.plugins.synthetic_status.status_api import (
+    SyntheticQuota,
+    SyntheticQuotaResult,
+)
+
+
+def test_custom_help_has_expected_entries():
+    entries = dict(_custom_help())
+    assert "synthetic-status" in entries
+    assert "provider" in entries
+    assert "status" in entries
+
+
+def test_fetch_synthetic_quota_success():
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "subscription": {
+            "limit": 135,
+            "requests": 28.55,
+            "renewsAt": "2025-10-27T02:01:31.030Z",
+        }
+    }
+
+    with patch(
+        "code_puppy.plugins.synthetic_status.status_api.requests.get"
+    ) as mock_get:
+        mock_get.return_value = mock_response
+        result = status_api.fetch_synthetic_quota("test-key")
+
+    assert result.ok is True
+    assert result.quota is not None
+    assert result.quota.limit == 135
+    assert result.quota.requests_used == 28.55
+    assert result.quota.renews_at_utc.tzinfo is not None
+    assert result.quota.renews_at_utc.tzinfo == timezone.utc
+
+
+def test_fetch_synthetic_quota_auth_error():
+    mock_response = MagicMock()
+    mock_response.status_code = 401
+
+    with patch(
+        "code_puppy.plugins.synthetic_status.status_api.requests.get"
+    ) as mock_get:
+        mock_get.return_value = mock_response
+        result = status_api.fetch_synthetic_quota("bad-key")
+
+    assert result.ok is False
+    assert "authentication failed" in (result.error or "").lower()
+
+
+def test_fetch_synthetic_quota_invalid_payload():
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"subscription": {"limit": "abc"}}
+
+    with patch(
+        "code_puppy.plugins.synthetic_status.status_api.requests.get"
+    ) as mock_get:
+        mock_get.return_value = mock_response
+        result = status_api.fetch_synthetic_quota("test-key")
+
+    assert result.ok is False
+    assert "invalid numeric quota values" in (result.error or "").lower()
+
+
+def test_fetch_synthetic_quota_timeout():
+    with patch(
+        "code_puppy.plugins.synthetic_status.status_api.requests.get",
+        side_effect=status_api.requests.Timeout(),
+    ):
+        result = status_api.fetch_synthetic_quota("test-key")
+
+    assert result.ok is False
+    assert "timed out" in (result.error or "").lower()
+
+
+def test_is_synthetic_only_provider_configured_true():
+    def fake_get_api_key(env_name: str) -> str | None:
+        return "x" if env_name == "SYN_API_KEY" else None
+
+    with patch(
+        "code_puppy.plugins.synthetic_status.register_callbacks.get_api_key",
+        side_effect=fake_get_api_key,
+    ):
+        assert _is_synthetic_only_provider_configured() is True
+
+
+def test_is_synthetic_only_provider_configured_false():
+    def fake_get_api_key(env_name: str) -> str | None:
+        if env_name in {"SYN_API_KEY", "OPENAI_API_KEY"}:
+            return "x"
+        return None
+
+    with patch(
+        "code_puppy.plugins.synthetic_status.register_callbacks.get_api_key",
+        side_effect=fake_get_api_key,
+    ):
+        assert _is_synthetic_only_provider_configured() is False
+
+
+def test_handle_provider_synthetic_status_command():
+    quota = SyntheticQuota(
+        limit=100,
+        requests_used=25,
+        renews_at_utc=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
+    )
+
+    with (
+        patch(
+            "code_puppy.plugins.synthetic_status.register_callbacks.resolve_syn_api_key",
+            return_value="test-key",
+        ),
+        patch(
+            "code_puppy.plugins.synthetic_status.register_callbacks.fetch_synthetic_quota",
+            return_value=SyntheticQuotaResult(quota=quota),
+        ),
+        patch(
+            "code_puppy.plugins.synthetic_status.register_callbacks.emit_info"
+        ) as mock_info,
+    ):
+        result = _handle_custom_command("/provider synthetic status", "provider")
+
+    assert result is True
+    assert mock_info.called
+
+
+def test_handle_provider_other_is_not_owned():
+    result = _handle_custom_command("/provider openai status", "provider")
+    assert result is None
+
+
+def test_handle_status_ambiguous_provider_message():
+    with (
+        patch(
+            "code_puppy.plugins.synthetic_status.register_callbacks._is_synthetic_only_provider_configured",
+            return_value=False,
+        ),
+        patch(
+            "code_puppy.plugins.synthetic_status.register_callbacks.emit_warning"
+        ) as mock_warning,
+    ):
+        result = _handle_custom_command("/status", "status")
+
+    assert result is True
+    assert mock_warning.called


### PR DESCRIPTION
Resolves #72 
## Summary
- added synthetic status plugin with slash commands
- added authenticated quotas API client with validation and error handling
- added plugin tests for command routing and quota parsing

## Commands
- /provider synthetic status
- /synthetic-status
- /status (guarded when synthetic is the only configured provider)

## Testing
- pytest -q tests/plugins/test_synthetic_status_plugin.py
- pytest -q tests/test_command_handler.py tests/test_prompt_toolkit_completion.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Synthetic provider status plugin enabling users to view subscription quota information, including usage limits, requests used, remaining quota, and renewal time.

* **Tests**
  * Added comprehensive test suite for the Synthetic status plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->