### PR TITLE
Perf/reduce redundant syscalls

### DIFF
--- a/code_puppy/command_line/utils.py
+++ b/code_puppy/command_line/utils.py
@@ -5,21 +5,16 @@ from rich.table import Table
 
 
 def list_directory(path: str = None) -> Tuple[List[str], List[str]]:
-    """
-    Returns (dirs, files) for the specified path, splitting out directories and files.
-    """
+    """Returns (dirs, files) for the specified path, splitting out directories and files."""
     if path is None:
         path = os.getcwd()
-    dirs, files = [], []
     try:
         with os.scandir(path) as it:
-            for entry in it:
-                if entry.is_dir(follow_symlinks=True):
-                    dirs.append(entry.name)
-                else:
-                    files.append(entry.name)
+            entries = list(it)
     except OSError as e:
         raise RuntimeError(f"Error listing directory: {e}") from e
+    dirs = [e.name for e in entries if e.is_dir(follow_symlinks=True)]
+    files = [e.name for e in entries if not e.is_dir(follow_symlinks=True)]
     return dirs, files
 
 

--- a/code_puppy/command_line/utils.py
+++ b/code_puppy/command_line/utils.py
@@ -10,13 +10,16 @@ def list_directory(path: str = None) -> Tuple[List[str], List[str]]:
     """
     if path is None:
         path = os.getcwd()
-    entries = []
+    dirs, files = [], []
     try:
-        entries = [e for e in os.listdir(path)]
-    except Exception as e:
+        with os.scandir(path) as it:
+            for entry in it:
+                if entry.is_dir(follow_symlinks=True):
+                    dirs.append(entry.name)
+                else:
+                    files.append(entry.name)
+    except OSError as e:
         raise RuntimeError(f"Error listing directory: {e}") from e
-    dirs = [e for e in entries if os.path.isdir(os.path.join(path, e))]
-    files = [e for e in entries if not os.path.isdir(os.path.join(path, e))]
     return dirs, files
 
 

--- a/code_puppy/command_line/utils.py
+++ b/code_puppy/command_line/utils.py
@@ -8,15 +8,19 @@ def list_directory(path: str = None) -> Tuple[List[str], List[str]]:
     """Returns (dirs, files) for the specified path, splitting out directories and files."""
     if path is None:
         path = os.getcwd()
+    dirs: List[str] = []
+    files: List[str] = []
     try:
         with os.scandir(path) as it:
-            entries = list(it)
+            for entry in it:
+                try:
+                    is_dir = entry.is_dir(follow_symlinks=True)
+                except OSError:
+                    is_dir = False
+                (dirs if is_dir else files).append(entry.name)
     except OSError as e:
         raise RuntimeError(f"Error listing directory: {e}") from e
-    dirs = [e.name for e in entries if e.is_dir(follow_symlinks=True)]
-    files = [e.name for e in entries if not e.is_dir(follow_symlinks=True)]
     return dirs, files
-
 
 def make_directory_table(path: str = None) -> Table:
     """

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -179,8 +179,7 @@ def ensure_config_exists():
     """
     # Create all XDG directories with 0700 permissions per XDG spec
     for directory in [CONFIG_DIR, DATA_DIR, CACHE_DIR, STATE_DIR]:
-        if not os.path.exists(directory):
-            os.makedirs(directory, mode=0o700, exist_ok=True)
+        os.makedirs(directory, mode=0o700, exist_ok=True)
     exists = os.path.isfile(CONFIG_FILE)
     config = configparser.ConfigParser()
     if exists:

--- a/code_puppy/error_logging.py
+++ b/code_puppy/error_logging.py
@@ -22,10 +22,7 @@ MAX_LOG_SIZE = 5 * 1024 * 1024  # 5MB
 def _rotate_log_if_needed() -> None:
     """Rotate the error log file if it exceeds MAX_LOG_SIZE."""
     try:
-        if (
-            os.path.exists(ERROR_LOG_FILE)
-            and os.path.getsize(ERROR_LOG_FILE) > MAX_LOG_SIZE
-        ):
+        if os.path.getsize(ERROR_LOG_FILE) > MAX_LOG_SIZE:
             rotated = ERROR_LOG_FILE + ".1"
             os.replace(ERROR_LOG_FILE, rotated)
     except OSError:

--- a/code_puppy/tools/file_operations.py
+++ b/code_puppy/tools/file_operations.py
@@ -149,21 +149,27 @@ def would_match_directory(pattern: str, directory: str) -> bool:
 
     return False
 
-
 @functools.lru_cache(maxsize=1)
-def _find_rg() -> str | None:
-    """Find ripgrep executable once and cache the result."""
+def _find_rg_cached() -> str | None:
     import sys
 
     rg_path = shutil.which("rg")
     if rg_path:
         return rg_path
+
     python_dir = os.path.dirname(sys.executable)
     for name in ["rg", "rg.exe"]:
         candidate = os.path.join(python_dir, name)
         if os.path.exists(candidate):
             return candidate
+
     return None
+
+def _find_rg() -> str | None:
+    path = _find_rg_cached()
+    if path is None:
+        _find_rg_cached.cache_clear()
+    return path
 
 
 def _list_files(

--- a/code_puppy/tools/file_operations.py
+++ b/code_puppy/tools/file_operations.py
@@ -437,10 +437,15 @@ def _read_file(
 ) -> ReadFileOutput:
     file_path = os.path.abspath(os.path.expanduser(file_path))
 
-    if not os.path.exists(file_path):
+    try:
+        _st = os.stat(file_path)
+    except FileNotFoundError:
         error_msg = f"File {file_path} does not exist"
         return ReadFileOutput(content=error_msg, num_tokens=0, error=error_msg)
-    if not os.path.isfile(file_path):
+    except OSError as e:
+        error_msg = f"Cannot access {file_path}: {e}"
+        return ReadFileOutput(content=error_msg, num_tokens=0, error=error_msg)
+    if not stat.S_ISREG(_st.st_mode):
         error_msg = f"{file_path} is not a file"
         return ReadFileOutput(content=error_msg, num_tokens=0, error=error_msg)
     try:


### PR DESCRIPTION
It was taking longer than it had any right to, so I took a look under the hood. This trims redundant filesystem syscalls (scandir/stat batching), caches ripgrep lookup, and removes a few avoidable checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Faster, more efficient directory and file scanning and deduplication for snappier browsing and searches.
  * Centralized and cached external search-tool lookup to speed repeated search operations.
* **Bug Fixes / Reliability**
  * More robust per-entry error handling to reduce failures during listing and reading.
  * Ensures config directories are created with secure permissions when needed.
  * Log rotation now behaves consistently even when log files are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->