### PR TITLE
Fix/cd command invalidate agent cache

### DIFF
--- a/code_puppy/command_line/core_commands.py
+++ b/code_puppy/command_line/core_commands.py
@@ -80,9 +80,13 @@ def handle_cd_command(command: str) -> bool:
             #Invalidate cached agent so system prompt refreshed with new CWD
             from code_puppy.agents.agent_manager import get_current_agent
 
-            agent = get_current_agent()
-            if agent is not None:
-                agent._code_generation_agent = None
+            try:
+                agent = get_current_agent()
+                if agent is not None:
+                    agent._code_generation_agent = None
+            except Exception as e:
+                emit_error(f"Error invalidating agent cache: {e}")
+                pass
 
             emit_success(f"Changed directory to: {target}")
         else:


### PR DESCRIPTION
When using `/cd` to change directories, the cached pydantic agent (`_code_generation_agent`) retains stale instructions containing the old `os.getcwd()` value. The model continues operating as if the user is in the previous directory, suggesting wrong file paths and misunderstanding project context.

**Root cause:** `handle_cd_command()` calls `os.chdir()` but never invalidates the cached agent. Other config-changing commands (`/model`, `/set`, `/reasoning`, `/verbosity`) already call `reload_code_generation_agent()` after changes, but `/cd` was missing this pattern.

**Affected scenarios:** `/resume` + `/cd` workflow, working across multiple projects in one session, any directory change mid-conversation.

### Fix (1 file, +8 lines)

**`/core_commands.py`**
After `os.chdir()` succeeds, sets `agent._code_generation_agent = None` to invalidate the cache. Triggers lazy rebuild on next user message via `run_with_mcp()` which checks: 
```python
self._code_generation_agent or self.reload_code_generation_agent()
```

**Fixes:** Agent using wrong working directory in system prompt after `/cd`, causing incorrect file path suggestions and project context confusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the code-generation context is refreshed when changing directories so generated code reflects the current workspace. This prevents stale context from affecting results and surfaces an error if the refresh fails, improving reliability when navigating between projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->