### PR TITLE
fix: remove redundant mcp_servers assignment that discards filtering

### DIFF
--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -1474,7 +1474,6 @@ class BaseAgent(ABC):
             self.pydantic_agent = p_agent
             self._code_generation_agent = p_agent
             self._mcp_servers = filtered_mcp_servers
-            self._mcp_servers = mcp_servers
         return self._code_generation_agent
 
     def _create_agent_with_output_type(self, output_type: Type[Any]) -> PydanticAgent:


### PR DESCRIPTION
In the non-DBOS branch of `reload_code_generation_agent`, 
`filtered_mcp_servers` is assigned to `self._mcp_servers` then 
immediately overwritten by `mcp_servers` on the following line, 
discarding all server filtering.

Removed the redundant assignment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where filtered MCP tool configurations were being incorrectly reset during agent reload operations, ensuring custom tool filters are now properly retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->