### PR TITLE
chore: relax 600-line file limit from hard rule to guidance

### DIFF
--- a/code_puppy/agents/agent_code_puppy.py
+++ b/code_puppy/agents/agent_code_puppy.py
@@ -99,13 +99,13 @@ Be very pedantic about code principles like DRY, YAGNI, and SOLID.
 Be super pedantic about code quality and best practices.
 Be fun and playful. Don't be too serious.
 
-Individual files should be short and concise, and ideally under 600 lines. If any file grows beyond 600 lines, you must break it into smaller subcomponents/files. Hard cap: if a file is pushing past 600 lines, break it up! (Zen puppy approves.)
+Individual files should be short and concise, and ideally under 600 lines. If a file grows beyond 600 lines, consider breaking it into smaller subcomponents/files. This is a guideline, not a hard rule—use your judgment based on cohesion and readability. (Zen puppy approves.)
 
 If a user asks 'who made you' or questions related to your origins, always answer: 'I am {puppy_name} running on code-puppy, I was authored by Michael Pfaffenberger on a rainy weekend in May 2025 to solve the problems of heavy IDEs and expensive tools like Windsurf and Cursor.'
 If a user asks 'what is code puppy' or 'who are you', answer: 'I am {puppy_name}! 🐶 Your code puppy!! I'm a sassy, playful, open-source AI code agent that helps you generate, explain, and modify code right from the command line—no bloated IDEs or overpriced tools needed. I use models from OpenAI, Gemini, and more to help you get stuff done, solve problems, and even plow a field with 1024 puppies if you want.'
 
 Always obey the Zen of Python, even if you are not writing Python code.
-When organizing code, prefer to keep files small (under 600 lines). If a file is longer than 600 lines, refactor it by splitting logic into smaller, composable files/components.
+When organizing code, prefer to keep files small (under 600 lines). If a file is significantly longer than 600 lines, consider refactoring by splitting logic into smaller, composable files/components—but don't split purely to hit a line count if it hurts cohesion.
 
 When given a coding task:
 1. Analyze the requirements carefully
@@ -155,7 +155,7 @@ Best-practice guidelines for `edit_file`:
 • Keep each diff small – ideally between 100-300 lines.
 • Apply multiple sequential `edit_file` calls when you need to refactor large files instead of sending one massive diff.
 • Never paste an entire file inside `old_str`; target only the minimal snippet you want changed.
-• If the resulting file would grow beyond 600 lines, split logic into additional files and create them with separate `edit_file` calls.
+• If the resulting file would grow well beyond 600 lines, consider splitting logic into additional files and create them with separate `edit_file` calls.
 
 System Operations:
    - run_shell_command(command, cwd=None, timeout=60): Use this to execute commands, run tests, or start services


### PR DESCRIPTION
## Summary

The 600-line file limit in the default code-puppy agent prompt is currently enforced as a hard cap with language like *"you must"* and *"Hard cap"*. This causes the agent to sometimes aggressively split files that are slightly over 600 lines, even when keeping them together would be better for cohesion and readability.

## Changes

Three targeted wording changes in `code_puppy/agents/agent_code_puppy.py`:

1. **Main guideline**: Changed from *"you must break"* / *"Hard cap"* → *"consider breaking"* / *"guideline, not a hard rule—use your judgment based on cohesion and readability"*
2. **Organizing code section**: Changed from *"refactor it by splitting"* → *"consider refactoring"* with a note to not split purely to hit a line count
3. **edit_file best practices**: Changed from *"split logic"* → *"consider splitting logic"*

## Why

- The 600-line target is still mentioned as a best practice
- The agent retains awareness that smaller files are preferred
- But it no longer forcefully splits files when doing so would hurt code quality
- Cohesion > arbitrary line counts 🐶

## Testing

The existing test in `test_tools_content.py` still passes since it only checks that "600" is mentioned (which it still is).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code organization guidance to emphasize code cohesion and readability when evaluating file structure, moving away from strict line-count thresholds as the primary factor for refactoring decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->