### PR TITLE
fix: disable termflow OSC 52 clipboard to prevent cross-session pollu…

### DIFF
--- a/code_puppy/agents/event_stream_handler.py
+++ b/code_puppy/agents/event_stream_handler.py
@@ -106,6 +106,11 @@ async def event_stream_handler(
 
     from termflow import Parser as TermflowParser
     from termflow import Renderer as TermflowRenderer
+    from termflow.render.style import RenderFeatures
+
+    # Disable OSC 52 clipboard integration to prevent cross-session clipboard pollution
+    # when multiple code-puppy instances are running concurrently
+    termflow_features = RenderFeatures(clipboard=False)
 
     # Use the module-level console (set via set_streaming_console)
     console = get_streaming_console()
@@ -190,7 +195,9 @@ async def event_stream_handler(
                 # Initialize termflow streaming for this text part
                 termflow_parsers[event.index] = TermflowParser()
                 termflow_renderers[event.index] = TermflowRenderer(
-                    output=console.file, width=console.width
+                    output=console.file,
+                    width=console.width,
+                    features=termflow_features,
                 )
                 termflow_line_buffers[event.index] = ""
                 # Handle initial content if present

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -11,6 +11,7 @@ apply_all_patches()
 import argparse
 import asyncio
 import os
+import platform
 import sys
 import time
 import traceback
@@ -561,9 +562,11 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
 
         except KeyboardInterrupt:
             # Handle Ctrl+C - cancel input and continue
-            # Windows-specific: Reset terminal state after interrupt to prevent
-            # the terminal from becoming unresponsive (can't type characters)
-            reset_windows_terminal_full()
+            # Reset terminal to fix CSI u mode garbage (^[[27;5;99~)
+            if platform.system() != "Windows":
+                reset_unix_terminal()
+            else:
+                reset_windows_terminal_full()
             # Stop wiggum mode on Ctrl+C
             from code_puppy.command_line.wiggum_state import (
                 is_wiggum_active,

--- a/code_puppy/terminal_utils.py
+++ b/code_puppy/terminal_utils.py
@@ -129,16 +129,24 @@ def reset_windows_terminal_full() -> None:
 def reset_unix_terminal() -> None:
     """Reset Unix/Linux/macOS terminal to sane state.
 
-    Uses the `reset` command to restore terminal sanity.
-    Silently fails if the command isn't available.
+    Disables CSI u / kitty keyboard protocol (fixes ^[[27;5;99~ from Ctrl+C)
+    and bracketed paste mode, then falls back to stty sane.
     """
     if platform.system() == "Windows":
         return
 
+    # Disable enhanced keyboard protocols left enabled by prompt_toolkit
     try:
-        subprocess.run(["reset"], check=True, capture_output=True)
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        pass  # Silently fail if reset command isn't available
+        sys.stdout.write("\x1b[<u\x1b[>4;0m\x1b[?2004l\x1b[0m")
+        sys.stdout.flush()
+    except Exception:
+        pass
+
+    # stty sane is more portable than `reset` and less disruptive
+    try:
+        subprocess.run(["stty", "sane"], capture_output=True, timeout=2)
+    except Exception:
+        pass
 
 
 def reset_terminal() -> None:

--- a/code_puppy/terminal_utils.py
+++ b/code_puppy/terminal_utils.py
@@ -129,16 +129,28 @@ def reset_windows_terminal_full() -> None:
 def reset_unix_terminal() -> None:
     """Reset Unix/Linux/macOS terminal to sane state.
 
-    Uses the `reset` command to restore terminal sanity.
-    Silently fails if the command isn't available.
+    Disables CSI u / kitty keyboard protocol (fixes ^[[27;5;99~ from Ctrl+C)
+    and bracketed paste mode, then falls back to stty sane (or reset).
     """
     if platform.system() == "Windows":
         return
 
+    # Disable enhanced keyboard protocols left enabled by prompt_toolkit
     try:
-        subprocess.run(["reset"], check=True, capture_output=True)
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        pass  # Silently fail if reset command isn't available
+        sys.stdout.write("\x1b[<u\x1b[>4;0m\x1b[?2004l\x1b[0m")
+        sys.stdout.flush()
+    except Exception:
+        pass
+
+    # stty sane is less disruptive than reset (preserves screen)
+    try:
+        subprocess.run(["stty", "sane"], capture_output=True, timeout=2)
+    except Exception:
+        # Fall back to reset if stty isn't available
+        try:
+            subprocess.run(["reset"], capture_output=True, timeout=2)
+        except Exception:
+            pass
 
 
 def reset_terminal() -> None:


### PR DESCRIPTION
Fix terminal corruption and clipboard pollution in long/concurrent sessions
───────────────────────────────────────────────────────────────────────────

Summary
Two terminal reliability fixes for users running long Code Puppy sessions or multiple instances concurrently.

Changes

1. Disable CSI u mode on Ctrl+C (terminal_utils.py, cli_runner.py)

When using Code Puppy for extended sessions, Ctrl+C would output ^[[27;5;99~ instead of interrupting, and garbage like O[ and I[ would appear on input lines.

Root cause: prompt_toolkit enables CSI u (kitty keyboard protocol) for enhanced key detection, but wasn't disabling it on KeyboardInterrupt.

Fix: reset_unix_terminal() now sends escape sequences to disable:
• CSI u / kitty keyboard protocol
• modifyOtherKeys mode
• bracketed paste mode

Also switched from reset to stty sane (more portable, less disruptive).

2. Disable termflow OSC 52 clipboard (event_stream_handler.py)

When multiple Code Puppy sessions run concurrently, termflow's auto-copy of code blocks via OSC 52 caused clipboard cross-pollination between sessions.

Fix: Pass RenderFeatures(clipboard=False) to TermflowRenderer.

Testing
• Long session Ctrl+C no longer produces escape sequence garbage
• Multiple concurrent sessions don't overwrite each other's clipboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled clipboard integration for streamed text rendering to avoid unintended clipboard interactions.

* **Bug Fixes**
  * Improved interrupt handling so terminal reset behaves appropriately on Unix vs Windows.
  * Made terminal reset more robust and portable by using direct control sequences and a safer fallback to restore a sane terminal state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->