### PR TITLE
Feat/scheduler daily at

### DIFF
--- a/code_puppy/plugins/scheduler/scheduler_wizard.py
+++ b/code_puppy/plugins/scheduler/scheduler_wizard.py
@@ -246,6 +246,7 @@ def create_task_wizard() -> Optional[dict]:
 
     if schedule_choice == "Daily at specific time(s)...":
         print("\n  Enter one or more 24-hour times separated by commas.")
+        print("  (24-hour clock: 1:00 PM = 13:00, 5:30 PM = 17:30, midnight = 00:00)")
         print("  Examples: 09:00   or   09:00,13:00,17:30\n")
         time_input = TextInputMenu(
             "Time(s) (HH:MM, comma-separated)", default="09:00"

--- a/code_puppy/plugins/scheduler/scheduler_wizard.py
+++ b/code_puppy/plugins/scheduler/scheduler_wizard.py
@@ -248,9 +248,7 @@ def create_task_wizard() -> Optional[dict]:
         print("\n  Enter one or more 24-hour times separated by commas.")
         print("  (24-hour clock: 1:00 PM = 13:00, 5:30 PM = 17:30, midnight = 00:00)")
         print("  Examples: 09:00   or   09:00,13:00,17:30\n")
-        time_input = TextInputMenu(
-            "Time(s) (HH:MM, comma-separated)", default="09:00"
-        )
+        time_input = TextInputMenu("Time(s) (HH:MM, comma-separated)", default="09:00")
         raw_times = time_input.run()
         if not raw_times:
             print("\n  ❌ Cancelled.")

--- a/code_puppy/scheduler/config.py
+++ b/code_puppy/scheduler/config.py
@@ -29,7 +29,7 @@ class ScheduledTask:
     prompt: str = ""
     agent: str = "code-puppy"
     model: str = ""  # Uses default if empty
-    schedule_type: str = "interval"  # "interval", "cron", "daily", "hourly"
+    schedule_type: str = "interval"  # "interval", "cron", "daily", "hourly", "daily_at"
     schedule_value: str = "1h"  # e.g., "30m", "1h", "0 9 * * *" for cron
     working_directory: str = "."
     log_file: str = ""  # Auto-generated if empty

--- a/code_puppy/scheduler/daemon.py
+++ b/code_puppy/scheduler/daemon.py
@@ -20,6 +20,7 @@ from code_puppy.scheduler.config import (
     load_tasks,
 )
 from code_puppy.scheduler.executor import execute_task
+from code_puppy.scheduler.time_utils import parse_times_hhmm
 
 # Global flag for graceful shutdown
 _shutdown_requested = False
@@ -35,17 +36,16 @@ def parse_daily_at_times(schedule_value: str) -> list:
         "09:00"          -> [(9, 0)]
         "09:00,17:30"    -> [(9, 0), (17, 30)]
     """
-    result = []
-    for entry in schedule_value.split(","):
-        entry = entry.strip()
-        try:
-            t = datetime.strptime(entry, "%H:%M")
-            result.append((t.hour, t.minute))
-        except ValueError:
-            print(
-                f"[Scheduler] Warning: Invalid time '{entry}' in daily_at schedule, skipping."
-            )
-    return result
+
+    def _warn(entry: str) -> None:
+        print(
+            f"[Scheduler] Warning: Invalid time '{entry}' in daily_at schedule, skipping."
+        )
+
+    return [
+        (int(hhmm[:2]), int(hhmm[3:]))
+        for hhmm in parse_times_hhmm(schedule_value, on_invalid=_warn)
+    ]
 
 
 def parse_interval(interval_str: str) -> Optional[timedelta]:

--- a/code_puppy/scheduler/daemon.py
+++ b/code_puppy/scheduler/daemon.py
@@ -29,7 +29,7 @@ def parse_daily_at_times(schedule_value: str) -> list:
     """Parse a comma-separated list of HH:MM times.
 
     Returns a list of (hour, minute) tuples for valid entries.
-    Invalid entries are silently skipped.
+    Invalid entries are skipped with a warning printed to stdout.
 
     Examples:
         "09:00"          -> [(9, 0)]
@@ -101,6 +101,13 @@ def should_run_task(task: ScheduledTask, now: datetime) -> bool:
         # Fire if *any* target time has passed today and hasn't been run since.
         # This is restart-safe: if the daemon was down at 09:00 and restarts
         # at 09:15 it will still fire, because now > 09:00 and last_run < 09:00.
+        #
+        # TIMEZONE NOTE: `now` is a naive datetime (system local time via
+        # datetime.now()). All HH:MM targets are therefore evaluated against
+        # the host's local clock. If the system timezone changes (e.g. DST
+        # transition or a manual tzdata update) task fire times will shift
+        # accordingly. Full tz-aware scheduling (zoneinfo / pytz) is left
+        # for a future iteration.
         times = parse_daily_at_times(task.schedule_value)
         if not times:
             print(

--- a/code_puppy/scheduler/daemon.py
+++ b/code_puppy/scheduler/daemon.py
@@ -42,7 +42,9 @@ def parse_daily_at_times(schedule_value: str) -> list:
             t = datetime.strptime(entry, "%H:%M")
             result.append((t.hour, t.minute))
         except ValueError:
-            print(f"[Scheduler] Warning: Invalid time '{entry}' in daily_at schedule, skipping.")
+            print(
+                f"[Scheduler] Warning: Invalid time '{entry}' in daily_at schedule, skipping."
+            )
     return result
 
 
@@ -101,7 +103,9 @@ def should_run_task(task: ScheduledTask, now: datetime) -> bool:
         # at 09:15 it will still fire, because now > 09:00 and last_run < 09:00.
         times = parse_daily_at_times(task.schedule_value)
         if not times:
-            print(f"[Scheduler] Warning: No valid times in daily_at schedule for: {task.name}")
+            print(
+                f"[Scheduler] Warning: No valid times in daily_at schedule for: {task.name}"
+            )
             return False
 
         last_run = datetime.fromisoformat(task.last_run) if task.last_run else None

--- a/code_puppy/scheduler/time_utils.py
+++ b/code_puppy/scheduler/time_utils.py
@@ -1,0 +1,51 @@
+"""Shared time-parsing utilities for the Code Puppy scheduler."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Callable, Optional
+
+
+def parse_times_hhmm(
+    raw: str,
+    on_invalid: Optional[Callable[[str], None]] = None,
+) -> list[str]:
+    """Parse a comma-separated string of HH:MM times into canonical form.
+
+    Each entry is stripped of whitespace, validated with strptime, and
+    normalised via strftime (so ``9:00`` becomes ``09:00``).  Duplicates
+    are removed while preserving the first-occurrence order.
+
+    Args:
+        raw: Comma-separated time string, e.g. ``"09:00,17:30"``.
+        on_invalid: Optional callback invoked with each entry that fails
+            ``%H:%M`` parsing.  When *None*, invalid entries are silently
+            dropped.
+
+    Returns:
+        Ordered, deduplicated list of canonical HH:MM strings.
+
+    Examples:
+        >>> parse_times_hhmm("09:00,17:30")
+        ['09:00', '17:30']
+        >>> parse_times_hhmm("9:0,09:00,bad")  # normalise + dedupe + skip
+        ['09:00']
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        try:
+            t = datetime.strptime(entry, "%H:%M")  # noqa: DTZ007
+            normalised = t.strftime("%H:%M")
+            if normalised not in seen:
+                seen.add(normalised)
+                result.append(normalised)
+        except ValueError:
+            if on_invalid is not None:
+                on_invalid(entry)
+
+    return result

--- a/tests/plugins/test_scheduler_wizard.py
+++ b/tests/plugins/test_scheduler_wizard.py
@@ -563,7 +563,11 @@ class TestCreateTaskWizard:
         mock_text.side_effect = text_instances
 
         sel_instances = [MagicMock(), MagicMock(), MagicMock()]
-        sel_instances[0].run.return_value = "Every hour"  # "Daily" removed; any valid choice works here
+        sel_instances[
+            0
+        ].run.return_value = (
+            "Every hour"  # "Daily" removed; any valid choice works here
+        )
         sel_instances[1].run.return_value = "code-puppy"
         sel_instances[2].run.return_value = "m1"
         mock_sel.side_effect = sel_instances
@@ -585,7 +589,9 @@ class TestCreateTaskWizard:
     @patch(f"{_MOD}.TextInputMenu")
     @patch(f"{_MOD}.SelectionMenu")
     @patch(f"{_MOD}.get_available_models_list", return_value=["m1"])
-    @patch(f"{_MOD}.get_available_agents_list", return_value=[("code-puppy", "Default")])
+    @patch(
+        f"{_MOD}.get_available_agents_list", return_value=[("code-puppy", "Default")]
+    )
     def test_daily_at_single_time(
         self, mock_agents, mock_models, mock_sel, mock_text, mock_multi, mock_confirm
     ):
@@ -619,7 +625,9 @@ class TestCreateTaskWizard:
     @patch(f"{_MOD}.TextInputMenu")
     @patch(f"{_MOD}.SelectionMenu")
     @patch(f"{_MOD}.get_available_models_list", return_value=["m1"])
-    @patch(f"{_MOD}.get_available_agents_list", return_value=[("code-puppy", "Default")])
+    @patch(
+        f"{_MOD}.get_available_agents_list", return_value=[("code-puppy", "Default")]
+    )
     def test_daily_at_multiple_times(
         self, mock_agents, mock_models, mock_sel, mock_text, mock_multi, mock_confirm
     ):
@@ -687,7 +695,9 @@ class TestCreateTaskWizard:
     @patch(f"{_MOD}.TextInputMenu")
     @patch(f"{_MOD}.SelectionMenu")
     @patch(f"{_MOD}.get_available_models_list", return_value=["m1"])
-    @patch(f"{_MOD}.get_available_agents_list", return_value=[("code-puppy", "Default")])
+    @patch(
+        f"{_MOD}.get_available_agents_list", return_value=[("code-puppy", "Default")]
+    )
     def test_daily_at_strips_invalid_times(
         self, mock_agents, mock_models, mock_sel, mock_text, mock_multi, mock_confirm
     ):
@@ -720,10 +730,18 @@ class TestCreateTaskWizard:
     @patch(f"{_MOD}.TextInputMenu")
     @patch(f"{_MOD}.SelectionMenu")
     @patch(f"{_MOD}.get_available_models_list", return_value=["m1"])
-    @patch(f"{_MOD}.get_available_agents_list", return_value=[("code-puppy", "Default")])
+    @patch(
+        f"{_MOD}.get_available_agents_list", return_value=[("code-puppy", "Default")]
+    )
     def test_daily_at_summary_display(
-        self, mock_agents, mock_models, mock_sel, mock_text, mock_multi, mock_confirm,
-        capsys
+        self,
+        mock_agents,
+        mock_models,
+        mock_sel,
+        mock_text,
+        mock_multi,
+        mock_confirm,
+        capsys,
     ):
         """Summary line should read 'daily at HH:MM' not the raw type/value."""
         from code_puppy.plugins.scheduler.scheduler_wizard import create_task_wizard

--- a/tests/scheduler/test_daily_at.py
+++ b/tests/scheduler/test_daily_at.py
@@ -1,0 +1,212 @@
+"""Tests for the daily_at schedule type.
+
+Covers parse_daily_at_times() and the daily_at branch of should_run_task().
+All wall-clock comparisons use an explicit `now` so tests never depend on
+the real system clock.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from code_puppy.scheduler.config import ScheduledTask
+from code_puppy.scheduler.daemon import parse_daily_at_times, should_run_task
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NOW = datetime(2026, 2, 27, 10, 0, 0)  # Friday, 10:00:00 am — fixed reference point
+
+
+def daily_at_task(times: str, last_run: str | None = None) -> ScheduledTask:
+    """Build a daily_at ScheduledTask with minimal boilerplate."""
+    task = ScheduledTask(
+        name="test-task",
+        prompt="do the thing",
+        schedule_type="daily_at",
+        schedule_value=times,
+    )
+    task.last_run = last_run
+    return task
+
+
+# ---------------------------------------------------------------------------
+# parse_daily_at_times
+# ---------------------------------------------------------------------------
+
+
+class TestParseDailyAtTimes:
+    """Unit tests for the time-string parser."""
+
+    def test_single_valid_time(self):
+        assert parse_daily_at_times("09:00") == [(9, 0)]
+
+    def test_multiple_valid_times(self):
+        assert parse_daily_at_times("09:00,13:00,17:30") == [(9, 0), (13, 0), (17, 30)]
+
+    def test_whitespace_around_commas_is_stripped(self):
+        assert parse_daily_at_times("09:00 , 17:00") == [(9, 0), (17, 0)]
+
+    def test_midnight(self):
+        assert parse_daily_at_times("00:00") == [(0, 0)]
+
+    def test_end_of_day(self):
+        assert parse_daily_at_times("23:59") == [(23, 59)]
+
+    def test_invalid_entry_is_skipped(self):
+        """A bad entry should not prevent valid ones from being returned."""
+        assert parse_daily_at_times("notaime,09:00") == [(9, 0)]
+
+    def test_all_invalid_returns_empty(self):
+        assert parse_daily_at_times("abc,xyz,9am") == []
+
+    def test_empty_string_returns_empty(self):
+        assert parse_daily_at_times("") == []
+
+    def test_missing_colon_is_invalid(self):
+        assert parse_daily_at_times("0900") == []
+
+    def test_out_of_range_hour_is_invalid(self):
+        assert parse_daily_at_times("25:00") == []
+
+    def test_out_of_range_minute_is_invalid(self):
+        assert parse_daily_at_times("10:60") == []
+
+    def test_invalid_warns_to_stdout(self, capsys):
+        parse_daily_at_times("bad")
+        out = capsys.readouterr().out
+        assert "Warning" in out
+        assert "bad" in out
+
+    def test_valid_entry_does_not_warn(self, capsys):
+        parse_daily_at_times("09:00")
+        assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# should_run_task — daily_at branch
+# ---------------------------------------------------------------------------
+
+
+class TestShouldRunTaskDailyAt:
+    """Behavioural tests for the daily_at scheduling logic."""
+
+    # -- basic fire / no-fire -------------------------------------------------
+
+    def test_never_run_fires_when_past_target(self):
+        """A task that has never run should fire once the target time passes."""
+        task = daily_at_task("09:00", last_run=None)
+        assert should_run_task(task, NOW) is True  # NOW is 10:00, target was 09:00
+
+    def test_never_run_does_not_fire_before_target(self):
+        """A task that has never run should NOT fire if the target is still in the future."""
+        task = daily_at_task("14:00", last_run=None)
+        assert should_run_task(task, NOW) is False  # NOW is 10:00, target is 14:00
+
+    def test_fires_exactly_at_target_time(self):
+        """The task should fire right at the target minute (boundary inclusive)."""
+        at_target = datetime(2026, 2, 27, 9, 0, 0)
+        task = daily_at_task("09:00", last_run=None)
+        assert should_run_task(task, at_target) is True
+
+    def test_does_not_fire_one_second_before_target(self):
+        """The task must NOT fire before the target minute starts."""
+        just_before = datetime(2026, 2, 27, 8, 59, 59)
+        task = daily_at_task("09:00", last_run=None)
+        assert should_run_task(task, just_before) is False
+
+    # -- last_run logic -------------------------------------------------------
+
+    def test_does_not_refire_after_running_today(self):
+        """Once a task has run today after the target, it must not fire again."""
+        ran_at_nine_oh_five = "2026-02-27T09:05:00"
+        task = daily_at_task("09:00", last_run=ran_at_nine_oh_five)
+        assert should_run_task(task, NOW) is False
+
+    def test_fires_when_last_run_was_yesterday(self):
+        """If last_run was yesterday the task is due again today."""
+        yesterday = "2026-02-26T09:05:00"
+        task = daily_at_task("09:00", last_run=yesterday)
+        assert should_run_task(task, NOW) is True
+
+    def test_restart_safe_fires_after_missed_window(self):
+        """If the daemon was down at fire-time it must catch up on next wakeup.
+
+        Scenario: target=09:00, daemon restarted at 09:47, last_run=yesterday.
+        """
+        restarted_late = datetime(2026, 2, 27, 9, 47, 0)
+        yesterday = "2026-02-26T22:00:00"
+        task = daily_at_task("09:00", last_run=yesterday)
+        assert should_run_task(task, restarted_late) is True
+
+    def test_last_run_before_target_but_same_day_fires(self):
+        """last_run earlier today but before the target should still trigger."""
+        ran_early_morning = "2026-02-27T07:00:00"  # before 09:00 target
+        task = daily_at_task("09:00", last_run=ran_early_morning)
+        assert should_run_task(task, NOW) is True
+
+    # -- multiple times -------------------------------------------------------
+
+    def test_multiple_times_first_due_second_future(self):
+        """With two targets, only fire if at least one is due and not yet run."""
+        # 09:00 passed, 17:00 is future — last_run is yesterday so 09:00 is due
+        yesterday = "2026-02-26T09:05:00"
+        task = daily_at_task("09:00,17:00", last_run=yesterday)
+        assert should_run_task(task, NOW) is True
+
+    def test_multiple_times_first_already_ran_second_future(self):
+        """If the only due target has already been serviced, do not fire."""
+        ran_after_nine = "2026-02-27T09:05:00"  # ran after 09:00 target
+        task = daily_at_task("09:00,17:00", last_run=ran_after_nine)
+        # 09:00 already serviced, 17:00 not yet reached
+        assert should_run_task(task, NOW) is False
+
+    def test_multiple_times_second_now_due(self):
+        """When a later target becomes due the task should fire."""
+        ran_after_nine = "2026-02-27T09:05:00"
+        at_five_pm = datetime(2026, 2, 27, 17, 1, 0)
+        task = daily_at_task("09:00,17:00", last_run=ran_after_nine)
+        assert should_run_task(task, at_five_pm) is True
+
+    def test_multiple_times_all_future(self):
+        """When all targets are still in the future nothing should fire."""
+        task = daily_at_task("13:00,17:00", last_run=None)
+        assert should_run_task(task, NOW) is False  # NOW is 10:00
+
+    def test_multiple_times_both_past_runs_on_first_match(self):
+        """If both targets have passed and last_run is yesterday, task fires."""
+        yesterday = "2026-02-26T22:00:00"
+        task = daily_at_task("08:00,09:00", last_run=yesterday)
+        assert should_run_task(task, NOW) is True
+
+    # -- edge cases & error handling ------------------------------------------
+
+    def test_disabled_task_never_fires(self):
+        task = daily_at_task("09:00", last_run=None)
+        task.enabled = False
+        assert should_run_task(task, NOW) is False
+
+    def test_all_invalid_times_returns_false_and_warns(self, capsys):
+        task = daily_at_task("bad,worse", last_run=None)
+        result = should_run_task(task, NOW)
+        assert result is False
+        out = capsys.readouterr().out
+        assert "Warning" in out
+
+    def test_mix_valid_and_invalid_times_uses_valid_ones(self):
+        """Invalid entries in schedule_value are skipped; valid ones still work."""
+        yesterday = "2026-02-26T09:05:00"
+        task = daily_at_task("bogus,09:00", last_run=yesterday)
+        assert should_run_task(task, NOW) is True
+
+    def test_midnight_target_fires_after_midnight(self):
+        just_after_midnight = datetime(2026, 2, 27, 0, 1, 0)
+        task = daily_at_task("00:00", last_run="2026-02-26T00:05:00")
+        assert should_run_task(task, just_after_midnight) is True
+
+    def test_midnight_target_does_not_fire_previous_night(self):
+        """Ran at 00:05 today — must not fire again until tomorrow's midnight."""
+        ran_this_morning = "2026-02-27T00:05:00"
+        task = daily_at_task("00:00", last_run=ran_this_morning)
+        assert should_run_task(task, NOW) is False

--- a/tests/scheduler/test_daily_at.py
+++ b/tests/scheduler/test_daily_at.py
@@ -7,8 +7,6 @@ the real system clock.
 
 from datetime import datetime
 
-import pytest
-
 from code_puppy.scheduler.config import ScheduledTask
 from code_puppy.scheduler.daemon import parse_daily_at_times, should_run_task
 

--- a/tests/scheduler/test_time_utils.py
+++ b/tests/scheduler/test_time_utils.py
@@ -1,0 +1,105 @@
+"""Tests for code_puppy.scheduler.time_utils.parse_times_hhmm."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from code_puppy.scheduler.time_utils import parse_times_hhmm
+
+
+class TestParseTimesHhmm:
+    # -- happy-path parsing ---------------------------------------------------
+
+    def test_single_valid_time(self):
+        assert parse_times_hhmm("09:00") == ["09:00"]
+
+    def test_multiple_valid_times(self):
+        assert parse_times_hhmm("09:00,17:30") == ["09:00", "17:30"]
+
+    def test_preserves_order(self):
+        assert parse_times_hhmm("17:30,09:00") == ["17:30", "09:00"]
+
+    def test_midnight(self):
+        assert parse_times_hhmm("00:00") == ["00:00"]
+
+    def test_end_of_day(self):
+        assert parse_times_hhmm("23:59") == ["23:59"]
+
+    # -- normalisation --------------------------------------------------------
+
+    def test_normalises_single_digit_hour(self):
+        """'9:00' should be normalised to '09:00'."""
+        assert parse_times_hhmm("9:00") == ["09:00"]
+
+    def test_normalises_single_digit_minute(self):
+        """strptime/strftime round-trip ensures two-digit minute."""
+        assert parse_times_hhmm("09:5") == ["09:05"]
+
+    # -- deduplication --------------------------------------------------------
+
+    def test_deduplicates_exact_duplicates(self):
+        assert parse_times_hhmm("09:00,09:00") == ["09:00"]
+
+    def test_deduplicates_normalised_equivalents(self):
+        """'9:00' and '09:00' represent the same time after normalisation."""
+        assert parse_times_hhmm("9:00,09:00") == ["09:00"]
+
+    def test_deduplicate_preserves_first_occurrence(self):
+        result = parse_times_hhmm("09:00,17:00,09:00,17:00")
+        assert result == ["09:00", "17:00"]
+
+    # -- whitespace handling --------------------------------------------------
+
+    def test_strips_whitespace_around_entries(self):
+        assert parse_times_hhmm(" 09:00 , 17:30 ") == ["09:00", "17:30"]
+
+    def test_empty_segments_between_commas_are_ignored(self):
+        assert parse_times_hhmm("09:00,,17:30") == ["09:00", "17:30"]
+
+    def test_leading_trailing_commas_are_ignored(self):
+        assert parse_times_hhmm(",09:00,") == ["09:00"]
+
+    # -- invalid entries ------------------------------------------------------
+
+    def test_empty_string_returns_empty_list(self):
+        assert parse_times_hhmm("") == []
+
+    def test_all_invalid_returns_empty_list(self):
+        assert parse_times_hhmm("bad,worse,9am") == []
+
+    def test_mixed_valid_and_invalid_keeps_valid(self):
+        assert parse_times_hhmm("09:00,bad,17:30") == ["09:00", "17:30"]
+
+    def test_missing_colon_is_invalid(self):
+        assert parse_times_hhmm("0900") == []
+
+    def test_out_of_range_hour_is_invalid(self):
+        assert parse_times_hhmm("25:00") == []
+
+    def test_out_of_range_minute_is_invalid(self):
+        assert parse_times_hhmm("09:60") == []
+
+    # -- on_invalid callback --------------------------------------------------
+
+    def test_on_invalid_called_for_each_bad_entry(self):
+        callback = MagicMock()
+        parse_times_hhmm("09:00,bad,worse", on_invalid=callback)
+        assert callback.call_count == 2
+        callback.assert_any_call("bad")
+        callback.assert_any_call("worse")
+
+    def test_on_invalid_not_called_for_valid_entries(self):
+        callback = MagicMock()
+        parse_times_hhmm("09:00,17:30", on_invalid=callback)
+        callback.assert_not_called()
+
+    def test_on_invalid_none_silently_skips(self):
+        """Default (no callback) must not raise for invalid input."""
+        result = parse_times_hhmm("garbage", on_invalid=None)
+        assert result == []
+
+    def test_on_invalid_not_called_for_empty_segments(self):
+        """Empty segments (trailing comma, double comma) are dropped silently."""
+        callback = MagicMock()
+        parse_times_hhmm("09:00,,", on_invalid=callback)
+        callback.assert_not_called()


### PR DESCRIPTION
## What

Adds a new `daily_at` schedule type that fires a scheduled task at one or more
specific wall-clock times each day (e.g. `09:00`, or `09:00,17:30`).

## Why

The existing schedule types (`interval`, `hourly`, `daily`, `cron`) don't let
users say _"run this at 9am"_. The `daily_at` type fills that gap with a simple
`HH:MM` format — no cron syntax required.

## Changes

### `code_puppy/scheduler/daemon.py`
- **`parse_daily_at_times(schedule_value)`** — parses a comma-separated string
  of `HH:MM` times into `(hour, minute)` tuples. Invalid entries are skipped
  with a warning rather than crashing the daemon.
- **`should_run_task()`** — new `daily_at` branch fires if any target time has
  passed today and `last_run` is before that target. Restart-safe: if the daemon
  was down at `09:00` and restarts at `09:15`, it still fires.

### `code_puppy/scheduler/config.py`
- Updated `schedule_type` field comment to document `daily_at` as a valid value.

### `code_puppy/plugins/scheduler/scheduler_wizard.py`
- Replaced the old `"Daily"` menu option with `"Daily at specific time(s)..."`.
- Collects time(s) via a `TextInputMenu`, validates each `HH:MM` entry, strips
  invalid ones with a warning, and aborts if none are valid.
- Summary display renders `"daily at 09:00,17:30"` instead of the raw internal
  type/value string.

## Tests

### `tests/scheduler/test_daily_at.py` _(new, 31 tests)_
Covers `parse_daily_at_times()` and all branches of `should_run_task()` for
the `daily_at` type. All wall-clock comparisons use a pinned `NOW` constant so
tests are never flaky.

| Group | What's covered |
|---|---|
| Parser | Single/multiple times, whitespace, midnight, 23:59, invalid formats, empty string, warns on bad input |
| Basic fire/no-fire | Never-run fires after target; future target doesn't fire; fires exactly at boundary; doesn't fire 1s before |
| `last_run` logic | Already ran today → no re-fire; ran yesterday → fires; restart-safe catch-up; ran before target same day → fires |
| Multiple times | First due + second future; first serviced + second future; second becomes due; all future; both past |
| Edge cases | Disabled task; all-invalid schedule; mix valid/invalid; midnight target |

### `tests/plugins/test_scheduler_wizard.py` _(6 new tests + 1 fix)_

| Test | What it guards |
|---|---|
| `test_daily_at_single_time` | Happy path — one `HH:MM` → `schedule_type="daily_at"` |
| `test_daily_at_multiple_times` | Comma list is preserved verbatim in `schedule_value` |
| `test_daily_at_cancel_time_input` | `None` from `TextInputMenu` → wizard returns `None` |
| `test_daily_at_all_invalid_times` | All-bad input → `None` |
| `test_daily_at_strips_invalid_times` | Bad entries dropped, valid ones kept |
| `test_daily_at_summary_display` | `"daily at HH:MM"` appears in stdout; raw `"daily_at"` string does not leak |
| `test_wizard_code_puppy_first` _(fix)_ | Was referencing `"Daily"` which was removed from `schedule_map`; updated to `"Every hour"` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Daily at specific time(s)..." scheduling to enter one or more validated HH:MM times.

* **Enhancements**
  * Renamed display option to "Daily (every 24h)"; summaries now show "daily at HH:MM" and scheduling better handles missed daily runs.

* **Documentation**
  * Config docs updated to list "daily_at" as a valid schedule type.

* **Tests**
  * Expanded unit and wizard tests for parsing, scheduling behavior, summaries, validation, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->