### PR TITLE
fix: drain escape sequences in cbreak listeners & disable mouse tracking leak

### DIFF
--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -1776,10 +1776,11 @@ class BaseAgent(ABC):
                 # keys, etc.) so partial sequences don't leak into the
                 # stdin buffer for the next reader (e.g., prompt_toolkit).
                 if data == "\x1b":
-                    for _ in range(256):
-                        if not select.select([stdin], [], [], 0.01)[0]:
-                            break
-                        stdin.read(1)
+                    from code_puppy.terminal_utils import (
+                        drain_stdin_escape_sequence,
+                    )
+
+                    drain_stdin_escape_sequence(stream=stdin)
                     continue
                 if data == "\x18":  # Ctrl+X
                     try:
@@ -1799,10 +1800,11 @@ class BaseAgent(ABC):
             # Drain any remaining escape sequence bytes before restoring
             # terminal attrs, so fragments don't leak to prompt_toolkit.
             try:
-                for _ in range(256):
-                    if not select.select([stdin], [], [], 0.01)[0]:
-                        break
-                    stdin.read(1)
+                from code_puppy.terminal_utils import (
+                    drain_stdin_escape_sequence,
+                )
+
+                drain_stdin_escape_sequence(stream=stdin)
             except Exception:
                 pass
             termios.tcsetattr(fd, termios.TCSADRAIN, original_attrs)

--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -1772,6 +1772,13 @@ class BaseAgent(ABC):
                 data = stdin.read(1)
                 if not data:
                     break
+                # Drain multi-byte escape sequences (mouse events, arrow
+                # keys, etc.) so partial sequences don't leak into the
+                # stdin buffer for the next reader (e.g., prompt_toolkit).
+                if data == "\x1b":
+                    while select.select([stdin], [], [], 0.01)[0]:
+                        stdin.read(1)
+                    continue
                 if data == "\x18":  # Ctrl+X
                     try:
                         on_escape()
@@ -1787,6 +1794,13 @@ class BaseAgent(ABC):
                     except Exception:
                         emit_warning("Cancel agent handler raised unexpectedly.")
         finally:
+            # Drain any remaining escape sequence bytes before restoring
+            # terminal attrs, so fragments don't leak to prompt_toolkit.
+            try:
+                while select.select([stdin], [], [], 0.01)[0]:
+                    stdin.read(1)
+            except Exception:
+                pass
             termios.tcsetattr(fd, termios.TCSADRAIN, original_attrs)
 
     async def run_with_mcp(

--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -1776,7 +1776,9 @@ class BaseAgent(ABC):
                 # keys, etc.) so partial sequences don't leak into the
                 # stdin buffer for the next reader (e.g., prompt_toolkit).
                 if data == "\x1b":
-                    while select.select([stdin], [], [], 0.01)[0]:
+                    for _ in range(256):
+                        if not select.select([stdin], [], [], 0.01)[0]:
+                            break
                         stdin.read(1)
                     continue
                 if data == "\x18":  # Ctrl+X
@@ -1797,7 +1799,9 @@ class BaseAgent(ABC):
             # Drain any remaining escape sequence bytes before restoring
             # terminal attrs, so fragments don't leak to prompt_toolkit.
             try:
-                while select.select([stdin], [], [], 0.01)[0]:
+                for _ in range(256):
+                    if not select.select([stdin], [], [], 0.01)[0]:
+                        break
                     stdin.read(1)
             except Exception:
                 pass

--- a/code_puppy/command_line/mcp/custom_server_form.py
+++ b/code_puppy/command_line/mcp/custom_server_form.py
@@ -638,13 +638,19 @@ class CustomServerForm:
             # previous prompt_toolkit Application left tracking enabled
             # (e.g., due to an exception or threading race), this ensures
             # the terminal stops sending mouse escape sequences.
-            from code_puppy.terminal_utils import disable_mouse_tracking
+            try:
+                from code_puppy.terminal_utils import disable_mouse_tracking
 
-            disable_mouse_tracking()
-            # Exit alternate screen buffer
-            sys.stdout.write("\033[?1049l")
-            sys.stdout.flush()
-            set_awaiting_user_input(False)
+                disable_mouse_tracking()
+            except Exception:
+                pass
+            finally:
+                # Exit alternate screen buffer — must always run even if
+                # disable_mouse_tracking fails, or the terminal stays in
+                # alt screen with input flags stuck.
+                sys.stdout.write("\033[?1049l")
+                sys.stdout.flush()
+                set_awaiting_user_input(False)
 
         # Clear exit message if not installing
         if self.result != "installed":

--- a/code_puppy/command_line/mcp/custom_server_form.py
+++ b/code_puppy/command_line/mcp/custom_server_form.py
@@ -611,7 +611,7 @@ class CustomServerForm:
             layout=layout,
             key_bindings=kb,
             full_screen=False,
-            mouse_support=True,
+            mouse_support=False,
         )
 
         set_awaiting_user_input(True)
