### PR TITLE
fix: add retry logic for transient HTTP errors during LLM streaming

### DIFF
--- a/code_puppy/plugins/synthetic_status/__init__.py
+++ b/code_puppy/plugins/synthetic_status/__init__.py
@@ -1,2 +1,1 @@
 """Synthetic provider status plugin."""
-

--- a/code_puppy/plugins/synthetic_status/register_callbacks.py
+++ b/code_puppy/plugins/synthetic_status/register_callbacks.py
@@ -62,9 +62,7 @@ def _render_synthetic_status_panel(
 def _handle_synthetic_status() -> None:
     api_key = resolve_syn_api_key()
     if not api_key:
-        emit_error(
-            "SYN_API_KEY is not configured. Set it with /set syn_api_key <key>."
-        )
+        emit_error("SYN_API_KEY is not configured. Set it with /set syn_api_key <key>.")
         return
 
     result = fetch_synthetic_quota(api_key=api_key)


### PR DESCRIPTION
## Summary

Adds `_run_with_streaming_retry` wrapper to catch and auto-retry transient
network errors that occur during streamed LLM responses. Currently these
errors crash with `Unexpected error` and require users to manually re-send
their prompt.

## Problem

`pydantic_agent.run()` can raise transient HTTP exceptions when the LLM
provider (or an intermediary proxy) drops the connection mid-stream:

| Exception | When it happens |
|-----------|----------------|
| `httpx.RemoteProtocolError` | Peer closes connection mid-stream |
| `httpx.ReadTimeout` | Read timeout during streaming |
| `httpcore.RemoteProtocolError` | Lower-level connection close |

Previously, none of these were caught — they fell through to the generic
`except* Exception` handler which logged the error and gave up.

**Observed impact:** 6 failures in 45 minutes during one session, 329+
occurrences in aggregate error logs. All would have auto-recovered with
retry logic.

## Changes

- **`code_puppy/agents/base_agent.py`**: Add `_run_with_streaming_retry()`
  with exponential backoff (1s, 2s, 4s) and up to 3 attempts. Wraps all
  three `pydantic_agent.run()` call sites (DBOS+MCP, DBOS-only, non-DBOS).
- **`tests/agents/test_streaming_retry.py`**: 9 unit tests covering success,
  each retryable type, exhaustion, non-retryable propagation, backoff
  verification, and mixed error recovery.

## Test Results

```
9 passed (new tests)
5745 passed (existing suite — 0 regressions)
```

Resolves #199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for streaming retry logic, covering immediate success, transient HTTP error handling, exponential backoff verification, retry exhaustion, and non-retryable error propagation.

* **Style**
  * Minor code formatting adjustments for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->