### PR TITLE
fix: remove duplicate _toolsets assignment in run_agent_task

### DIFF
--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -1906,7 +1906,6 @@ class BaseAgent(ABC):
                     # Temporarily add MCP servers to the DBOS agent using internal _toolsets
                     original_toolsets = pydantic_agent._toolsets
                     pydantic_agent._toolsets = original_toolsets + self._mcp_servers
-                    pydantic_agent._toolsets = original_toolsets + self._mcp_servers
 
                     try:
                         # Set the workflow ID for DBOS context so DBOS and Code Puppy ID match


### PR DESCRIPTION
In `run_agent_task()`, `pydantic_agent._toolsets` is assigned the same value twice on consecutive lines when injecting MCP servers for DBOS execution. Removed the redundant assignment.