@@ -634,6 +634,13 @@ class CustomServerForm:
             app.run(in_thread=True)
 
         finally:
+            # Explicitly disable mouse tracking as a safety net — if any
+            # previous prompt_toolkit Application left tracking enabled
+            # (e.g., due to an exception or threading race), this ensures
+            # the terminal stops sending mouse escape sequences.
+            from code_puppy.terminal_utils import disable_mouse_tracking
+
+            disable_mouse_tracking()
             # Exit alternate screen buffer
             sys.stdout.write("\033[?1049l")
             sys.stdout.flush()

--- a/code_puppy/terminal_utils.py
+++ b/code_puppy/terminal_utils.py
@@ -126,6 +126,59 @@ def reset_windows_terminal_full() -> None:
     flush_windows_keyboard_buffer()
 
 
+def disable_mouse_tracking() -> None:
+    """Explicitly disable all mouse tracking escape sequences.
+
+    Sends the standard VT100 escape sequences to disable mouse click,
+    any-event, urxvt, and SGR mouse tracking modes. This is a safety net
+    for when prompt_toolkit or other TUI components fail to clean up
+    mouse tracking on exit (e.g., due to exceptions or threading issues).
+
+    Safe to call even if mouse tracking was never enabled.
+    """
+    if platform.system() == "Windows":
+        return
+
+    try:
+        sys.stdout.write(
+            "\x1b[?1000l"  # Disable mouse click tracking
+            "\x1b[?1003l"  # Disable any-event mouse tracking
+            "\x1b[?1015l"  # Disable urxvt mouse mode
+            "\x1b[?1006l"  # Disable SGR mouse mode
+        )
+        sys.stdout.flush()
+    except Exception:
+        pass  # Best effort — silently ignore errors
+
+
+def drain_stdin_escape_sequence() -> None:
+    """Drain any pending multi-byte escape sequence bytes from stdin.
+
+    When reading stdin byte-by-byte in cbreak/raw mode, mouse events and
+    other terminal escape sequences produce multi-byte sequences (e.g.,
+    ``\\x1b[<0;15;20M`` for a mouse click). If a reader stops mid-sequence,
+    the remaining bytes stay in the stdin buffer and appear as garbled
+    characters when the next reader (e.g., prompt_toolkit) takes over.
+
+    This function drains all currently pending bytes from stdin within a
+    short timeout window, preventing escape sequence fragments from leaking.
+    """
+    if platform.system() == "Windows":
+        return
+
+    try:
+        import select
+
+        fd = sys.stdin
+        # Drain all pending bytes (10 ms timeout per byte — enough for
+        # escape sequences which arrive in a burst, but won't block on
+        # genuinely empty stdin).
+        while select.select([fd], [], [], 0.01)[0]:
+            fd.read(1)
+    except Exception:
+        pass  # Best effort — silently ignore errors
+
+
 def reset_unix_terminal() -> None:
     """Reset Unix/Linux/macOS terminal to sane state.
 

--- a/code_puppy/terminal_utils.py
+++ b/code_puppy/terminal_utils.py
@@ -151,7 +151,9 @@ def disable_mouse_tracking() -> None:
         pass  # Best effort — silently ignore errors
 
 
-def drain_stdin_escape_sequence(max_bytes: int = 256) -> None:
+def drain_stdin_escape_sequence(
+    stream=None, max_bytes: int = 256
+) -> None:
     """Drain any pending multi-byte escape sequence bytes from stdin.
 
     When reading stdin byte-by-byte in cbreak/raw mode, mouse events and
@@ -164,6 +166,7 @@ def drain_stdin_escape_sequence(max_bytes: int = 256) -> None:
     short timeout window, preventing escape sequence fragments from leaking.
 
     Args:
+        stream: File-like object to drain. Defaults to ``sys.stdin``.
         max_bytes: Safety cap to prevent infinite loops if stdin is flooded
             (e.g., continuous mouse events). 256 bytes covers any realistic
             burst of pending escape sequences.
@@ -174,7 +177,7 @@ def drain_stdin_escape_sequence(max_bytes: int = 256) -> None:
     try:
         import select
 
-        fd = sys.stdin
+        fd = stream if stream is not None else sys.stdin
         # Drain all pending bytes (10 ms timeout per byte — enough for
         # escape sequences which arrive in a burst, but won't block on
         # genuinely empty stdin).

--- a/code_puppy/terminal_utils.py
+++ b/code_puppy/terminal_utils.py
@@ -151,7 +151,7 @@ def disable_mouse_tracking() -> None:
         pass  # Best effort — silently ignore errors
 
 
