### PR TITLE
feat: configurable timeout support for custom model endpoints, allowing users to specify custom timeouts for slow or unreliable API endpoints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,47 @@ Then just use /model and tab to select your round-robin model!
 
 The `rotate_every` parameter controls how many requests are made to each model before rotating to the next one. In this example, the round-robin model will use each Qwen model for 5 consecutive requests before moving to the next model in the sequence.
 
+## Custom Model Timeouts
+
+For custom model endpoints (`custom_openai`, `custom_anthropic`, `custom_gemini`, `cerebras`), you can configure custom timeout values to handle slow or unreliable endpoints. The default timeout for these custom endpoint models is 180 seconds.
+
+**Note:** Other model types have different default timeouts:
+- ChatGPT/Codex models: 300 seconds (5 minutes)
+- Regular Anthropic models: 180 seconds
+- Gemini models: 180 seconds
+
+### Configuration
+Add a `timeout` field to your model configuration in `~/.code_puppy/extra_models.json`:
+
+```json
+{
+  "slow_model": {
+    "type": "custom_openai",
+    "name": "gpt-4",
+    "custom_endpoint": {
+      "url": "https://slow-endpoint.example.com/v1",
+      "api_key": "$API_KEY",
+      "timeout": 600
+    }
+  },
+  "fast_model": {
+    "type": "cerebras", 
+    "name": "llama3.1-8b",
+    "custom_endpoint": {
+      "url": "https://api.cerebras.ai/v1",
+      "api_key": "$CEREBRAS_API_KEY"
+    },
+    "timeout": 300
+  }
+}
+```
+
+The `timeout` value can be specified either:
+- Inside the `custom_endpoint` object (recommended for endpoint-specific timeouts)
+- At the top level of the model config (affects all custom endpoint types)
+
+Timeout values must be positive numbers (integers or floats) representing seconds. If no timeout is specified, the default 180-second timeout is used for custom endpoint models.
+
 ---
 
 ## Create your own Agent!!!

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -312,7 +312,20 @@ def get_custom_config(model_config):
         verify = custom_config["ca_certs_path"]
     else:
         verify = None
-    return url, headers, verify, api_key
+
+    timeout = custom_config.get("timeout", model_config.get("timeout"))
+    if timeout is not None:
+        if isinstance(timeout, str):
+            try:
+                timeout = float(timeout)
+            except ValueError:
+                raise ValueError("Custom endpoint timeout must be a number")
+        if not isinstance(timeout, (int, float)):
+            raise ValueError("Custom endpoint timeout must be a number")
+        if timeout <= 0:
+            raise ValueError("Custom endpoint timeout must be greater than zero")
+
+    return url, headers, verify, api_key, timeout
 
 
 class ModelFactory:
@@ -499,7 +512,7 @@ class ModelFactory:
             return AnthropicModel(model_name=model_config["name"], provider=provider)
 
         elif model_type == "custom_anthropic":
-            url, headers, verify, api_key = get_custom_config(model_config)
+            url, headers, verify, api_key, timeout = get_custom_config(model_config)
             if not api_key:
                 emit_warning(
                     f"API key is not set for custom Anthropic endpoint; skipping model '{model_config.get('name')}'."
@@ -515,7 +528,7 @@ class ModelFactory:
             client = ClaudeCacheAsyncClient(
                 headers=headers,
                 verify=verify,
-                timeout=180,
+                timeout=timeout if timeout is not None else 180,
                 http2=http2_enabled,
             )
 
@@ -609,8 +622,10 @@ class ModelFactory:
             return model
 
         elif model_type == "custom_openai":
-            url, headers, verify, api_key = get_custom_config(model_config)
-            client = create_async_client(headers=headers, verify=verify)
+            url, headers, verify, api_key, timeout = get_custom_config(model_config)
+            client = create_async_client(
+                headers=headers, verify=verify, timeout=timeout if timeout is not None else 180
+            )
             provider_args = {"base_url": url}
             if isinstance(client, httpx.AsyncClient):
                 provider_args["http_client"] = client
@@ -694,14 +709,16 @@ class ModelFactory:
                 )
                 return None
 
