### PR TITLE
feat: browser-based /copilot-login via GitHub Device Flow

### DIFF
--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -55,6 +55,7 @@ GEMINI_MODELS_FILE = os.path.join(DATA_DIR, "gemini_models.json")
 CHATGPT_MODELS_FILE = os.path.join(DATA_DIR, "chatgpt_models.json")
 CLAUDE_MODELS_FILE = os.path.join(DATA_DIR, "claude_models.json")
 ANTIGRAVITY_MODELS_FILE = os.path.join(DATA_DIR, "antigravity_models.json")
+COPILOT_MODELS_FILE = os.path.join(DATA_DIR, "copilot_models.json")
 
 # Cache files (XDG_CACHE_HOME)
 AUTOSAVE_DIR = os.path.join(CACHE_DIR, "autosaves")

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -168,10 +168,52 @@ def make_model_settings(
 
     model_settings: ModelSettings = ModelSettings(**model_settings_dict)
 
-    if "gpt-5" in model_name:
+    # Copilot models use OpenAI-compatible format even for Claude backends.
+    # Claude thinking translates to reasoning_effort; GPT models get the
+    # standard OpenAI reasoning settings.
+    model_type = model_config.get("type")
+    is_copilot = model_type == "copilot"
+    copilot_underlying = model_config.get("name", "").lower() if is_copilot else ""
+
+    if is_copilot and copilot_underlying.startswith("claude-"):
+        # Copilot wraps Claude behind an OpenAI-compatible API.
+        # Translate extended_thinking / effort into reasoning_effort.
+        from code_puppy.model_utils import get_default_extended_thinking
+
+        default_thinking = get_default_extended_thinking(copilot_underlying)
+        extended_thinking = effective_settings.get(
+            "extended_thinking", default_thinking
+        )
+        # Legacy boolean compat
+        if extended_thinking is True:
+            extended_thinking = "enabled"
+        elif extended_thinking is False:
+            extended_thinking = "off"
+
+        if extended_thinking in ("enabled", "adaptive"):
+            # Map effort setting to reasoning_effort for the OpenAI format
+            effort = effective_settings.get("effort", "high")
+            model_settings_dict["openai_reasoning_effort"] = effort
+
+        # Strip Anthropic-only keys that leaked from effective_settings
+        for key in ("extended_thinking", "budget_tokens", "interleaved_thinking"):
+            model_settings_dict.pop(key, None)
+
+        model_settings = OpenAIChatModelSettings(**model_settings_dict)
+
+    elif is_copilot and (
+        copilot_underlying.startswith("gpt-")
+        or copilot_underlying.startswith("o3")
+        or copilot_underlying.startswith("o4")
+    ):
+        # Copilot GPT/O-series — the Copilot API currently does NOT
+        # support reasoning_effort for GPT models (400 Bad Request).
+        # Just use plain OpenAIChatModelSettings without reasoning params.
+        model_settings = OpenAIChatModelSettings(**model_settings_dict)
+
+    elif "gpt-5" in model_name:
         model_settings_dict["openai_reasoning_effort"] = get_openai_reasoning_effort()
 
-        model_type = model_config.get("type")
         uses_responses_api = (
             model_type == "chatgpt_oauth"
             or (model_type == "openai" and "codex" in model_name)
@@ -340,6 +382,7 @@ class ModelFactory:
             ANTIGRAVITY_MODELS_FILE,
             CHATGPT_MODELS_FILE,
             CLAUDE_MODELS_FILE,
+            COPILOT_MODELS_FILE,
             GEMINI_MODELS_FILE,
         )
 
@@ -350,6 +393,7 @@ class ModelFactory:
             (pathlib.Path(CLAUDE_MODELS_FILE), "Claude Code OAuth models", True),
             (pathlib.Path(GEMINI_MODELS_FILE), "Gemini OAuth models", False),
             (pathlib.Path(ANTIGRAVITY_MODELS_FILE), "Antigravity OAuth models", False),
+            (pathlib.Path(COPILOT_MODELS_FILE), "Copilot models", False),
         ]
 
         for source_path, label, use_filtered in extra_sources:

--- a/code_puppy/plugins/copilot_auth/__init__.py
+++ b/code_puppy/plugins/copilot_auth/__init__.py
@@ -1,0 +1,12 @@
+"""GitHub Copilot auth plugin for Code Puppy.
+
+Authenticates with GitHub (or GitHub Enterprise) via the browser-based
+Device Flow and exchanges the resulting OAuth token for a short-lived
+Copilot session token to access the Copilot API.
+
+Commands:
+- ``/copilot-login``  — authenticate via browser
+- ``/copilot-status`` — show auth & model status
+- ``/copilot-logout`` — remove tokens and registered models
+"""
+