-def drain_stdin_escape_sequence() -> None:
+def drain_stdin_escape_sequence(max_bytes: int = 256) -> None:
     """Drain any pending multi-byte escape sequence bytes from stdin.
 
     When reading stdin byte-by-byte in cbreak/raw mode, mouse events and
@@ -162,6 +162,11 @@ def drain_stdin_escape_sequence() -> None:
 
     This function drains all currently pending bytes from stdin within a
     short timeout window, preventing escape sequence fragments from leaking.
+
+    Args:
+        max_bytes: Safety cap to prevent infinite loops if stdin is flooded
+            (e.g., continuous mouse events). 256 bytes covers any realistic
+            burst of pending escape sequences.
     """
     if platform.system() == "Windows":
         return
@@ -173,8 +178,10 @@ def drain_stdin_escape_sequence() -> None:
         # Drain all pending bytes (10 ms timeout per byte — enough for
         # escape sequences which arrive in a burst, but won't block on
         # genuinely empty stdin).
-        while select.select([fd], [], [], 0.01)[0]:
+        drained = 0
+        while drained < max_bytes and select.select([fd], [], [], 0.01)[0]:
             fd.read(1)
+            drained += 1
     except Exception:
         pass  # Best effort — silently ignore errors
 

--- a/code_puppy/terminal_utils.py
+++ b/code_puppy/terminal_utils.py
@@ -151,9 +151,7 @@ def disable_mouse_tracking() -> None:
         pass  # Best effort — silently ignore errors
 
 