-            url, headers, verify, api_key = get_custom_config(model_config)
+            url, headers, verify, api_key, timeout = get_custom_config(model_config)
             if not api_key:
                 emit_warning(
                     f"API key is not set for custom Gemini endpoint; skipping model '{model_config.get('name')}'."
                 )
                 return None
 
-            client = create_async_client(headers=headers, verify=verify)
+            client = create_async_client(
+                headers=headers, verify=verify, timeout=timeout if timeout is not None else 180
+            )
             model = GeminiModel(
                 model_name=model_config["name"],
                 api_key=api_key,
@@ -720,7 +737,7 @@ class ModelFactory:
                         profile = profile.update(qwen_model_profile("qwen-3-coder"))
                     return profile
 
-            url, headers, verify, api_key = get_custom_config(model_config)
+            url, headers, verify, api_key, timeout = get_custom_config(model_config)
             if not api_key:
                 emit_warning(
                     f"API key is not set for Cerebras endpoint; skipping model '{model_config.get('name')}'."
@@ -732,7 +749,10 @@ class ModelFactory:
             # absurdly aggressive Retry-After headers (they send 60s!)
             # Note: model_config["name"] is "zai-glm-4.7", not "cerebras"
             client = create_async_client(
-                headers=headers, verify=verify, model_name="cerebras"
+                headers=headers,
+                verify=verify,
+                model_name="cerebras",
+                timeout=timeout if timeout is not None else 180,
             )
             provider_args = dict(
                 api_key=api_key,

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -313,8 +313,10 @@ def get_custom_config(model_config):
     else:
         verify = None
 
-    timeout = custom_config.get("timeout", model_config.get("timeout"))
+    timeout = model_config.get("timeout", custom_config.get("timeout"))
     if timeout is not None:
+        if isinstance(timeout, bool):
+            raise ValueError("Custom endpoint timeout must be a number")
         if isinstance(timeout, str):
             try:
                 timeout = float(timeout)
@@ -624,7 +626,9 @@ class ModelFactory:
         elif model_type == "custom_openai":
             url, headers, verify, api_key, timeout = get_custom_config(model_config)
             client = create_async_client(
-                headers=headers, verify=verify, timeout=timeout if timeout is not None else 180
+                headers=headers,
+                verify=verify,
+                timeout=timeout if timeout is not None else 180,
             )
             provider_args = {"base_url": url}
             if isinstance(client, httpx.AsyncClient):
@@ -717,7 +721,9 @@ class ModelFactory:
                 return None
 
             client = create_async_client(
-                headers=headers, verify=verify, timeout=timeout if timeout is not None else 180
+                headers=headers,
+                verify=verify,
+                timeout=timeout if timeout is not None else 180,
             )
             model = GeminiModel(
                 model_name=model_config["name"],

--- a/code_puppy/plugins/antigravity_oauth/register_callbacks.py
+++ b/code_puppy/plugins/antigravity_oauth/register_callbacks.py
@@ -429,7 +429,7 @@ def _create_antigravity_model(model_name: str, model_config: Dict, config: Dict)
     except ImportError:
         AntigravityModel = None  # type: ignore
 
-    url, headers, verify, api_key = get_custom_config(model_config)
+    url, headers, verify, api_key, timeout = get_custom_config(model_config)
     if not api_key:
         emit_warning(
             f"API key is not set for Antigravity endpoint; skipping model '{model_config.get('name')}'."

--- a/code_puppy/plugins/claude_code_oauth/register_callbacks.py
+++ b/code_puppy/plugins/claude_code_oauth/register_callbacks.py
@@ -301,7 +301,7 @@ def _create_claude_code_model(model_name: str, model_config: Dict, config: Dict)
     from code_puppy.http_utils import get_cert_bundle_path
     from code_puppy.model_factory import get_custom_config
 
-    url, headers, verify, api_key = get_custom_config(model_config)
+    url, headers, verify, api_key, timeout = get_custom_config(model_config)
 
     # Refresh token if this is from the plugin
     if model_config.get("oauth_source") == "claude-code-plugin":

--- a/tests/plugins/test_antigravity_callbacks_coverage.py
+++ b/tests/plugins/test_antigravity_callbacks_coverage.py
@@ -756,7 +756,7 @@ class TestCreateAntigravityModel:
         with (
             patch(
                 "code_puppy.model_factory.get_custom_config",
-                return_value=("http://url", {}, None, None),
+                return_value=("http://url", {}, None, None, None),
             ),
             patch(
                 "code_puppy.plugins.antigravity_oauth.register_callbacks.emit_warning"
@@ -772,7 +772,7 @@ class TestCreateAntigravityModel:
         with (
             patch(
                 "code_puppy.model_factory.get_custom_config",
-                return_value=("http://url", {}, None, "key"),
+                return_value=("http://url", {}, None, "key", None),
             ),
             patch(
                 "code_puppy.plugins.antigravity_oauth.register_callbacks.load_stored_tokens",
@@ -792,7 +792,7 @@ class TestCreateAntigravityModel:
         with (
             patch(
                 "code_puppy.model_factory.get_custom_config",
-                return_value=("http://url", {}, None, "key"),
+                return_value=("http://url", {}, None, "key", None),
             ),
             patch(
                 "code_puppy.plugins.antigravity_oauth.register_callbacks.load_stored_tokens",
@@ -831,7 +831,7 @@ class TestCreateAntigravityModel:
         with (
             patch(
                 "code_puppy.model_factory.get_custom_config",
-                return_value=("http://url", {}, None, "key"),
+                return_value=("http://url", {}, None, "key", None),
             ),
             patch(
                 "code_puppy.plugins.antigravity_oauth.register_callbacks.load_stored_tokens",
@@ -873,7 +873,7 @@ class TestCreateAntigravityModel:
         with (
             patch(
                 "code_puppy.model_factory.get_custom_config",
-                return_value=("http://url", {}, None, "key"),
+                return_value=("http://url", {}, None, "key", None),
             ),
             patch(
                 "code_puppy.plugins.antigravity_oauth.register_callbacks.load_stored_tokens",
@@ -907,7 +907,7 @@ class TestCreateAntigravityModel:
         with (
             patch(
                 "code_puppy.model_factory.get_custom_config",
-                return_value=("http://url", {}, None, "key"),
+                return_value=("http://url", {}, None, "key", None),
             ),
             patch(
                 "code_puppy.plugins.antigravity_oauth.register_callbacks.load_stored_tokens",
@@ -953,7 +953,7 @@ class TestCreateAntigravityModel:
         with (
             patch(
                 "code_puppy.model_factory.get_custom_config",
-                return_value=("http://url", {}, None, "key"),
+                return_value=("http://url", {}, None, "key", None),
             ),
             patch(
                 "code_puppy.plugins.antigravity_oauth.register_callbacks.load_stored_tokens",

--- a/tests/plugins/test_claude_code_oauth_callbacks.py
+++ b/tests/plugins/test_claude_code_oauth_callbacks.py
@@ -543,7 +543,7 @@ class TestCreateClaudeCodeModel:
     @patch(f"{MOD}.get_valid_access_token", return_value="refreshed_token")
     @patch(
         "code_puppy.model_factory.get_custom_config",
-        return_value=("https://api.example.com", {}, None, "old_key"),
+        return_value=("https://api.example.com", {}, None, "old_key", None),
     )
     @patch(
         "code_puppy.config.get_effective_model_settings",
@@ -566,7 +566,7 @@ class TestCreateClaudeCodeModel:
     @patch(f"{MOD}.get_valid_access_token", return_value=None)
     @patch(
         "code_puppy.model_factory.get_custom_config",
-        return_value=("https://api.example.com", {}, None, None),
+        return_value=("https://api.example.com", {}, None, None, None),
     )
     @patch("code_puppy.config.get_effective_model_settings", return_value={})
     @patch(f"{MOD}.emit_warning")
@@ -582,6 +582,7 @@ class TestCreateClaudeCodeModel:
             {"anthropic-beta": "existing-beta"},
             "/cert",
             "key123",
+            None,
         ),
     )
     @patch(
@@ -603,6 +604,7 @@ class TestCreateClaudeCodeModel:
             {"anthropic-beta": "interleaved-thinking-2025-05-14"},
             "/cert",
             "key123",
+            None,
         ),
     )
     @patch(
@@ -619,7 +621,7 @@ class TestCreateClaudeCodeModel:
 
     @patch(
         "code_puppy.model_factory.get_custom_config",
-        return_value=("https://api.example.com", {}, "/cert", "key123"),
+        return_value=("https://api.example.com", {}, "/cert", "key123", None),
     )
     @patch(
         "code_puppy.config.get_effective_model_settings",
@@ -638,6 +640,7 @@ class TestCreateClaudeCodeModel:
             {"anthropic-beta": "some-other-beta"},
             "/cert",
             "key123",
+            None,
         ),
     )
     @patch(
@@ -652,7 +655,7 @@ class TestCreateClaudeCodeModel:
 
     @patch(
         "code_puppy.model_factory.get_custom_config",
-        return_value=("https://api.example.com", {}, "/cert", "key123"),
+        return_value=("https://api.example.com", {}, "/cert", "key123", None),
     )
     @patch(
         "code_puppy.config.get_effective_model_settings",
@@ -666,7 +669,7 @@ class TestCreateClaudeCodeModel:
 
     @patch(
         "code_puppy.model_factory.get_custom_config",
-        return_value=("https://api.example.com", {}, "/cert", "key123"),
+        return_value=("https://api.example.com", {}, "/cert", "key123", None),
     )
     @patch(
         "code_puppy.config.get_effective_model_settings",

--- a/tests/plugins/test_claude_code_oauth_coverage.py
+++ b/tests/plugins/test_claude_code_oauth_coverage.py
@@ -761,7 +761,8 @@ class TestCreateClaudeCodeModel:
 
         with (
             patch(
-                f"{_MF}.get_custom_config", return_value=("http://url", {}, None, None, None)
+                f"{_MF}.get_custom_config",
+                return_value=("http://url", {}, None, None, None),
             ),
             patch(f"{_RC}.emit_warning"),
         ):

--- a/tests/plugins/test_claude_code_oauth_coverage.py
+++ b/tests/plugins/test_claude_code_oauth_coverage.py
@@ -736,7 +736,7 @@ def _model_patches(
     with (
         patch(
             f"{_MF}.get_custom_config",
-            return_value=("http://url", headers, verify, api_key),
+            return_value=("http://url", headers, verify, api_key, None),
         ),
         patch(
             f"{_CFG}.get_effective_model_settings",
@@ -761,7 +761,7 @@ class TestCreateClaudeCodeModel:
 
         with (
             patch(
-                f"{_MF}.get_custom_config", return_value=("http://url", {}, None, None)
+                f"{_MF}.get_custom_config", return_value=("http://url", {}, None, None, None)
             ),
             patch(f"{_RC}.emit_warning"),
         ):

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -147,7 +147,9 @@ def test_custom_openai_timeout_config(monkeypatch):
         mock_client.return_value = httpx.AsyncClient(timeout=600)
         model = ModelFactory.get_model("custom", config)
 
-    mock_client.assert_called_once_with(headers={"X-Api-Key": "ok"}, verify=False, timeout=600)
+    mock_client.assert_called_once_with(
+        headers={"X-Api-Key": "ok"}, verify=False, timeout=600
+    )
     assert model is not None
 
 
@@ -171,7 +173,9 @@ def test_custom_gemini_timeout_config(monkeypatch):
         mock_client.return_value = httpx.AsyncClient(timeout=600)
         model = ModelFactory.get_model("custom", config)
 
-    mock_client.assert_called_once_with(headers={"X-Api-Key": "ok"}, verify=False, timeout=600)
+    mock_client.assert_called_once_with(
+        headers={"X-Api-Key": "ok"}, verify=False, timeout=600
+    )
     assert model is not None
 
 
@@ -191,9 +195,14 @@ def test_custom_anthropic_timeout_config(monkeypatch):
         }
     }
 
-    with patch("code_puppy.model_factory.ClaudeCacheAsyncClient") as mock_client, patch(
-        "code_puppy.model_factory.make_anthropic_provider"
-    ) as mock_provider, patch("code_puppy.model_factory.AsyncAnthropic") as mock_anthropic:
+    with (
+        patch("code_puppy.model_factory.ClaudeCacheAsyncClient") as mock_client,
+        patch("code_puppy.model_factory.make_anthropic_provider") as mock_provider,
+        patch("code_puppy.model_factory.AsyncAnthropic") as mock_anthropic,
+        patch(
+            "code_puppy.model_factory.get_http2", return_value=False
+        ) as mock_get_http2,
+    ):
         mock_client.return_value = MagicMock()
         mock_provider.return_value = MagicMock()
         mock_anthropic.return_value = MagicMock()
@@ -341,3 +350,64 @@ def test_extra_models_exception_handling(tmp_path, monkeypatch, caplog):
 
     # Check that warning was logged
     assert "Failed to load extra models config" in caplog.text
+
+
+def test_custom_timeout_invalid_values():
+    """Test that invalid timeout values are rejected."""
+    config = {
+        "custom": {
+            "type": "custom_openai",
+            "name": "gpt-4",
+            "custom_endpoint": {
+                "url": "https://api.example.com/v1",
+                "api_key": "$API_KEY",
+            },
+        }
+    }
+
+    # Test invalid timeout values that should be rejected as non-numeric
+    invalid_non_numeric = ["abc", True]
+    for invalid_timeout in invalid_non_numeric:
+        config["custom"]["custom_endpoint"]["timeout"] = invalid_timeout
+        with pytest.raises(
+            ValueError, match="Custom endpoint timeout must be a number"
+        ):
+            ModelFactory.get_model("custom", config)
+
+    # Test invalid numeric values (zero or negative)
+    invalid_numeric = [0, -1]
+    for invalid_timeout in invalid_numeric:
+        config["custom"]["custom_endpoint"]["timeout"] = invalid_timeout
+        with pytest.raises(
+            ValueError, match="Custom endpoint timeout must be greater than zero"
+        ):
+            ModelFactory.get_model("custom", config)
+
+
+def test_custom_timeout_precedence(monkeypatch):
+    """Test that top-level timeout takes precedence over custom_endpoint.timeout."""
+    monkeypatch.setenv("OPENAI_API_KEY", "ok")
+    config = {
+        "custom": {
+            "type": "custom_openai",
+            "name": "gpt-4",
+            "timeout": 300,  # Top-level timeout
+            "custom_endpoint": {
+                "url": "https://api.example.com/v1",
+                "api_key": "$OPENAI_API_KEY",
+                "timeout": 600,  # Custom endpoint timeout (should be ignored)
+            },
+        }
+    }
+
+    with patch("code_puppy.model_factory.create_async_client") as mock_client:
+        mock_client.return_value = httpx.AsyncClient(timeout=300)
+        model = ModelFactory.get_model("custom", config)
+
+    # Should use top-level timeout (300), not custom_endpoint timeout (600)
+    mock_client.assert_called_once_with(
+        headers={},
+        verify=None,
+        timeout=300,
+    )
+    assert model is not None

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -199,9 +199,7 @@ def test_custom_anthropic_timeout_config(monkeypatch):
         patch("code_puppy.model_factory.ClaudeCacheAsyncClient") as mock_client,
         patch("code_puppy.model_factory.make_anthropic_provider") as mock_provider,
         patch("code_puppy.model_factory.AsyncAnthropic") as mock_anthropic,
-        patch(
-            "code_puppy.model_factory.get_http2", return_value=False
-        ) as mock_get_http2,
+        patch("code_puppy.model_factory.get_http2", return_value=False),
     ):
         mock_client.return_value = MagicMock()
         mock_provider.return_value = MagicMock()

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -1,6 +1,7 @@
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 from code_puppy.model_factory import ModelFactory
@@ -124,6 +125,116 @@ def test_custom_openai_happy(monkeypatch):
     model = ModelFactory.get_model("custom", config)
     assert model is not None
     assert hasattr(model.provider, "base_url")
+
+
+def test_custom_openai_timeout_config(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "ok")
+    config = {
+        "custom": {
+            "type": "custom_openai",
+            "name": "cust",
+            "custom_endpoint": {
+                "url": "https://fake.url",
+                "headers": {"X-Api-Key": "$OPENAI_API_KEY"},
+                "ca_certs_path": False,
+                "api_key": "$OPENAI_API_KEY",
+            },
+            "timeout": 600,
+        }
+    }
+
+    with patch("code_puppy.model_factory.create_async_client") as mock_client:
+        mock_client.return_value = httpx.AsyncClient(timeout=600)
+        model = ModelFactory.get_model("custom", config)
+
+    mock_client.assert_called_once_with(headers={"X-Api-Key": "ok"}, verify=False, timeout=600)
+    assert model is not None
+
+
+def test_custom_gemini_timeout_config(monkeypatch):
+    monkeypatch.setenv("CUSTOM_API_KEY", "ok")
+    config = {
+        "custom": {
+            "type": "custom_gemini",
+            "name": "gemini",
+            "custom_endpoint": {
+                "url": "https://fake.url",
+                "headers": {"X-Api-Key": "$CUSTOM_API_KEY"},
+                "ca_certs_path": False,
+                "api_key": "$CUSTOM_API_KEY",
+            },
+            "timeout": 600,
+        }
+    }
+
+    with patch("code_puppy.model_factory.create_async_client") as mock_client:
+        mock_client.return_value = httpx.AsyncClient(timeout=600)
+        model = ModelFactory.get_model("custom", config)
+
+    mock_client.assert_called_once_with(headers={"X-Api-Key": "ok"}, verify=False, timeout=600)
+    assert model is not None
+
+
+def test_custom_anthropic_timeout_config(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "ok")
+    config = {
+        "custom": {
+            "type": "custom_anthropic",
+            "name": "claude",
+            "custom_endpoint": {
+                "url": "https://fake.url",
+                "headers": {"X-Api-Key": "$OPENAI_API_KEY"},
+                "ca_certs_path": False,
+                "api_key": "$OPENAI_API_KEY",
+            },
+            "timeout": 600,
+        }
+    }
+
+    with patch("code_puppy.model_factory.ClaudeCacheAsyncClient") as mock_client, patch(
+        "code_puppy.model_factory.make_anthropic_provider"
+    ) as mock_provider, patch("code_puppy.model_factory.AsyncAnthropic") as mock_anthropic:
+        mock_client.return_value = MagicMock()
+        mock_provider.return_value = MagicMock()
+        mock_anthropic.return_value = MagicMock()
+        model = ModelFactory.get_model("custom", config)
+
+    mock_client.assert_called_once_with(
+        headers={"X-Api-Key": "ok"},
+        verify=False,
+        timeout=600,
+        http2=False,
+    )
+    assert model is not None
+
+
+def test_cerebras_timeout_config(monkeypatch):
+    monkeypatch.setenv("CUSTOM_API_KEY", "ok")
+    config = {
+        "custom": {
+            "type": "cerebras",
+            "name": "zai-glm-4.7",
+            "custom_endpoint": {
+                "url": "https://fake.url",
+                "headers": {"X-Api-Key": "$CUSTOM_API_KEY"},
+                "ca_certs_path": False,
+                "api_key": "$CUSTOM_API_KEY",
+            },
+            "timeout": 600,
+        }
+    }
+
+    with patch("code_puppy.model_factory.create_async_client") as mock_client:
+        mock_client.return_value = httpx.AsyncClient(timeout=600)
+        model = ModelFactory.get_model("custom", config)
+
+    mock_client.assert_called_once_with(
+        headers={"X-Api-Key": "ok", "X-Cerebras-3rd-Party-Integration": "code-puppy"},
+        verify=False,
+        model_name="cerebras",
+        timeout=600,
+    )
+    assert model is not None
 
 
 def test_anthropic_missing_api_key(monkeypatch):

--- a/tests/test_model_factory_coverage.py
+++ b/tests/test_model_factory_coverage.py
@@ -306,7 +306,7 @@ class TestGetCustomConfig:
         with patch(
             "code_puppy.model_factory.get_api_key", return_value="resolved-token"
         ):
-            url, headers, verify, api_key = get_custom_config(config)
+            url, headers, verify, api_key, timeout = get_custom_config(config)
             assert headers["Authorization"] == "resolved-token"
 
     def test_get_custom_config_inline_env_vars_with_spaces(self):
@@ -331,7 +331,7 @@ class TestGetCustomConfig:
             "code_puppy.model_factory.get_api_key", side_effect=mock_get_api_key
         ):
             with patch("code_puppy.model_factory.emit_warning"):
-                url, headers, verify, api_key = get_custom_config(config)
+                url, headers, verify, api_key, timeout = get_custom_config(config)
                 assert headers["Authorization"] == "Bearer my-token part2 extra-value"
 
     def test_get_custom_config_inline_env_var_missing(self):
@@ -347,7 +347,7 @@ class TestGetCustomConfig:
 
         with patch("code_puppy.model_factory.get_api_key", return_value=None):
             with patch("code_puppy.model_factory.emit_warning") as mock_warn:
-                url, headers, verify, api_key = get_custom_config(config)
+                url, headers, verify, api_key, timeout = get_custom_config(config)
                 assert headers["Auth"] == "prefix  suffix"
                 mock_warn.assert_called()
 
@@ -365,7 +365,7 @@ class TestGetCustomConfig:
         with patch(
             "code_puppy.model_factory.get_api_key", return_value="resolved-api-key"
         ):
-            url, headers, verify, api_key = get_custom_config(config)
+            url, headers, verify, api_key, timeout = get_custom_config(config)
             assert api_key == "resolved-api-key"
 
     def test_get_custom_config_api_key_missing_env(self):
@@ -381,7 +381,7 @@ class TestGetCustomConfig:
 
         with patch("code_puppy.model_factory.get_api_key", return_value=None):
             with patch("code_puppy.model_factory.emit_warning") as mock_warn:
-                url, headers, verify, api_key = get_custom_config(config)
+                url, headers, verify, api_key, timeout = get_custom_config(config)
                 assert api_key is None
                 mock_warn.assert_called()
 
@@ -396,7 +396,7 @@ class TestGetCustomConfig:
             }
         }
 
-        url, headers, verify, api_key = get_custom_config(config)
+        url, headers, verify, api_key, timeout = get_custom_config(config)
         assert api_key == "raw-api-key-value"
 
     def test_get_custom_config_ca_certs_path(self):
@@ -410,7 +410,7 @@ class TestGetCustomConfig:
             }
         }
 
-        url, headers, verify, api_key = get_custom_config(config)
+        url, headers, verify, api_key, timeout = get_custom_config(config)
         assert verify == "/path/to/certs.pem"
 
 


### PR DESCRIPTION
## Changes Made
- **Modified `get_custom_config()`** in `model_factory.py` to parse and validate timeout values from model configuration
- **Updated model creation logic** for `custom_openai`, `custom_anthropic`, `custom_gemini`, and `cerebras` model types to use configured timeouts
- **Added comprehensive test coverage** with timeout configuration tests for all affected model types
- **Updated README.md** with documentation for the new timeout configuration feature

## Configuration
Users can now specify timeouts in their `extra_models.json`:

```json
{
  "slow_model": {
    "type": "custom_openai",
    "name": "gpt-4",
    "custom_endpoint": {
      "url": "https://slow-endpoint.example.com/v1",
      "api_key": "$API_KEY",
      "timeout": 600
    }
  }
}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Custom Model Timeouts" section describing per-model timeout configuration, defaults (custom endpoints 180s; ChatGPT/Codex 300s; Anthropic/Gemini 180s), config location, and fallback behavior.

* **New Features**
  * Per-model request timeouts for custom endpoint model types via extra models configuration (top-level or inside custom endpoint).

* **Tests**
  * Added coverage for timeout parsing, validation, precedence, and propagation into client construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->