--- a/code_puppy/plugins/copilot_auth/config.py
+++ b/code_puppy/plugins/copilot_auth/config.py
@@ -1,0 +1,95 @@
+"""Configuration constants for the GitHub Copilot auth plugin."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from code_puppy import config
+
+# GitHub Copilot auth configuration
+COPILOT_AUTH_CONFIG: Dict[str, Any] = {
+    # Copilot session-token endpoints
+    "github_token_url": "https://api.github.com/copilot_internal/v2/token",
+    # GHE template: replace {host}
+    "ghe_token_url_template": "https://{host}/api/v3/copilot_internal/v2/token",
+    # OpenAI-compatible Copilot chat API (default; overridden per-host at runtime)
+    "api_base_url": "https://api.githubcopilot.com",
+    # Model prefix in Code Puppy
+    "prefix": "copilot-",
+    "default_context_length": 128000,
+    # Headers expected by the Copilot API
+    "editor_version": "JetBrains-IU/2024.3",
+    "editor_plugin_version": "copilot/2.0.0",
+    "copilot_integration_id": "vscode-chat",
+    "openai_intent": "conversation-panel",
+}
+
+# GitHub Device Flow configuration — browser-based auth with no IDE required.
+# Uses the VS Code Copilot extension's public client ID which supports Device Flow.
+DEVICE_FLOW_CONFIG: Dict[str, Any] = {
+    "client_id": "Iv1.b507a08c87ecfe98",
+    "scope": "read:user",
+    # Endpoint templates — {host} is replaced at runtime
+    "device_code_url": "https://{host}/login/device/code",
+    "access_token_url": "https://{host}/login/oauth/access_token",
+    # Polling defaults (server may override via response)
+    "default_poll_interval": 5,
+    "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+}
+
+# Models known to be available via Copilot (costs are $0 via Copilot).
+# The /copilot-login flow will also try to fetch the live model list.
+DEFAULT_COPILOT_MODELS = [
+    "gpt-4o",
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "o4-mini",
+    "o3",
+    "claude-opus-4.6",
+    "claude-opus-4",
+    "claude-sonnet-4",
+    "claude-sonnet-4.5",
+    "claude-haiku-4.5",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+]
+
+# Per-model context-length overrides (tokens).
+COPILOT_MODEL_CONTEXT_LENGTHS: Dict[str, int] = {
+    "gpt-4o": 64000,
+    "gpt-4.1": 128000,
+    "gpt-4.1-mini": 128000,
+    "o4-mini": 128000,
+    "o3": 128000,
+    "claude-opus-4.6": 200000,
+    "claude-opus-4": 200000,
+    "claude-sonnet-4": 128000,
+    "claude-sonnet-4.5": 128000,
+    "claude-haiku-4.5": 128000,
+    "gemini-2.5-pro": 128000,
+    "gemini-2.5-flash": 128000,
+}
+
+
+
+def get_copilot_models_path() -> Path:
+    """Return path for persisted copilot_models.json (XDG_DATA_HOME)."""
+    data_dir = Path(config.DATA_DIR)
+    data_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    return data_dir / "copilot_models.json"
+
+
+def get_session_cache_path() -> Path:
+    """Return path for caching the short-lived Copilot session token."""
+    data_dir = Path(config.DATA_DIR)
+    data_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    return data_dir / "copilot_session.json"
+
+
+def get_device_token_storage_path() -> Path:
+    """Return path for storing tokens obtained via the GitHub Device Flow."""
+    data_dir = Path(config.DATA_DIR)
+    data_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    return data_dir / "copilot_device_tokens.json"
+

--- a/code_puppy/plugins/copilot_auth/reasoning_client.py
+++ b/code_puppy/plugins/copilot_auth/reasoning_client.py
@@ -1,0 +1,415 @@
+"""Reasoning-opaque round-trip interceptor for Copilot Claude models.
+
+The Copilot API returns two fields on Claude assistant messages:
+
+- ``reasoning_text``: the model's chain-of-thought (human-readable)
+- ``reasoning_opaque``: encrypted round-trip blob (**must** be echoed back)
+
+pydantic-ai's ``openai_chat_send_back_thinking_parts="field"`` mode preserves
+``reasoning_text`` across tool calls, but it doesn't know about
+``reasoning_opaque``.  The Copilot API returns **400 Bad Request** if
+``reasoning_text`` is sent without the accompanying ``reasoning_opaque``.
+
+This module monkey-patches the httpx client to transparently:
+
+1. Capture ``reasoning_opaque`` (keyed by ``reasoning_text``) from responses
+2. Inject the matching ``reasoning_opaque`` into outgoing request messages
+
+The approach mirrors ``ChatGPTCodexAsyncClient`` and ``AntigravityClient``
+patterns already in the codebase.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import Any, Dict
+
+import httpx
+from httpx import AsyncByteStream
+
+logger = logging.getLogger(__name__)
+
+# Cap the cache so it can't grow forever across long sessions.
+_MAX_CACHE_ENTRIES = 256
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _text_key(text: str) -> str:
+    """Short SHA-256 prefix — enough to avoid collisions in practice."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:32]
+
+
+# ---------------------------------------------------------------------------
+# Stream wrapper — captures opaque data as SSE events flow through
+# ---------------------------------------------------------------------------
+
+class _OpaqueCapturingStream(AsyncByteStream):
+    """Async byte-stream wrapper that taps ``reasoning_opaque`` from SSE.
+
+    Yields every byte unchanged so downstream consumers (the OpenAI SDK)
+    see the exact same data.  Internally it buffers bytes, splits SSE
+    lines, parses JSON, and pairs ``reasoning_text`` chunks with
+    ``reasoning_opaque`` chunks for storage in *opaque_cache*.
+
+    Inherits from ``httpx.AsyncByteStream`` so that
+    ``httpx.Response.aclose()`` recognises us as an async stream and
+    doesn't blow up with *"Attempted to call an async close on an sync
+    stream"*.  Ask me how I know.
+    """
+
+    def __init__(
+        self,
+        inner_stream: Any,
+        opaque_cache: Dict[str, str],
+        thinking_field: str,
+    ):
+        self._inner = inner_stream
+        self._opaque_cache = opaque_cache
+        self._thinking_field = thinking_field
+        self._buffer = ""
+        self._text_parts: list[str] = []
+        self._opaque_parts: list[str] = []
+
+    # -- async-iterator protocol ------------------------------------------
+
+    def __aiter__(self):
+        return self._iter_impl()
+
+    async def _iter_impl(self):
+        try:
+            async for chunk in self._inner:
+                self._feed(chunk)
+                yield chunk
+        finally:
+            self._flush()
+
+    async def aclose(self):
+        self._flush()
+        if hasattr(self._inner, "aclose"):
+            await self._inner.aclose()
+
+    # Fallback for any attributes we don't explicitly handle.
+    def __getattr__(self, name: str):
+        return getattr(self._inner, name)
+
+    # -- SSE parsing -------------------------------------------------------
+
+    def _feed(self, chunk: bytes) -> None:
+        self._buffer += chunk.decode("utf-8", errors="replace")
+        self._process_buffer()
+
+    def _process_buffer(self) -> None:
+        while "\n" in self._buffer:
+            line, self._buffer = self._buffer.split("\n", 1)
+            line = line.strip()
+            if not line.startswith("data: "):
+                continue
+            data_str = line[6:]
+            if data_str == "[DONE]":
+                self._flush()
+                continue
+            try:
+                event = json.loads(data_str)
+                self._extract_from_event(event)
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+    def _extract_from_event(self, event: dict) -> None:
+        for choice in event.get("choices", []):
+            # Streaming deltas
+            delta = choice.get("delta") or {}
+            self._collect(delta)
+            # Non-streaming message (fallback)
+            message = choice.get("message") or {}
+            self._collect(message)
+            # Flush when the model signals it's done with this turn
+            if choice.get("finish_reason"):
+                self._flush()
+
+    def _collect(self, obj: dict) -> None:
+        text_chunk = obj.get(self._thinking_field)
+        if text_chunk:
+            self._text_parts.append(text_chunk)
+        opaque_chunk = obj.get("reasoning_opaque")
+        if opaque_chunk:
+            self._opaque_parts.append(opaque_chunk)
+
+    def _flush(self) -> None:
+        if self._opaque_parts and self._text_parts:
+            text = "".join(self._text_parts)
+            opaque = "".join(self._opaque_parts)
+            key = _text_key(text)
+            self._opaque_cache[key] = opaque
+            logger.debug(
+                "Captured reasoning_opaque (%d chars) for key %.8s…",
+                len(opaque),
+                key,
+            )
+            # Evict oldest entry if we exceed the cap.
+            while len(self._opaque_cache) > _MAX_CACHE_ENTRIES:
+                first_key = next(iter(self._opaque_cache))
+                del self._opaque_cache[first_key]
+        self._text_parts = []
+        self._opaque_parts = []
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming capture (safety net)
+# ---------------------------------------------------------------------------
+
+def _capture_from_content(
+    content: bytes,
+    opaque_cache: Dict[str, str],
+    thinking_field: str,
+) -> None:
+    """Extract ``reasoning_opaque`` from an already-read response body."""
+    try:
+        data = json.loads(content)
+        for choice in data.get("choices", []):
+            msg = choice.get("message") or {}
+            text = msg.get(thinking_field)
+            opaque = msg.get("reasoning_opaque")
+            if text and opaque:
+                opaque_cache[_text_key(text)] = opaque
+    except (json.JSONDecodeError, TypeError, AttributeError):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Request-side injection
+# ---------------------------------------------------------------------------
+
+def _rebuild_request_body(
+    request: httpx.Request,
+    body: dict,
+    client: httpx.AsyncClient,
+) -> None:
+    """Replace the request body in-place (mirrors ChatGPTCodexAsyncClient)."""
+    new_body = json.dumps(body).encode("utf-8")
+    rebuilt = client.build_request(
+        method=request.method,
+        url=request.url,
+        headers=request.headers,
+        content=new_body,
+    )
+    if hasattr(rebuilt, "_content"):
+        request._content = rebuilt._content  # type: ignore[attr-defined]
+    if hasattr(rebuilt, "stream"):
+        request.stream = rebuilt.stream
+    if hasattr(rebuilt, "extensions"):
+        request.extensions = rebuilt.extensions
+    request.headers["Content-Length"] = str(len(new_body))
+
+
+def _inject_opaque_into_request(
+    request: httpx.Request,
+    opaque_cache: Dict[str, str],
+    client: httpx.AsyncClient,
+    thinking_field: str,
+) -> None:
+    """Add stored ``reasoning_opaque`` to assistant messages that need it.
+
+    **Prevention layer**: if we can't find a matching opaque for a
+    ``reasoning_text``, we strip that field entirely rather than sending
+    it bare (which would trigger a 400).
+    """
+    try:
+        body_bytes = request.content
+        if not body_bytes:
+            return
+
+        body = json.loads(body_bytes)
+        if not isinstance(body, dict):
+            return
+
+        messages = body.get("messages")
+        if not messages:
+            return
+
+        modified = False
+        injected = 0
+        stripped = 0
+
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("role") != "assistant":
+                continue
+            if thinking_field not in msg:
+                continue
+            if "reasoning_opaque" in msg:
+                # Already has opaque — don't touch.
+                continue
+
+            key = _text_key(msg[thinking_field])
+            opaque = opaque_cache.get(key)
+            if opaque:
+                msg["reasoning_opaque"] = opaque
+                modified = True
+                injected += 1
+            else:
+                # SAFETY: No matching opaque → strip reasoning_text to
+                # prevent the 400.  Losing thinking context is better
+                # than crashing the conversation.
+                del msg[thinking_field]
+                modified = True
+                stripped += 1
+                logger.debug(
+                    "Stripped orphaned %s (no opaque in cache)",
+                    thinking_field,
+                )
+
+        if not modified:
+            return
+
+        _rebuild_request_body(request, body, client)
+
+        if injected:
+            logger.debug(
+                "Injected reasoning_opaque into %d assistant message(s)",
+                injected,
+            )
+        if stripped:
+            logger.debug(
+                "Stripped %d orphaned %s field(s) (cache miss)",
+                stripped,
+                thinking_field,
+            )
+    except Exception as exc:
+        # Never crash the real request.
+        logger.debug("Failed to inject reasoning_opaque: %s", exc)
+
+
+def _strip_all_reasoning_fields(
+    request: httpx.Request,
+    client: httpx.AsyncClient,
+    thinking_field: str,
+) -> bool:
+    """Remove ALL reasoning fields from the request body.
+
+    **Recovery layer**: called after a 400 to retry without any reasoning
+    context.  Degrades gracefully to the old ``send_back_thinking_parts=False``
+    behaviour — thinking disappears after tool calls, but the conversation
+    keeps working.
+
+    Returns True if the body was modified.
+    """
+    try:
+        body_bytes = request.content
+        if not body_bytes:
+            return False
+
+        body = json.loads(body_bytes)
+        if not isinstance(body, dict):
+            return False
+
+        messages = body.get("messages")
+        if not messages:
+            return False
+
+        modified = False
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("role") != "assistant":
+                continue
+            for field in (thinking_field, "reasoning_opaque"):
+                if field in msg:
+                    del msg[field]
+                    modified = True
+
+        if modified:
+            _rebuild_request_body(request, body, client)
+
+        return modified
+    except Exception as exc:
+        logger.debug("Failed to strip reasoning fields: %s", exc)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Public API — single entry-point
+# ---------------------------------------------------------------------------
+
+def patch_client_for_reasoning_opaque(
+    client: httpx.AsyncClient,
+    thinking_field: str = "reasoning_text",
+) -> None:
+    """Monkey-patch *client* to round-trip ``reasoning_opaque`` transparently.
+
+    Call **after** creating the client but **before** handing it to
+    ``OpenAIProvider``.  Works with plain ``httpx.AsyncClient`` and the
+    ``RetryingAsyncClient`` subclass returned by ``create_async_client``.
+
+    Args:
+        client: The httpx async client to patch.
+        thinking_field: JSON field name that carries the thinking content
+            (default ``"reasoning_text"`` — the Copilot Claude convention).
+    """
+    opaque_cache: Dict[str, str] = {}
+    original_send = client.send
+
+    async def _patched_send(
+        request: httpx.Request, *args: Any, **kwargs: Any
+    ) -> httpx.Response:
+        # 1) Inject reasoning_opaque into outgoing POST bodies.
+        #    Also strips orphaned reasoning_text with no cached opaque.
+        if request.method == "POST":
+            _inject_opaque_into_request(
+                request, opaque_cache, client, thinking_field
+            )
+
+        # 2) Let the real send (incl. auth + retries) run.
+        response = await original_send(request, *args, **kwargs)
+
+        # 3) RECOVERY: If the API still returns 400, it's likely because
+        #    our reasoning fields are wrong/stale.  Strip them all and
+        #    retry once.  This degrades to "no thinking after tool calls"
+        #    but keeps the conversation alive.
+        if (
+            response.status_code == 400
+            and request.method == "POST"
+        ):
+            # Read the error body for diagnostics before retrying.
+            try:
+                err_body = response.content.decode("utf-8", errors="replace")
+            except Exception:
+                err_body = "<unreadable>"
+            logger.warning(
+                "Copilot 400 — attempting recovery by stripping reasoning "
+                "fields and retrying.  Error: %.300s",
+                err_body,
+            )
+            if _strip_all_reasoning_fields(request, client, thinking_field):
+                response = await original_send(request, *args, **kwargs)
+                if response.status_code == 200:
+                    logger.info(
+                        "Recovery succeeded — reasoning stripped, "
+                        "conversation continues without thinking context."
+                    )
+                else:
+                    logger.warning(
+                        "Recovery retry also failed (%d) — returning "
+                        "retry response.",
+                        response.status_code,
+                    )
+
+        # 4) Capture reasoning_opaque from successful responses.
+        if response.status_code == 200:
+            if response.is_stream_consumed:
+                _capture_from_content(
+                    response.content, opaque_cache, thinking_field
+                )
+            elif hasattr(response, "stream") and response.stream is not None:
+                response.stream = _OpaqueCapturingStream(
+                    response.stream, opaque_cache, thinking_field
+                )
+
+        return response
+
+    client.send = _patched_send  # type: ignore[method-assign]

--- a/code_puppy/plugins/copilot_auth/register_callbacks.py
+++ b/code_puppy/plugins/copilot_auth/register_callbacks.py
@@ -1,0 +1,451 @@
+"""GitHub Copilot auth plugin — callback registrations.
+
+Provides:
+- ``/copilot-login``  — browser-based GitHub Device Flow auth
+- ``/copilot-status`` — show auth & model status
+- ``/copilot-logout`` — remove tokens and registered Copilot models
+- ``copilot`` model-type handler for ``model_factory``
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from code_puppy.callbacks import register_callback
+from code_puppy.messaging import emit_error, emit_info, emit_success, emit_warning
+
+from .config import COPILOT_AUTH_CONFIG
+from .utils import (
+    add_models_to_config,
+    clear_caches,
+    fetch_copilot_models,
+    get_api_endpoint_for_host,
+    get_token_for_host,
+    get_valid_session_token,
+    load_copilot_models,
+    load_device_tokens,
+    poll_for_token,
+    remove_copilot_models,
+    save_device_token,
+    start_device_flow,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# /help entries
+# ---------------------------------------------------------------------------
+
+def _custom_help() -> List[Tuple[str, str]]:
+    return [
+        (
+            "copilot-login",
+            "Authenticate with GitHub/GitHub Enterprise Copilot via browser",
+        ),
+        ("copilot-status", "Show GitHub Copilot authentication status and models"),
+        ("copilot-logout", "Remove Copilot tokens and registered models"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# /copilot-status
+# ---------------------------------------------------------------------------
+
+def _handle_copilot_status() -> None:
+    tokens = load_device_tokens()
+
+    if not tokens:
+        emit_warning(
+            "🔓 GitHub Copilot: Not authenticated.\n"
+            "   Run /copilot-login to sign in via your browser."
+        )
+        return
+
+    emit_success("🔐 GitHub Copilot: Authenticated")
+    for t in tokens:
+        host_label = t.host
+        user_label = f" ({t.user})" if t.user else ""
+        emit_info(f"   • {host_label}{user_label}")
+
+    # Check session token for each host
+    for t in tokens:
+        session = get_valid_session_token(t.oauth_token, t.host)
+        if session:
+            emit_info(f"   ✅ {t.host}: active session (auto-refreshes on expiry)")
+        else:
+            emit_warning(f"   ⚠️  {t.host}: could not obtain a session token — may be expired")
+            emit_info(f"      Run /copilot-login {t.host} to re-authenticate.")
+
+    # Registered models
+    models = load_copilot_models()
+    copilot_models = [
+        name for name, cfg in models.items()
+        if cfg.get("oauth_source") == "copilot-auth-plugin"
+    ]
+    if copilot_models:
+        emit_info(f"🎯 Registered Copilot models: {', '.join(sorted(copilot_models))}")
+    else:
+        emit_warning("⚠️  No Copilot models registered yet. Run /copilot-login to set up.")
+
+
+# ---------------------------------------------------------------------------
+# /copilot-logout
+# ---------------------------------------------------------------------------
+
+def _handle_copilot_logout() -> None:
+    errors: list[str] = []
+
+    # 1. Remove registered models from copilot_models.json
+    removed = remove_copilot_models()
+    if removed:
+        emit_info(f"Removed {removed} Copilot model(s) from configuration")
+    else:
+        emit_info("No Copilot models were registered")
+
+    # 2. Delete on-disk token/session caches
+    from .config import get_device_token_storage_path, get_session_cache_path
+
+    for path in (get_session_cache_path(), get_device_token_storage_path()):
+        if path.exists():
+            try:
+                path.unlink()
+            except Exception as exc:
+                errors.append(f"Could not remove {path.name}: {exc}")
+
+    # 3. Clear in-memory session and endpoint caches
+    clear_caches()
+
+    # 4. If the active model was a copilot model, reset it so the app
+    #    doesn't keep trying to use a model whose tokens are gone.
+    try:
+        from code_puppy.config import clear_model_cache, get_model_name, reset_session_model
+
+        current = get_model_name()
+        if current and current.startswith(COPILOT_AUTH_CONFIG["prefix"]):
+            reset_session_model()
+            clear_model_cache()
+            emit_info(f"Reset active model (was {current})")
+    except Exception:
+        pass  # Non-critical — worst case the next prompt will error and user switches
+
+    # 5. Report outcome
+    if errors:
+        for err in errors:
+            emit_warning(err)
+        emit_warning("Copilot logout completed with errors (see above)")
+    else:
+        emit_success("Copilot logout complete — all tokens removed")
+
+
+# ---------------------------------------------------------------------------
+# /copilot-login — browser-based GitHub Device Flow
+# ---------------------------------------------------------------------------
+
+def _normalize_github_host(raw_host: str) -> str | None:
+    """Validate and normalize a GitHub hostname for safe URL interpolation.
+
+    The hostname is interpolated into URLs like
+    ``https://{host}/login/device/code``, so we must reject anything that
+    could alter the URL structure (schemes, paths, credentials, etc.).
+
+    Returns:
+        The cleaned lowercase hostname on success, or ``None`` if the input
+        is invalid.
+
+    Rejects inputs containing:
+        - URL schemes    (``://``)   — e.g. ``https://evil.com``
+        - Path segments  (``/``, ``\\``) — e.g. ``github.com/evil``
+        - Credentials    (``@``)     — e.g. ``user@attacker.tld``
+        - Query strings  (``?``)     — e.g. ``host?q=1``
+        - Fragments      (``#``)     — e.g. ``host#frag``
+    """
+    host = raw_host.strip().lower()
+    if not host:
+        return "github.com"
+
+    # Block characters that would alter URL structure when interpolated
+    unsafe_chars = ("://", "/", "\\", "@", "?", "#")
+    for marker in unsafe_chars:
+        if marker in host:
+            return None
+
+    # Strip trailing dots (DNS allows them but they're not meaningful here)
+    return host.rstrip(".")
+
+
+def _handle_copilot_login(command: str) -> None:
+    """Authenticate with GitHub Copilot via the GitHub Device Flow.
+
+    Opens a browser for the user to enter a one-time code.  Supports
+    GitHub Enterprise by passing the hostname:
+    ``/copilot-login ghes.example.com``
+
+    When no hostname is given the user is prompted (default: github.com).
+    """
+    # Parse optional GHE hostname from command arguments
+    parts = command.strip().split()
+    host: str | None = None
+    if len(parts) > 1:
+        host = parts[1].strip()
+
+    # If no host was provided as an argument, prompt the user
+    if not host:
+        emit_info(
+            "🌐 Enter your GitHub hostname — just the domain, no https:// or path.\n"
+            "   Examples: github.com, ghe.mycompany.com\n"
+            "   Press Enter to use github.com."
+        )
+        try:
+            from prompt_toolkit import prompt as pt_prompt
+
+            raw = pt_prompt("GitHub host: ", default="github.com").strip()
+            host = raw if raw else "github.com"
+        except ImportError:
+            host = "github.com"
+        except (EOFError, KeyboardInterrupt):
+            emit_warning("Copilot login cancelled.")
+            return
+
+    # Validate the hostname before interpolating it into any URLs
+    host = _normalize_github_host(host)
+    if not host:
+        emit_error(
+            "Invalid hostname — expected a bare domain like github.com or ghe.mycompany.com.\n"
+            "   Do not include https://, paths, or special characters."
+        )
+        return
+
+    if host != "github.com":
+        emit_info(f"Using GitHub Enterprise host: {host}")
+
+    emit_info(f"🔑 Starting GitHub Device Flow for {host}…")
+
+    device_resp = start_device_flow(host)
+    if not device_resp:
+        emit_error(
+            "Failed to start Device Flow. Check your network connection "
+            "and ensure the host is reachable."
+        )
+        return
+
+    user_code = device_resp["user_code"]
+    verification_uri = device_resp.get("verification_uri", f"https://{host}/login/device")
+    expires_in = int(device_resp.get("expires_in", 900))
+    interval = int(device_resp.get("interval", 5))
+
+    # Show the code prominently
+    emit_success(f"🔗 Your one-time code:  {user_code}")
+    emit_info(f"   Open {verification_uri} and enter the code above.")
+
+    # Try to open the browser
+    try:
+        import webbrowser
+
+        from code_puppy.tools.common import should_suppress_browser
+
+        if should_suppress_browser():
+            emit_info(f"[HEADLESS MODE] Visit: {verification_uri}")
+        else:
+            webbrowser.open(verification_uri)
+    except Exception as exc:
+        logger.debug("Could not open browser: %s", exc)
+        emit_info(f"Please open this URL manually: {verification_uri}")
+
+    emit_info("⏳ Waiting for you to authorize in the browser…")
+
+    oauth_token = poll_for_token(
+        device_code=device_resp["device_code"],
+        host=host,
+        interval=interval,
+        expires_in=expires_in,
+    )
+
+    if not oauth_token:
+        emit_error(
+            "Authorization was not completed in time, or was denied. "
+            "Please try /copilot-login again."
+        )
+        return
+
+    emit_success("✅ GitHub authorization successful!")
+
+    # Persist the token
+    if not save_device_token(host, oauth_token):
+        emit_warning("Token obtained but could not be saved to disk.")
+
+    # Exchange for Copilot session token & register models
+    emit_info("Exchanging for Copilot session token…")
+    session = get_valid_session_token(oauth_token, host)
+    if not session:
+        emit_warning(
+            "Got a GitHub token but could not obtain a Copilot session token.\n"
+            "   Your GitHub account may not have Copilot access."
+        )
+        return
+
+    emit_success("✅ Copilot session token obtained")
+
+    emit_info("Fetching available Copilot models…")
+    model_list = fetch_copilot_models(session, host)
+    if model_list and add_models_to_config(model_list, host):
+        emit_success(
+            f"Registered {len(model_list)} Copilot model(s). "
+            "Use the `copilot-` prefix with /model."
+        )
+        try:
+            from code_puppy.model_switching import set_model_and_reload_agent
+
+            default_model = f"{COPILOT_AUTH_CONFIG['prefix']}{model_list[0]}"
+            set_model_and_reload_agent(default_model)
+        except Exception as exc:
+            logger.debug("Could not auto-switch to Copilot model: %s", exc)
+    else:
+        emit_warning("Could not register Copilot models.")
+
+
+# ---------------------------------------------------------------------------
+# custom_command dispatcher
+# ---------------------------------------------------------------------------
+
+def _handle_custom_command(command: str, name: str) -> Optional[bool]:
+    if not name:
+        return None
+    if name == "copilot-login":
+        _handle_copilot_login(command)
+        return True
+    if name == "copilot-status":
+        _handle_copilot_status()
+        return True
+    if name == "copilot-logout":
+        _handle_copilot_logout()
+        return True
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Model-type handler — creates OpenAI-compatible model for Copilot API
+# ---------------------------------------------------------------------------
+
+def _create_copilot_model(
+    model_name: str, model_config: Dict, config: Dict
+) -> Any:
+    """Create an OpenAI-compatible model backed by GitHub Copilot API.
+
+    Called by ``model_factory`` when ``type == "copilot"``.
+
+    Uses a dynamic auth flow that refreshes the short-lived Copilot session
+    token automatically before each API request, preventing mid-conversation
+    token expiry errors.
+    """
+    import httpx
+    from pydantic_ai.models.openai import OpenAIChatModel
+    from pydantic_ai.providers.openai import OpenAIProvider
+
+    from code_puppy.http_utils import create_async_client
+
+    # Discover token — match against the host stored in the model config
+    host = model_config.get("copilot_host", "github.com")
+    preferred = get_token_for_host(host)
+    if not preferred:
+        emit_warning(
+            f"No Copilot token available for host '{host}'; skipping model '{model_config.get('name')}'. "
+            "Run /copilot-login first."
+        )
+        return None
+
+    # Verify we can get an initial session token
+    session_token = get_valid_session_token(preferred.oauth_token, preferred.host)
+    if not session_token:
+        emit_warning(
+            f"Could not obtain Copilot session token; skipping model '{model_config.get('name')}'. "
+            "Run /copilot-login to re-authenticate."
+        )
+        return None
+
+    # Build HTTP client with Copilot-required headers and dynamic token refresh.
+    # The CopilotAuth flow replaces the Authorization header before every request,
+    # so the session token is always fresh even for long-running conversations.
+    copilot_headers = {
+        "Editor-Version": COPILOT_AUTH_CONFIG["editor_version"],
+        "Editor-Plugin-Version": COPILOT_AUTH_CONFIG["editor_plugin_version"],
+        "Copilot-Integration-Id": COPILOT_AUTH_CONFIG["copilot_integration_id"],
+        "Openai-Intent": COPILOT_AUTH_CONFIG["openai_intent"],
+    }
+
+    class _CopilotAuth(httpx.Auth):
+        """httpx auth flow that refreshes the Copilot session token per-request."""
+
+        def __init__(self, oauth_token: str, token_host: str):
+            self._oauth_token = oauth_token
+            self._host = token_host
+
+        def auth_flow(self, request: httpx.Request):
+            token = get_valid_session_token(self._oauth_token, self._host)
+            if token:
+                request.headers["Authorization"] = f"Bearer {token}"
+            yield request
+
+    client = create_async_client(headers=copilot_headers)
+    # Attach the dynamic auth so every request gets a fresh token
+    client.auth = _CopilotAuth(preferred.oauth_token, preferred.host)
+
+    # Use the API endpoint discovered during session-token exchange.
+    # Falls back to whatever was stored in the model config at registration.
+    base_url = get_api_endpoint_for_host(host)
+    if base_url == COPILOT_AUTH_CONFIG["api_base_url"]:
+        config_url = model_config.get("custom_endpoint", {}).get("url")
+        if config_url:
+            base_url = config_url
+
+    # Use a placeholder API key — the actual token is injected by _CopilotAuth
+    provider = OpenAIProvider(
+        api_key="copilot-session-managed",
+        base_url=base_url,
+        http_client=client,
+    )
+
+    # Build a model profile that tells pydantic-ai how to handle thinking.
+    # Claude models behind the Copilot API return thinking in a custom field
+    # called "reasoning_text" (and encrypted round-trip data in "reasoning_opaque").
+    profile = None
+    underlying_name = model_config.get("name", "").lower()
+    if underlying_name.startswith("claude-"):
+        from pydantic_ai.profiles.openai import OpenAIModelProfile
+
+        from .reasoning_client import patch_client_for_reasoning_opaque
+
+        # Enable field-mode so thinking persists across tool calls.
+        # The reasoning_opaque round-trip interceptor (patched onto the
+        # httpx client below) captures the encrypted blob from responses
+        # and re-injects it into subsequent requests, preventing 400s.
+        profile = OpenAIModelProfile(
+            openai_chat_thinking_field="reasoning_text",
+            openai_supports_reasoning=True,
+            openai_chat_send_back_thinking_parts="field",
+        )
+        patch_client_for_reasoning_opaque(client, thinking_field="reasoning_text")
+
+    model = OpenAIChatModel(
+        model_name=model_config["name"],
+        provider=provider,
+        profile=profile,
+    )
+    model.provider = provider
+    return model
+
+
+def _register_model_types() -> List[Dict[str, Any]]:
+    """Register the ``copilot`` model type handler."""
+    return [{"type": "copilot", "handler": _create_copilot_model}]
+
+
+# ---------------------------------------------------------------------------
+# Hook registrations — executed at module import time
+# ---------------------------------------------------------------------------
+
+register_callback("custom_command_help", _custom_help)
+register_callback("custom_command", _handle_custom_command)
+register_callback("register_model_type", _register_model_types)
+

--- a/code_puppy/plugins/copilot_auth/utils.py
+++ b/code_puppy/plugins/copilot_auth/utils.py
@@ -1,0 +1,580 @@
+"""Utility helpers for the GitHub Copilot auth plugin.
+
+Handles browser-based Device Flow authentication, session-token exchange /
+caching, and model registration persistence.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from .config import (
+    COPILOT_AUTH_CONFIG,
+    COPILOT_MODEL_CONTEXT_LENGTHS,
+    DEFAULT_COPILOT_MODELS,
+    DEVICE_FLOW_CONFIG,
+    get_copilot_models_path,
+    get_device_token_storage_path,
+    get_session_cache_path,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Token storage — persisted tokens obtained via the Device Flow
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CopilotToken:
+    """An OAuth token for a GitHub host."""
+
+    host: str  # "github.com" or a GHE hostname
+    oauth_token: str
+    user: str = ""
+
+
+def get_token_for_host(host: str) -> Optional[CopilotToken]:
+    """Return a stored Device Flow token whose host matches *host* exactly.
+
+    Returns ``None`` if no token for the given host is found.
+    """
+    tokens = load_device_tokens()
+    for t in tokens:
+        if t.host == host:
+            return t
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Device Flow — browser-based GitHub OAuth (no IDE required)
+# ---------------------------------------------------------------------------
+
+def start_device_flow(host: str = "github.com") -> Optional[Dict[str, Any]]:
+    """Initiate the GitHub Device Flow and return the device code response.
+
+    Returns a dict with ``device_code``, ``user_code``, ``verification_uri``,
+    ``expires_in``, and ``interval`` on success, or ``None`` on failure.
+    """
+    url = DEVICE_FLOW_CONFIG["device_code_url"].format(host=host)
+    payload = {
+        "client_id": DEVICE_FLOW_CONFIG["client_id"],
+        "scope": DEVICE_FLOW_CONFIG["scope"],
+    }
+    headers = {"Accept": "application/json"}
+    try:
+        resp = requests.post(url, data=payload, headers=headers, timeout=30)
+        if resp.status_code == 200:
+            data = resp.json()
+            if data.get("device_code") and data.get("user_code"):
+                return data
+            logger.warning("Device flow response missing required fields: %s", data)
+        else:
+            logger.warning(
+                "Device flow initiation failed: %s %s", resp.status_code, resp.text[:300]
+            )
+    except Exception as exc:
+        logger.warning("Device flow error: %s", exc)
+    return None
+
+
+def poll_for_token(
+    device_code: str,
+    host: str = "github.com",
+    interval: int = 5,
+    expires_in: int = 900,
+) -> Optional[str]:
+    """Poll GitHub until the user completes the Device Flow authorization.
+
+    Returns the OAuth ``access_token`` on success, or ``None`` on timeout/denial.
+    """
+    url = DEVICE_FLOW_CONFIG["access_token_url"].format(host=host)
+    payload = {
+        "client_id": DEVICE_FLOW_CONFIG["client_id"],
+        "device_code": device_code,
+        "grant_type": DEVICE_FLOW_CONFIG["grant_type"],
+    }
+    headers = {"Accept": "application/json"}
+
+    deadline = time.time() + expires_in
+    poll_interval = max(interval, DEVICE_FLOW_CONFIG["default_poll_interval"])
+
+    while time.time() < deadline:
+        time.sleep(poll_interval)
+        try:
+            resp = requests.post(url, data=payload, headers=headers, timeout=30)
+            data = resp.json() if resp.status_code == 200 else {}
+        except Exception as exc:
+            logger.warning("Device flow poll error: %s", exc)
+            continue
+
+        token = data.get("access_token")
+        if token:
+            return token
+
+        error = data.get("error", "")
+        if error == "authorization_pending":
+            continue
+        if error == "slow_down":
+            poll_interval += 5
+            continue
+        if error in ("expired_token", "access_denied", "unsupported_grant_type"):
+            logger.warning("Device flow denied or expired: %s", error)
+            return None
+        # Unknown error — keep trying until deadline
+        logger.debug("Device flow poll returned: %s", data)
+
+    return None
+
+
+def save_device_token(host: str, oauth_token: str, user: str = "") -> bool:
+    """Persist a token obtained via the Device Flow to disk."""
+    try:
+        path = get_device_token_storage_path()
+        data: Dict[str, Any] = {}
+        if path.exists():
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        data[host] = {
+            "oauth_token": oauth_token,
+            "user": user,
+            "created_at": time.time(),
+        }
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2)
+        path.chmod(0o600)
+        return True
+    except Exception as exc:
+        logger.error("Failed to save device token: %s", exc)
+        return False
+
+
+def load_device_tokens() -> List[CopilotToken]:
+    """Load tokens previously obtained via the Device Flow."""
+    tokens: List[CopilotToken] = []
+    try:
+        path = get_device_token_storage_path()
+        if not path.exists():
+            return tokens
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, dict):
+            for host, entry in data.items():
+                if not isinstance(entry, dict):
+                    continue
+                oauth_token = entry.get("oauth_token")
+                if oauth_token:
+                    tokens.append(
+                        CopilotToken(
+                            host=host,
+                            oauth_token=oauth_token,
+                            user=entry.get("user", ""),
+                        )
+                    )
+    except Exception as exc:
+        logger.warning("Failed to load device tokens: %s", exc)
+    return tokens
+
+
+# ---------------------------------------------------------------------------
+# Session token exchange — converts long-lived OAuth token → short-lived
+# Copilot API bearer token (typically valid ~30 min).
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SessionToken:
+    """A short-lived Copilot API session token."""
+
+    token: str
+    expires_at: float  # Unix timestamp
+    api_endpoint: str = ""  # API base URL from the token response (may differ per region/host)
+
+
+# Module-level cache keyed by (host, oauth_token[:16])
+_session_cache: Dict[str, SessionToken] = {}
+
+# Stores the API base URL returned by the most recent session-token exchange
+# per host, so that model registration can use it.
+_host_api_endpoints: Dict[str, str] = {}
+
+
+def _cache_key(oauth_token: str, host: str) -> str:
+    return f"{host}:{oauth_token[:16]}"
+
+
+def _token_endpoint(host: str) -> str:
+    """Return the Copilot session-token endpoint for the given host."""
+    if host == "github.com":
+        return COPILOT_AUTH_CONFIG["github_token_url"]
+    return COPILOT_AUTH_CONFIG["ghe_token_url_template"].format(host=host)
+
+
+def exchange_for_session_token(
+    oauth_token: str, host: str = "github.com"
+) -> Optional[SessionToken]:
+    """Exchange a GitHub OAuth token for a short-lived Copilot session token.
+
+    The response ``endpoints.api`` value is the correct API base URL for this
+    token and may differ from the default (e.g. regional or GHE deployments).
+    """
+    url = _token_endpoint(host)
+    headers = {
+        "Authorization": f"token {oauth_token}",
+        "Accept": "application/json",
+        "Editor-Version": COPILOT_AUTH_CONFIG["editor_version"],
+        "Editor-Plugin-Version": COPILOT_AUTH_CONFIG["editor_plugin_version"],
+        "Copilot-Integration-Id": COPILOT_AUTH_CONFIG["copilot_integration_id"],
+    }
+    try:
+        resp = requests.get(url, headers=headers, timeout=30)
+        if resp.status_code == 200:
+            data = resp.json()
+            token_str = data.get("token")
+            expires_at = data.get("expires_at", 0)
+            if token_str:
+                # Extract the API endpoint — the token is only valid against
+                # this specific URL. Falls back to the default if missing.
+                endpoints = data.get("endpoints") or {}
+                api_endpoint = (
+                    endpoints.get("api", "").rstrip("/")
+                    or COPILOT_AUTH_CONFIG["api_base_url"]
+                )
+                # Remember this for model registration
+                _host_api_endpoints[host] = api_endpoint
+                logger.debug(
+                    "Copilot session for %s: api_endpoint=%s", host, api_endpoint
+                )
+
+                st = SessionToken(
+                    token=token_str,
+                    expires_at=float(expires_at),
+                    api_endpoint=api_endpoint,
+                )
+                # Persist to disk so we survive process restarts within the window
+                _persist_session(st, host, oauth_token)
+                return st
+            logger.warning("Token endpoint returned 200 but no 'token' field")
+        elif resp.status_code == 401:
+            logger.warning(
+                "Copilot token exchange returned 401 — OAuth token may be revoked."
+            )
+        else:
+            logger.warning(
+                "Copilot token exchange failed: %s %s", resp.status_code, resp.text[:200]
+            )
+    except requests.exceptions.Timeout:
+        logger.warning("Timeout exchanging Copilot token for host %s", host)
+    except Exception as exc:
+        logger.warning("Copilot token exchange error: %s", exc)
+    return None
+
+
+def _persist_session(st: SessionToken, host: str, oauth_token: str = "") -> None:
+    """Write session token to disk for reuse after restarts.
+
+    Stores a fingerprint of the OAuth token so that a persisted session is
+    only reused when the same OAuth token is still active.
+    """
+    try:
+        path = get_session_cache_path()
+        data: Dict[str, Any] = {}
+        if path.exists():
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        data[host] = {
+            "token": st.token,
+            "expires_at": st.expires_at,
+            "api_endpoint": st.api_endpoint,
+            "oauth_fingerprint": oauth_token[:16] if oauth_token else "",
+        }
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2)
+        path.chmod(0o600)
+    except Exception as exc:
+        logger.debug("Could not persist session token: %s", exc)
+
+
+def _load_persisted_session(host: str, oauth_token: str = "") -> Optional[SessionToken]:
+    """Load a previously persisted session token from disk.
+
+    If *oauth_token* is provided, the persisted entry is only returned when
+    its stored fingerprint matches ``oauth_token[:16]``, preventing
+    cross-account reuse after a re-login.
+    """
+    try:
+        path = get_session_cache_path()
+        if not path.exists():
+            return None
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        entry = data.get(host)
+        if entry:
+            # Verify the stored fingerprint matches the current OAuth token
+            stored_fp = entry.get("oauth_fingerprint", "")
+            if oauth_token and stored_fp and stored_fp != oauth_token[:16]:
+                logger.debug("Persisted session fingerprint mismatch for %s — skipping", host)
+                return None
+
+            api_endpoint = entry.get("api_endpoint", COPILOT_AUTH_CONFIG["api_base_url"])
+            # Restore the host→endpoint mapping
+            if api_endpoint:
+                _host_api_endpoints[host] = api_endpoint
+            return SessionToken(
+                token=entry["token"],
+                expires_at=float(entry["expires_at"]),
+                api_endpoint=api_endpoint,
+            )
+    except Exception as exc:
+        logger.debug("Could not load persisted session: %s", exc)
+    return None
+
+
+def get_valid_session_token(
+    oauth_token: str, host: str = "github.com"
+) -> Optional[str]:
+    """Return a valid Copilot session token, refreshing if needed.
+
+    Checks in-memory cache → on-disk cache → exchanges for a new one.
+    Returns the raw bearer token string or ``None``.
+    """
+    key = _cache_key(oauth_token, host)
+
+    # 1) In-memory cache
+    cached = _session_cache.get(key)
+    if cached and cached.expires_at > time.time() + 60:
+        # Ensure host→endpoint mapping is populated
+        if cached.api_endpoint:
+            _host_api_endpoints[host] = cached.api_endpoint
+        return cached.token
+
+    # 2) On-disk cache (with fingerprint verification)
+    persisted = _load_persisted_session(host, oauth_token)
+    if persisted and persisted.expires_at > time.time() + 60:
+        _session_cache[key] = persisted
+        return persisted.token
+
+    # 3) Exchange
+    new_token = exchange_for_session_token(oauth_token, host)
+    if new_token:
+        _session_cache[key] = new_token
+        return new_token.token
+
+    return None
+
+
+def get_api_endpoint_for_host(host: str) -> str:
+    """Return the Copilot API base URL for the given host.
+
+    The correct endpoint is discovered during session-token exchange
+    (the ``endpoints.api`` field in the response).  Falls back to the
+    default ``api.githubcopilot.com`` if no exchange has happened yet.
+    """
+    return _host_api_endpoints.get(host, COPILOT_AUTH_CONFIG["api_base_url"])
+
+
+def clear_caches() -> None:
+    """Reset all in-memory session and endpoint caches.
+
+    Called by ``/copilot-logout`` to ensure no stale Copilot state remains.
+    """
+    _session_cache.clear()
+    _host_api_endpoints.clear()
+
+
+# ---------------------------------------------------------------------------
+# Model persistence — copilot_models.json
+# ---------------------------------------------------------------------------
+
+def load_copilot_models() -> Dict[str, Any]:
+    """Load registered Copilot models from copilot_models.json."""
+    try:
+        path = get_copilot_models_path()
+        if path.exists():
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if isinstance(data, dict):
+                return data
+            logger.warning("copilot_models.json is not a JSON object — ignoring")
+    except Exception as exc:
+        logger.error("Failed to load Copilot models: %s", exc)
+    return {}
+
+
+def save_copilot_models(models: Dict[str, Any]) -> bool:
+    """Persist Copilot models to copilot_models.json."""
+    try:
+        path = get_copilot_models_path()
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(models, fh, indent=2)
+        return True
+    except Exception as exc:
+        logger.error("Failed to save Copilot models: %s", exc)
+    return False
+
+
+def remove_copilot_models() -> int:
+    """Remove all Copilot-sourced models from copilot_models.json."""
+    try:
+        models = load_copilot_models()
+        to_remove = [
+            name
+            for name, cfg in models.items()
+            if cfg.get("oauth_source") == "copilot-auth-plugin"
+        ]
+        for name in to_remove:
+            models.pop(name, None)
+        if save_copilot_models(models):
+            return len(to_remove)
+    except Exception as exc:
+        logger.error("Error removing Copilot models: %s", exc)
+    return 0
+
+
+def fetch_copilot_models(
+    session_token: str, host: str = "github.com"
+) -> List[str]:
+    """Try to fetch the model catalogue from the Copilot API.
+
+    Falls back to ``DEFAULT_COPILOT_MODELS`` if the endpoint is unavailable.
+    Uses the host-specific API endpoint discovered during token exchange.
+    """
+    api_base = get_api_endpoint_for_host(host)
+    url = f"{api_base}/models"
+    headers = {
+        "Authorization": f"Bearer {session_token}",
+        "Accept": "application/json",
+        "Editor-Version": COPILOT_AUTH_CONFIG["editor_version"],
+        "Editor-Plugin-Version": COPILOT_AUTH_CONFIG["editor_plugin_version"],
+        "Copilot-Integration-Id": COPILOT_AUTH_CONFIG["copilot_integration_id"],
+        "Openai-Intent": COPILOT_AUTH_CONFIG["openai_intent"],
+    }
+    try:
+        resp = requests.get(url, headers=headers, timeout=15)
+        if resp.status_code == 200:
+            data = resp.json()
+            model_list = data.get("data") or data.get("models") or []
+            if isinstance(model_list, list):
+                ids = []
+                for m in model_list:
+                    if isinstance(m, dict):
+                        mid = m.get("id") or m.get("name")
+                        if mid:
+                            ids.append(mid)
+                    elif isinstance(m, str):
+                        ids.append(m)
+                if ids:
+                    logger.info("Fetched %d models from Copilot API", len(ids))
+                    return ids
+    except Exception as exc:
+        logger.debug("Could not fetch Copilot model list: %s", exc)
+
+    logger.info("Using default Copilot model list")
+    return DEFAULT_COPILOT_MODELS
+
+
+def _is_claude_model(model_name: str) -> bool:
+    """Check if a model name refers to a Claude/Anthropic model."""
+    return model_name.lower().startswith("claude-")
+
+
+def _is_openai_model(model_name: str) -> bool:
+    """Check if a model name refers to an OpenAI/GPT model."""
+    lower = model_name.lower()
+    return (
+        lower.startswith("gpt-")
+        or lower.startswith("o3")
+        or lower.startswith("o4")
+    )
+
+
+def _build_claude_model_settings(model_name: str) -> Dict[str, Any]:
+    """Build model_settings fields for a Claude model.
+
+    Mirrors the conventions in the claude_code_oauth plugin's
+    ``_build_model_entry``.
+    """
+    supported_settings = [
+        "temperature",
+        "extended_thinking",
+        "budget_tokens",
+        "interleaved_thinking",
+    ]
+
+    # Opus 4-6 (e.g. claude-opus-4.6) supports the effort setting,
+    # same as the claude_code_oauth plugin.
+    lower = model_name.lower()
+    if "opus-4.6" in lower or "opus-4-6" in lower or "4-6-opus" in lower:
+        supported_settings.append("effort")
+
+    return {"supported_settings": supported_settings}
+
+
+def _build_openai_model_settings(model_name: str) -> Dict[str, Any]:
+    """Build model_settings fields for an OpenAI/GPT model behind Copilot.
+
+    The Copilot API only proxies a subset of OpenAI features.  Currently
+    none of the GPT models exposed through Copilot support
+    ``reasoning_effort``, ``summary``, or ``verbosity`` — sending those
+    parameters results in a 400 Bad Request.  Only basic ``temperature``
+    is safe.
+    """
+    return {"supported_settings": ["temperature"]}
+
+
+def _model_settings_for(model_name: str) -> Dict[str, Any]:
+    """Return family-specific config fields for a Copilot model.
+
+    Claude models get extended_thinking/effort/etc.; OpenAI models get
+    reasoning_effort/summary/verbosity; everything else gets temperature.
+    """
+    if _is_claude_model(model_name):
+        return _build_claude_model_settings(model_name)
+    if _is_openai_model(model_name):
+        return _build_openai_model_settings(model_name)
+    # Fallback for other providers (Gemini, etc.)
+    return {"supported_settings": ["temperature"]}
+
+
+def add_models_to_config(
+    models: List[str],
+    host: str = "github.com",
+) -> bool:
+    """Register Copilot models in copilot_models.json."""
+    try:
+        copilot_models = load_copilot_models()
+        added = 0
+        prefix = COPILOT_AUTH_CONFIG["prefix"]
+        # Use the API endpoint from session-token exchange (critical for GHE).
+        api_url = get_api_endpoint_for_host(host)
+        for model_name in models:
+            prefixed = f"{prefix}{model_name}"
+            entry: Dict[str, Any] = {
+                "type": "copilot",
+                "name": model_name,
+                "custom_endpoint": {
+                    "url": api_url,
+                },
+                "context_length": COPILOT_MODEL_CONTEXT_LENGTHS.get(
+                    model_name,
+                    COPILOT_AUTH_CONFIG["default_context_length"],
+                ),
+                "copilot_host": host,
+                "oauth_source": "copilot-auth-plugin",
+            }
+            # Merge family-specific settings (supported_settings, etc.)
+            entry.update(_model_settings_for(model_name))
+            copilot_models[prefixed] = entry
+            added += 1
+        if save_copilot_models(copilot_models):
+            logger.info("Registered %d Copilot models (api: %s)", added, api_url)
+            return True
+    except Exception as exc:
+        logger.error("Error adding Copilot models to config: %s", exc)
+    return False
+

--- a/tests/plugins/test_copilot_auth_model.py
+++ b/tests/plugins/test_copilot_auth_model.py
@@ -1,0 +1,401 @@
+"""Tests for the copilot_auth plugin's _create_copilot_model and _CopilotAuth.
+
+Verifies that the dynamic token refresh auth flow correctly refreshes
+the Copilot session token before every HTTP request, preventing the
+30-minute token expiry issue during long-running conversations.
+"""
+
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FakeCopilotToken:
+    host: str
+    oauth_token: str
+    user: str = ""
+
+
+FAKE_CONFIG = {
+    "editor_version": "JetBrains-IU/2024.3",
+    "editor_plugin_version": "copilot/2.0.0",
+    "copilot_integration_id": "vscode-chat",
+    "openai_intent": "conversation-panel",
+    "api_base_url": "https://api.githubcopilot.com",
+    "prefix": "copilot-",
+}
+
+
+def _model_config(name: str = "gpt-4o", host: str = "github.com") -> dict:
+    return {
+        "name": name,
+        "copilot_host": host,
+        "custom_endpoint": {"url": "https://custom.example.com/v1"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# _CopilotAuth auth flow tests
+# ---------------------------------------------------------------------------
+
+class TestCopilotAuth:
+    """Test the _CopilotAuth httpx.Auth subclass injected per-request."""
+
+    def _make_auth(self, oauth_token: str = "ghp_fake123", host: str = "github.com"):
+        """Import and instantiate _CopilotAuth from within _create_copilot_model's closure.
+
+        Since _CopilotAuth is defined inside _create_copilot_model, we replicate
+        it here for direct unit testing.  The integration test below validates
+        the real wiring.
+        """
+        import httpx as _httpx
+
+        from code_puppy.plugins.copilot_auth.utils import get_valid_session_token
+
+        class _CopilotAuth(_httpx.Auth):
+            def __init__(self, oauth_token: str, token_host: str):
+                self._oauth_token = oauth_token
+                self._host = token_host
+
+            def auth_flow(self, request: _httpx.Request):
+                token = get_valid_session_token(self._oauth_token, self._host)
+                if token:
+                    request.headers["Authorization"] = f"Bearer {token}"
+                yield request
+
+        return _CopilotAuth(oauth_token, host)
+
+    @patch("code_puppy.plugins.copilot_auth.utils.get_valid_session_token")
+    def test_auth_flow_sets_authorization_header(self, mock_get_token):
+        """Auth flow should set Authorization header with fresh session token."""
+        mock_get_token.return_value = "fresh_session_token_abc"
+
+        auth = self._make_auth("ghp_oauth_token", "github.com")
+        request = httpx.Request("POST", "https://api.githubcopilot.com/chat/completions")
+
+        # Exhaust the generator (httpx auth_flow protocol)
+        flow = auth.auth_flow(request)
+        modified_request = next(flow)
+
+        assert modified_request.headers["Authorization"] == "Bearer fresh_session_token_abc"
+        mock_get_token.assert_called_once_with("ghp_oauth_token", "github.com")
+
+    @patch("code_puppy.plugins.copilot_auth.utils.get_valid_session_token")
+    def test_auth_flow_skips_header_when_token_is_none(self, mock_get_token):
+        """Auth flow should not set Authorization if get_valid_session_token returns None."""
+        mock_get_token.return_value = None
+
+        auth = self._make_auth("ghp_dead_token", "github.com")
+        request = httpx.Request("POST", "https://api.githubcopilot.com/chat/completions")
+
+        flow = auth.auth_flow(request)
+        modified_request = next(flow)
+
+        assert "Authorization" not in modified_request.headers
+        mock_get_token.assert_called_once()
+
+    @patch("code_puppy.plugins.copilot_auth.utils.get_valid_session_token")
+    def test_auth_flow_refreshes_on_every_call(self, mock_get_token):
+        """Each request should trigger a fresh get_valid_session_token call."""
+        mock_get_token.side_effect = ["token_1", "token_2", "token_3"]
+
+        auth = self._make_auth()
+
+        for i, expected in enumerate(["token_1", "token_2", "token_3"], 1):
+            request = httpx.Request("POST", "https://api.githubcopilot.com/chat/completions")
+            flow = auth.auth_flow(request)
+            modified = next(flow)
+            assert modified.headers["Authorization"] == f"Bearer {expected}"
+
+        assert mock_get_token.call_count == 3
+
+    @patch("code_puppy.plugins.copilot_auth.utils.get_valid_session_token")
+    def test_auth_flow_passes_correct_host(self, mock_get_token):
+        """Auth flow should pass the configured host to get_valid_session_token."""
+        mock_get_token.return_value = "ghe_token"
+
+        auth = self._make_auth("ghp_enterprise", "github.enterprise.com")
+        request = httpx.Request("POST", "https://api.githubcopilot.com/chat/completions")
+
+        flow = auth.auth_flow(request)
+        next(flow)
+
+        mock_get_token.assert_called_once_with("ghp_enterprise", "github.enterprise.com")
+
+
+# ---------------------------------------------------------------------------
+# _create_copilot_model integration tests
+# ---------------------------------------------------------------------------
+
+class TestCreateCopilotModel:
+    """Test the _create_copilot_model factory function."""
+
+    MODULE = "code_puppy.plugins.copilot_auth.register_callbacks"
+
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_token_for_host")
+    def test_returns_none_when_no_token(self, mock_get_token):
+        """Should return None and warn when no Copilot token is available."""
+        mock_get_token.return_value = None
+
+        from code_puppy.plugins.copilot_auth.register_callbacks import (
+            _create_copilot_model,
+        )
+
+        with patch(f"{self.MODULE}.emit_warning") as mock_warn:
+            result = _create_copilot_model("copilot-gpt-4o", _model_config(), {})
+
+        assert result is None
+        mock_warn.assert_called_once()
+        assert "No Copilot token" in mock_warn.call_args[0][0]
+
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_valid_session_token")
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_token_for_host")
+    def test_returns_none_when_session_token_fails(self, mock_get_token, mock_session):
+        """Should return None when session token exchange fails."""
+        mock_get_token.return_value = FakeCopilotToken(
+            host="github.com", oauth_token="ghp_test"
+        )
+        mock_session.return_value = None
+
+        from code_puppy.plugins.copilot_auth.register_callbacks import (
+            _create_copilot_model,
+        )
+
+        with patch(f"{self.MODULE}.emit_warning") as mock_warn:
+            result = _create_copilot_model("copilot-gpt-4o", _model_config(), {})
+
+        assert result is None
+        mock_warn.assert_called_once()
+        assert "session token" in mock_warn.call_args[0][0]
+
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_api_endpoint_for_host")
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_valid_session_token")
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_token_for_host")
+    def test_creates_model_with_dynamic_auth(
+        self, mock_get_token, mock_session, mock_endpoint
+    ):
+        """Should create an OpenAIChatModel with _CopilotAuth attached to the client."""
+        mock_get_token.return_value = FakeCopilotToken(
+            host="github.com", oauth_token="ghp_real"
+        )
+        mock_session.return_value = "initial_session_token"
+        mock_endpoint.return_value = "https://api.githubcopilot.com"
+
+        from code_puppy.plugins.copilot_auth.register_callbacks import (
+            _create_copilot_model,
+        )
+
+        config = _model_config()
+        result = _create_copilot_model("copilot-gpt-4o", config, {})
+
+        assert result is not None
+        # Verify the model was created
+        assert hasattr(result, "provider")
+
+        # Verify the HTTP client has auth attached
+        # provider.client is AsyncOpenAI; provider.client._client is the httpx client
+        http_client = result.provider.client._client
+        assert http_client.auth is not None
+        # The auth should be an instance of the inner _CopilotAuth class
+        assert hasattr(http_client.auth, "_oauth_token")
+        assert http_client.auth._oauth_token == "ghp_real"
+        assert http_client.auth._host == "github.com"
+
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_api_endpoint_for_host")
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_valid_session_token")
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_token_for_host")
+    def test_provider_uses_placeholder_api_key(
+        self, mock_get_token, mock_session, mock_endpoint
+    ):
+        """Provider should use a placeholder API key, not the session token."""
+        mock_get_token.return_value = FakeCopilotToken(
+            host="github.com", oauth_token="ghp_real"
+        )
+        mock_session.return_value = "session_token_that_expires"
+        mock_endpoint.return_value = "https://api.githubcopilot.com"
+
+        from code_puppy.plugins.copilot_auth.register_callbacks import (
+            _create_copilot_model,
+        )
+
+        result = _create_copilot_model("copilot-gpt-4o", _model_config(), {})
+        assert result is not None
+
+        # The provider should NOT have the session token baked in as api_key.
+        # The api_key lives on the AsyncOpenAI client inside the provider.
+        assert result.provider.client.api_key == "copilot-session-managed"
+
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_api_endpoint_for_host")
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_valid_session_token")
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_token_for_host")
+    def test_falls_back_to_config_url(
+        self, mock_get_token, mock_session, mock_endpoint
+    ):
+        """Should use custom_endpoint URL when api endpoint matches default."""
+        mock_get_token.return_value = FakeCopilotToken(
+            host="github.com", oauth_token="ghp_real"
+        )
+        mock_session.return_value = "tok"
+        # Return the default — triggers fallback to config URL
+        mock_endpoint.return_value = FAKE_CONFIG["api_base_url"]
+
+        from code_puppy.plugins.copilot_auth.register_callbacks import (
+            _create_copilot_model,
+        )
+
+        config = _model_config()
+        result = _create_copilot_model("copilot-gpt-4o", config, {})
+        assert result is not None
+
+        # Should have fallen back to the custom_endpoint URL
+        provider = result.provider
+        assert "custom.example.com" in str(provider.base_url)
+
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_api_endpoint_for_host")
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_valid_session_token")
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_token_for_host")
+    def test_uses_discovered_endpoint(
+        self, mock_get_token, mock_session, mock_endpoint
+    ):
+        """Should use the discovered endpoint when it differs from default."""
+        mock_get_token.return_value = FakeCopilotToken(
+            host="github.com", oauth_token="ghp_real"
+        )
+        mock_session.return_value = "tok"
+        mock_endpoint.return_value = "https://copilot-proxy.us-east.com"
+
+        from code_puppy.plugins.copilot_auth.register_callbacks import (
+            _create_copilot_model,
+        )
+
+        result = _create_copilot_model("copilot-gpt-4o", _model_config(), {})
+        assert result is not None
+
+        provider = result.provider
+        assert "copilot-proxy.us-east.com" in str(provider.base_url)
+
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_api_endpoint_for_host")
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_valid_session_token")
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_token_for_host")
+    def test_client_has_copilot_headers(
+        self, mock_get_token, mock_session, mock_endpoint
+    ):
+        """HTTP client should include Copilot-specific headers."""
+        mock_get_token.return_value = FakeCopilotToken(
+            host="github.com", oauth_token="ghp_real"
+        )
+        mock_session.return_value = "tok"
+        mock_endpoint.return_value = "https://api.githubcopilot.com"
+
+        from code_puppy.plugins.copilot_auth.register_callbacks import (
+            _create_copilot_model,
+        )
+
+        result = _create_copilot_model("copilot-gpt-4o", _model_config(), {})
+        assert result is not None
+
+        client = result.provider.client._client
+        client_headers = dict(client.headers)
+
+        assert client_headers.get("editor-version") == FAKE_CONFIG["editor_version"]
+        assert client_headers.get("editor-plugin-version") == FAKE_CONFIG["editor_plugin_version"]
+        assert client_headers.get("copilot-integration-id") == FAKE_CONFIG["copilot_integration_id"]
+        assert client_headers.get("openai-intent") == FAKE_CONFIG["openai_intent"]
+
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_api_endpoint_for_host")
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_valid_session_token")
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_token_for_host")
+    def test_ghe_host_is_passed_through(
+        self, mock_get_token, mock_session, mock_endpoint
+    ):
+        """Should pass GHE host through to token lookups and auth."""
+        ghe_host = "github.enterprise.corp"
+        mock_get_token.return_value = FakeCopilotToken(
+            host=ghe_host, oauth_token="ghp_ghe"
+        )
+        mock_session.return_value = "ghe_session"
+        mock_endpoint.return_value = "https://copilot-proxy.enterprise.corp"
+
+        from code_puppy.plugins.copilot_auth.register_callbacks import (
+            _create_copilot_model,
+        )
+
+        config = _model_config(host=ghe_host)
+        result = _create_copilot_model("copilot-gpt-4o", config, {})
+        assert result is not None
+
+        mock_get_token.assert_called_once_with(ghe_host)
+        mock_session.assert_called_once_with("ghp_ghe", ghe_host)
+
+        # Auth should use the GHE host
+        auth = result.provider.client._client.auth
+        assert auth._host == ghe_host
+
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_api_endpoint_for_host")
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_valid_session_token")
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_token_for_host")
+    def test_claude_model_has_interleaved_thinking_profile(
+        self, mock_get_token, mock_session, mock_endpoint
+    ):
+        """Claude models should send thinking parts back via field mode.
+
+        This ensures interleaved thinking works across tool calls —
+        without it, thinking only appears on the first response.
+        """
+        mock_get_token.return_value = FakeCopilotToken(
+            host="github.com", oauth_token="ghp_real"
+        )
+        mock_session.return_value = "tok"
+        mock_endpoint.return_value = "https://api.githubcopilot.com"
+
+        from code_puppy.plugins.copilot_auth.register_callbacks import (
+            _create_copilot_model,
+        )
+
+        # Claude underlying model — should get thinking profile
+        config = _model_config(name="claude-sonnet-4")
+        result = _create_copilot_model("copilot-claude-sonnet-4", config, {})
+        assert result is not None
+
+        from pydantic_ai.profiles.openai import OpenAIModelProfile
+
+        profile = OpenAIModelProfile.from_profile(result.profile)
+        assert profile.openai_chat_thinking_field == "reasoning_text"
+        assert profile.openai_supports_reasoning is True
+        # Must be 'field' — NOT False — so thinking persists across tool calls
+        assert profile.openai_chat_send_back_thinking_parts == "field"
+
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_api_endpoint_for_host")
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_valid_session_token")
+    @patch(f"code_puppy.plugins.copilot_auth.register_callbacks.get_token_for_host")
+    def test_non_claude_model_has_no_thinking_profile(
+        self, mock_get_token, mock_session, mock_endpoint
+    ):
+        """Non-Claude models (e.g. GPT) should NOT get a thinking profile."""
+        mock_get_token.return_value = FakeCopilotToken(
+            host="github.com", oauth_token="ghp_real"
+        )
+        mock_session.return_value = "tok"
+        mock_endpoint.return_value = "https://api.githubcopilot.com"
+
+        from code_puppy.plugins.copilot_auth.register_callbacks import (
+            _create_copilot_model,
+        )
+
+        # GPT model — should NOT get a custom thinking profile
+        config = _model_config(name="gpt-4o")
+        result = _create_copilot_model("copilot-gpt-4o", config, {})
+        assert result is not None
+
+        from pydantic_ai.profiles.openai import OpenAIModelProfile
+
+        profile = OpenAIModelProfile.from_profile(result.profile)
+        # No thinking field should be configured for GPT models
+        assert profile.openai_chat_thinking_field is None

--- a/tests/plugins/test_copilot_reasoning_client.py
+++ b/tests/plugins/test_copilot_reasoning_client.py
@@ -1,0 +1,747 @@
+"""Tests for the reasoning_opaque round-trip interceptor.
+
+Verifies that reasoning_client.py correctly:
+- Captures reasoning_opaque from streaming SSE responses
+- Captures reasoning_opaque from non-streaming responses
+- Injects reasoning_opaque into outgoing request bodies
+- Handles edge cases gracefully (malformed JSON, missing fields, etc.)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from code_puppy.plugins.copilot_auth.reasoning_client import (
+    _MAX_CACHE_ENTRIES,
+    _OpaqueCapturingStream,
+    _capture_from_content,
+    _inject_opaque_into_request,
+    _strip_all_reasoning_fields,
+    _text_key,
+    patch_client_for_reasoning_opaque,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sse_line(data: dict) -> bytes:
+    return f"data: {json.dumps(data)}\n\n".encode()
+
+
+def _sse_done() -> bytes:
+    return b"data: [DONE]\n\n"
+
+
+def _make_streaming_event(
+    reasoning_text: str | None = None,
+    reasoning_opaque: str | None = None,
+    finish_reason: str | None = None,
+) -> dict:
+    delta: dict = {}
+    if reasoning_text is not None:
+        delta["reasoning_text"] = reasoning_text
+    if reasoning_opaque is not None:
+        delta["reasoning_opaque"] = reasoning_opaque
+    choice: dict = {"delta": delta, "index": 0}
+    if finish_reason:
+        choice["finish_reason"] = finish_reason
+    return {"choices": [choice]}
+
+
+def _make_non_streaming_response(
+    reasoning_text: str,
+    reasoning_opaque: str,
+) -> bytes:
+    return json.dumps({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": "Hello!",
+                "reasoning_text": reasoning_text,
+                "reasoning_opaque": reasoning_opaque,
+            }
+        }]
+    }).encode()
+
+
+def _make_request_body(messages: list[dict]) -> bytes:
+    return json.dumps({"model": "claude-sonnet-4", "messages": messages}).encode()
+
+
+class FakeAsyncStream:
+    """Minimal async-iterable that yields byte chunks."""
+
+    def __init__(self, chunks: list[bytes]):
+        self._chunks = chunks
+
+    def __aiter__(self):
+        return self._iter()
+
+    async def _iter(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+# ---------------------------------------------------------------------------
+# _text_key
+# ---------------------------------------------------------------------------
+
+class TestTextKey:
+    def test_deterministic(self):
+        assert _text_key("hello") == _text_key("hello")
+
+    def test_different_inputs_differ(self):
+        assert _text_key("hello") != _text_key("world")
+
+    def test_returns_32_chars(self):
+        assert len(_text_key("anything")) == 32
+
+
+# ---------------------------------------------------------------------------
+# _OpaqueCapturingStream
+# ---------------------------------------------------------------------------
+
+class TestOpaqueCapturingStream:
+    @pytest.mark.asyncio
+    async def test_captures_opaque_from_streaming_deltas(self):
+        cache: dict[str, str] = {}
+        chunks = [
+            _sse_line(_make_streaming_event(reasoning_text="Think")),
+            _sse_line(_make_streaming_event(reasoning_text="ing...")),
+            _sse_line(_make_streaming_event(reasoning_opaque="opaque_part1")),
+            _sse_line(_make_streaming_event(reasoning_opaque="_part2")),
+            _sse_line(_make_streaming_event(finish_reason="stop")),
+            _sse_done(),
+        ]
+        inner = FakeAsyncStream(chunks)
+        wrapper = _OpaqueCapturingStream(inner, cache, "reasoning_text")
+
+        collected = []
+        async for chunk in wrapper:
+            collected.append(chunk)
+
+        # All bytes pass through unchanged
+        assert collected == chunks
+
+        # Opaque was captured, keyed by the full text
+        key = _text_key("Thinking...")
+        assert key in cache
+        assert cache[key] == "opaque_part1_part2"
+
+    @pytest.mark.asyncio
+    async def test_passthrough_when_no_opaque(self):
+        cache: dict[str, str] = {}
+        chunks = [
+            _sse_line(_make_streaming_event(reasoning_text="Just thinking")),
+            _sse_line(_make_streaming_event(finish_reason="stop")),
+            _sse_done(),
+        ]
+        inner = FakeAsyncStream(chunks)
+        wrapper = _OpaqueCapturingStream(inner, cache, "reasoning_text")
+
+        async for _ in wrapper:
+            pass
+
+        # No opaque data → nothing cached
+        assert cache == {}
+
+    @pytest.mark.asyncio
+    async def test_handles_malformed_json_gracefully(self):
+        cache: dict[str, str] = {}
+        chunks = [
+            b"data: {invalid json}\n\n",
+            _sse_line(_make_streaming_event(reasoning_text="OK")),
+            _sse_line(_make_streaming_event(reasoning_opaque="opq")),
+            _sse_line(_make_streaming_event(finish_reason="stop")),
+        ]
+        inner = FakeAsyncStream(chunks)
+        wrapper = _OpaqueCapturingStream(inner, cache, "reasoning_text")
+
+        collected = []
+        async for chunk in wrapper:
+            collected.append(chunk)
+
+        # Should still capture from valid events
+        assert _text_key("OK") in cache
+
+    @pytest.mark.asyncio
+    async def test_aclose_flushes_remaining(self):
+        cache: dict[str, str] = {}
+        chunks = [
+            _sse_line(_make_streaming_event(reasoning_text="partial")),
+            _sse_line(_make_streaming_event(reasoning_opaque="opq_data")),
+            # No finish_reason, no [DONE] — simulates abrupt close
+        ]
+        inner = FakeAsyncStream(chunks)
+        wrapper = _OpaqueCapturingStream(inner, cache, "reasoning_text")
+
+        async for _ in wrapper:
+            pass
+        # The finally in _iter_impl calls _flush after iteration
+
+        assert _text_key("partial") in cache
+        assert cache[_text_key("partial")] == "opq_data"
+
+
+# ---------------------------------------------------------------------------
+# _capture_from_content (non-streaming)
+# ---------------------------------------------------------------------------
+
+class TestCaptureFromContent:
+    def test_captures_from_non_streaming_response(self):
+        cache: dict[str, str] = {}
+        content = _make_non_streaming_response("My thoughts", "encrypted_blob")
+        _capture_from_content(content, cache, "reasoning_text")
+
+        key = _text_key("My thoughts")
+        assert key in cache
+        assert cache[key] == "encrypted_blob"
+
+    def test_ignores_response_without_opaque(self):
+        cache: dict[str, str] = {}
+        content = json.dumps({
+            "choices": [{"message": {"reasoning_text": "thoughts"}}]
+        }).encode()
+        _capture_from_content(content, cache, "reasoning_text")
+        assert cache == {}
+
+    def test_handles_bad_json(self):
+        cache: dict[str, str] = {}
+        _capture_from_content(b"not json", cache, "reasoning_text")
+        assert cache == {}
+
+
+# ---------------------------------------------------------------------------
+# _inject_opaque_into_request
+# ---------------------------------------------------------------------------
+
+class TestInjectOpaqueIntoRequest:
+    def test_injects_opaque_for_matching_assistant_message(self):
+        thinking_text = "I'm thinking deeply"
+        cache = {_text_key(thinking_text): "encrypted_opaque_data"}
+
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "reasoning_text": thinking_text, "content": "Hello!"},
+        ]
+        body = _make_request_body(messages)
+        request = httpx.Request("POST", "https://api.example.com/v1/chat/completions", content=body)
+
+        client = httpx.AsyncClient()
+        _inject_opaque_into_request(request, cache, client, "reasoning_text")
+
+        result_body = json.loads(request.content)
+        assistant_msg = result_body["messages"][1]
+        assert assistant_msg["reasoning_opaque"] == "encrypted_opaque_data"
+
+    def test_skips_messages_that_already_have_opaque(self):
+        thinking_text = "Some thoughts"
+        cache = {_text_key(thinking_text): "new_opaque"}
+
+        messages = [
+            {
+                "role": "assistant",
+                "reasoning_text": thinking_text,
+                "reasoning_opaque": "original_opaque",
+                "content": "Hi",
+            },
+        ]
+        body = _make_request_body(messages)
+        request = httpx.Request("POST", "https://api.example.com/v1/chat/completions", content=body)
+
+        client = httpx.AsyncClient()
+        _inject_opaque_into_request(request, cache, client, "reasoning_text")
+
+        result_body = json.loads(request.content)
+        # Should NOT overwrite existing opaque
+        assert result_body["messages"][0]["reasoning_opaque"] == "original_opaque"
+
+    def test_no_op_for_non_assistant_messages(self):
+        cache = {_text_key("stuff"): "opaque"}
+        messages = [{"role": "user", "content": "Hi", "reasoning_text": "stuff"}]
+        body = _make_request_body(messages)
+        request = httpx.Request("POST", "https://api.example.com/v1/chat/completions", content=body)
+
+        original_content = request.content
+        client = httpx.AsyncClient()
+        _inject_opaque_into_request(request, cache, client, "reasoning_text")
+
+        # Content should be unchanged (user messages don't get opaque)
+        assert request.content == original_content
+
+    def test_strips_reasoning_text_on_cache_miss(self):
+        """When no opaque is cached, reasoning_text is stripped to prevent 400."""
+        cache: dict[str, str] = {}
+        messages = [
+            {"role": "assistant", "reasoning_text": "unknown thoughts", "content": "Hi"},
+        ]
+        body = _make_request_body(messages)
+        request = httpx.Request("POST", "https://api.example.com/v1/chat/completions", content=body)
+
+        client = httpx.AsyncClient()
+        _inject_opaque_into_request(request, cache, client, "reasoning_text")
+
+        result_body = json.loads(request.content)
+        # reasoning_text should have been stripped
+        assert "reasoning_text" not in result_body["messages"][0]
+        # content should still be there
+        assert result_body["messages"][0]["content"] == "Hi"
+
+    def test_handles_empty_body_gracefully(self):
+        cache = {_text_key("x"): "y"}
+        request = httpx.Request("POST", "https://api.example.com/v1/chat/completions")
+        client = httpx.AsyncClient()
+        # Should not raise
+        _inject_opaque_into_request(request, cache, client, "reasoning_text")
+
+    def test_handles_non_json_body_gracefully(self):
+        cache = {_text_key("x"): "y"}
+        request = httpx.Request(
+            "POST", "https://api.example.com/v1/chat/completions",
+            content=b"not json",
+        )
+        client = httpx.AsyncClient()
+        _inject_opaque_into_request(request, cache, client, "reasoning_text")
+
+
+# ---------------------------------------------------------------------------
+# _strip_all_reasoning_fields (recovery layer)
+# ---------------------------------------------------------------------------
+
+class TestStripAllReasoningFields:
+    def test_strips_both_fields_from_assistant_messages(self):
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {
+                "role": "assistant",
+                "content": "Hello!",
+                "reasoning_text": "some thoughts",
+                "reasoning_opaque": "encrypted_blob",
+            },
+            {"role": "user", "content": "How?"},
+            {
+                "role": "assistant",
+                "content": "Like this.",
+                "reasoning_text": "more thoughts",
+            },
+        ]
+        body = _make_request_body(messages)
+        request = httpx.Request("POST", "https://api.example.com/v1/chat/completions", content=body)
+        client = httpx.AsyncClient()
+
+        result = _strip_all_reasoning_fields(request, client, "reasoning_text")
+
+        assert result is True
+        result_body = json.loads(request.content)
+        for msg in result_body["messages"]:
+            assert "reasoning_text" not in msg
+            assert "reasoning_opaque" not in msg
+        # Content should be preserved
+        assert result_body["messages"][1]["content"] == "Hello!"
+        assert result_body["messages"][3]["content"] == "Like this."
+
+    def test_returns_false_when_nothing_to_strip(self):
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        body = _make_request_body(messages)
+        request = httpx.Request("POST", "https://api.example.com/v1/chat/completions", content=body)
+        client = httpx.AsyncClient()
+
+        result = _strip_all_reasoning_fields(request, client, "reasoning_text")
+        assert result is False
+
+    def test_does_not_touch_user_messages(self):
+        messages = [
+            {"role": "user", "content": "Hi", "reasoning_text": "sneaky"},
+        ]
+        body = _make_request_body(messages)
+        request = httpx.Request("POST", "https://api.example.com/v1/chat/completions", content=body)
+        client = httpx.AsyncClient()
+
+        result = _strip_all_reasoning_fields(request, client, "reasoning_text")
+        assert result is False
+
+    def test_handles_empty_body(self):
+        request = httpx.Request("POST", "https://api.example.com/v1/chat/completions")
+        client = httpx.AsyncClient()
+        result = _strip_all_reasoning_fields(request, client, "reasoning_text")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# 400 retry integration (patch_client_for_reasoning_opaque)
+# ---------------------------------------------------------------------------
+
+class TestRetryOn400:
+    @pytest.mark.asyncio
+    async def test_prevention_strips_orphaned_reasoning_text(self):
+        """Prevention layer: orphaned reasoning_text is stripped before send.
+
+        If we have no cached opaque, the reasoning_text gets removed
+        *before* the request is sent, so we never even hit a 400.
+        """
+        call_count = 0
+        sent_bodies: list[dict] = []
+
+        client = httpx.AsyncClient()
+
+        # Patch client.send directly (no opaque cache = prevention kicks in)
+        from code_puppy.plugins.copilot_auth.reasoning_client import (
+            _inject_opaque_into_request,
+        )
+
+        opaque_cache: dict[str, str] = {}  # Empty — will trigger stripping
+        real_build = client.build_request
+
+        async def tracking_send(request, *args, **kwargs):
+            nonlocal call_count
+            if request.method == "POST":
+                _inject_opaque_into_request(
+                    request, opaque_cache, client, "reasoning_text"
+                )
+            call_count += 1
+            body = json.loads(request.content) if request.content else {}
+            sent_bodies.append(body)
+            return httpx.Response(200, content=b'{"choices": []}', request=request)
+
+        client.send = tracking_send
+
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "reasoning_text": "deep thoughts", "content": "Hello!"},
+        ]
+        body = json.dumps({"model": "claude-sonnet-4", "messages": messages}).encode()
+        request = httpx.Request(
+            "POST", "https://api.example.com/v1/chat/completions", content=body
+        )
+
+        response = await client.send(request)
+
+        assert response.status_code == 200
+        assert call_count == 1  # Only one call — no retry needed
+        # reasoning_text was stripped before sending
+        sent_msgs = sent_bodies[0]["messages"]
+        assert "reasoning_text" not in sent_msgs[1]
+
+    @pytest.mark.asyncio
+    async def test_recovery_strips_and_retries_on_400(self):
+        """Recovery layer: if we get a 400 despite injection, strip and retry.
+
+        Simulates stale/bad opaque data that passes prevention but the
+        API still rejects.
+        """
+        call_count = 0
+
+        from code_puppy.plugins.copilot_auth.reasoning_client import (
+            _inject_opaque_into_request,
+            _strip_all_reasoning_fields,
+        )
+
+        thinking_text = "deep thoughts"
+        # Seed cache with BAD opaque — will pass prevention but API rejects
+        opaque_cache = {_text_key(thinking_text): "stale_bad_opaque"}
+
+        client = httpx.AsyncClient()
+
+        async def fake_send(request, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            body = json.loads(request.content) if request.content else {}
+            msgs = body.get("messages", [])
+            has_opaque = any(
+                "reasoning_opaque" in m for m in msgs if isinstance(m, dict)
+            )
+            if has_opaque:
+                # API rejects stale opaque
+                return httpx.Response(
+                    400,
+                    content=b'{"error": "invalid reasoning_opaque"}',
+                    request=request,
+                )
+            return httpx.Response(
+                200,
+                content=b'{"choices": [{"message": {"content": "ok"}}]}',
+                request=request,
+            )
+
+        # Wire up manually: inject → send → on 400, strip → retry
+        async def orchestrated_send(request, *args, **kwargs):
+            if request.method == "POST":
+                _inject_opaque_into_request(
+                    request, opaque_cache, client, "reasoning_text"
+                )
+            response = await fake_send(request, *args, **kwargs)
+            if response.status_code == 400 and request.method == "POST":
+                if _strip_all_reasoning_fields(request, client, "reasoning_text"):
+                    response = await fake_send(request, *args, **kwargs)
+            return response
+
+        client.send = orchestrated_send
+
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "reasoning_text": thinking_text, "content": "Hello!"},
+            {"role": "user", "content": "Now what?"},
+        ]
+        body = json.dumps({"model": "claude-sonnet-4", "messages": messages}).encode()
+        request = httpx.Request(
+            "POST", "https://api.example.com/v1/chat/completions", content=body
+        )
+
+        response = await client.send(request)
+
+        # First call: 400 (bad opaque). Second call: 200 (reasoning stripped).
+        assert response.status_code == 200
+        assert call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# patch_client_for_reasoning_opaque (integration)
+# ---------------------------------------------------------------------------
+
+class TestPatchClientIntegration:
+    """End-to-end tests through the actual patched client pipeline.
+
+    These replace the original stub tests that only verified send was
+    replaced.  The trick: set ``client.send`` to a fake *before* calling
+    ``patch_client_for_reasoning_opaque``, so the patch captures the fake
+    as ``original_send`` inside its closure.
+    """
+
+    @pytest.mark.asyncio
+    async def test_full_round_trip_captures_and_injects_opaque(self):
+        """Response → cache → next request: opaque survives the round-trip."""
+        thinking = "Let me analyze this step by step"
+        opaque = "encrypted_round_trip_data_abc123"
+        captured_requests: list[dict] = []
+
+        async def fake_send(request, *args, **kwargs):
+            if request.method == "POST" and request.content:
+                captured_requests.append(json.loads(request.content))
+            return httpx.Response(
+                200,
+                content=_make_non_streaming_response(thinking, opaque),
+                request=request,
+            )
+
+        client = httpx.AsyncClient()
+        client.send = fake_send  # Captured as original_send by patch
+        patch_client_for_reasoning_opaque(client)
+
+        # 1st call — seeds the opaque cache from the response
+        req1 = httpx.Request(
+            "POST",
+            "https://api.example.com/chat/completions",
+            content=_make_request_body(
+                [{"role": "user", "content": "Hi"}]
+            ),
+        )
+        await client.send(req1)
+
+        # 2nd call — assistant message with reasoning_text should get
+        # the cached opaque injected before reaching fake_send
+        req2 = httpx.Request(
+            "POST",
+            "https://api.example.com/chat/completions",
+            content=_make_request_body([
+                {"role": "user", "content": "Hi"},
+                {"role": "assistant", "reasoning_text": thinking, "content": "Hello!"},
+                {"role": "user", "content": "Follow up?"},
+            ]),
+        )
+        await client.send(req2)
+
+        # The fake_send should have received the injected opaque
+        assistant_msg = captured_requests[1]["messages"][1]
+        assert assistant_msg["reasoning_opaque"] == opaque
+        assert assistant_msg["reasoning_text"] == thinking  # Preserved
+
+    @pytest.mark.asyncio
+    async def test_get_requests_pass_through_unmodified(self):
+        """GET requests should flow straight through without interception."""
+        received_methods: list[str] = []
+
+        async def fake_send(request, *args, **kwargs):
+            received_methods.append(request.method)
+            return httpx.Response(200, content=b'{"ok": true}', request=request)
+
+        client = httpx.AsyncClient()
+        client.send = fake_send
+        patch_client_for_reasoning_opaque(client)
+
+        req = httpx.Request("GET", "https://api.example.com/models")
+        resp = await client.send(req)
+
+        assert resp.status_code == 200
+        assert received_methods == ["GET"]
+
+    @pytest.mark.asyncio
+    async def test_recovery_400_retries_through_patched_pipeline(self):
+        """Full pipeline: stale opaque → 400 → strip → retry → 200."""
+        thinking = "deep analysis"
+        opaque = "stale_encrypted_blob"
+        call_count = 0
+
+        async def fake_send(request, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            body = json.loads(request.content) if request.content else {}
+            msgs = body.get("messages", [])
+            has_opaque = any(
+                "reasoning_opaque" in m for m in msgs if isinstance(m, dict)
+            )
+            if call_count == 1:
+                # Seed call — return opaque so it's cached
+                return httpx.Response(
+                    200,
+                    content=_make_non_streaming_response(thinking, opaque),
+                    request=request,
+                )
+            if has_opaque:
+                # API rejects stale opaque
+                return httpx.Response(
+                    400,
+                    content=b'{"error": "invalid reasoning_opaque"}',
+                    request=request,
+                )
+            # After strip, no opaque → success
+            return httpx.Response(
+                200,
+                content=b'{"choices": [{"message": {"content": "ok"}}]}',
+                request=request,
+            )
+
+        client = httpx.AsyncClient()
+        client.send = fake_send
+        patch_client_for_reasoning_opaque(client)
+
+        # Seed the cache
+        req1 = httpx.Request(
+            "POST",
+            "https://api.example.com/chat/completions",
+            content=_make_request_body(
+                [{"role": "user", "content": "Hi"}]
+            ),
+        )
+        await client.send(req1)
+
+        # Now send with reasoning_text — opaque will be injected (stale),
+        # API returns 400, recovery strips and retries → 200
+        req2 = httpx.Request(
+            "POST",
+            "https://api.example.com/chat/completions",
+            content=_make_request_body([
+                {"role": "user", "content": "Hi"},
+                {"role": "assistant", "reasoning_text": thinking, "content": "Hello!"},
+                {"role": "user", "content": "Now what?"},
+            ]),
+        )
+        resp = await client.send(req2)
+
+        assert resp.status_code == 200
+        # 1 seed + 1 rejected + 1 retry = 3 calls
+        assert call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_recovery_returns_retry_response_when_both_fail(self):
+        """When recovery also fails, the RETRY response is returned.
+
+        Regression: the old log message said "returning original error"
+        but the code actually returned the retry response.  Now both
+        the log and the behaviour agree.
+        """
+        thinking = "some analysis"
+        opaque = "will_go_stale"
+        call_count = 0
+
+        async def fake_send(request, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Seed call
+                return httpx.Response(
+                    200,
+                    content=_make_non_streaming_response(thinking, opaque),
+                    request=request,
+                )
+            if call_count == 2:
+                # First real call: 400 (stale opaque)
+                return httpx.Response(
+                    400,
+                    content=b'{"error": "bad opaque"}',
+                    request=request,
+                )
+            # Retry after strip: ALSO fails with a distinct status
+            return httpx.Response(
+                502,
+                content=b'{"error": "gateway timeout"}',
+                request=request,
+            )
+
+        client = httpx.AsyncClient()
+        client.send = fake_send
+        patch_client_for_reasoning_opaque(client)
+
+        # Seed
+        req1 = httpx.Request(
+            "POST",
+            "https://api.example.com/chat/completions",
+            content=_make_request_body(
+                [{"role": "user", "content": "Hi"}]
+            ),
+        )
+        await client.send(req1)
+
+        # Trigger: 400 → strip → retry → 502
+        req2 = httpx.Request(
+            "POST",
+            "https://api.example.com/chat/completions",
+            content=_make_request_body([
+                {"role": "user", "content": "Hi"},
+                {"role": "assistant", "reasoning_text": thinking, "content": "Hello!"},
+            ]),
+        )
+        resp = await client.send(req2)
+
+        # Must be the RETRY response (502), NOT the original (400)
+        assert resp.status_code == 502
+        assert call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Cache eviction
+# ---------------------------------------------------------------------------
+
+class TestCacheEviction:
+    @pytest.mark.asyncio
+    async def test_cache_evicts_oldest_entries(self):
+        cache: dict[str, str] = {}
+        # Fill cache beyond max
+        for i in range(_MAX_CACHE_ENTRIES + 10):
+            cache[_text_key(f"text_{i}")] = f"opaque_{i}"
+
+        # Simulate a flush that would trigger eviction
+        chunks = [
+            _sse_line(_make_streaming_event(reasoning_text="final")),
+            _sse_line(_make_streaming_event(reasoning_opaque="final_opaque")),
+            _sse_line(_make_streaming_event(finish_reason="stop")),
+        ]
+        inner = FakeAsyncStream(chunks)
+        wrapper = _OpaqueCapturingStream(inner, cache, "reasoning_text")
+
+        async for _ in wrapper:
+            pass
+
+        # Cache should have been trimmed
+        assert len(cache) <= _MAX_CACHE_ENTRIES
+        # The newest entry should still be there
+        assert _text_key("final") in cache


### PR DESCRIPTION
[Demo of login and thinking](https://imgur.com/a/zbbdQYL)
Context : Needed a way to use code-puppy with my Enterprise git copilot license this device flow solves that with browser auth

- Add /copilot-login command using GitHub Device Flow
- Support GitHub Enterprise via hostname prompt
- Auto-discover regional API endpoints from session token exchange
- manually verified the login works with an enterprise account and code puppy can access models
- the thinking portion works for the copilot anthropic models for now
<img width="866" height="589" alt="image" src="https://github.com/user-attachments/assets/175cf211-0f61-4c8e-98f6-7661f2d42bb1" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub Copilot authentication via OAuth Device Flow (including GitHub Enterprise) with commands: /copilot-login, /copilot-status, /copilot-logout.
  * Automatic fetching, persistent storage, registration, and dynamic use of Copilot models alongside other AI providers; automatic session refresh per request.
  * Session and device-token caching on disk to reduce repeated logins.
* **Documentation**
  * Help text and command guidance added for Copilot auth commands.
* **Tests**
  * New tests covering Copilot model creation and per-request auth behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->