-def drain_stdin_escape_sequence(
-    stream=None, max_bytes: int = 256
-) -> None:
+def drain_stdin_escape_sequence(stream=None, max_bytes: int = 256) -> None:
     """Drain any pending multi-byte escape sequence bytes from stdin.
 
     When reading stdin byte-by-byte in cbreak/raw mode, mouse events and

--- a/code_puppy/tools/command_runner.py
+++ b/code_puppy/tools/command_runner.py
@@ -396,7 +396,9 @@ def _listen_for_ctrl_x_posix(
             # keys, etc.) so partial sequences don't leak into the
             # stdin buffer for the next reader (e.g., prompt_toolkit).
             if data == "\x1b":
-                while select.select([stdin], [], [], 0.01)[0]:
+                for _ in range(256):
+                    if not select.select([stdin], [], [], 0.01)[0]:
+                        break
                     stdin.read(1)
                 continue
             if data == "\x18":  # Ctrl+X
@@ -410,7 +412,9 @@ def _listen_for_ctrl_x_posix(
         # Drain any remaining escape sequence bytes before restoring
         # terminal attrs, so fragments don't leak to prompt_toolkit.
         try:
-            while select.select([stdin], [], [], 0.01)[0]:
+            for _ in range(256):
+                if not select.select([stdin], [], [], 0.01)[0]:
+                    break
                 stdin.read(1)
         except Exception:
             pass

--- a/code_puppy/tools/command_runner.py
+++ b/code_puppy/tools/command_runner.py
@@ -392,6 +392,13 @@ def _listen_for_ctrl_x_posix(
             data = stdin.read(1)
             if not data:
                 break
+            # Drain multi-byte escape sequences (mouse events, arrow
+            # keys, etc.) so partial sequences don't leak into the
+            # stdin buffer for the next reader (e.g., prompt_toolkit).
+            if data == "\x1b":
+                while select.select([stdin], [], [], 0.01)[0]:
+                    stdin.read(1)
+                continue
             if data == "\x18":  # Ctrl+X
                 try:
                     on_escape()
@@ -400,6 +407,13 @@ def _listen_for_ctrl_x_posix(
                         "Ctrl+X handler raised unexpectedly; Ctrl+C still works."
                     )
     finally:
+        # Drain any remaining escape sequence bytes before restoring
+        # terminal attrs, so fragments don't leak to prompt_toolkit.
+        try:
+            while select.select([stdin], [], [], 0.01)[0]:
+                stdin.read(1)
+        except Exception:
+            pass
         termios.tcsetattr(fd, termios.TCSADRAIN, original_attrs)
 
 

--- a/code_puppy/tools/command_runner.py
+++ b/code_puppy/tools/command_runner.py
@@ -396,10 +396,11 @@ def _listen_for_ctrl_x_posix(
             # keys, etc.) so partial sequences don't leak into the
             # stdin buffer for the next reader (e.g., prompt_toolkit).
             if data == "\x1b":
-                for _ in range(256):
-                    if not select.select([stdin], [], [], 0.01)[0]:
-                        break
-                    stdin.read(1)
+                from code_puppy.terminal_utils import (
+                    drain_stdin_escape_sequence,
+                )
+
+                drain_stdin_escape_sequence(stream=stdin)
                 continue
             if data == "\x18":  # Ctrl+X
                 try:
@@ -412,10 +413,9 @@ def _listen_for_ctrl_x_posix(
         # Drain any remaining escape sequence bytes before restoring
         # terminal attrs, so fragments don't leak to prompt_toolkit.
         try:
-            for _ in range(256):
-                if not select.select([stdin], [], [], 0.01)[0]:
-                    break
-                stdin.read(1)
+            from code_puppy.terminal_utils import drain_stdin_escape_sequence
+
+            drain_stdin_escape_sequence(stream=stdin)
         except Exception:
             pass
         termios.tcsetattr(fd, termios.TCSADRAIN, original_attrs)

--- a/tests/agents/test_base_agent_full_coverage.py
+++ b/tests/agents/test_base_agent_full_coverage.py
@@ -2129,9 +2129,11 @@ class TestLoadPuppyRulesFromFiles:
             patch("code_puppy.config.CONFIG_DIR", str(tmp_path / "nonexistent")),
             patch(
                 "pathlib.Path.exists",
-                side_effect=lambda self: str(self) == str(rules_file)
-                or str(self).endswith("AGENTS.md")
-                and "nonexistent" not in str(self),
+                side_effect=lambda self: (
+                    str(self) == str(rules_file)
+                    or str(self).endswith("AGENTS.md")
+                    and "nonexistent" not in str(self)
+                ),
             ),
         ):
             # Complex to test due to pathlib patching, just test cached path

--- a/tests/command_line/test_model_settings_menu_coverage.py
+++ b/tests/command_line/test_model_settings_menu_coverage.py
@@ -151,10 +151,13 @@ class TestModelSettings:
     def test_load_model_settings_with_openai(
         self, mock_supports, mock_get_all, mock_effort, mock_verb
     ):
-        mock_supports.side_effect = lambda m, s: s in (
-            "temperature",
-            "reasoning_effort",
-            "verbosity",
+        mock_supports.side_effect = lambda m, s: (
+            s
+            in (
+                "temperature",
+                "reasoning_effort",
+                "verbosity",
+            )
         )
         menu = _make_menu()
         menu._load_model_settings("gpt-5")


### PR DESCRIPTION
## Summary

Fixes #244 — After prolonged use of Code Puppy, mouse actions in the terminal send garbled escape sequence characters into the prompt, rendering them meaningless.

## Root Cause

Three interacting bugs compound over long sessions:

1. **`_listen_for_ctrl_x_posix`** (in `base_agent.py` and `command_runner.py`) reads stdin byte-by-byte in cbreak mode but never drains multi-byte escape sequences (mouse events, arrow keys, etc.). When the listener stops mid-sequence, the remaining bytes leak into the stdin buffer and appear as garbled characters when prompt_toolkit takes over.

2. **`custom_server_form.py`** is the only TUI component with `mouse_support=True`. If cleanup fails (threading race, exception during `run(in_thread=True)`), mouse tracking stays permanently enabled, flooding stdin with escape sequences on every mouse action.

3. **Concurrent stdin access** between the cbreak listener thread and prompt_toolkit Applications fragments escape sequences across readers.

## Changes

### `code_puppy/agents/base_agent.py`
- When ESC (`\x1b`) is read, drain all subsequent bytes within 10ms timeout instead of discarding just one byte (matching the pattern already used in `ask_user_question/tui_loop.py`)
- Added a final drain in the `finally` block before restoring terminal attrs

### `code_puppy/tools/command_runner.py`
- Same fix as `base_agent.py` — drain escape sequences on ESC byte and in finally block

### `code_puppy/command_line/mcp/custom_server_form.py`
- Changed `mouse_support=True` → `mouse_support=False` (consistent with all 17 other TUI components)
- Added explicit `disable_mouse_tracking()` call in the `finally` block as a safety net

### `code_puppy/terminal_utils.py`
- Added `disable_mouse_tracking()`: sends VT100 escape sequences to disable all mouse tracking modes
- Added `drain_stdin_escape_sequence()`: drains pending bytes from stdin to prevent escape sequence fragment leaks

## Testing

- All existing command runner tests pass (82 passed, 3 skipped)
- All ask_user_question tests pass (163 passed)
- New helper functions importable and callable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incomplete escape sequences from leaking into subsequent input, avoiding spurious key/mouse events.
  * Disabled mouse support in an interactive form and ensured mouse tracking is reliably turned off on exit.
  * Added cleanup to drain remaining escape bytes on exit so leftover sequences no longer affect future prompts.

* **Tests**
  * Minor test formatting tweaks (no behavioral changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->