### PR TITLE
fix: allow resume_message_count=0 to disable resume history display

### DIFF
--- a/code_puppy/command_line/autosave_menu.py
+++ b/code_puppy/command_line/autosave_menu.py
@@ -429,7 +429,8 @@ def display_resumed_history(
     # Use config value if num_messages not explicitly provided
     if num_messages is None:
         num_messages = get_resume_message_count()
-
+    if num_messages <= 0:
+        return
     console = Console()
     total_messages = len(history)
 

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -1133,7 +1133,7 @@ def get_resume_message_count() -> int:
     val = get_value("resume_message_count")
     try:
         configured_value = int(val) if val else 50
-        # Enforce reasonable bounds: minimum 1, maximum 100
+        # Enforce reasonable bounds: minimum 0 (disabled), maximum 100
         return max(0, min(configured_value, 100))
     except (ValueError, TypeError):
         return 50

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -1134,7 +1134,7 @@ def get_resume_message_count() -> int:
     try:
         configured_value = int(val) if val else 50
         # Enforce reasonable bounds: minimum 1, maximum 100
-        return max(1, min(configured_value, 100))
+        return max(0, min(configured_value, 100))
     except (ValueError, TypeError):
         return 50
 


### PR DESCRIPTION
get_resume_message_count() enforced a minimum of 1, making it impossible to fully disable the resume history display.

Changed the lower bound from 1 to 0 so users can set resume_message_count=0` to suppress the display entirely, as requested in #213.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted resume message count minimum to allow 0 (disabled) while keeping the 100 maximum.
  * Prevented rendering resumed history when the requested message count is zero or negative, avoiding unnecessary display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->