### PR TITLE
feat: add Shift+Enter as newline insert keybinding

### DIFF
--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -355,7 +355,7 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
     emit_system_message("Type 'clear' to reset the conversation history.")
     emit_system_message("Type /help to view all commands")
     emit_system_message(
-        "Type @ for path completion, or /model to pick a model. Toggle multiline with Alt+M or F2; newline: Ctrl+J."
+        "Type @ for path completion, or /model to pick a model. Toggle multiline with Alt+M or F2; newline: Shift+Enter or Ctrl+J."
     )
     emit_system_message("Paste images: Ctrl+V (even on Mac!), F3, or /paste command.")
     import platform

--- a/code_puppy/command_line/prompt_toolkit_completion.py
+++ b/code_puppy/command_line/prompt_toolkit_completion.py
@@ -642,6 +642,17 @@ async def get_input_with_combined_completion(
     except Exception:
         pass
 
+    # Shift+Enter for newline (terminal-dependent — works in modern terminals
+    # like kitty, WezTerm, iTerm2, and Windows Terminal that support CSI u /
+    # kitty keyboard protocol; silently ignored on older terminals).
+    try:
+
+        @bindings.add("s-enter", eager=True)
+        def _(event):
+            event.app.current_buffer.insert_text("\n")
+    except Exception:
+        pass
+
     # Enter behavior depends on multiline mode
     @bindings.add("enter", filter=~is_searching, eager=True)
     def _(event):

--- a/tests/command_line/test_prompt_toolkit_coverage.py
+++ b/tests/command_line/test_prompt_toolkit_coverage.py
@@ -985,6 +985,14 @@ class TestKeyBindings:
             handler(event)
             event.app.current_buffer.insert_text.assert_called_with("\n")
 
+    def test_shift_enter_newline(self, captured_bindings):
+        """Test shift-enter inserts newline (terminal-dependent)."""
+        handler = self._find_handler(captured_bindings, "s-enter")
+        if handler is not None:
+            event = MagicMock()
+            handler(event)
+            event.app.current_buffer.insert_text.assert_called_with("\n")
+
     def test_ctrl_v_linux_xsel_fallback_filenotfound(self, captured_bindings):
         """Cover the FileNotFoundError xsel fallback path."""
         handler = self._find_handler(captured_bindings, "c-v")


### PR DESCRIPTION
## What

Adds **Shift+Enter** (`s-enter`) as a new keybinding for inserting newlines in the interactive prompt, alongside the existing Ctrl+J and Ctrl+Enter options.

## Why

Shift+Enter is the most intuitive newline shortcut for most users — it's the standard in Slack, Discord, Teams, ChatGPT, and virtually every modern chat UI. Adding it reduces the learning curve for new users who would otherwise need to discover Ctrl+J or toggle multiline mode.

## Changes

**3 files changed, 20 insertions(+), 1 deletion(-)**

### `code_puppy/command_line/prompt_toolkit_completion.py`
- Added `s-enter` key binding following the identical pattern used by `c-enter` (lines 637–643): `try/except` guard with `eager=True`, since Shift+Enter is terminal-dependent (works in modern terminals supporting CSI u / kitty keyboard protocol — kitty, WezTerm, iTerm2, Windows Terminal; silently ignored on older terminals).

### `code_puppy/cli_runner.py`
- Updated help text from `"newline: Ctrl+J"` → `"newline: Shift+Enter or Ctrl+J"` — uses "or" (not comma) to clearly indicate these are alternatives, not a sequence.

### `tests/command_line/test_prompt_toolkit_coverage.py`
- Added `test_shift_enter_newline` mirroring the existing `test_ctrl_enter_newline` pattern exactly: finds the handler via `_find_handler`, guards with `if handler is not None` (since the binding is terminal-dependent), and asserts `insert_text("\n")`.

## Note on `command_line/` modification

Per `AGENTS.md`, new functionality should prefer the plugin/callback system over direct edits to `code_puppy/command_line/`. However, there is **no hook** for key binding registration — `callbacks.py` has no phase for input bindings, prompt session configuration, or TUI customization. The `KeyBindings` object is created locally inside `get_input_with_combined_completion()` and passed directly to `PromptSession()`, with no extension point for plugins.

This change adds 11 lines to an existing block of key binding definitions (Ctrl+J, Ctrl+Enter, multiline Enter) in the only location where those bindings can live. It follows the established pattern exactly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added Shift+Enter keyboard shortcut for inserting newlines in interactive CLI input.

## Tests
* Added test coverage for the Shift+Enter newline functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->