### PR TITLE
feat: Add Azure AI Foundry plugin for Anthropic Claude models

### DIFF
--- a/code_puppy/claude_cache_client.py
+++ b/code_puppy/claude_cache_client.py
@@ -638,28 +638,10 @@ def _inject_cache_control_in_payload(payload: dict[str, Any]) -> None:
     return
 
 
-def patch_anthropic_client_messages(client: Any) -> None:
-    """Monkey-patch AsyncAnthropic.messages.create to inject cache_control.
-
-    This operates at the highest level: just before Anthropic SDK serializes
-    the request into HTTP. That means no httpx / Pydantic shenanigans can
-    undo it.
-    """
-
-    if AsyncAnthropic is None or not isinstance(client, AsyncAnthropic):  # type: ignore[arg-type]
-        return
-
-    try:
-        messages_obj = getattr(client, "messages", None)
-        if messages_obj is None:
-            return
-        original_create: Callable[..., Any] = messages_obj.create
-    except Exception:  # pragma: no cover - defensive
-        return
+def _make_cache_wrapper(original_create: Callable[..., Any]) -> Callable[..., Any]:
+    """Create a wrapped version of messages.create that injects cache_control."""
 
     async def wrapped_create(*args: Any, **kwargs: Any):
-        # Anthropic messages.create takes a mix of positional/kw args.
-        # The payload is usually in kwargs for the Python SDK.
         if kwargs:
             _inject_cache_control_in_payload(kwargs)
         elif args:
@@ -669,4 +651,33 @@ def patch_anthropic_client_messages(client: Any) -> None:
 
         return await original_create(*args, **kwargs)
 
-    messages_obj.create = wrapped_create  # type: ignore[assignment]
+    return wrapped_create
+
+
+def patch_anthropic_client_messages(client: Any) -> None:
+    """Monkey-patch AsyncAnthropic messages.create to inject cache_control.
+
+    Patches both client.messages.create AND client.beta.messages.create
+    since pydantic-ai uses the beta endpoint.
+    """
+
+    if AsyncAnthropic is None or not isinstance(client, AsyncAnthropic):  # type: ignore[arg-type]
+        return
+
+    # Patch client.messages.create
+    try:
+        messages_obj = getattr(client, "messages", None)
+        if messages_obj is not None:
+            messages_obj.create = _make_cache_wrapper(messages_obj.create)  # type: ignore[assignment]
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+    # Patch client.beta.messages.create (used by pydantic-ai)
+    try:
+        beta_obj = getattr(client, "beta", None)
+        if beta_obj is not None:
+            beta_messages_obj = getattr(beta_obj, "messages", None)
+            if beta_messages_obj is not None:
+                beta_messages_obj.create = _make_cache_wrapper(beta_messages_obj.create)  # type: ignore[assignment]
+    except Exception:  # pragma: no cover - defensive
+        pass

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -103,6 +103,18 @@ def get_api_key(env_var_name: str) -> str | None:
     return os.environ.get(env_var_name)
 
 
+# Model types that use the Anthropic Messages API under the hood.
+# These all need Anthropic-specific settings (thinking, effort, etc.).
+_ANTHROPIC_MODEL_TYPES = frozenset({"anthropic", "azure_foundry", "claude_code"})
+
+
+def _is_anthropic_model(model_name: str, model_config: dict[str, Any]) -> bool:
+    """Check if a model uses the Anthropic API (by name prefix or config type)."""
+    if model_name.startswith("claude-") or model_name.startswith("anthropic-"):
+        return True
+    return model_config.get("type") in _ANTHROPIC_MODEL_TYPES
+
+
 def make_model_settings(
     model_name: str, max_tokens: int | None = None
 ) -> ModelSettings:
@@ -234,7 +246,7 @@ def make_model_settings(
                 verbosity = get_openai_verbosity()
                 model_settings_dict["extra_body"] = {"verbosity": verbosity}
             model_settings = OpenAIChatModelSettings(**model_settings_dict)
-    elif model_name.startswith("claude-") or model_name.startswith("anthropic-"):
+    elif _is_anthropic_model(model_name, model_config):
         # Handle Anthropic extended thinking settings
         # Remove top_p as Anthropic doesn't support it with extended thinking
         model_settings_dict.pop("top_p", None)
@@ -271,7 +283,12 @@ def make_model_settings(
         # pydantic-ai doesn't have a native field for output_config yet,
         # so we inject it through extra_body which gets merged into the
         # HTTP request body.
-        if model_supports_setting(model_name, "effort"):
+        # NOTE: effort/output_config only applies to adaptive thinking.
+        # With standard "enabled" thinking, budget_tokens controls depth.
+        if (
+            model_supports_setting(model_name, "effort")
+            and extended_thinking == "adaptive"
+        ):
             effort = effective_settings.get("effort", "high")
             if "anthropic_thinking" in model_settings_dict:
                 extra_body = model_settings_dict.get("extra_body") or {}

--- a/code_puppy/plugins/azure_foundry/README.md
+++ b/code_puppy/plugins/azure_foundry/README.md
@@ -134,7 +134,7 @@ Configured Models (3):
 2. **Token Refresh**: The `get_bearer_token_provider` function handles automatic
    token refresh before expiry
 
-3. **API Calls**: Creates an `AsyncAnthropicAzure` client that uses the native
+3. **API Calls**: Creates an `AsyncAnthropicFoundry` client that uses the native
    Anthropic Messages API (not OpenAI format)
 
 4. **Integration**: Wraps the client in pydantic-ai's `AnthropicModel` for

--- a/code_puppy/plugins/azure_foundry/README.md
+++ b/code_puppy/plugins/azure_foundry/README.md
@@ -1,0 +1,200 @@
+# Azure AI Foundry Plugin for Code Puppy
+
+This plugin enables Code Puppy to use Anthropic Claude models hosted on
+Microsoft Azure AI Foundry with Azure AD (Entra ID) authentication.
+
+## Overview
+
+Azure AI Foundry provides enterprise-grade hosting of Anthropic Claude models
+within the Microsoft Azure cloud. This plugin uses your existing Azure CLI
+credentials (`az login`) to authenticate, eliminating the need for API keys.
+
+## Supported Models
+
+| Model | Context Length | Deployment Name (Default) |
+|-------|----------------|---------------------------|
+| Claude Opus 4.6 | 1M tokens | `claude-opus-4-6` |
+| Claude Sonnet 4.6 | 1M tokens | `claude-sonnet-4-6` |
+| Claude Haiku 4.5 | 200K tokens | `claude-haiku-4-5` |
+
+Deployment names are user-configurable during setup.
+
+## Prerequisites
+
+1. **Azure subscription** with access to Azure AI Foundry
+2. **Azure CLI** installed and authenticated (`az login`)
+3. **Claude model deployments** provisioned in your Azure AI Foundry resource
+4. **Python packages**: `azure-identity>=1.15.0` (installed with Code Puppy)
+
+## Quick Start
+
+### 1. Authenticate with Azure
+
+```bash
+az login
+```
+
+### 2. Set Your Resource Name
+
+```bash
+export ANTHROPIC_FOUNDRY_RESOURCE=your-resource-name
+```
+
+### 3. Run Interactive Setup
+
+```bash
+pup
+/foundry-setup
+```
+
+The wizard will guide you through configuring your model deployments.
+
+### 4. Start Using Foundry Models
+
+```bash
+/model foundry-claude-opus
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `ANTHROPIC_FOUNDRY_RESOURCE` | Your Azure AI Foundry resource name | Yes |
+| `ANTHROPIC_FOUNDRY_BASE_URL` | Override the base URL (optional) | No |
+
+### Model Configuration
+
+Models are stored in `~/.code_puppy/extra_models.json`:
+
+```json
+{
+  "foundry-claude-opus": {
+    "type": "azure_foundry",
+    "name": "it-entra-claude-opus-4-6[1m]",
+    "foundry_resource": "$ANTHROPIC_FOUNDRY_RESOURCE",
+    "context_length": 1000000,
+    "supported_settings": ["temperature", "extended_thinking", "budget_tokens"]
+  },
+  "foundry-claude-sonnet": {
+    "type": "azure_foundry",
+    "name": "it-entra-claude-sonnet-4-6[1m]",
+    "foundry_resource": "$ANTHROPIC_FOUNDRY_RESOURCE",
+    "context_length": 1000000,
+    "supported_settings": ["temperature", "extended_thinking", "budget_tokens"]
+  },
+  "foundry-claude-haiku": {
+    "type": "azure_foundry",
+    "name": "it-entra-claude-haiku-4-5",
+    "foundry_resource": "$ANTHROPIC_FOUNDRY_RESOURCE",
+    "context_length": 200000,
+    "supported_settings": ["temperature", "extended_thinking", "budget_tokens"]
+  }
+}
+```
+
+**Configuration Fields:**
+
+- `type`: Must be `"azure_foundry"` to route to this plugin
+- `name`: Your Azure deployment name (e.g., `it-entra-claude-opus-4-6[1m]`)
+- `foundry_resource`: Resource name (supports `$ENV_VAR` syntax)
+- `context_length`: Model context window in tokens
+- `supported_settings`: List of supported model settings
+
+## Slash Commands
+
+| Command | Description |
+|---------|-------------|
+| `/foundry-status` | Check Azure AD authentication status and configured models |
+| `/foundry-setup` | Interactive wizard to configure Foundry models |
+| `/foundry-remove` | Remove all Foundry model configurations |
+
+### Example: /foundry-status
+
+```
+Azure AI Foundry Status
+========================================
+Authentication: Valid (expires in 45 minutes)
+   Logged in as: user@company.com
+
+Foundry Resource: my-foundry-resource
+
+Configured Models (3):
+   - foundry-claude-opus: it-entra-claude-opus-4-6[1m]
+   - foundry-claude-sonnet: it-entra-claude-sonnet-4-6[1m]
+   - foundry-claude-haiku: it-entra-claude-haiku-4-5
+```
+
+## How It Works
+
+1. **Token Acquisition**: Uses `AzureCliCredential` from `azure-identity` to
+   obtain tokens from your `az login` session
+
+2. **Token Refresh**: The `get_bearer_token_provider` function handles automatic
+   token refresh before expiry
+
+3. **API Calls**: Creates an `AsyncAnthropicAzure` client that uses the native
+   Anthropic Messages API (not OpenAI format)
+
+4. **Integration**: Wraps the client in pydantic-ai's `AnthropicModel` for
+   seamless integration with Code Puppy's agent system
+
+## Troubleshooting
+
+### "CredentialUnavailableError" or "Not authenticated"
+
+Run `az login` to authenticate with Azure:
+
+```bash
+az login
+```
+
+### "Resource not found" or "404 errors"
+
+1. Verify `ANTHROPIC_FOUNDRY_RESOURCE` is set correctly
+2. Check that your model deployments exist in Azure AI Foundry
+3. Ensure the deployment names match your configuration
+
+### Token Expiry
+
+Tokens are automatically refreshed by the Azure Identity library. If you
+encounter issues, try:
+
+```bash
+az account get-access-token --resource https://cognitiveservices.azure.com
+```
+
+### Model Not Found
+
+After running `/foundry-setup`, verify configuration with `/foundry-status`.
+Check that deployment names match exactly (case-sensitive).
+
+## Architecture
+
+```
+code_puppy/plugins/azure_foundry/
+├── __init__.py              # Package marker and version
+├── config.py                # Constants and configuration helpers
+├── token.py                 # Azure AD token provider
+├── utils.py                 # Configuration file utilities
+└── register_callbacks.py    # Plugin callbacks and model handler
+```
+
+## Security Notes
+
+- **No API keys stored**: Authentication uses Azure AD tokens only
+- **Token caching**: Managed by Azure CLI, not stored by this plugin
+- **Credential scope**: Limited to `https://cognitiveservices.azure.com/.default`
+
+## Contributing
+
+This plugin follows Code Puppy's plugin architecture. Key callbacks:
+
+- `register_model_type`: Registers `azure_foundry` type handler
+- `custom_command`: Handles `/foundry-*` slash commands
+- `custom_command_help`: Provides help text for commands
+
+## License
+
+Same as Code Puppy (see repository LICENSE file).

--- a/code_puppy/plugins/azure_foundry/README.md
+++ b/code_puppy/plugins/azure_foundry/README.md
@@ -97,10 +97,36 @@ Models are stored in `~/.code_puppy/extra_models.json`:
 **Configuration Fields:**
 
 - `type`: Must be `"azure_foundry"` to route to this plugin
-- `name`: Your Azure deployment name (e.g., `it-entra-claude-opus-4-6[1m]`)
+- `name`: Your Azure deployment name (e.g., `it-entra-claude-opus-4-6`)
 - `foundry_resource`: Resource name (supports `$ENV_VAR` syntax)
 - `context_length`: Model context window in tokens
 - `supported_settings`: List of supported model settings
+
+## Context Window Configuration
+
+Deployment names can include a context window suffix following the Claude Code format:
+- `[1m]` - 1 million tokens
+- `[2m]` - 2 million tokens
+- `[200k]` - 200 thousand tokens
+- `[500k]` - 500 thousand tokens
+
+When you specify a deployment name with a context suffix (e.g., `it-entra-claude-opus-4-6[1m]`):
+1. The suffix is **automatically stripped** before sending to Azure
+2. The `context_length` is set based on the parsed suffix
+
+**Example:**
+
+During `/foundry-setup`, if you enter:
+```
+Opus deployment name: it-entra-claude-opus-4-6[1m]
+```
+
+The saved configuration will have:
+- `name`: `it-entra-claude-opus-4-6` (suffix stripped)
+- `context_length`: `1000000` (parsed from `[1m]`)
+
+This is useful when your Azure deployment names don't include the context indicator,
+but you want to configure the context length.
 
 ## Slash Commands
 

--- a/code_puppy/plugins/azure_foundry/README.md
+++ b/code_puppy/plugins/azure_foundry/README.md
@@ -75,21 +75,21 @@ Models are stored in `~/.code_puppy/extra_models.json`:
     "name": "it-entra-claude-opus-4-6[1m]",
     "foundry_resource": "$ANTHROPIC_FOUNDRY_RESOURCE",
     "context_length": 1000000,
-    "supported_settings": ["temperature", "extended_thinking", "budget_tokens"]
+    "supported_settings": ["temperature", "extended_thinking", "effort"]
   },
   "foundry-claude-sonnet": {
     "type": "azure_foundry",
     "name": "it-entra-claude-sonnet-4-6[1m]",
     "foundry_resource": "$ANTHROPIC_FOUNDRY_RESOURCE",
     "context_length": 1000000,
-    "supported_settings": ["temperature", "extended_thinking", "budget_tokens"]
+    "supported_settings": ["temperature", "interleaved_thinking", "thinking_budget"]
   },
   "foundry-claude-haiku": {
     "type": "azure_foundry",
     "name": "it-entra-claude-haiku-4-5",
     "foundry_resource": "$ANTHROPIC_FOUNDRY_RESOURCE",
     "context_length": 200000,
-    "supported_settings": ["temperature", "extended_thinking", "budget_tokens"]
+    "supported_settings": ["temperature", "interleaved_thinking", "thinking_budget"]
   }
 }
 ```
@@ -101,6 +101,18 @@ Models are stored in `~/.code_puppy/extra_models.json`:
 - `foundry_resource`: Resource name (supports `$ENV_VAR` syntax)
 - `context_length`: Model context window in tokens
 - `supported_settings`: List of supported model settings
+
+## Model Settings by Tier
+
+### Opus 4.6 Models
+- `temperature`: Temperature for sampling (0-1)
+- `extended_thinking`: Enable thinking (defaults to "adaptive")
+- `effort`: Thinking effort level ("low", "medium", "high")
+
+### Sonnet & Haiku Models
+- `temperature`: Temperature for sampling (0-1)
+- `interleaved_thinking`: Enable interleaved thinking (boolean)
+- `thinking_budget`: Maximum tokens for internal reasoning
 
 ## Context Window Configuration
 

--- a/code_puppy/plugins/azure_foundry/__init__.py
+++ b/code_puppy/plugins/azure_foundry/__init__.py
@@ -1,0 +1,15 @@
+"""Azure AI Foundry Plugin for Code Puppy.
+
+This plugin enables Code Puppy to use Anthropic Claude models hosted on
+Microsoft Azure AI Foundry with Azure AD (Entra ID) authentication.
+
+The plugin uses the `az login` credentials from the Azure CLI to authenticate,
+eliminating the need for API keys.
+
+Supported models:
+- Claude Opus 4.6 (1M context)
+- Claude Sonnet 4.6 (1M context)
+- Claude Haiku 4.5 (200K context)
+"""
+
+__version__ = "0.1.0"

--- a/code_puppy/plugins/azure_foundry/config.py
+++ b/code_puppy/plugins/azure_foundry/config.py
@@ -21,9 +21,9 @@ TOKEN_REFRESH_BUFFER = 300
 
 # Default context lengths for different model tiers
 DEFAULT_CONTEXT_LENGTHS: dict[str, int] = {
-    "opus": 1000000,    # 1M tokens for Opus models
+    "opus": 1000000,  # 1M tokens for Opus models
     "sonnet": 1000000,  # 1M tokens for Sonnet models
-    "haiku": 200000,    # 200K tokens for Haiku models
+    "haiku": 200000,  # 200K tokens for Haiku models
 }
 
 # Default deployment name patterns (can be overridden by user)

--- a/code_puppy/plugins/azure_foundry/config.py
+++ b/code_puppy/plugins/azure_foundry/config.py
@@ -1,0 +1,84 @@
+"""Configuration constants for the Azure AI Foundry plugin.
+
+This module defines constants used throughout the plugin for Azure AD
+authentication and model configuration.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+from code_puppy.config import DATA_DIR
+
+# Azure AD scope for Cognitive Services (used for token acquisition)
+# This scope is required for authenticating with Azure AI Foundry
+AZURE_COGNITIVE_SCOPE = "https://cognitiveservices.azure.com/.default"
+
+# Token refresh buffer in seconds (refresh 5 minutes before expiry)
+TOKEN_REFRESH_BUFFER = 300
+
+# Default context lengths for different model tiers
+DEFAULT_CONTEXT_LENGTHS: Dict[str, int] = {
+    "opus": 1000000,    # 1M tokens for Opus models
+    "sonnet": 1000000,  # 1M tokens for Sonnet models
+    "haiku": 200000,    # 200K tokens for Haiku models
+}
+
+# Default deployment name patterns (can be overridden by user)
+DEFAULT_DEPLOYMENT_NAMES: Dict[str, str] = {
+    "opus": "claude-opus-4-6",
+    "sonnet": "claude-sonnet-4-6",
+    "haiku": "claude-haiku-4-5",
+}
+
+# Environment variable names
+ENV_FOUNDRY_RESOURCE = "ANTHROPIC_FOUNDRY_RESOURCE"
+ENV_FOUNDRY_BASE_URL = "ANTHROPIC_FOUNDRY_BASE_URL"
+
+
+def get_foundry_resource() -> str | None:
+    """Get the Azure Foundry resource name from environment.
+
+    Returns:
+        The resource name if set, None otherwise.
+    """
+    return os.environ.get(ENV_FOUNDRY_RESOURCE)
+
+
+def get_foundry_base_url() -> str | None:
+    """Get the Azure Foundry base URL from environment.
+
+    If ANTHROPIC_FOUNDRY_BASE_URL is set, use it directly.
+    Otherwise, construct from ANTHROPIC_FOUNDRY_RESOURCE.
+
+    Returns:
+        The base URL if determinable, None otherwise.
+    """
+    base_url = os.environ.get(ENV_FOUNDRY_BASE_URL)
+    if base_url:
+        return base_url
+
+    resource = get_foundry_resource()
+    if resource:
+        return f"https://{resource}.services.ai.azure.com/anthropic/v1"
+
+    return None
+
+
+def get_extra_models_path() -> Path:
+    """Get the path to the extra_models.json file.
+
+    Returns:
+        Path to the extra models configuration file.
+    """
+    return Path(DATA_DIR) / "extra_models.json"
+
+
+# Plugin configuration for model creation
+AZURE_FOUNDRY_CONFIG: Dict[str, Any] = {
+    "scope": AZURE_COGNITIVE_SCOPE,
+    "token_refresh_buffer": TOKEN_REFRESH_BUFFER,
+    "supported_settings": ["temperature", "extended_thinking", "budget_tokens"],
+}

--- a/code_puppy/plugins/azure_foundry/config.py
+++ b/code_puppy/plugins/azure_foundry/config.py
@@ -80,5 +80,8 @@ def get_extra_models_path() -> Path:
 AZURE_FOUNDRY_CONFIG: dict[str, Any] = {
     "scope": AZURE_COGNITIVE_SCOPE,
     "token_refresh_buffer": TOKEN_REFRESH_BUFFER,
-    "supported_settings": ["temperature", "extended_thinking", "budget_tokens"],
 }
+
+# Note: supported_settings is determined per-tier in build_foundry_model_config():
+# - Opus 4.6: ["temperature", "extended_thinking", "effort"]
+# - Sonnet/Haiku: ["temperature", "interleaved_thinking", "thinking_budget"]

--- a/code_puppy/plugins/azure_foundry/config.py
+++ b/code_puppy/plugins/azure_foundry/config.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 from code_puppy.config import DATA_DIR
 
@@ -20,14 +20,14 @@ AZURE_COGNITIVE_SCOPE = "https://cognitiveservices.azure.com/.default"
 TOKEN_REFRESH_BUFFER = 300
 
 # Default context lengths for different model tiers
-DEFAULT_CONTEXT_LENGTHS: Dict[str, int] = {
+DEFAULT_CONTEXT_LENGTHS: dict[str, int] = {
     "opus": 1000000,    # 1M tokens for Opus models
     "sonnet": 1000000,  # 1M tokens for Sonnet models
     "haiku": 200000,    # 200K tokens for Haiku models
 }
 
 # Default deployment name patterns (can be overridden by user)
-DEFAULT_DEPLOYMENT_NAMES: Dict[str, str] = {
+DEFAULT_DEPLOYMENT_NAMES: dict[str, str] = {
     "opus": "claude-opus-4-6",
     "sonnet": "claude-sonnet-4-6",
     "haiku": "claude-haiku-4-5",
@@ -77,7 +77,7 @@ def get_extra_models_path() -> Path:
 
 
 # Plugin configuration for model creation
-AZURE_FOUNDRY_CONFIG: Dict[str, Any] = {
+AZURE_FOUNDRY_CONFIG: dict[str, Any] = {
     "scope": AZURE_COGNITIVE_SCOPE,
     "token_refresh_buffer": TOKEN_REFRESH_BUFFER,
     "supported_settings": ["temperature", "extended_thinking", "budget_tokens"],

--- a/code_puppy/plugins/azure_foundry/register_callbacks.py
+++ b/code_puppy/plugins/azure_foundry/register_callbacks.py
@@ -241,12 +241,17 @@ def _custom_help() -> list[tuple[str, str]]:
 def _handle_custom_command(command: str, name: str) -> bool | None:
     """Handle custom slash commands for the Azure Foundry plugin.
 
+    Dispatches to handlers for "foundry-status", "foundry-setup", and
+    "foundry-remove" commands.
+
     Args:
         command: The full command string.
         name: The command name (without slash).
 
     Returns:
-        True if the command was handled, None otherwise.
+        True if the command was handled successfully.
+        False if the command was recognized but handler() raised an exception.
+        None if the command is not handled by this plugin.
     """
     handlers = {
         "foundry-status": _handle_foundry_status,
@@ -378,12 +383,6 @@ def _create_azure_foundry_model(
         )
         return AnthropicModel(model_name=deployment_name, provider=provider)
 
-    except ImportError as e:
-        emit_error(
-            f"Failed to create Azure Foundry model '{model_name}': "
-            f"Missing dependency - {e}"
-        )
-        return None
     except Exception as e:
         emit_error(f"Failed to create Azure Foundry model '{model_name}': {e}")
         logger.exception(f"Error creating Azure Foundry model: {e}")

--- a/code_puppy/plugins/azure_foundry/register_callbacks.py
+++ b/code_puppy/plugins/azure_foundry/register_callbacks.py
@@ -378,10 +378,16 @@ def _create_azure_foundry_model(
             anthropic_client=anthropic_client,
         )
 
+        model = AnthropicModel(model_name=deployment_name, provider=provider)
+        # Preserve the public model.provider attribute (convention used by other model factories)
+        model.provider = provider
         logger.info(
-            f"Created Azure Foundry model: {model_name} -> {deployment_name} @ {resource_name}"
+            "Created Azure Foundry model: %s -> %s @ %s",
+            model_name,
+            deployment_name,
+            resource_name,
         )
-        return AnthropicModel(model_name=deployment_name, provider=provider)
+        return model
 
     except Exception as e:
         emit_error(f"Failed to create Azure Foundry model '{model_name}': {e}")

--- a/code_puppy/plugins/azure_foundry/register_callbacks.py
+++ b/code_puppy/plugins/azure_foundry/register_callbacks.py
@@ -1,0 +1,376 @@
+"""Azure AI Foundry Plugin callbacks for Code Puppy CLI.
+
+This plugin enables Code Puppy to use Anthropic Claude models hosted on
+Microsoft Azure AI Foundry with Azure AD (Entra ID) authentication.
+
+The plugin uses credentials from `az login` to authenticate, eliminating
+the need for API keys.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from code_puppy.callbacks import register_callback
+from code_puppy.command_line.utils import safe_input
+from code_puppy.messaging import emit_error, emit_info, emit_success, emit_warning
+from code_puppy.tools.command_runner import set_awaiting_user_input
+
+from .config import (
+    DEFAULT_DEPLOYMENT_NAMES,
+    ENV_FOUNDRY_RESOURCE,
+    get_foundry_resource,
+)
+from .token import get_token_provider
+from .utils import (
+    add_foundry_models_to_config,
+    get_foundry_models_from_config,
+    remove_foundry_models_from_config,
+    resolve_env_var,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Slash Command Handlers
+# ============================================================================
+
+
+def _handle_foundry_status() -> None:
+    """Handle the /foundry-status command.
+
+    Displays the current Azure AD authentication status and configured
+    Foundry models.
+    """
+    emit_info("")
+    emit_info("Azure AI Foundry Status")
+    emit_info("=" * 40)
+
+    # Check Azure AD authentication
+    token_provider = get_token_provider()
+    is_auth, status_msg, user_info = token_provider.check_auth_status()
+
+    if is_auth:
+        emit_success(f"Authentication: {status_msg}")
+        if user_info:
+            emit_info(f"   Logged in as: {user_info}")
+    else:
+        emit_warning(f"Authentication: {status_msg}")
+
+    # Check resource configuration
+    resource = get_foundry_resource()
+    emit_info("")
+    if resource:
+        emit_info(f"Foundry Resource: {resource}")
+    else:
+        emit_warning(f"Foundry Resource: Not set (set {ENV_FOUNDRY_RESOURCE})")
+
+    # List configured models
+    foundry_models = get_foundry_models_from_config()
+    emit_info("")
+    if foundry_models:
+        emit_info(f"Configured Models ({len(foundry_models)}):")
+        for model_key, config in foundry_models.items():
+            deployment = config.get("name", "unknown")
+            emit_info(f"   - {model_key}: {deployment}")
+    else:
+        emit_info("Configured Models: None")
+        emit_info("   Run /foundry-setup to configure models")
+
+    emit_info("")
+
+
+def _handle_foundry_setup() -> None:
+    """Handle the /foundry-setup command.
+
+    Interactive wizard to configure Azure Foundry models.
+    """
+    emit_info("")
+    emit_info("Azure AI Foundry Setup")
+    emit_info("=" * 40)
+    emit_info("")
+
+    # Check Azure CLI authentication first
+    emit_info("Step 1: Checking Azure CLI authentication...")
+    token_provider = get_token_provider()
+    is_auth, status_msg, user_info = token_provider.check_auth_status()
+
+    if not is_auth:
+        emit_error(f"   {status_msg}")
+        emit_info("")
+        emit_info("Please run 'az login' first, then try again.")
+        return
+
+    emit_success(f"   Authenticated: {status_msg}")
+    if user_info:
+        emit_info(f"   User: {user_info}")
+    emit_info("")
+
+    # Get resource name
+    set_awaiting_user_input(True)
+    try:
+        emit_info("Step 2: Azure Resource Name")
+        current_resource = get_foundry_resource()
+        if current_resource:
+            emit_info(f"   Current: {current_resource}")
+
+        resource_prompt = "Enter your Azure Foundry resource name"
+        if current_resource:
+            resource_prompt += f" [{current_resource}]"
+        resource_prompt += ": "
+
+        resource_input = safe_input(resource_prompt).strip()
+        resource_name = resource_input if resource_input else current_resource
+
+        if not resource_name:
+            emit_error("Resource name is required.")
+            return
+
+        emit_info("")
+
+        # Get deployment names
+        emit_info("Step 3: Model Deployments")
+        emit_info("   Enter deployment names (press Enter to skip a model)")
+        emit_info("")
+
+        opus_default = DEFAULT_DEPLOYMENT_NAMES["opus"]
+        sonnet_default = DEFAULT_DEPLOYMENT_NAMES["sonnet"]
+        haiku_default = DEFAULT_DEPLOYMENT_NAMES["haiku"]
+
+        opus_input = safe_input(f"   Opus deployment name [{opus_default}]: ").strip()
+        opus_deployment = opus_input if opus_input else opus_default
+
+        sonnet_input = safe_input(f"   Sonnet deployment name [{sonnet_default}]: ").strip()
+        sonnet_deployment = sonnet_input if sonnet_input else sonnet_default
+
+        haiku_input = safe_input(f"   Haiku deployment name [{haiku_default}]: ").strip()
+        haiku_deployment = haiku_input if haiku_input else haiku_default
+
+    except (KeyboardInterrupt, EOFError):
+        emit_info("")
+        emit_warning("Setup cancelled.")
+        return
+    finally:
+        set_awaiting_user_input(False)
+
+    emit_info("")
+
+    # Save configuration
+    emit_info("Step 4: Saving configuration...")
+
+    # Set environment variable hint
+    if not get_foundry_resource():
+        emit_info(f"   Set {ENV_FOUNDRY_RESOURCE}={resource_name} in your environment")
+
+    # Add models to config
+    added_models = add_foundry_models_to_config(
+        resource_name=resource_name,
+        opus_deployment=opus_deployment if opus_deployment != opus_default or opus_input else None,
+        sonnet_deployment=sonnet_deployment if sonnet_deployment != sonnet_default or sonnet_input else None,
+        haiku_deployment=haiku_deployment if haiku_deployment != haiku_default or haiku_input else None,
+    )
+
+    # If user entered defaults, add them too
+    if not added_models:
+        added_models = add_foundry_models_to_config(
+            resource_name=resource_name,
+            opus_deployment=opus_deployment,
+            sonnet_deployment=sonnet_deployment,
+            haiku_deployment=haiku_deployment,
+        )
+
+    emit_info("")
+    if added_models:
+        emit_success(f"Configuration saved! Added {len(added_models)} model(s):")
+        for model_key in added_models:
+            emit_info(f"   - {model_key}")
+        emit_info("")
+        emit_info(f"Use '/model {added_models[0]}' to switch to a Foundry model.")
+    else:
+        emit_warning("No models were added. Check the configuration.")
+
+    emit_info("")
+
+
+def _handle_foundry_remove() -> None:
+    """Handle the /foundry-remove command.
+
+    Removes all Azure Foundry model configurations.
+    """
+    removed = remove_foundry_models_from_config()
+    if removed:
+        emit_success(f"Removed {len(removed)} Foundry model(s):")
+        for model_key in removed:
+            emit_info(f"   - {model_key}")
+    else:
+        emit_info("No Foundry models found in configuration.")
+
+
+# ============================================================================
+# Custom Command Registration
+# ============================================================================
+
+
+def _custom_help() -> List[Tuple[str, str]]:
+    """Return help entries for custom commands."""
+    return [
+        ("foundry-status", "Check Azure AI Foundry authentication and configuration status"),
+        ("foundry-setup", "Interactive wizard to configure Azure Foundry models"),
+        ("foundry-remove", "Remove all Azure Foundry model configurations"),
+    ]
+
+
+def _handle_custom_command(command: str, name: str) -> Optional[bool]:
+    """Handle custom slash commands for the Azure Foundry plugin.
+
+    Args:
+        command: The full command string.
+        name: The command name (without slash).
+
+    Returns:
+        True if the command was handled, None otherwise.
+    """
+    if name == "foundry-status":
+        _handle_foundry_status()
+        return True
+
+    if name == "foundry-setup":
+        _handle_foundry_setup()
+        return True
+
+    if name == "foundry-remove":
+        _handle_foundry_remove()
+        return True
+
+    return None
+
+
+# ============================================================================
+# Model Type Handler
+# ============================================================================
+
+
+def _create_azure_foundry_model(
+    model_name: str, model_config: Dict, config: Dict
+) -> Any:
+    """Create an Azure Foundry model instance.
+
+    This handler is registered via the 'register_model_type' callback to handle
+    models with type='azure_foundry'.
+
+    Args:
+        model_name: The model key name (e.g., 'foundry-claude-opus').
+        model_config: The model configuration dictionary.
+        config: The full models configuration.
+
+    Returns:
+        An AnthropicModel instance configured for Azure Foundry, or None on error.
+    """
+    from anthropic import AsyncAnthropicFoundry
+    from pydantic_ai.models.anthropic import AnthropicModel
+
+    from code_puppy.claude_cache_client import patch_anthropic_client_messages
+    from code_puppy.config import get_effective_model_settings
+    from code_puppy.model_factory import CONTEXT_1M_BETA
+    from code_puppy.provider_identity import (
+        make_anthropic_provider,
+        resolve_provider_identity,
+    )
+
+    # Get the Foundry resource name
+    resource_config = model_config.get("foundry_resource", f"${ENV_FOUNDRY_RESOURCE}")
+    resource_name = resolve_env_var(resource_config)
+
+    if not resource_name:
+        emit_warning(
+            f"Azure Foundry resource not configured for model '{model_name}'. "
+            f"Set {ENV_FOUNDRY_RESOURCE} or run /foundry-setup."
+        )
+        return None
+
+    # Get the deployment name (model name in Azure)
+    deployment_name = model_config.get("name")
+    if not deployment_name:
+        emit_warning(f"Deployment name not specified for model '{model_name}'.")
+        return None
+
+    # Get the token provider
+    token_provider = get_token_provider()
+
+    # Check authentication status
+    is_auth, status_msg, _ = token_provider.check_auth_status()
+    if not is_auth:
+        emit_warning(
+            f"Azure AD authentication failed for model '{model_name}': {status_msg}"
+        )
+        return None
+
+    try:
+        # Create the Azure Foundry Anthropic client with token provider
+        # AsyncAnthropicFoundry uses the resource name to construct the endpoint
+        anthropic_client = AsyncAnthropicFoundry(
+            resource=resource_name,
+            azure_ad_token_provider=token_provider.get_token,
+        )
+
+        # Patch for cache control injection
+        patch_anthropic_client_messages(anthropic_client)
+
+        # Check for interleaved thinking setting
+        effective_settings = get_effective_model_settings(model_name)
+        interleaved_thinking = effective_settings.get("interleaved_thinking", False)
+
+        # Build anthropic-beta header if needed
+        beta_parts: List[str] = []
+        if interleaved_thinking:
+            beta_parts.append("interleaved-thinking-2025-05-14")
+
+        # Add 1M context beta header for long-context models
+        context_length = model_config.get("context_length", 200000)
+        if context_length >= 1_000_000:
+            beta_parts.append(CONTEXT_1M_BETA)
+
+        if beta_parts:
+            # Set default headers on the client
+            anthropic_client._custom_headers = anthropic_client._custom_headers or {}
+            anthropic_client._custom_headers["anthropic-beta"] = ",".join(beta_parts)
+
+        # Create the pydantic-ai provider and model
+        provider_identity = resolve_provider_identity(model_name, model_config)
+        provider = make_anthropic_provider(
+            provider_identity,
+            anthropic_client=anthropic_client,
+        )
+
+        logger.info(
+            f"Created Azure Foundry model: {model_name} -> {deployment_name} @ {resource_name}"
+        )
+        return AnthropicModel(model_name=deployment_name, provider=provider)
+
+    except ImportError as e:
+        emit_error(
+            f"Failed to create Azure Foundry model '{model_name}': "
+            f"Missing dependency - {e}"
+        )
+        return None
+    except Exception as e:
+        emit_error(f"Failed to create Azure Foundry model '{model_name}': {e}")
+        logger.exception(f"Error creating Azure Foundry model: {e}")
+        return None
+
+
+def _register_model_types() -> List[Dict[str, Any]]:
+    """Register the azure_foundry model type handler."""
+    return [{"type": "azure_foundry", "handler": _create_azure_foundry_model}]
+
+
+# ============================================================================
+# Callback Registration
+# ============================================================================
+
+# Register all callbacks when this module is imported
+register_callback("custom_command_help", _custom_help)
+register_callback("custom_command", _handle_custom_command)
+register_callback("register_model_type", _register_model_types)

--- a/code_puppy/plugins/azure_foundry/register_callbacks.py
+++ b/code_puppy/plugins/azure_foundry/register_callbacks.py
@@ -379,8 +379,6 @@ def _create_azure_foundry_model(
         )
 
         model = AnthropicModel(model_name=deployment_name, provider=provider)
-        # Preserve the public model.provider attribute (convention used by other model factories)
-        model.provider = provider
         logger.info(
             "Created Azure Foundry model: %s -> %s @ %s",
             model_name,

--- a/code_puppy/plugins/azure_foundry/register_callbacks.py
+++ b/code_puppy/plugins/azure_foundry/register_callbacks.py
@@ -185,28 +185,14 @@ def _handle_foundry_setup() -> None:
             f"   Tip: Set {ENV_FOUNDRY_RESOURCE}={resource_name} in your environment"
         )
 
-    # Add models to config
+    # Add models to config — always pass the resolved deployment names so that
+    # pressing Enter (which keeps the default) is persisted, not treated as None.
     added_models = add_foundry_models_to_config(
         resource_name=resource_name,
-        opus_deployment=opus_deployment
-        if opus_deployment != opus_default or opus_input
-        else None,
-        sonnet_deployment=sonnet_deployment
-        if sonnet_deployment != sonnet_default or sonnet_input
-        else None,
-        haiku_deployment=haiku_deployment
-        if haiku_deployment != haiku_default or haiku_input
-        else None,
+        opus_deployment=opus_deployment,
+        sonnet_deployment=sonnet_deployment,
+        haiku_deployment=haiku_deployment,
     )
-
-    # If user entered defaults, add them too
-    if not added_models:
-        added_models = add_foundry_models_to_config(
-            resource_name=resource_name,
-            opus_deployment=opus_deployment,
-            sonnet_deployment=sonnet_deployment,
-            haiku_deployment=haiku_deployment,
-        )
 
     _print()
     if added_models:
@@ -262,19 +248,23 @@ def _handle_custom_command(command: str, name: str) -> bool | None:
     Returns:
         True if the command was handled, None otherwise.
     """
-    if name == "foundry-status":
-        _handle_foundry_status()
-        return True
+    handlers = {
+        "foundry-status": _handle_foundry_status,
+        "foundry-setup": _handle_foundry_setup,
+        "foundry-remove": _handle_foundry_remove,
+    }
 
-    if name == "foundry-setup":
-        _handle_foundry_setup()
-        return True
+    handler = handlers.get(name)
+    if handler is None:
+        return None
 
-    if name == "foundry-remove":
-        _handle_foundry_remove()
+    try:
+        handler()
         return True
-
-    return None
+    except Exception as e:
+        logger.exception("Error handling /%s command: %s", name, e)
+        emit_error(f"Command /{name} failed: {e}")
+        return False
 
 
 # ============================================================================
@@ -298,8 +288,15 @@ def _create_azure_foundry_model(
     Returns:
         An AnthropicModel instance configured for Azure Foundry, or None on error.
     """
-    from anthropic import AsyncAnthropicFoundry
-    from pydantic_ai.models.anthropic import AnthropicModel
+    try:
+        from anthropic import AsyncAnthropicFoundry
+        from pydantic_ai.models.anthropic import AnthropicModel
+    except ImportError as e:
+        emit_error(
+            f"Failed to create Azure Foundry model '{model_name}': "
+            f"Missing dependency - {e}"
+        )
+        return None
 
     from code_puppy.claude_cache_client import patch_anthropic_client_messages
     from code_puppy.config import get_effective_model_settings
@@ -338,16 +335,6 @@ def _create_azure_foundry_model(
         return None
 
     try:
-        # Create the Azure Foundry Anthropic client with token provider
-        # AsyncAnthropicFoundry uses the resource name to construct the endpoint
-        anthropic_client = AsyncAnthropicFoundry(
-            resource=resource_name,
-            azure_ad_token_provider=token_provider.get_token,
-        )
-
-        # Patch for cache control injection
-        patch_anthropic_client_messages(anthropic_client)
-
         # Check for interleaved thinking setting
         effective_settings = get_effective_model_settings(model_name)
         interleaved_thinking = effective_settings.get("interleaved_thinking", False)
@@ -362,11 +349,22 @@ def _create_azure_foundry_model(
         if context_length >= 1_000_000:
             beta_parts.append(CONTEXT_1M_BETA)
 
+        # Build default headers dict if we have beta features
+        default_headers: dict[str, str] | None = None
         if beta_parts:
-            # Set default headers using the public API
-            anthropic_client = anthropic_client.with_options(
-                default_headers={"anthropic-beta": ",".join(beta_parts)}
-            )
+            default_headers = {"anthropic-beta": ",".join(beta_parts)}
+
+        # Create the Azure Foundry Anthropic client with token provider
+        # Note: We pass default_headers here because AsyncAnthropicFoundry.with_options()
+        # has a bug where copy() passes auth_token which isn't a valid __init__ param
+        anthropic_client = AsyncAnthropicFoundry(
+            resource=resource_name,
+            azure_ad_token_provider=token_provider.get_token,
+            default_headers=default_headers,
+        )
+
+        # Patch for cache control injection
+        patch_anthropic_client_messages(anthropic_client)
 
         # Create the pydantic-ai provider and model
         provider_identity = resolve_provider_identity(model_name, model_config)

--- a/code_puppy/plugins/azure_foundry/register_callbacks.py
+++ b/code_puppy/plugins/azure_foundry/register_callbacks.py
@@ -340,9 +340,9 @@ def _create_azure_foundry_model(
         return None
 
     try:
-        # Check for interleaved thinking setting
+        # Check for interleaved thinking setting (default True for Foundry models)
         effective_settings = get_effective_model_settings(model_name)
-        interleaved_thinking = effective_settings.get("interleaved_thinking", False)
+        interleaved_thinking = effective_settings.get("interleaved_thinking", True)
 
         # Build anthropic-beta header if needed
         beta_parts: list[str] = []

--- a/code_puppy/plugins/azure_foundry/register_callbacks.py
+++ b/code_puppy/plugins/azure_foundry/register_callbacks.py
@@ -10,7 +10,8 @@ the need for API keys.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+import sys
+from typing import Any
 
 from code_puppy.callbacks import register_callback
 from code_puppy.command_line.utils import safe_input
@@ -96,7 +97,6 @@ def _handle_foundry_setup() -> None:
     Interactive wizard to configure Azure Foundry models.
     Uses print() for synchronous output to avoid message bus buffering issues.
     """
-    import sys
 
     def _print(msg: str = "") -> None:
         """Print with immediate flush."""
@@ -232,7 +232,7 @@ def _handle_foundry_remove() -> None:
 # ============================================================================
 
 
-def _custom_help() -> List[Tuple[str, str]]:
+def _custom_help() -> list[tuple[str, str]]:
     """Return help entries for custom commands."""
     return [
         ("foundry-status", "Check Azure AI Foundry authentication and configuration status"),
@@ -241,7 +241,7 @@ def _custom_help() -> List[Tuple[str, str]]:
     ]
 
 
-def _handle_custom_command(command: str, name: str) -> Optional[bool]:
+def _handle_custom_command(command: str, name: str) -> bool | None:
     """Handle custom slash commands for the Azure Foundry plugin.
 
     Args:
@@ -272,7 +272,7 @@ def _handle_custom_command(command: str, name: str) -> Optional[bool]:
 
 
 def _create_azure_foundry_model(
-    model_name: str, model_config: Dict, config: Dict
+    model_name: str, model_config: dict, config: dict
 ) -> Any:
     """Create an Azure Foundry model instance.
 
@@ -342,7 +342,7 @@ def _create_azure_foundry_model(
         interleaved_thinking = effective_settings.get("interleaved_thinking", False)
 
         # Build anthropic-beta header if needed
-        beta_parts: List[str] = []
+        beta_parts: list[str] = []
         if interleaved_thinking:
             beta_parts.append("interleaved-thinking-2025-05-14")
 
@@ -380,7 +380,7 @@ def _create_azure_foundry_model(
         return None
 
 
-def _register_model_types() -> List[Dict[str, Any]]:
+def _register_model_types() -> list[dict[str, Any]]:
     """Register the azure_foundry model type handler."""
     return [{"type": "azure_foundry", "handler": _create_azure_foundry_model}]
 

--- a/code_puppy/plugins/azure_foundry/register_callbacks.py
+++ b/code_puppy/plugins/azure_foundry/register_callbacks.py
@@ -363,9 +363,10 @@ def _create_azure_foundry_model(
             beta_parts.append(CONTEXT_1M_BETA)
 
         if beta_parts:
-            # Set default headers on the client
-            anthropic_client._custom_headers = anthropic_client._custom_headers or {}
-            anthropic_client._custom_headers["anthropic-beta"] = ",".join(beta_parts)
+            # Set default headers using the public API
+            anthropic_client = anthropic_client.with_options(
+                default_headers={"anthropic-beta": ",".join(beta_parts)}
+            )
 
         # Create the pydantic-ai provider and model
         provider_identity = resolve_provider_identity(model_name, model_config)

--- a/code_puppy/plugins/azure_foundry/register_callbacks.py
+++ b/code_puppy/plugins/azure_foundry/register_callbacks.py
@@ -181,14 +181,22 @@ def _handle_foundry_setup() -> None:
 
     # Set environment variable hint
     if not get_foundry_resource():
-        _print(f"   Tip: Set {ENV_FOUNDRY_RESOURCE}={resource_name} in your environment")
+        _print(
+            f"   Tip: Set {ENV_FOUNDRY_RESOURCE}={resource_name} in your environment"
+        )
 
     # Add models to config
     added_models = add_foundry_models_to_config(
         resource_name=resource_name,
-        opus_deployment=opus_deployment if opus_deployment != opus_default or opus_input else None,
-        sonnet_deployment=sonnet_deployment if sonnet_deployment != sonnet_default or sonnet_input else None,
-        haiku_deployment=haiku_deployment if haiku_deployment != haiku_default or haiku_input else None,
+        opus_deployment=opus_deployment
+        if opus_deployment != opus_default or opus_input
+        else None,
+        sonnet_deployment=sonnet_deployment
+        if sonnet_deployment != sonnet_default or sonnet_input
+        else None,
+        haiku_deployment=haiku_deployment
+        if haiku_deployment != haiku_default or haiku_input
+        else None,
     )
 
     # If user entered defaults, add them too
@@ -235,7 +243,10 @@ def _handle_foundry_remove() -> None:
 def _custom_help() -> list[tuple[str, str]]:
     """Return help entries for custom commands."""
     return [
-        ("foundry-status", "Check Azure AI Foundry authentication and configuration status"),
+        (
+            "foundry-status",
+            "Check Azure AI Foundry authentication and configuration status",
+        ),
         ("foundry-setup", "Interactive wizard to configure Azure Foundry models"),
         ("foundry-remove", "Remove all Azure Foundry model configurations"),
     ]

--- a/code_puppy/plugins/azure_foundry/register_callbacks.py
+++ b/code_puppy/plugins/azure_foundry/register_callbacks.py
@@ -59,16 +59,24 @@ def _handle_foundry_status() -> None:
     else:
         emit_warning(f"Authentication: {status_msg}")
 
-    # Check resource configuration
+    # List configured models and check resource
+    foundry_models = get_foundry_models_from_config()
+
+    # Check resource - from env var or from configured models
     resource = get_foundry_resource()
+    if not resource and foundry_models:
+        # Get resource from first configured model
+        first_model = next(iter(foundry_models.values()))
+        resource = first_model.get("foundry_resource", "")
+        if resource.startswith("$"):
+            resource = None  # It's an unresolved env var reference
+
     emit_info("")
     if resource:
         emit_info(f"Foundry Resource: {resource}")
     else:
         emit_warning(f"Foundry Resource: Not set (set {ENV_FOUNDRY_RESOURCE})")
 
-    # List configured models
-    foundry_models = get_foundry_models_from_config()
     emit_info("")
     if foundry_models:
         emit_info(f"Configured Models ({len(foundry_models)}):")
@@ -86,83 +94,94 @@ def _handle_foundry_setup() -> None:
     """Handle the /foundry-setup command.
 
     Interactive wizard to configure Azure Foundry models.
+    Uses print() for synchronous output to avoid message bus buffering issues.
     """
-    emit_info("")
-    emit_info("Azure AI Foundry Setup")
-    emit_info("=" * 40)
-    emit_info("")
+    import sys
+
+    def _print(msg: str = "") -> None:
+        """Print with immediate flush."""
+        print(msg, flush=True)
+
+    _print()
+    _print("Azure AI Foundry Setup")
+    _print("=" * 40)
+    _print()
 
     # Check Azure CLI authentication first
-    emit_info("Step 1: Checking Azure CLI authentication...")
+    _print("Step 1: Checking Azure CLI authentication...")
     token_provider = get_token_provider()
     is_auth, status_msg, user_info = token_provider.check_auth_status()
 
     if not is_auth:
-        emit_error(f"   {status_msg}")
-        emit_info("")
-        emit_info("Please run 'az login' first, then try again.")
+        _print(f"   ERROR: {status_msg}")
+        _print()
+        _print("Please run 'az login' first, then try again.")
         return
 
-    emit_success(f"   Authenticated: {status_msg}")
+    _print(f"   OK: {status_msg}")
     if user_info:
-        emit_info(f"   User: {user_info}")
-    emit_info("")
+        _print(f"   User: {user_info}")
+    _print()
 
     # Get resource name
+    _print("Step 2: Azure Resource Name")
+    current_resource = get_foundry_resource()
+    if current_resource:
+        _print(f"   Current: {current_resource}")
+
+    resource_prompt = "   Enter resource name"
+    if current_resource:
+        resource_prompt += f" [{current_resource}]"
+    resource_prompt += ": "
+
     set_awaiting_user_input(True)
     try:
-        emit_info("Step 2: Azure Resource Name")
-        current_resource = get_foundry_resource()
-        if current_resource:
-            emit_info(f"   Current: {current_resource}")
-
-        resource_prompt = "Enter your Azure Foundry resource name"
-        if current_resource:
-            resource_prompt += f" [{current_resource}]"
-        resource_prompt += ": "
-
+        sys.stdout.flush()
         resource_input = safe_input(resource_prompt).strip()
         resource_name = resource_input if resource_input else current_resource
 
         if not resource_name:
-            emit_error("Resource name is required.")
+            _print("   ERROR: Resource name is required.")
             return
 
-        emit_info("")
+        _print()
 
         # Get deployment names
-        emit_info("Step 3: Model Deployments")
-        emit_info("   Enter deployment names (press Enter to skip a model)")
-        emit_info("")
+        _print("Step 3: Model Deployments")
+        _print("   Enter deployment names (press Enter to use default)")
+        _print()
 
         opus_default = DEFAULT_DEPLOYMENT_NAMES["opus"]
         sonnet_default = DEFAULT_DEPLOYMENT_NAMES["sonnet"]
         haiku_default = DEFAULT_DEPLOYMENT_NAMES["haiku"]
 
-        opus_input = safe_input(f"   Opus deployment name [{opus_default}]: ").strip()
+        sys.stdout.flush()
+        opus_input = safe_input(f"   Opus [{opus_default}]: ").strip()
         opus_deployment = opus_input if opus_input else opus_default
 
-        sonnet_input = safe_input(f"   Sonnet deployment name [{sonnet_default}]: ").strip()
+        sys.stdout.flush()
+        sonnet_input = safe_input(f"   Sonnet [{sonnet_default}]: ").strip()
         sonnet_deployment = sonnet_input if sonnet_input else sonnet_default
 
-        haiku_input = safe_input(f"   Haiku deployment name [{haiku_default}]: ").strip()
+        sys.stdout.flush()
+        haiku_input = safe_input(f"   Haiku [{haiku_default}]: ").strip()
         haiku_deployment = haiku_input if haiku_input else haiku_default
 
     except (KeyboardInterrupt, EOFError):
-        emit_info("")
-        emit_warning("Setup cancelled.")
+        _print()
+        _print("Setup cancelled.")
         return
     finally:
         set_awaiting_user_input(False)
 
-    emit_info("")
+    _print()
 
     # Save configuration
-    emit_info("Step 4: Saving configuration...")
+    _print("Step 4: Saving configuration...")
 
     # Set environment variable hint
     if not get_foundry_resource():
-        emit_info(f"   Set {ENV_FOUNDRY_RESOURCE}={resource_name} in your environment")
+        _print(f"   Tip: Set {ENV_FOUNDRY_RESOURCE}={resource_name} in your environment")
 
     # Add models to config
     added_models = add_foundry_models_to_config(
@@ -181,17 +200,17 @@ def _handle_foundry_setup() -> None:
             haiku_deployment=haiku_deployment,
         )
 
-    emit_info("")
+    _print()
     if added_models:
-        emit_success(f"Configuration saved! Added {len(added_models)} model(s):")
+        _print(f"OK: Configuration saved! Added {len(added_models)} model(s):")
         for model_key in added_models:
-            emit_info(f"   - {model_key}")
-        emit_info("")
-        emit_info(f"Use '/model {added_models[0]}' to switch to a Foundry model.")
+            _print(f"   - {model_key}")
+        _print()
+        _print(f"Use '/model {added_models[0]}' to switch to a Foundry model.")
     else:
-        emit_warning("No models were added. Check the configuration.")
+        _print("WARNING: No models were added. Check the configuration.")
 
-    emit_info("")
+    _print()
 
 
 def _handle_foundry_remove() -> None:

--- a/code_puppy/plugins/azure_foundry/token.py
+++ b/code_puppy/plugins/azure_foundry/token.py
@@ -11,14 +11,14 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Callable, Optional, Tuple
+from collections.abc import Callable
 
 from .config import AZURE_COGNITIVE_SCOPE, TOKEN_REFRESH_BUFFER
 
 logger = logging.getLogger(__name__)
 
 # Singleton instance of the token provider
-_token_provider_instance: Optional["AzureFoundryTokenProvider"] = None
+_token_provider_instance: "AzureFoundryTokenProvider | None" = None
 
 
 class AzureFoundryTokenProvider:
@@ -43,9 +43,9 @@ class AzureFoundryTokenProvider:
         """
         self._scope = scope
         self._credential = None
-        self._token_provider_func: Optional[Callable[[], str]] = None
+        self._token_provider_func: Callable[[], str] | None = None
         self._initialized = False
-        self._init_error: Optional[str] = None
+        self._init_error: str | None = None
 
     def _ensure_initialized(self) -> bool:
         """Lazily initialize the Azure credential.
@@ -105,7 +105,7 @@ class AzureFoundryTokenProvider:
             logger.error(f"Failed to acquire token: {e}")
             raise RuntimeError(f"Failed to acquire Azure AD token: {e}") from e
 
-    def check_auth_status(self) -> Tuple[bool, str, Optional[str]]:
+    def check_auth_status(self) -> tuple[bool, str, str | None]:
         """Check if Azure CLI authentication is valid.
 
         Returns:

--- a/code_puppy/plugins/azure_foundry/token.py
+++ b/code_puppy/plugins/azure_foundry/token.py
@@ -139,7 +139,11 @@ class AzureFoundryTokenProvider:
                         payload += "=" * padding
                     decoded = base64.urlsafe_b64decode(payload)
                     claims = json.loads(decoded)
-                    user_info = claims.get("upn") or claims.get("email") or claims.get("preferred_username")
+                    user_info = (
+                        claims.get("upn")
+                        or claims.get("email")
+                        or claims.get("preferred_username")
+                    )
             except Exception:
                 # Ignore errors in user info extraction
                 pass
@@ -147,7 +151,11 @@ class AzureFoundryTokenProvider:
             if expires_in > TOKEN_REFRESH_BUFFER:
                 return True, f"Valid (expires in {expires_in // 60} minutes)", user_info
             else:
-                return True, f"Valid but expiring soon ({expires_in} seconds)", user_info
+                return (
+                    True,
+                    f"Valid but expiring soon ({expires_in} seconds)",
+                    user_info,
+                )
 
         except Exception as e:
             error_name = type(e).__name__

--- a/code_puppy/plugins/azure_foundry/token.py
+++ b/code_puppy/plugins/azure_foundry/token.py
@@ -1,0 +1,174 @@
+"""Azure AD token provider for Azure AI Foundry authentication.
+
+This module provides token management for authenticating with Azure AI Foundry
+using credentials from the Azure CLI (`az login`).
+
+The token provider uses `AzureCliCredential` from the `azure-identity` library
+to obtain tokens without requiring API keys.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Callable, Optional, Tuple
+
+from .config import AZURE_COGNITIVE_SCOPE, TOKEN_REFRESH_BUFFER
+
+logger = logging.getLogger(__name__)
+
+# Singleton instance of the token provider
+_token_provider_instance: Optional["AzureFoundryTokenProvider"] = None
+
+
+class AzureFoundryTokenProvider:
+    """Provides Azure AD tokens for Anthropic Foundry using az login credentials.
+
+    This class wraps the Azure CLI credential to provide tokens for
+    authenticating with Azure AI Foundry. It handles token caching and
+    provides status checking functionality.
+
+    Example:
+        >>> provider = AzureFoundryTokenProvider()
+        >>> token = provider.get_token()
+        >>> # Use token for API calls
+    """
+
+    def __init__(self, scope: str = AZURE_COGNITIVE_SCOPE):
+        """Initialize the token provider.
+
+        Args:
+            scope: The Azure AD scope for token acquisition.
+                   Defaults to the Cognitive Services scope.
+        """
+        self._scope = scope
+        self._credential = None
+        self._token_provider_func: Optional[Callable[[], str]] = None
+        self._initialized = False
+        self._init_error: Optional[str] = None
+
+    def _ensure_initialized(self) -> bool:
+        """Lazily initialize the Azure credential.
+
+        Returns:
+            True if initialization succeeded, False otherwise.
+        """
+        if self._initialized:
+            return self._init_error is None
+
+        try:
+            from azure.identity import AzureCliCredential, get_bearer_token_provider
+
+            self._credential = AzureCliCredential()
+            self._token_provider_func = get_bearer_token_provider(
+                self._credential, self._scope
+            )
+            self._initialized = True
+            self._init_error = None
+            logger.debug("Azure CLI credential initialized successfully")
+            return True
+
+        except ImportError as e:
+            self._initialized = True
+            self._init_error = f"azure-identity package not installed: {e}"
+            logger.error(self._init_error)
+            return False
+
+        except Exception as e:
+            self._initialized = True
+            self._init_error = f"Failed to initialize Azure credential: {e}"
+            logger.error(self._init_error)
+            return False
+
+    def get_token(self) -> str:
+        """Get a valid access token for Azure AI Foundry.
+
+        The token is obtained from the Azure CLI credential and is
+        automatically refreshed when needed by the underlying provider.
+
+        Returns:
+            A valid access token string.
+
+        Raises:
+            RuntimeError: If the token provider is not initialized or
+                         if token acquisition fails.
+        """
+        if not self._ensure_initialized():
+            raise RuntimeError(self._init_error or "Token provider not initialized")
+
+        if self._token_provider_func is None:
+            raise RuntimeError("Token provider function not available")
+
+        try:
+            return self._token_provider_func()
+        except Exception as e:
+            logger.error(f"Failed to acquire token: {e}")
+            raise RuntimeError(f"Failed to acquire Azure AD token: {e}") from e
+
+    def check_auth_status(self) -> Tuple[bool, str, Optional[str]]:
+        """Check if Azure CLI authentication is valid.
+
+        Returns:
+            A tuple of (is_authenticated, status_message, user_info):
+            - is_authenticated: True if auth is valid, False otherwise
+            - status_message: Human-readable status description
+            - user_info: Email/UPN of logged-in user if available
+        """
+        if not self._ensure_initialized():
+            return False, self._init_error or "Not initialized", None
+
+        try:
+            # Try to get a token to verify authentication
+            token = self._credential.get_token(self._scope)
+            expires_in = int(token.expires_on - time.time())
+
+            # Try to get user info from the token
+            user_info = None
+            try:
+                # The token is a JWT, we can decode the payload to get user info
+                import base64
+                import json
+
+                # Split the JWT and decode the payload (second part)
+                parts = token.token.split(".")
+                if len(parts) >= 2:
+                    # Add padding if needed
+                    payload = parts[1]
+                    padding = 4 - len(payload) % 4
+                    if padding != 4:
+                        payload += "=" * padding
+                    decoded = base64.urlsafe_b64decode(payload)
+                    claims = json.loads(decoded)
+                    user_info = claims.get("upn") or claims.get("email") or claims.get("preferred_username")
+            except Exception:
+                # Ignore errors in user info extraction
+                pass
+
+            if expires_in > TOKEN_REFRESH_BUFFER:
+                return True, f"Valid (expires in {expires_in // 60} minutes)", user_info
+            else:
+                return True, f"Valid but expiring soon ({expires_in} seconds)", user_info
+
+        except Exception as e:
+            error_name = type(e).__name__
+            if "CredentialUnavailableError" in error_name:
+                return False, "Not authenticated - run 'az login'", None
+            return False, f"Authentication error: {e}", None
+
+
+def get_token_provider() -> AzureFoundryTokenProvider:
+    """Get the singleton token provider instance.
+
+    Returns:
+        The global AzureFoundryTokenProvider instance.
+    """
+    global _token_provider_instance
+    if _token_provider_instance is None:
+        _token_provider_instance = AzureFoundryTokenProvider()
+    return _token_provider_instance
+
+
+def reset_token_provider() -> None:
+    """Reset the singleton token provider (useful for testing)."""
+    global _token_provider_instance
+    _token_provider_instance = None

--- a/code_puppy/plugins/azure_foundry/utils.py
+++ b/code_puppy/plugins/azure_foundry/utils.py
@@ -1,0 +1,217 @@
+"""Utility functions for the Azure AI Foundry plugin.
+
+This module provides helper functions for configuration management,
+environment variable resolution, and model configuration.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from .config import (
+    DEFAULT_CONTEXT_LENGTHS,
+    ENV_FOUNDRY_RESOURCE,
+    get_extra_models_path,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_env_var(value: str) -> str:
+    """Resolve a value that may contain an environment variable reference.
+
+    If the value starts with '$', it's treated as an environment variable
+    reference and resolved. Otherwise, the value is returned as-is.
+
+    Args:
+        value: The value to resolve, possibly starting with '$'.
+
+    Returns:
+        The resolved value.
+
+    Example:
+        >>> os.environ["MY_VAR"] = "test"
+        >>> resolve_env_var("$MY_VAR")
+        'test'
+        >>> resolve_env_var("literal")
+        'literal'
+    """
+    if value and value.startswith("$"):
+        env_var = value[1:]
+        resolved = os.environ.get(env_var)
+        if resolved is None:
+            logger.warning(f"Environment variable '{env_var}' not set")
+            return ""
+        return resolved
+    return value
+
+
+def load_extra_models() -> Dict[str, Any]:
+    """Load the extra_models.json configuration file.
+
+    Returns:
+        Dictionary containing model configurations, or empty dict if file
+        doesn't exist or is invalid.
+    """
+    extra_models_path = get_extra_models_path()
+    if not extra_models_path.exists():
+        return {}
+
+    try:
+        with open(extra_models_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except json.JSONDecodeError as e:
+        logger.error(f"Invalid JSON in extra_models.json: {e}")
+        return {}
+    except Exception as e:
+        logger.error(f"Error loading extra_models.json: {e}")
+        return {}
+
+
+def save_extra_models(models: Dict[str, Any]) -> bool:
+    """Save model configurations to extra_models.json.
+
+    Args:
+        models: Dictionary of model configurations to save.
+
+    Returns:
+        True if save succeeded, False otherwise.
+    """
+    extra_models_path = get_extra_models_path()
+
+    try:
+        # Ensure directory exists
+        extra_models_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Atomic write using temp file
+        temp_path = extra_models_path.with_suffix(".tmp")
+        with open(temp_path, "w", encoding="utf-8") as f:
+            json.dump(models, f, indent=2, ensure_ascii=False)
+        temp_path.replace(extra_models_path)
+
+        logger.info(f"Saved {len(models)} models to extra_models.json")
+        return True
+
+    except Exception as e:
+        logger.error(f"Error saving extra_models.json: {e}")
+        return False
+
+
+def build_foundry_model_config(
+    deployment_name: str,
+    model_tier: str,
+    foundry_resource: Optional[str] = None,
+    context_length: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Build a Code Puppy model configuration for an Azure Foundry deployment.
+
+    Args:
+        deployment_name: The deployment name in Azure Foundry.
+        model_tier: One of "opus", "sonnet", or "haiku".
+        foundry_resource: The Foundry resource name. If None, uses env var reference.
+        context_length: Override for context length. If None, uses default for tier.
+
+    Returns:
+        Dictionary containing the model configuration.
+    """
+    if context_length is None:
+        context_length = DEFAULT_CONTEXT_LENGTHS.get(model_tier.lower(), 200000)
+
+    resource_value = foundry_resource if foundry_resource else f"${ENV_FOUNDRY_RESOURCE}"
+
+    return {
+        "type": "azure_foundry",
+        "provider": "azure_foundry",
+        "name": deployment_name,
+        "foundry_resource": resource_value,
+        "context_length": context_length,
+        "supported_settings": ["temperature", "extended_thinking", "budget_tokens"],
+    }
+
+
+def add_foundry_models_to_config(
+    resource_name: str,
+    opus_deployment: Optional[str] = None,
+    sonnet_deployment: Optional[str] = None,
+    haiku_deployment: Optional[str] = None,
+) -> List[str]:
+    """Add Azure Foundry model configurations to extra_models.json.
+
+    Args:
+        resource_name: The Azure Foundry resource name.
+        opus_deployment: Deployment name for Opus model (optional).
+        sonnet_deployment: Deployment name for Sonnet model (optional).
+        haiku_deployment: Deployment name for Haiku model (optional).
+
+    Returns:
+        List of model keys that were added.
+    """
+    models = load_extra_models()
+    added_models: List[str] = []
+
+    deployments = [
+        ("opus", opus_deployment, "foundry-claude-opus"),
+        ("sonnet", sonnet_deployment, "foundry-claude-sonnet"),
+        ("haiku", haiku_deployment, "foundry-claude-haiku"),
+    ]
+
+    for tier, deployment, model_key in deployments:
+        if deployment:
+            # Check for 1M context indicator in deployment name
+            context_length = None
+            if "[1m]" in deployment.lower() or "1m" in deployment.lower():
+                context_length = 1000000
+
+            config = build_foundry_model_config(
+                deployment_name=deployment,
+                model_tier=tier,
+                foundry_resource=resource_name,
+                context_length=context_length,
+            )
+            models[model_key] = config
+            added_models.append(model_key)
+
+    if added_models and save_extra_models(models):
+        return added_models
+
+    return []
+
+
+def remove_foundry_models_from_config() -> List[str]:
+    """Remove all Azure Foundry model configurations from extra_models.json.
+
+    Returns:
+        List of model keys that were removed.
+    """
+    models = load_extra_models()
+    removed_models: List[str] = []
+
+    keys_to_remove = [
+        key for key, config in models.items()
+        if isinstance(config, dict) and config.get("type") == "azure_foundry"
+    ]
+
+    for key in keys_to_remove:
+        del models[key]
+        removed_models.append(key)
+
+    if removed_models:
+        save_extra_models(models)
+
+    return removed_models
+
+
+def get_foundry_models_from_config() -> Dict[str, Any]:
+    """Get all Azure Foundry model configurations from extra_models.json.
+
+    Returns:
+        Dictionary of model key -> config for all Foundry models.
+    """
+    models = load_extra_models()
+    return {
+        key: config for key, config in models.items()
+        if isinstance(config, dict) and config.get("type") == "azure_foundry"
+    }

--- a/code_puppy/plugins/azure_foundry/utils.py
+++ b/code_puppy/plugins/azure_foundry/utils.py
@@ -249,7 +249,9 @@ def remove_foundry_models_from_config() -> list[str]:
         removed_models.append(key)
 
     if removed_models:
-        save_extra_models(models)
+        if not save_extra_models(models):
+            logger.error("Failed to persist model removal")
+            return []
 
     return removed_models
 

--- a/code_puppy/plugins/azure_foundry/utils.py
+++ b/code_puppy/plugins/azure_foundry/utils.py
@@ -173,13 +173,25 @@ def build_foundry_model_config(
         foundry_resource if foundry_resource else f"${ENV_FOUNDRY_RESOURCE}"
     )
 
+    # All Anthropic models need extended_thinking + budget_tokens for the
+    # request body, plus interleaved_thinking for the beta header.
+    # Opus additionally supports effort (hand-in-hand with adaptive thinking).
+    supported_settings = [
+        "temperature",
+        "extended_thinking",
+        "budget_tokens",
+        "interleaved_thinking",
+    ]
+    if model_tier.lower() == "opus":
+        supported_settings.append("effort")
+
     return {
         "type": "azure_foundry",
         "provider": "azure_foundry",
         "name": deployment_name,
         "foundry_resource": resource_value,
         "context_length": context_length,
-        "supported_settings": ["temperature", "extended_thinking", "budget_tokens"],
+        "supported_settings": supported_settings,
     }
 
 

--- a/code_puppy/plugins/azure_foundry/utils.py
+++ b/code_puppy/plugins/azure_foundry/utils.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from .config import (
     DEFAULT_CONTEXT_LENGTHS,
@@ -49,7 +49,7 @@ def resolve_env_var(value: str) -> str:
     return value
 
 
-def load_extra_models() -> Dict[str, Any]:
+def load_extra_models() -> dict[str, Any]:
     """Load the extra_models.json configuration file.
 
     Returns:
@@ -71,7 +71,7 @@ def load_extra_models() -> Dict[str, Any]:
         return {}
 
 
-def save_extra_models(models: Dict[str, Any]) -> bool:
+def save_extra_models(models: dict[str, Any]) -> bool:
     """Save model configurations to extra_models.json.
 
     Args:
@@ -103,9 +103,9 @@ def save_extra_models(models: Dict[str, Any]) -> bool:
 def build_foundry_model_config(
     deployment_name: str,
     model_tier: str,
-    foundry_resource: Optional[str] = None,
-    context_length: Optional[int] = None,
-) -> Dict[str, Any]:
+    foundry_resource: str | None = None,
+    context_length: int | None = None,
+) -> dict[str, Any]:
     """Build a Code Puppy model configuration for an Azure Foundry deployment.
 
     Args:
@@ -134,10 +134,10 @@ def build_foundry_model_config(
 
 def add_foundry_models_to_config(
     resource_name: str,
-    opus_deployment: Optional[str] = None,
-    sonnet_deployment: Optional[str] = None,
-    haiku_deployment: Optional[str] = None,
-) -> List[str]:
+    opus_deployment: str | None = None,
+    sonnet_deployment: str | None = None,
+    haiku_deployment: str | None = None,
+) -> list[str]:
     """Add Azure Foundry model configurations to extra_models.json.
 
     Args:
@@ -150,7 +150,7 @@ def add_foundry_models_to_config(
         List of model keys that were added.
     """
     models = load_extra_models()
-    added_models: List[str] = []
+    added_models: list[str] = []
 
     deployments = [
         ("opus", opus_deployment, "foundry-claude-opus"),
@@ -180,14 +180,14 @@ def add_foundry_models_to_config(
     return []
 
 
-def remove_foundry_models_from_config() -> List[str]:
+def remove_foundry_models_from_config() -> list[str]:
     """Remove all Azure Foundry model configurations from extra_models.json.
 
     Returns:
         List of model keys that were removed.
     """
     models = load_extra_models()
-    removed_models: List[str] = []
+    removed_models: list[str] = []
 
     keys_to_remove = [
         key for key, config in models.items()
@@ -204,7 +204,7 @@ def remove_foundry_models_from_config() -> List[str]:
     return removed_models
 
 
-def get_foundry_models_from_config() -> Dict[str, Any]:
+def get_foundry_models_from_config() -> dict[str, Any]:
     """Get all Azure Foundry model configurations from extra_models.json.
 
     Returns:

--- a/code_puppy/plugins/azure_foundry/utils.py
+++ b/code_puppy/plugins/azure_foundry/utils.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from typing import Any
 
 from .config import (
@@ -18,6 +19,54 @@ from .config import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Context window suffix pattern: [<number><unit>] where unit is k or m (case-insensitive)
+# Examples: [200k], [500k], [1m], [2m]
+_CONTEXT_SUFFIX_PATTERN = re.compile(r"\[(\d+)([km])\]", re.IGNORECASE)
+
+# Multipliers for context window units
+_CONTEXT_MULTIPLIERS = {
+    "k": 1_000,
+    "m": 1_000_000,
+}
+
+
+def parse_context_window_suffix(name: str) -> tuple[str, int | None]:
+    """Parse and extract context window suffix from a model/deployment name.
+
+    Supports Claude Code format: [<number><unit>] where unit is 'k' (thousands)
+    or 'm' (millions). Examples: [200k], [500k], [1m], [2m]
+
+    Args:
+        name: The model or deployment name, possibly with context suffix.
+              e.g., "it-entra-claude-opus-4-6[1m]"
+
+    Returns:
+        A tuple of (stripped_name, context_length):
+        - stripped_name: The name with the suffix removed
+        - context_length: The parsed context length in tokens, or None if no suffix
+
+    Examples:
+        >>> parse_context_window_suffix("claude-opus-4-6[1m]")
+        ('claude-opus-4-6', 1000000)
+        >>> parse_context_window_suffix("claude-sonnet[200k]")
+        ('claude-sonnet', 200000)
+        >>> parse_context_window_suffix("claude-haiku-4-5")
+        ('claude-haiku-4-5', None)
+    """
+    match = _CONTEXT_SUFFIX_PATTERN.search(name)
+    if not match:
+        return name, None
+
+    number = int(match.group(1))
+    unit = match.group(2).lower()
+    multiplier = _CONTEXT_MULTIPLIERS[unit]
+    context_length = number * multiplier
+
+    # Remove the suffix from the name
+    stripped_name = _CONTEXT_SUFFIX_PATTERN.sub("", name).strip()
+
+    return stripped_name, context_length
 
 
 def resolve_env_var(value: str) -> str:
@@ -120,7 +169,9 @@ def build_foundry_model_config(
     if context_length is None:
         context_length = DEFAULT_CONTEXT_LENGTHS.get(model_tier.lower(), 200000)
 
-    resource_value = foundry_resource if foundry_resource else f"${ENV_FOUNDRY_RESOURCE}"
+    resource_value = (
+        foundry_resource if foundry_resource else f"${ENV_FOUNDRY_RESOURCE}"
+    )
 
     return {
         "type": "azure_foundry",
@@ -160,13 +211,11 @@ def add_foundry_models_to_config(
 
     for tier, deployment, model_key in deployments:
         if deployment:
-            # Check for 1M context indicator in deployment name
-            context_length = None
-            if "[1m]" in deployment.lower() or "1m" in deployment.lower():
-                context_length = 1000000
+            # Parse context window suffix (Claude Code format: [200k], [1m], etc.)
+            actual_deployment, context_length = parse_context_window_suffix(deployment)
 
             config = build_foundry_model_config(
-                deployment_name=deployment,
+                deployment_name=actual_deployment,
                 model_tier=tier,
                 foundry_resource=resource_name,
                 context_length=context_length,
@@ -190,7 +239,8 @@ def remove_foundry_models_from_config() -> list[str]:
     removed_models: list[str] = []
 
     keys_to_remove = [
-        key for key, config in models.items()
+        key
+        for key, config in models.items()
         if isinstance(config, dict) and config.get("type") == "azure_foundry"
     ]
 
@@ -212,6 +262,7 @@ def get_foundry_models_from_config() -> dict[str, Any]:
     """
     models = load_extra_models()
     return {
-        key: config for key, config in models.items()
+        key: config
+        for key, config in models.items()
         if isinstance(config, dict) and config.get("type") == "azure_foundry"
     }

--- a/code_puppy/plugins/copilot_auth/__init__.py
+++ b/code_puppy/plugins/copilot_auth/__init__.py
@@ -9,4 +9,3 @@ Commands:
 - ``/copilot-status`` — show auth & model status
 - ``/copilot-logout`` — remove tokens and registered models
 """
-

--- a/code_puppy/plugins/copilot_auth/config.py
+++ b/code_puppy/plugins/copilot_auth/config.py
@@ -72,7 +72,6 @@ COPILOT_MODEL_CONTEXT_LENGTHS: Dict[str, int] = {
 }
 
 
-
 def get_copilot_models_path() -> Path:
     """Return path for persisted copilot_models.json (XDG_DATA_HOME)."""
     data_dir = Path(config.DATA_DIR)
@@ -92,4 +91,3 @@ def get_device_token_storage_path() -> Path:
     data_dir = Path(config.DATA_DIR)
     data_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
     return data_dir / "copilot_device_tokens.json"
-

--- a/code_puppy/plugins/copilot_auth/reasoning_client.py
+++ b/code_puppy/plugins/copilot_auth/reasoning_client.py
@@ -39,6 +39,7 @@ _MAX_CACHE_ENTRIES = 256
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _text_key(text: str) -> str:
     """Short SHA-256 prefix — enough to avoid collisions in practice."""
     return hashlib.sha256(text.encode("utf-8")).hexdigest()[:32]
@@ -47,6 +48,7 @@ def _text_key(text: str) -> str:
 # ---------------------------------------------------------------------------
 # Stream wrapper — captures opaque data as SSE events flow through
 # ---------------------------------------------------------------------------
+
 
 class _OpaqueCapturingStream(AsyncByteStream):
     """Async byte-stream wrapper that taps ``reasoning_opaque`` from SSE.
@@ -162,6 +164,7 @@ class _OpaqueCapturingStream(AsyncByteStream):
 # Non-streaming capture (safety net)
 # ---------------------------------------------------------------------------
 
+
 def _capture_from_content(
     content: bytes,
     opaque_cache: Dict[str, str],
@@ -183,6 +186,7 @@ def _capture_from_content(
 # ---------------------------------------------------------------------------
 # Request-side injection
 # ---------------------------------------------------------------------------
+
 
 def _rebuild_request_body(
     request: httpx.Request,
@@ -336,6 +340,7 @@ def _strip_all_reasoning_fields(
 # Public API — single entry-point
 # ---------------------------------------------------------------------------
 
+
 def patch_client_for_reasoning_opaque(
     client: httpx.AsyncClient,
     thinking_field: str = "reasoning_text",
@@ -360,9 +365,7 @@ def patch_client_for_reasoning_opaque(
         # 1) Inject reasoning_opaque into outgoing POST bodies.
         #    Also strips orphaned reasoning_text with no cached opaque.
         if request.method == "POST":
-            _inject_opaque_into_request(
-                request, opaque_cache, client, thinking_field
-            )
+            _inject_opaque_into_request(request, opaque_cache, client, thinking_field)
 
         # 2) Let the real send (incl. auth + retries) run.
         response = await original_send(request, *args, **kwargs)
@@ -371,10 +374,7 @@ def patch_client_for_reasoning_opaque(
         #    our reasoning fields are wrong/stale.  Strip them all and
         #    retry once.  This degrades to "no thinking after tool calls"
         #    but keeps the conversation alive.
-        if (
-            response.status_code == 400
-            and request.method == "POST"
-        ):
+        if response.status_code == 400 and request.method == "POST":
             # Read the error body for diagnostics before retrying.
             try:
                 err_body = response.content.decode("utf-8", errors="replace")
@@ -394,17 +394,14 @@ def patch_client_for_reasoning_opaque(
                     )
                 else:
                     logger.warning(
-                        "Recovery retry also failed (%d) — returning "
-                        "retry response.",
+                        "Recovery retry also failed (%d) — returning retry response.",
                         response.status_code,
                     )
 
         # 4) Capture reasoning_opaque from successful responses.
         if response.status_code == 200:
             if response.is_stream_consumed:
-                _capture_from_content(
-                    response.content, opaque_cache, thinking_field
-                )
+                _capture_from_content(response.content, opaque_cache, thinking_field)
             elif hasattr(response, "stream") and response.stream is not None:
                 response.stream = _OpaqueCapturingStream(
                     response.stream, opaque_cache, thinking_field

--- a/code_puppy/plugins/copilot_auth/utils.py
+++ b/code_puppy/plugins/copilot_auth/utils.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 # Token storage — persisted tokens obtained via the Device Flow
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class CopilotToken:
     """An OAuth token for a GitHub host."""
@@ -56,6 +57,7 @@ def get_token_for_host(host: str) -> Optional[CopilotToken]:
 # Device Flow — browser-based GitHub OAuth (no IDE required)
 # ---------------------------------------------------------------------------
 
+
 def start_device_flow(host: str = "github.com") -> Optional[Dict[str, Any]]:
     """Initiate the GitHub Device Flow and return the device code response.
 
@@ -77,7 +79,9 @@ def start_device_flow(host: str = "github.com") -> Optional[Dict[str, Any]]:
             logger.warning("Device flow response missing required fields: %s", data)
         else:
             logger.warning(
-                "Device flow initiation failed: %s %s", resp.status_code, resp.text[:300]
+                "Device flow initiation failed: %s %s",
+                resp.status_code,
+                resp.text[:300],
             )
     except Exception as exc:
         logger.warning("Device flow error: %s", exc)
@@ -187,13 +191,16 @@ def load_device_tokens() -> List[CopilotToken]:
 # Copilot API bearer token (typically valid ~30 min).
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class SessionToken:
     """A short-lived Copilot API session token."""
 
     token: str
     expires_at: float  # Unix timestamp
-    api_endpoint: str = ""  # API base URL from the token response (may differ per region/host)
+    api_endpoint: str = (
+        ""  # API base URL from the token response (may differ per region/host)
+    )
 
 
 # Module-level cache keyed by (host, oauth_token[:16])
@@ -266,7 +273,9 @@ def exchange_for_session_token(
             )
         else:
             logger.warning(
-                "Copilot token exchange failed: %s %s", resp.status_code, resp.text[:200]
+                "Copilot token exchange failed: %s %s",
+                resp.status_code,
+                resp.text[:200],
             )
     except requests.exceptions.Timeout:
         logger.warning("Timeout exchanging Copilot token for host %s", host)
@@ -318,10 +327,14 @@ def _load_persisted_session(host: str, oauth_token: str = "") -> Optional[Sessio
             # Verify the stored fingerprint matches the current OAuth token
             stored_fp = entry.get("oauth_fingerprint", "")
             if oauth_token and stored_fp and stored_fp != oauth_token[:16]:
-                logger.debug("Persisted session fingerprint mismatch for %s — skipping", host)
+                logger.debug(
+                    "Persisted session fingerprint mismatch for %s — skipping", host
+                )
                 return None
 
-            api_endpoint = entry.get("api_endpoint", COPILOT_AUTH_CONFIG["api_base_url"])
+            api_endpoint = entry.get(
+                "api_endpoint", COPILOT_AUTH_CONFIG["api_base_url"]
+            )
             # Restore the host→endpoint mapping
             if api_endpoint:
                 _host_api_endpoints[host] = api_endpoint
@@ -391,6 +404,7 @@ def clear_caches() -> None:
 # Model persistence — copilot_models.json
 # ---------------------------------------------------------------------------
 
+
 def load_copilot_models() -> Dict[str, Any]:
     """Load registered Copilot models from copilot_models.json."""
     try:
@@ -436,9 +450,7 @@ def remove_copilot_models() -> int:
     return 0
 
 
-def fetch_copilot_models(
-    session_token: str, host: str = "github.com"
-) -> List[str]:
+def fetch_copilot_models(session_token: str, host: str = "github.com") -> List[str]:
     """Try to fetch the model catalogue from the Copilot API.
 
     Falls back to ``DEFAULT_COPILOT_MODELS`` if the endpoint is unavailable.
@@ -486,11 +498,7 @@ def _is_claude_model(model_name: str) -> bool:
 def _is_openai_model(model_name: str) -> bool:
     """Check if a model name refers to an OpenAI/GPT model."""
     lower = model_name.lower()
-    return (
-        lower.startswith("gpt-")
-        or lower.startswith("o3")
-        or lower.startswith("o4")
-    )
+    return lower.startswith("gpt-") or lower.startswith("o3") or lower.startswith("o4")
 
 
 def _build_claude_model_settings(model_name: str) -> Dict[str, Any]:
@@ -577,4 +585,3 @@ def add_models_to_config(
     except Exception as exc:
         logger.error("Error adding Copilot models to config: %s", exc)
     return False
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "websockets>=12.0",
     "termflow-md>=0.1.8",
     "Pillow>=10.0.0",
-    "anthropic>=0.80.0"
+    "anthropic>=0.80.0",
+    "azure-identity>=1.15.0"
 ]
 dev-dependencies = [
     "pytest>=8.3.4",

--- a/tests/plugins/test_azure_foundry.py
+++ b/tests/plugins/test_azure_foundry.py
@@ -1,0 +1,714 @@
+"""Comprehensive test suite for the Azure AI Foundry plugin.
+
+Tests cover token provider, configuration utilities, model creation,
+and slash command handlers with comprehensive mocking.
+"""
+
+import json
+import os
+import time
+from unittest.mock import Mock, patch
+
+import pytest
+
+
+# ============================================================================
+# FIXTURES
+# ============================================================================
+
+
+@pytest.fixture
+def mock_azure_token():
+    """Sample Azure AD token response."""
+    return Mock(
+        token="eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJ1cG4iOiJ1c2VyQGNvbXBhbnkuY29tIn0.sig",
+        expires_on=time.time() + 3600,
+    )
+
+
+@pytest.fixture
+def sample_foundry_config():
+    """Sample Foundry model configuration."""
+    return {
+        "foundry-claude-opus": {
+            "type": "azure_foundry",
+            "name": "it-entra-claude-opus-4-6[1m]",
+            "foundry_resource": "my-resource",
+            "context_length": 1000000,
+            "supported_settings": ["temperature", "extended_thinking", "budget_tokens"],
+        }
+    }
+
+
+@pytest.fixture
+def temp_extra_models(tmp_path, sample_foundry_config):
+    """Create a temporary extra_models.json file."""
+    extra_models_path = tmp_path / "extra_models.json"
+    with open(extra_models_path, "w") as f:
+        json.dump(sample_foundry_config, f)
+    return extra_models_path
+
+
+# ============================================================================
+# CONFIG MODULE TESTS
+# ============================================================================
+
+
+class TestConfig:
+    """Test configuration module functions."""
+
+    def test_azure_cognitive_scope_constant(self):
+        """Test that the Azure scope constant is correct."""
+        from code_puppy.plugins.azure_foundry.config import AZURE_COGNITIVE_SCOPE
+
+        assert AZURE_COGNITIVE_SCOPE == "https://cognitiveservices.azure.com/.default"
+
+    def test_default_deployment_names(self):
+        """Test default deployment name constants."""
+        from code_puppy.plugins.azure_foundry.config import DEFAULT_DEPLOYMENT_NAMES
+
+        assert "opus" in DEFAULT_DEPLOYMENT_NAMES
+        assert "sonnet" in DEFAULT_DEPLOYMENT_NAMES
+        assert "haiku" in DEFAULT_DEPLOYMENT_NAMES
+
+    def test_default_context_lengths(self):
+        """Test default context length constants."""
+        from code_puppy.plugins.azure_foundry.config import DEFAULT_CONTEXT_LENGTHS
+
+        assert DEFAULT_CONTEXT_LENGTHS["opus"] == 1000000
+        assert DEFAULT_CONTEXT_LENGTHS["sonnet"] == 1000000
+        assert DEFAULT_CONTEXT_LENGTHS["haiku"] == 200000
+
+    def test_get_foundry_resource_from_env(self):
+        """Test getting resource name from environment."""
+        from code_puppy.plugins.azure_foundry.config import get_foundry_resource
+
+        with patch.dict(os.environ, {"ANTHROPIC_FOUNDRY_RESOURCE": "test-resource"}):
+            assert get_foundry_resource() == "test-resource"
+
+    def test_get_foundry_resource_not_set(self):
+        """Test getting resource name when not set."""
+        from code_puppy.plugins.azure_foundry.config import get_foundry_resource
+
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove the env var if it exists
+            os.environ.pop("ANTHROPIC_FOUNDRY_RESOURCE", None)
+            assert get_foundry_resource() is None
+
+    def test_get_foundry_base_url_from_resource(self):
+        """Test constructing base URL from resource name."""
+        from code_puppy.plugins.azure_foundry.config import get_foundry_base_url
+
+        with patch.dict(
+            os.environ,
+            {"ANTHROPIC_FOUNDRY_RESOURCE": "my-resource"},
+            clear=True,
+        ):
+            os.environ.pop("ANTHROPIC_FOUNDRY_BASE_URL", None)
+            url = get_foundry_base_url()
+            assert url == "https://my-resource.services.ai.azure.com/anthropic/v1"
+
+    def test_get_foundry_base_url_override(self):
+        """Test using explicit base URL override."""
+        from code_puppy.plugins.azure_foundry.config import get_foundry_base_url
+
+        with patch.dict(
+            os.environ,
+            {"ANTHROPIC_FOUNDRY_BASE_URL": "https://custom.endpoint.com"},
+        ):
+            url = get_foundry_base_url()
+            assert url == "https://custom.endpoint.com"
+
+
+# ============================================================================
+# TOKEN PROVIDER TESTS
+# ============================================================================
+
+
+class TestAzureFoundryTokenProvider:
+    """Test Azure AD token provider functionality."""
+
+    def test_singleton_pattern(self):
+        """Test that get_token_provider returns singleton."""
+        from code_puppy.plugins.azure_foundry.token import (
+            get_token_provider,
+            reset_token_provider,
+        )
+
+        reset_token_provider()
+        provider1 = get_token_provider()
+        provider2 = get_token_provider()
+        assert provider1 is provider2
+
+    def test_reset_token_provider(self):
+        """Test resetting the singleton instance."""
+        from code_puppy.plugins.azure_foundry.token import (
+            get_token_provider,
+            reset_token_provider,
+        )
+
+        provider1 = get_token_provider()
+        reset_token_provider()
+        provider2 = get_token_provider()
+        assert provider1 is not provider2
+
+    def test_get_token_success(self, mock_azure_token):
+        """Test successful token acquisition."""
+        from code_puppy.plugins.azure_foundry.token import (
+            AzureFoundryTokenProvider,
+            reset_token_provider,
+        )
+
+        reset_token_provider()
+
+        mock_cred = Mock()
+        mock_token_func = Mock(return_value="test_token_123")
+
+        with patch("azure.identity.AzureCliCredential", return_value=mock_cred):
+            with patch("azure.identity.get_bearer_token_provider", return_value=mock_token_func):
+                provider = AzureFoundryTokenProvider()
+                token = provider.get_token()
+
+                assert token == "test_token_123"
+                mock_token_func.assert_called_once()
+
+    def test_check_auth_status_valid(self, mock_azure_token):
+        """Test auth status check when authenticated."""
+        from code_puppy.plugins.azure_foundry.token import (
+            AzureFoundryTokenProvider,
+            reset_token_provider,
+        )
+
+        reset_token_provider()
+
+        mock_cred = Mock()
+        mock_cred.get_token.return_value = mock_azure_token
+
+        with patch("azure.identity.AzureCliCredential", return_value=mock_cred):
+            with patch("azure.identity.get_bearer_token_provider", return_value=Mock()):
+                provider = AzureFoundryTokenProvider()
+                is_auth, status, user_info = provider.check_auth_status()
+
+                assert is_auth is True
+                assert "Valid" in status
+
+    def test_check_auth_status_not_authenticated(self):
+        """Test auth status when not logged in."""
+        from code_puppy.plugins.azure_foundry.token import (
+            AzureFoundryTokenProvider,
+            reset_token_provider,
+        )
+
+        reset_token_provider()
+
+        mock_cred = Mock()
+        # Simulate CredentialUnavailableError
+        mock_cred.get_token.side_effect = Exception("CredentialUnavailableError: Not logged in")
+
+        with patch("azure.identity.AzureCliCredential", return_value=mock_cred):
+            with patch("azure.identity.get_bearer_token_provider", return_value=Mock()):
+                provider = AzureFoundryTokenProvider()
+                is_auth, status, user_info = provider.check_auth_status()
+
+                assert is_auth is False
+
+    def test_init_error_handling(self):
+        """Test initialization error handling."""
+        from code_puppy.plugins.azure_foundry.token import (
+            AzureFoundryTokenProvider,
+            reset_token_provider,
+        )
+
+        reset_token_provider()
+
+        # Create a provider that will fail to initialize
+        with patch("azure.identity.AzureCliCredential", side_effect=Exception("Init failed")):
+            provider = AzureFoundryTokenProvider()
+            is_auth, status, user_info = provider.check_auth_status()
+
+            assert is_auth is False
+            assert "Init failed" in status or "Failed" in status
+
+
+# ============================================================================
+# UTILS MODULE TESTS
+# ============================================================================
+
+
+class TestResolveEnvVar:
+    """Test environment variable resolution."""
+
+    def test_resolve_env_var_with_dollar(self):
+        """Test resolving $VAR syntax."""
+        from code_puppy.plugins.azure_foundry.utils import resolve_env_var
+
+        with patch.dict(os.environ, {"MY_VAR": "resolved_value"}):
+            assert resolve_env_var("$MY_VAR") == "resolved_value"
+
+    def test_resolve_env_var_literal(self):
+        """Test literal values pass through."""
+        from code_puppy.plugins.azure_foundry.utils import resolve_env_var
+
+        assert resolve_env_var("literal_value") == "literal_value"
+
+    def test_resolve_env_var_not_set(self):
+        """Test resolving unset environment variable."""
+        from code_puppy.plugins.azure_foundry.utils import resolve_env_var
+
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("UNSET_VAR", None)
+            assert resolve_env_var("$UNSET_VAR") == ""
+
+    def test_resolve_env_var_empty(self):
+        """Test empty string passes through."""
+        from code_puppy.plugins.azure_foundry.utils import resolve_env_var
+
+        assert resolve_env_var("") == ""
+
+
+class TestLoadSaveExtraModels:
+    """Test extra_models.json loading and saving."""
+
+    def test_load_extra_models_not_exists(self, tmp_path):
+        """Test loading when file doesn't exist."""
+        from code_puppy.plugins.azure_foundry.utils import load_extra_models
+
+        with patch(
+            "code_puppy.plugins.azure_foundry.utils.get_extra_models_path",
+            return_value=tmp_path / "nonexistent.json",
+        ):
+            result = load_extra_models()
+            assert result == {}
+
+    def test_load_extra_models_success(self, temp_extra_models, sample_foundry_config):
+        """Test successful loading of extra_models.json."""
+        from code_puppy.plugins.azure_foundry.utils import load_extra_models
+
+        with patch(
+            "code_puppy.plugins.azure_foundry.utils.get_extra_models_path",
+            return_value=temp_extra_models,
+        ):
+            result = load_extra_models()
+            assert result == sample_foundry_config
+
+    def test_load_extra_models_invalid_json(self, tmp_path):
+        """Test loading invalid JSON."""
+        from code_puppy.plugins.azure_foundry.utils import load_extra_models
+
+        invalid_path = tmp_path / "invalid.json"
+        invalid_path.write_text("not valid json {{{")
+
+        with patch(
+            "code_puppy.plugins.azure_foundry.utils.get_extra_models_path",
+            return_value=invalid_path,
+        ):
+            result = load_extra_models()
+            assert result == {}
+
+    def test_save_extra_models_success(self, tmp_path):
+        """Test successful saving of models."""
+        from code_puppy.plugins.azure_foundry.utils import save_extra_models
+
+        models_path = tmp_path / "models.json"
+
+        with patch(
+            "code_puppy.plugins.azure_foundry.utils.get_extra_models_path",
+            return_value=models_path,
+        ):
+            result = save_extra_models({"test": {"type": "azure_foundry"}})
+            assert result is True
+            assert models_path.exists()
+
+            with open(models_path) as f:
+                saved = json.load(f)
+            assert saved == {"test": {"type": "azure_foundry"}}
+
+
+class TestBuildFoundryModelConfig:
+    """Test model configuration building."""
+
+    def test_build_config_with_defaults(self):
+        """Test building config with default values."""
+        from code_puppy.plugins.azure_foundry.utils import build_foundry_model_config
+
+        config = build_foundry_model_config(
+            deployment_name="claude-opus-4-6",
+            model_tier="opus",
+        )
+
+        assert config["type"] == "azure_foundry"
+        assert config["provider"] == "azure_foundry"
+        assert config["name"] == "claude-opus-4-6"
+        assert config["context_length"] == 1000000
+        assert "foundry_resource" in config
+
+    def test_build_config_with_custom_resource(self):
+        """Test building config with explicit resource."""
+        from code_puppy.plugins.azure_foundry.utils import build_foundry_model_config
+
+        config = build_foundry_model_config(
+            deployment_name="my-opus",
+            model_tier="opus",
+            foundry_resource="custom-resource",
+        )
+
+        assert config["foundry_resource"] == "custom-resource"
+
+    def test_build_config_with_custom_context_length(self):
+        """Test building config with custom context length."""
+        from code_puppy.plugins.azure_foundry.utils import build_foundry_model_config
+
+        config = build_foundry_model_config(
+            deployment_name="my-haiku",
+            model_tier="haiku",
+            context_length=500000,
+        )
+
+        assert config["context_length"] == 500000
+
+
+class TestAddRemoveFoundryModels:
+    """Test adding and removing Foundry models from config."""
+
+    def test_add_foundry_models(self, tmp_path):
+        """Test adding models to configuration."""
+        from code_puppy.plugins.azure_foundry.utils import (
+            add_foundry_models_to_config,
+            load_extra_models,
+        )
+
+        models_path = tmp_path / "models.json"
+
+        with patch(
+            "code_puppy.plugins.azure_foundry.utils.get_extra_models_path",
+            return_value=models_path,
+        ):
+            added = add_foundry_models_to_config(
+                resource_name="my-resource",
+                opus_deployment="it-entra-claude-opus-4-6[1m]",
+                sonnet_deployment="it-entra-claude-sonnet-4-6[1m]",
+            )
+
+            assert "foundry-claude-opus" in added
+            assert "foundry-claude-sonnet" in added
+            assert "foundry-claude-haiku" not in added
+
+            models = load_extra_models()
+            assert "foundry-claude-opus" in models
+            assert models["foundry-claude-opus"]["name"] == "it-entra-claude-opus-4-6[1m]"
+
+    def test_remove_foundry_models(self, tmp_path, sample_foundry_config):
+        """Test removing Foundry models from configuration."""
+        from code_puppy.plugins.azure_foundry.utils import remove_foundry_models_from_config
+
+        models_path = tmp_path / "models.json"
+        with open(models_path, "w") as f:
+            json.dump(sample_foundry_config, f)
+
+        with patch(
+            "code_puppy.plugins.azure_foundry.utils.get_extra_models_path",
+            return_value=models_path,
+        ):
+            removed = remove_foundry_models_from_config()
+            assert "foundry-claude-opus" in removed
+
+            with open(models_path) as f:
+                remaining = json.load(f)
+            assert "foundry-claude-opus" not in remaining
+
+
+class TestGetFoundryModelsFromConfig:
+    """Test getting Foundry models from configuration."""
+
+    def test_get_foundry_models(self, temp_extra_models, sample_foundry_config):
+        """Test filtering Foundry models from config."""
+        from code_puppy.plugins.azure_foundry.utils import get_foundry_models_from_config
+
+        with patch(
+            "code_puppy.plugins.azure_foundry.utils.get_extra_models_path",
+            return_value=temp_extra_models,
+        ):
+            models = get_foundry_models_from_config()
+            assert "foundry-claude-opus" in models
+
+    def test_get_foundry_models_mixed_types(self, tmp_path):
+        """Test filtering when other model types present."""
+        from code_puppy.plugins.azure_foundry.utils import get_foundry_models_from_config
+
+        mixed_config = {
+            "foundry-model": {"type": "azure_foundry", "name": "test"},
+            "openai-model": {"type": "openai", "name": "gpt-4"},
+            "anthropic-model": {"type": "anthropic", "name": "claude"},
+        }
+        models_path = tmp_path / "models.json"
+        with open(models_path, "w") as f:
+            json.dump(mixed_config, f)
+
+        with patch(
+            "code_puppy.plugins.azure_foundry.utils.get_extra_models_path",
+            return_value=models_path,
+        ):
+            foundry_models = get_foundry_models_from_config()
+            assert len(foundry_models) == 1
+            assert "foundry-model" in foundry_models
+
+
+# ============================================================================
+# REGISTER CALLBACKS TESTS
+# ============================================================================
+
+
+class TestSlashCommands:
+    """Test slash command handlers."""
+
+    @patch("code_puppy.plugins.azure_foundry.register_callbacks.get_token_provider")
+    @patch("code_puppy.plugins.azure_foundry.register_callbacks.get_foundry_resource")
+    @patch("code_puppy.plugins.azure_foundry.register_callbacks.get_foundry_models_from_config")
+    @patch("code_puppy.plugins.azure_foundry.register_callbacks.emit_info")
+    @patch("code_puppy.plugins.azure_foundry.register_callbacks.emit_success")
+    def test_handle_foundry_status_authenticated(
+        self, mock_emit_success, mock_emit_info, mock_get_models, mock_get_resource, mock_get_provider
+    ):
+        """Test /foundry-status when authenticated."""
+        from code_puppy.plugins.azure_foundry.register_callbacks import _handle_foundry_status
+
+        mock_provider = Mock()
+        mock_provider.check_auth_status.return_value = (
+            True,
+            "Valid (expires in 45 minutes)",
+            "user@company.com",
+        )
+        mock_get_provider.return_value = mock_provider
+        mock_get_resource.return_value = "my-resource"
+        mock_get_models.return_value = {
+            "foundry-claude-opus": {"name": "claude-opus-4-6"}
+        }
+
+        _handle_foundry_status()
+
+        mock_emit_success.assert_called()
+        # Check that authentication status was displayed
+        calls = [str(call) for call in mock_emit_success.call_args_list]
+        assert any("Valid" in str(c) for c in calls)
+
+    @patch("code_puppy.plugins.azure_foundry.register_callbacks.get_token_provider")
+    @patch("code_puppy.plugins.azure_foundry.register_callbacks.emit_warning")
+    @patch("code_puppy.plugins.azure_foundry.register_callbacks.emit_info")
+    def test_handle_foundry_status_not_authenticated(
+        self, mock_emit_info, mock_emit_warning, mock_get_provider
+    ):
+        """Test /foundry-status when not authenticated."""
+        from code_puppy.plugins.azure_foundry.register_callbacks import _handle_foundry_status
+
+        mock_provider = Mock()
+        mock_provider.check_auth_status.return_value = (
+            False,
+            "Not authenticated - run 'az login'",
+            None,
+        )
+        mock_get_provider.return_value = mock_provider
+
+        _handle_foundry_status()
+
+        mock_emit_warning.assert_called()
+
+    def test_handle_custom_command_status(self):
+        """Test custom command routing to status."""
+        from code_puppy.plugins.azure_foundry.register_callbacks import _handle_custom_command
+
+        with patch(
+            "code_puppy.plugins.azure_foundry.register_callbacks._handle_foundry_status"
+        ) as mock_status:
+            result = _handle_custom_command("/foundry-status", "foundry-status")
+            assert result is True
+            mock_status.assert_called_once()
+
+    def test_handle_custom_command_setup(self):
+        """Test custom command routing to setup."""
+        from code_puppy.plugins.azure_foundry.register_callbacks import _handle_custom_command
+
+        with patch(
+            "code_puppy.plugins.azure_foundry.register_callbacks._handle_foundry_setup"
+        ) as mock_setup:
+            result = _handle_custom_command("/foundry-setup", "foundry-setup")
+            assert result is True
+            mock_setup.assert_called_once()
+
+    def test_handle_custom_command_remove(self):
+        """Test custom command routing to remove."""
+        from code_puppy.plugins.azure_foundry.register_callbacks import _handle_custom_command
+
+        with patch(
+            "code_puppy.plugins.azure_foundry.register_callbacks._handle_foundry_remove"
+        ) as mock_remove:
+            result = _handle_custom_command("/foundry-remove", "foundry-remove")
+            assert result is True
+            mock_remove.assert_called_once()
+
+    def test_handle_custom_command_unknown(self):
+        """Test custom command returns None for unknown commands."""
+        from code_puppy.plugins.azure_foundry.register_callbacks import _handle_custom_command
+
+        result = _handle_custom_command("/other-command", "other-command")
+        assert result is None
+
+    def test_custom_help_entries(self):
+        """Test that help entries are returned."""
+        from code_puppy.plugins.azure_foundry.register_callbacks import _custom_help
+
+        help_entries = _custom_help()
+        assert len(help_entries) == 3
+
+        command_names = [entry[0] for entry in help_entries]
+        assert "foundry-status" in command_names
+        assert "foundry-setup" in command_names
+        assert "foundry-remove" in command_names
+
+
+class TestRegisterModelTypes:
+    """Test model type registration."""
+
+    def test_register_model_types(self):
+        """Test that azure_foundry model type is registered."""
+        from code_puppy.plugins.azure_foundry.register_callbacks import _register_model_types
+
+        registrations = _register_model_types()
+        assert len(registrations) == 1
+        assert registrations[0]["type"] == "azure_foundry"
+        assert callable(registrations[0]["handler"])
+
+
+class TestCreateAzureFoundryModel:
+    """Test Azure Foundry model creation."""
+
+    def test_create_model_no_resource(self):
+        """Test model creation fails without resource."""
+        from code_puppy.plugins.azure_foundry.register_callbacks import _create_azure_foundry_model
+
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("ANTHROPIC_FOUNDRY_RESOURCE", None)
+
+            with patch("code_puppy.plugins.azure_foundry.register_callbacks.emit_warning") as mock_warn:
+                result = _create_azure_foundry_model(
+                    model_name="foundry-test",
+                    model_config={"name": "test-deployment"},
+                    config={},
+                )
+
+                assert result is None
+                mock_warn.assert_called()
+
+    def test_create_model_no_deployment_name(self):
+        """Test model creation fails without deployment name."""
+        from code_puppy.plugins.azure_foundry.register_callbacks import _create_azure_foundry_model
+
+        with patch("code_puppy.plugins.azure_foundry.register_callbacks.emit_warning") as mock_warn:
+            result = _create_azure_foundry_model(
+                model_name="foundry-test",
+                model_config={"foundry_resource": "my-resource"},  # Missing 'name'
+                config={},
+            )
+
+            assert result is None
+            mock_warn.assert_called()
+
+    def test_create_model_auth_failed(self):
+        """Test model creation fails when not authenticated."""
+        from code_puppy.plugins.azure_foundry.register_callbacks import _create_azure_foundry_model
+
+        mock_provider = Mock()
+        mock_provider.check_auth_status.return_value = (
+            False,
+            "Not authenticated",
+            None,
+        )
+
+        with patch("code_puppy.plugins.azure_foundry.register_callbacks.get_token_provider", return_value=mock_provider):
+            with patch("code_puppy.plugins.azure_foundry.register_callbacks.emit_warning") as mock_warn:
+                result = _create_azure_foundry_model(
+                    model_name="foundry-test",
+                    model_config={
+                        "name": "test-deployment",
+                        "foundry_resource": "my-resource",
+                    },
+                    config={},
+                )
+
+                assert result is None
+                mock_warn.assert_called()
+
+    def test_create_model_success(self):
+        """Test successful model creation."""
+        from code_puppy.plugins.azure_foundry.register_callbacks import _create_azure_foundry_model
+
+        # Setup mocks
+        mock_provider = Mock()
+        mock_provider.check_auth_status.return_value = (True, "Valid", "user@test.com")
+        mock_provider.get_token = Mock(return_value="token123")
+
+        mock_client = Mock()
+        mock_client._custom_headers = {}
+        mock_model = Mock()
+
+        with patch("code_puppy.plugins.azure_foundry.register_callbacks.get_token_provider", return_value=mock_provider):
+            # Patch at anthropic module since it's imported inside the function
+            with patch("anthropic.AsyncAnthropicFoundry", return_value=mock_client) as mock_azure_class:
+                with patch("code_puppy.claude_cache_client.patch_anthropic_client_messages"):
+                    with patch("code_puppy.config.get_effective_model_settings", return_value={}):
+                        with patch("code_puppy.provider_identity.resolve_provider_identity", return_value="identity"):
+                            with patch("code_puppy.provider_identity.make_anthropic_provider", return_value=Mock()):
+                                with patch("pydantic_ai.models.anthropic.AnthropicModel", return_value=mock_model):
+                                    result = _create_azure_foundry_model(
+                                        model_name="foundry-claude-opus",
+                                        model_config={
+                                            "name": "it-entra-claude-opus-4-6[1m]",
+                                            "foundry_resource": "my-resource",
+                                            "context_length": 1000000,
+                                        },
+                                        config={},
+                                    )
+
+                                    assert result is mock_model
+                                    mock_azure_class.assert_called_once()
+                                    # Verify resource parameter
+                                    call_kwargs = mock_azure_class.call_args.kwargs
+                                    assert "resource" in call_kwargs
+                                    assert call_kwargs["resource"] == "my-resource"
+
+
+# ============================================================================
+# INTEGRATION TESTS
+# ============================================================================
+
+
+class TestPluginCallbackRegistration:
+    """Test that callbacks are properly registered on import."""
+
+    def test_callbacks_registered(self):
+        """Test that importing the module registers callbacks."""
+        # Import triggers callback registration (side effect is intentional)
+        import code_puppy.plugins.azure_foundry.register_callbacks  # noqa: F401
+
+        from code_puppy.callbacks import get_callbacks
+
+        # Check that there are callbacks registered for each phase
+        help_callbacks = get_callbacks("custom_command_help")
+        assert len(help_callbacks) > 0
+
+        cmd_callbacks = get_callbacks("custom_command")
+        assert len(cmd_callbacks) > 0
+
+        model_callbacks = get_callbacks("register_model_type")
+        assert len(model_callbacks) > 0
+
+    def test_help_includes_foundry_commands(self):
+        """Test that foundry commands are in help output."""
+        # Import the module to ensure callbacks are registered
+        from code_puppy.plugins.azure_foundry.register_callbacks import _custom_help
+
+        help_entries = _custom_help()
+        command_names = [name for name, _ in help_entries]
+
+        assert "foundry-status" in command_names
+        assert "foundry-setup" in command_names
+        assert "foundry-remove" in command_names

--- a/tests/plugins/test_azure_foundry.py
+++ b/tests/plugins/test_azure_foundry.py
@@ -367,6 +367,91 @@ class TestBuildFoundryModelConfig:
         assert config["context_length"] == 500000
 
 
+class TestParseContextWindowSuffix:
+    """Tests for parse_context_window_suffix function."""
+
+    def test_parse_1m_suffix(self):
+        """Test parsing [1m] suffix."""
+        from code_puppy.plugins.azure_foundry.utils import parse_context_window_suffix
+
+        name, context = parse_context_window_suffix("claude-opus-4-6[1m]")
+        assert name == "claude-opus-4-6"
+        assert context == 1_000_000
+
+    def test_parse_200k_suffix(self):
+        """Test parsing [200k] suffix."""
+        from code_puppy.plugins.azure_foundry.utils import parse_context_window_suffix
+
+        name, context = parse_context_window_suffix("claude-haiku[200k]")
+        assert name == "claude-haiku"
+        assert context == 200_000
+
+    def test_parse_500k_suffix(self):
+        """Test parsing [500k] suffix."""
+        from code_puppy.plugins.azure_foundry.utils import parse_context_window_suffix
+
+        name, context = parse_context_window_suffix("my-model[500k]")
+        assert name == "my-model"
+        assert context == 500_000
+
+    def test_parse_2m_suffix(self):
+        """Test parsing [2m] suffix for future models."""
+        from code_puppy.plugins.azure_foundry.utils import parse_context_window_suffix
+
+        name, context = parse_context_window_suffix("future-model[2m]")
+        assert name == "future-model"
+        assert context == 2_000_000
+
+    def test_case_insensitive_m(self):
+        """Test that suffix parsing is case-insensitive for M."""
+        from code_puppy.plugins.azure_foundry.utils import parse_context_window_suffix
+
+        name, context = parse_context_window_suffix("model[1M]")
+        assert name == "model"
+        assert context == 1_000_000
+
+    def test_case_insensitive_k(self):
+        """Test that suffix parsing is case-insensitive for K."""
+        from code_puppy.plugins.azure_foundry.utils import parse_context_window_suffix
+
+        name, context = parse_context_window_suffix("model[200K]")
+        assert name == "model"
+        assert context == 200_000
+
+    def test_no_suffix(self):
+        """Test model name without context suffix."""
+        from code_puppy.plugins.azure_foundry.utils import parse_context_window_suffix
+
+        name, context = parse_context_window_suffix("claude-haiku-4-5")
+        assert name == "claude-haiku-4-5"
+        assert context is None
+
+    def test_preserves_other_brackets(self):
+        """Test that non-context brackets are preserved."""
+        from code_puppy.plugins.azure_foundry.utils import parse_context_window_suffix
+
+        # [beta] doesn't match the pattern [<number><k|m>], so it's preserved
+        name, context = parse_context_window_suffix("model-[beta]-v1")
+        assert name == "model-[beta]-v1"
+        assert context is None
+
+    def test_empty_string(self):
+        """Test handling of empty string."""
+        from code_puppy.plugins.azure_foundry.utils import parse_context_window_suffix
+
+        name, context = parse_context_window_suffix("")
+        assert name == ""
+        assert context is None
+
+    def test_multiple_numbers(self):
+        """Test parsing larger numbers like [10m]."""
+        from code_puppy.plugins.azure_foundry.utils import parse_context_window_suffix
+
+        name, context = parse_context_window_suffix("model[10m]")
+        assert name == "model"
+        assert context == 10_000_000
+
+
 class TestAddRemoveFoundryModels:
     """Test adding and removing Foundry models from config."""
 
@@ -395,7 +480,10 @@ class TestAddRemoveFoundryModels:
 
             models = load_extra_models()
             assert "foundry-claude-opus" in models
-            assert models["foundry-claude-opus"]["name"] == "it-entra-claude-opus-4-6[1m]"
+            # [1m] suffix is stripped from deployment name
+            assert models["foundry-claude-opus"]["name"] == "it-entra-claude-opus-4-6"
+            # Context length is set based on parsed suffix
+            assert models["foundry-claude-opus"]["context_length"] == 1_000_000
 
     def test_remove_foundry_models(self, tmp_path, sample_foundry_config):
         """Test removing Foundry models from configuration."""

--- a/tests/plugins/test_azure_foundry.py
+++ b/tests/plugins/test_azure_foundry.py
@@ -165,7 +165,9 @@ class TestAzureFoundryTokenProvider:
         mock_token_func = Mock(return_value="test_token_123")
 
         with patch("azure.identity.AzureCliCredential", return_value=mock_cred):
-            with patch("azure.identity.get_bearer_token_provider", return_value=mock_token_func):
+            with patch(
+                "azure.identity.get_bearer_token_provider", return_value=mock_token_func
+            ):
                 provider = AzureFoundryTokenProvider()
                 token = provider.get_token()
 
@@ -203,7 +205,9 @@ class TestAzureFoundryTokenProvider:
 
         mock_cred = Mock()
         # Simulate CredentialUnavailableError
-        mock_cred.get_token.side_effect = Exception("CredentialUnavailableError: Not logged in")
+        mock_cred.get_token.side_effect = Exception(
+            "CredentialUnavailableError: Not logged in"
+        )
 
         with patch("azure.identity.AzureCliCredential", return_value=mock_cred):
             with patch("azure.identity.get_bearer_token_provider", return_value=Mock()):
@@ -222,7 +226,9 @@ class TestAzureFoundryTokenProvider:
         reset_token_provider()
 
         # Create a provider that will fail to initialize
-        with patch("azure.identity.AzureCliCredential", side_effect=Exception("Init failed")):
+        with patch(
+            "azure.identity.AzureCliCredential", side_effect=Exception("Init failed")
+        ):
             provider = AzureFoundryTokenProvider()
             is_auth, status, user_info = provider.check_auth_status()
 
@@ -487,7 +493,9 @@ class TestAddRemoveFoundryModels:
 
     def test_remove_foundry_models(self, tmp_path, sample_foundry_config):
         """Test removing Foundry models from configuration."""
-        from code_puppy.plugins.azure_foundry.utils import remove_foundry_models_from_config
+        from code_puppy.plugins.azure_foundry.utils import (
+            remove_foundry_models_from_config,
+        )
 
         models_path = tmp_path / "models.json"
         with open(models_path, "w") as f:
@@ -510,7 +518,9 @@ class TestGetFoundryModelsFromConfig:
 
     def test_get_foundry_models(self, temp_extra_models, sample_foundry_config):
         """Test filtering Foundry models from config."""
-        from code_puppy.plugins.azure_foundry.utils import get_foundry_models_from_config
+        from code_puppy.plugins.azure_foundry.utils import (
+            get_foundry_models_from_config,
+        )
 
         with patch(
             "code_puppy.plugins.azure_foundry.utils.get_extra_models_path",
@@ -521,7 +531,9 @@ class TestGetFoundryModelsFromConfig:
 
     def test_get_foundry_models_mixed_types(self, tmp_path):
         """Test filtering when other model types present."""
-        from code_puppy.plugins.azure_foundry.utils import get_foundry_models_from_config
+        from code_puppy.plugins.azure_foundry.utils import (
+            get_foundry_models_from_config,
+        )
 
         mixed_config = {
             "foundry-model": {"type": "azure_foundry", "name": "test"},
@@ -551,14 +563,23 @@ class TestSlashCommands:
 
     @patch("code_puppy.plugins.azure_foundry.register_callbacks.get_token_provider")
     @patch("code_puppy.plugins.azure_foundry.register_callbacks.get_foundry_resource")
-    @patch("code_puppy.plugins.azure_foundry.register_callbacks.get_foundry_models_from_config")
+    @patch(
+        "code_puppy.plugins.azure_foundry.register_callbacks.get_foundry_models_from_config"
+    )
     @patch("code_puppy.plugins.azure_foundry.register_callbacks.emit_info")
     @patch("code_puppy.plugins.azure_foundry.register_callbacks.emit_success")
     def test_handle_foundry_status_authenticated(
-        self, mock_emit_success, mock_emit_info, mock_get_models, mock_get_resource, mock_get_provider
+        self,
+        mock_emit_success,
+        mock_emit_info,
+        mock_get_models,
+        mock_get_resource,
+        mock_get_provider,
     ):
         """Test /foundry-status when authenticated."""
-        from code_puppy.plugins.azure_foundry.register_callbacks import _handle_foundry_status
+        from code_puppy.plugins.azure_foundry.register_callbacks import (
+            _handle_foundry_status,
+        )
 
         mock_provider = Mock()
         mock_provider.check_auth_status.return_value = (
@@ -586,7 +607,9 @@ class TestSlashCommands:
         self, mock_emit_info, mock_emit_warning, mock_get_provider
     ):
         """Test /foundry-status when not authenticated."""
-        from code_puppy.plugins.azure_foundry.register_callbacks import _handle_foundry_status
+        from code_puppy.plugins.azure_foundry.register_callbacks import (
+            _handle_foundry_status,
+        )
 
         mock_provider = Mock()
         mock_provider.check_auth_status.return_value = (
@@ -602,7 +625,9 @@ class TestSlashCommands:
 
     def test_handle_custom_command_status(self):
         """Test custom command routing to status."""
-        from code_puppy.plugins.azure_foundry.register_callbacks import _handle_custom_command
+        from code_puppy.plugins.azure_foundry.register_callbacks import (
+            _handle_custom_command,
+        )
 
         with patch(
             "code_puppy.plugins.azure_foundry.register_callbacks._handle_foundry_status"
@@ -613,7 +638,9 @@ class TestSlashCommands:
 
     def test_handle_custom_command_setup(self):
         """Test custom command routing to setup."""
-        from code_puppy.plugins.azure_foundry.register_callbacks import _handle_custom_command
+        from code_puppy.plugins.azure_foundry.register_callbacks import (
+            _handle_custom_command,
+        )
 
         with patch(
             "code_puppy.plugins.azure_foundry.register_callbacks._handle_foundry_setup"
@@ -624,7 +651,9 @@ class TestSlashCommands:
 
     def test_handle_custom_command_remove(self):
         """Test custom command routing to remove."""
-        from code_puppy.plugins.azure_foundry.register_callbacks import _handle_custom_command
+        from code_puppy.plugins.azure_foundry.register_callbacks import (
+            _handle_custom_command,
+        )
 
         with patch(
             "code_puppy.plugins.azure_foundry.register_callbacks._handle_foundry_remove"
@@ -635,7 +664,9 @@ class TestSlashCommands:
 
     def test_handle_custom_command_unknown(self):
         """Test custom command returns None for unknown commands."""
-        from code_puppy.plugins.azure_foundry.register_callbacks import _handle_custom_command
+        from code_puppy.plugins.azure_foundry.register_callbacks import (
+            _handle_custom_command,
+        )
 
         result = _handle_custom_command("/other-command", "other-command")
         assert result is None
@@ -658,7 +689,9 @@ class TestRegisterModelTypes:
 
     def test_register_model_types(self):
         """Test that azure_foundry model type is registered."""
-        from code_puppy.plugins.azure_foundry.register_callbacks import _register_model_types
+        from code_puppy.plugins.azure_foundry.register_callbacks import (
+            _register_model_types,
+        )
 
         registrations = _register_model_types()
         assert len(registrations) == 1
@@ -671,12 +704,16 @@ class TestCreateAzureFoundryModel:
 
     def test_create_model_no_resource(self):
         """Test model creation fails without resource."""
-        from code_puppy.plugins.azure_foundry.register_callbacks import _create_azure_foundry_model
+        from code_puppy.plugins.azure_foundry.register_callbacks import (
+            _create_azure_foundry_model,
+        )
 
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop("ANTHROPIC_FOUNDRY_RESOURCE", None)
 
-            with patch("code_puppy.plugins.azure_foundry.register_callbacks.emit_warning") as mock_warn:
+            with patch(
+                "code_puppy.plugins.azure_foundry.register_callbacks.emit_warning"
+            ) as mock_warn:
                 result = _create_azure_foundry_model(
                     model_name="foundry-test",
                     model_config={"name": "test-deployment"},
@@ -688,9 +725,13 @@ class TestCreateAzureFoundryModel:
 
     def test_create_model_no_deployment_name(self):
         """Test model creation fails without deployment name."""
-        from code_puppy.plugins.azure_foundry.register_callbacks import _create_azure_foundry_model
+        from code_puppy.plugins.azure_foundry.register_callbacks import (
+            _create_azure_foundry_model,
+        )
 
-        with patch("code_puppy.plugins.azure_foundry.register_callbacks.emit_warning") as mock_warn:
+        with patch(
+            "code_puppy.plugins.azure_foundry.register_callbacks.emit_warning"
+        ) as mock_warn:
             result = _create_azure_foundry_model(
                 model_name="foundry-test",
                 model_config={"foundry_resource": "my-resource"},  # Missing 'name'
@@ -702,7 +743,9 @@ class TestCreateAzureFoundryModel:
 
     def test_create_model_auth_failed(self):
         """Test model creation fails when not authenticated."""
-        from code_puppy.plugins.azure_foundry.register_callbacks import _create_azure_foundry_model
+        from code_puppy.plugins.azure_foundry.register_callbacks import (
+            _create_azure_foundry_model,
+        )
 
         mock_provider = Mock()
         mock_provider.check_auth_status.return_value = (
@@ -711,8 +754,13 @@ class TestCreateAzureFoundryModel:
             None,
         )
 
-        with patch("code_puppy.plugins.azure_foundry.register_callbacks.get_token_provider", return_value=mock_provider):
-            with patch("code_puppy.plugins.azure_foundry.register_callbacks.emit_warning") as mock_warn:
+        with patch(
+            "code_puppy.plugins.azure_foundry.register_callbacks.get_token_provider",
+            return_value=mock_provider,
+        ):
+            with patch(
+                "code_puppy.plugins.azure_foundry.register_callbacks.emit_warning"
+            ) as mock_warn:
                 result = _create_azure_foundry_model(
                     model_name="foundry-test",
                     model_config={
@@ -727,7 +775,9 @@ class TestCreateAzureFoundryModel:
 
     def test_create_model_success(self):
         """Test successful model creation."""
-        from code_puppy.plugins.azure_foundry.register_callbacks import _create_azure_foundry_model
+        from code_puppy.plugins.azure_foundry.register_callbacks import (
+            _create_azure_foundry_model,
+        )
 
         # Setup mocks
         mock_provider = Mock()
@@ -738,14 +788,33 @@ class TestCreateAzureFoundryModel:
         mock_client._custom_headers = {}
         mock_model = Mock()
 
-        with patch("code_puppy.plugins.azure_foundry.register_callbacks.get_token_provider", return_value=mock_provider):
+        with patch(
+            "code_puppy.plugins.azure_foundry.register_callbacks.get_token_provider",
+            return_value=mock_provider,
+        ):
             # Patch at anthropic module since it's imported inside the function
-            with patch("anthropic.AsyncAnthropicFoundry", return_value=mock_client) as mock_azure_class:
-                with patch("code_puppy.claude_cache_client.patch_anthropic_client_messages"):
-                    with patch("code_puppy.config.get_effective_model_settings", return_value={}):
-                        with patch("code_puppy.provider_identity.resolve_provider_identity", return_value="identity"):
-                            with patch("code_puppy.provider_identity.make_anthropic_provider", return_value=Mock()):
-                                with patch("pydantic_ai.models.anthropic.AnthropicModel", return_value=mock_model):
+            with patch(
+                "anthropic.AsyncAnthropicFoundry", return_value=mock_client
+            ) as mock_azure_class:
+                with patch(
+                    "code_puppy.claude_cache_client.patch_anthropic_client_messages"
+                ):
+                    with patch(
+                        "code_puppy.config.get_effective_model_settings",
+                        return_value={},
+                    ):
+                        with patch(
+                            "code_puppy.provider_identity.resolve_provider_identity",
+                            return_value="identity",
+                        ):
+                            with patch(
+                                "code_puppy.provider_identity.make_anthropic_provider",
+                                return_value=Mock(),
+                            ):
+                                with patch(
+                                    "pydantic_ai.models.anthropic.AnthropicModel",
+                                    return_value=mock_model,
+                                ):
                                     result = _create_azure_foundry_model(
                                         model_name="foundry-claude-opus",
                                         model_config={

--- a/tests/plugins/test_copilot_reasoning_client.py
+++ b/tests/plugins/test_copilot_reasoning_client.py
@@ -9,9 +9,7 @@ Verifies that reasoning_client.py correctly:
 
 from __future__ import annotations
 
-import asyncio
 import json
-from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -30,6 +28,7 @@ from code_puppy.plugins.copilot_auth.reasoning_client import (
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _sse_line(data: dict) -> bytes:
     return f"data: {json.dumps(data)}\n\n".encode()
@@ -59,16 +58,20 @@ def _make_non_streaming_response(
     reasoning_text: str,
     reasoning_opaque: str,
 ) -> bytes:
-    return json.dumps({
-        "choices": [{
-            "message": {
-                "role": "assistant",
-                "content": "Hello!",
-                "reasoning_text": reasoning_text,
-                "reasoning_opaque": reasoning_opaque,
-            }
-        }]
-    }).encode()
+    return json.dumps(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "Hello!",
+                        "reasoning_text": reasoning_text,
+                        "reasoning_opaque": reasoning_opaque,
+                    }
+                }
+            ]
+        }
+    ).encode()
 
 
 def _make_request_body(messages: list[dict]) -> bytes:
@@ -93,6 +96,7 @@ class FakeAsyncStream:
 # _text_key
 # ---------------------------------------------------------------------------
 
+
 class TestTextKey:
     def test_deterministic(self):
         assert _text_key("hello") == _text_key("hello")
@@ -107,6 +111,7 @@ class TestTextKey:
 # ---------------------------------------------------------------------------
 # _OpaqueCapturingStream
 # ---------------------------------------------------------------------------
+
 
 class TestOpaqueCapturingStream:
     @pytest.mark.asyncio
@@ -194,6 +199,7 @@ class TestOpaqueCapturingStream:
 # _capture_from_content (non-streaming)
 # ---------------------------------------------------------------------------
 
+
 class TestCaptureFromContent:
     def test_captures_from_non_streaming_response(self):
         cache: dict[str, str] = {}
@@ -206,9 +212,9 @@ class TestCaptureFromContent:
 
     def test_ignores_response_without_opaque(self):
         cache: dict[str, str] = {}
-        content = json.dumps({
-            "choices": [{"message": {"reasoning_text": "thoughts"}}]
-        }).encode()
+        content = json.dumps(
+            {"choices": [{"message": {"reasoning_text": "thoughts"}}]}
+        ).encode()
         _capture_from_content(content, cache, "reasoning_text")
         assert cache == {}
 
@@ -222,6 +228,7 @@ class TestCaptureFromContent:
 # _inject_opaque_into_request
 # ---------------------------------------------------------------------------
 
+
 class TestInjectOpaqueIntoRequest:
     def test_injects_opaque_for_matching_assistant_message(self):
         thinking_text = "I'm thinking deeply"
@@ -232,7 +239,9 @@ class TestInjectOpaqueIntoRequest:
             {"role": "assistant", "reasoning_text": thinking_text, "content": "Hello!"},
         ]
         body = _make_request_body(messages)
-        request = httpx.Request("POST", "https://api.example.com/v1/chat/completions", content=body)
+        request = httpx.Request(
+            "POST", "https://api.example.com/v1/chat/completions", content=body
+        )
 
         client = httpx.AsyncClient()
         _inject_opaque_into_request(request, cache, client, "reasoning_text")
@@ -254,7 +263,9 @@ class TestInjectOpaqueIntoRequest:
             },
         ]
         body = _make_request_body(messages)
-        request = httpx.Request("POST", "https://api.example.com/v1/chat/completions", content=body)
+        request = httpx.Request(
+            "POST", "https://api.example.com/v1/chat/completions", content=body
+        )
 
         client = httpx.AsyncClient()
         _inject_opaque_into_request(request, cache, client, "reasoning_text")
@@ -267,7 +278,9 @@ class TestInjectOpaqueIntoRequest:
         cache = {_text_key("stuff"): "opaque"}
         messages = [{"role": "user", "content": "Hi", "reasoning_text": "stuff"}]
         body = _make_request_body(messages)
-        request = httpx.Request("POST", "https://api.example.com/v1/chat/completions", content=body)
+        request = httpx.Request(
+            "POST", "https://api.example.com/v1/chat/completions", content=body
+        )
 
         original_content = request.content
         client = httpx.AsyncClient()
@@ -280,10 +293,16 @@ class TestInjectOpaqueIntoRequest:
         """When no opaque is cached, reasoning_text is stripped to prevent 400."""
         cache: dict[str, str] = {}
         messages = [
-            {"role": "assistant", "reasoning_text": "unknown thoughts", "content": "Hi"},
+            {
+                "role": "assistant",
+                "reasoning_text": "unknown thoughts",
+                "content": "Hi",
+            },
         ]
         body = _make_request_body(messages)
-        request = httpx.Request("POST", "https://api.example.com/v1/chat/completions", content=body)
+        request = httpx.Request(
+            "POST", "https://api.example.com/v1/chat/completions", content=body
+        )
 
         client = httpx.AsyncClient()
         _inject_opaque_into_request(request, cache, client, "reasoning_text")
@@ -304,7 +323,8 @@ class TestInjectOpaqueIntoRequest:
     def test_handles_non_json_body_gracefully(self):
         cache = {_text_key("x"): "y"}
         request = httpx.Request(
-            "POST", "https://api.example.com/v1/chat/completions",
+            "POST",
+            "https://api.example.com/v1/chat/completions",
             content=b"not json",
         )
         client = httpx.AsyncClient()
@@ -314,6 +334,7 @@ class TestInjectOpaqueIntoRequest:
 # ---------------------------------------------------------------------------
 # _strip_all_reasoning_fields (recovery layer)
 # ---------------------------------------------------------------------------
+
 
 class TestStripAllReasoningFields:
     def test_strips_both_fields_from_assistant_messages(self):
@@ -333,7 +354,9 @@ class TestStripAllReasoningFields:
             },
         ]
         body = _make_request_body(messages)
-        request = httpx.Request("POST", "https://api.example.com/v1/chat/completions", content=body)
+        request = httpx.Request(
+            "POST", "https://api.example.com/v1/chat/completions", content=body
+        )
         client = httpx.AsyncClient()
 
         result = _strip_all_reasoning_fields(request, client, "reasoning_text")
@@ -353,7 +376,9 @@ class TestStripAllReasoningFields:
             {"role": "assistant", "content": "Hello!"},
         ]
         body = _make_request_body(messages)
-        request = httpx.Request("POST", "https://api.example.com/v1/chat/completions", content=body)
+        request = httpx.Request(
+            "POST", "https://api.example.com/v1/chat/completions", content=body
+        )
         client = httpx.AsyncClient()
 
         result = _strip_all_reasoning_fields(request, client, "reasoning_text")
@@ -364,7 +389,9 @@ class TestStripAllReasoningFields:
             {"role": "user", "content": "Hi", "reasoning_text": "sneaky"},
         ]
         body = _make_request_body(messages)
-        request = httpx.Request("POST", "https://api.example.com/v1/chat/completions", content=body)
+        request = httpx.Request(
+            "POST", "https://api.example.com/v1/chat/completions", content=body
+        )
         client = httpx.AsyncClient()
 
         result = _strip_all_reasoning_fields(request, client, "reasoning_text")
@@ -380,6 +407,7 @@ class TestStripAllReasoningFields:
 # ---------------------------------------------------------------------------
 # 400 retry integration (patch_client_for_reasoning_opaque)
 # ---------------------------------------------------------------------------
+
 
 class TestRetryOn400:
     @pytest.mark.asyncio
@@ -400,7 +428,6 @@ class TestRetryOn400:
         )
 
         opaque_cache: dict[str, str] = {}  # Empty — will trigger stripping
-        real_build = client.build_request
 
         async def tracking_send(request, *args, **kwargs):
             nonlocal call_count
@@ -417,7 +444,11 @@ class TestRetryOn400:
 
         messages = [
             {"role": "user", "content": "Hi"},
-            {"role": "assistant", "reasoning_text": "deep thoughts", "content": "Hello!"},
+            {
+                "role": "assistant",
+                "reasoning_text": "deep thoughts",
+                "content": "Hello!",
+            },
         ]
         body = json.dumps({"model": "claude-sonnet-4", "messages": messages}).encode()
         request = httpx.Request(
@@ -508,6 +539,7 @@ class TestRetryOn400:
 # patch_client_for_reasoning_opaque (integration)
 # ---------------------------------------------------------------------------
 
+
 class TestPatchClientIntegration:
     """End-to-end tests through the actual patched client pipeline.
 
@@ -541,9 +573,7 @@ class TestPatchClientIntegration:
         req1 = httpx.Request(
             "POST",
             "https://api.example.com/chat/completions",
-            content=_make_request_body(
-                [{"role": "user", "content": "Hi"}]
-            ),
+            content=_make_request_body([{"role": "user", "content": "Hi"}]),
         )
         await client.send(req1)
 
@@ -552,11 +582,17 @@ class TestPatchClientIntegration:
         req2 = httpx.Request(
             "POST",
             "https://api.example.com/chat/completions",
-            content=_make_request_body([
-                {"role": "user", "content": "Hi"},
-                {"role": "assistant", "reasoning_text": thinking, "content": "Hello!"},
-                {"role": "user", "content": "Follow up?"},
-            ]),
+            content=_make_request_body(
+                [
+                    {"role": "user", "content": "Hi"},
+                    {
+                        "role": "assistant",
+                        "reasoning_text": thinking,
+                        "content": "Hello!",
+                    },
+                    {"role": "user", "content": "Follow up?"},
+                ]
+            ),
         )
         await client.send(req2)
 
@@ -628,9 +664,7 @@ class TestPatchClientIntegration:
         req1 = httpx.Request(
             "POST",
             "https://api.example.com/chat/completions",
-            content=_make_request_body(
-                [{"role": "user", "content": "Hi"}]
-            ),
+            content=_make_request_body([{"role": "user", "content": "Hi"}]),
         )
         await client.send(req1)
 
@@ -639,11 +673,17 @@ class TestPatchClientIntegration:
         req2 = httpx.Request(
             "POST",
             "https://api.example.com/chat/completions",
-            content=_make_request_body([
-                {"role": "user", "content": "Hi"},
-                {"role": "assistant", "reasoning_text": thinking, "content": "Hello!"},
-                {"role": "user", "content": "Now what?"},
-            ]),
+            content=_make_request_body(
+                [
+                    {"role": "user", "content": "Hi"},
+                    {
+                        "role": "assistant",
+                        "reasoning_text": thinking,
+                        "content": "Hello!",
+                    },
+                    {"role": "user", "content": "Now what?"},
+                ]
+            ),
         )
         resp = await client.send(req2)
 
@@ -695,9 +735,7 @@ class TestPatchClientIntegration:
         req1 = httpx.Request(
             "POST",
             "https://api.example.com/chat/completions",
-            content=_make_request_body(
-                [{"role": "user", "content": "Hi"}]
-            ),
+            content=_make_request_body([{"role": "user", "content": "Hi"}]),
         )
         await client.send(req1)
 
@@ -705,10 +743,16 @@ class TestPatchClientIntegration:
         req2 = httpx.Request(
             "POST",
             "https://api.example.com/chat/completions",
-            content=_make_request_body([
-                {"role": "user", "content": "Hi"},
-                {"role": "assistant", "reasoning_text": thinking, "content": "Hello!"},
-            ]),
+            content=_make_request_body(
+                [
+                    {"role": "user", "content": "Hi"},
+                    {
+                        "role": "assistant",
+                        "reasoning_text": thinking,
+                        "content": "Hello!",
+                    },
+                ]
+            ),
         )
         resp = await client.send(req2)
 
@@ -720,6 +764,7 @@ class TestPatchClientIntegration:
 # ---------------------------------------------------------------------------
 # Cache eviction
 # ---------------------------------------------------------------------------
+
 
 class TestCacheEviction:
     @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.94.0"
+version = "0.79.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -34,9 +34,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/d7/11a649b986da06aaeb81334632f1843d70e3797f54ca4a9c5d604b7987d0/anthropic-0.94.0.tar.gz", hash = "sha256:dde8c57de73538c5136c1bca9b16da92e75446b53a73562cc911574e4934435c", size = 654236, upload-time = "2026-04-10T22:27:59.853Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/b1/91aea3f8fd180d01d133d931a167a78a3737b3fd39ccef2ae8d6619c24fd/anthropic-0.79.0.tar.gz", hash = "sha256:8707aafb3b1176ed6c13e2b1c9fb3efddce90d17aee5d8b83a86c70dcdcca871", size = 509825, upload-time = "2026-02-07T18:06:18.388Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/ac/7185750e8688f6ff79b0e3d6a61372c88b81ba81fcda8798c70598e18aca/anthropic-0.94.0-py3-none-any.whl", hash = "sha256:42550b401eed8fcd7f6654234560f99c428306301bca726d32bca4bfb6feb748", size = 627519, upload-time = "2026-04-10T22:27:57.541Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b2/cc0b8e874a18d7da50b0fda8c99e4ac123f23bf47b471827c5f6f3e4a767/anthropic-0.79.0-py3-none-any.whl", hash = "sha256:04cbd473b6bbda4ca2e41dd670fe2f829a911530f01697d0a1e37321eb75f3cf", size = 405918, upload-time = "2026-02-07T18:06:20.246Z" },
 ]
 
 [[package]]
@@ -59,6 +59,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
+]
+
+[[package]]
+name = "azure-core"
+version = "1.39.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/83/bbde3faa84ddcb8eb0eca4b3ffb3221252281db4ce351300fe248c5c70b1/azure_core-1.39.0.tar.gz", hash = "sha256:8a90a562998dd44ce84597590fff6249701b98c0e8797c95fcdd695b54c35d74", size = 367531, upload-time = "2026-03-19T01:31:29.461Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/d6/8ebcd05b01a580f086ac9a97fb9fac65c09a4b012161cc97c21a336e880b/azure_core-1.39.0-py3-none-any.whl", hash = "sha256:4ac7b70fab5438c3f68770649a78daf97833caa83827f91df9c14e0e0ea7d34f", size = 218318, upload-time = "2026-03-19T01:31:31.25Z" },
+]
+
+[[package]]
+name = "azure-identity"
+version = "1.25.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "msal" },
+    { name = "msal-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/0e/3a63efb48aa4a5ae2cfca61ee152fbcb668092134d3eb8bfda472dd5c617/azure_identity-1.25.3.tar.gz", hash = "sha256:ab23c0d63015f50b630ef6c6cf395e7262f439ce06e5d07a64e874c724f8d9e6", size = 286304, upload-time = "2026-03-13T01:12:20.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/9a/417b3a533e01953a7c618884df2cb05a71e7b68bdbce4fbdb62349d2a2e8/azure_identity-1.25.3-py3-none-any.whl", hash = "sha256:f4d0b956a8146f30333e071374171f3cfa7bdb8073adb8c3814b65567aa7447c", size = 192138, upload-time = "2026-03-13T01:12:22.951Z" },
 ]
 
 [[package]]
@@ -189,10 +218,11 @@ wheels = [
 
 [[package]]
 name = "code-puppy"
-version = "0.0.451"
+version = "0.0.443"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "azure-identity" },
     { name = "dbos" },
     { name = "fastapi" },
     { name = "httpx", extra = ["http2"] },
@@ -228,7 +258,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.80.0" },
+    { name = "anthropic", specifier = "==0.79.0" },
+    { name = "azure-identity", specifier = ">=1.15.0" },
     { name = "dbos", specifier = ">=2.11.0" },
     { name = "fastapi", specifier = ">=0.109.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.24.1" },
@@ -239,7 +270,7 @@ requires-dist = [
     { name = "playwright", specifier = ">=1.40.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.52" },
     { name = "pydantic", specifier = ">=2.4.0" },
-    { name = "pydantic-ai-slim", extras = ["openai", "anthropic", "mcp"], specifier = "==1.80.0" },
+    { name = "pydantic-ai-slim", extras = ["openai", "anthropic", "mcp"], specifier = "==1.56.0" },
     { name = "pyfiglet", specifier = ">=0.8.post1" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "rapidfuzz", specifier = ">=3.13.0" },
@@ -480,12 +511,15 @@ wheels = [
 ]
 
 [[package]]
-name = "griffelib"
-version = "2.0.2"
+name = "griffe"
+version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+dependencies = [
+    { name = "colorama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/0c/3a471b6e31951dce2360477420d0a8d1e00dea6cf33b70f3e8c3ab6e28e1/griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea", size = 424112, upload-time = "2025-11-10T15:03:15.52Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3", size = 150705, upload-time = "2025-11-10T15:03:13.549Z" },
 ]
 
 [[package]]
@@ -781,8 +815,34 @@ wheels = [
 ]
 
 [[package]]
+name = "msal"
+version = "1.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/cb/b02b0f748ac668922364ccb3c3bff5b71628a05f5adfec2ba2a5c3031483/msal-1.36.0.tar.gz", hash = "sha256:3f6a4af2b036b476a4215111c4297b4e6e236ed186cd804faefba23e4990978b", size = 174217, upload-time = "2026-04-09T10:20:33.525Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/d3/414d1f0a5f6f4fe5313c2b002c54e78a3332970feb3f5fed14237aa17064/msal-1.36.0-py3-none-any.whl", hash = "sha256:36ecac30e2ff4322d956029aabce3c82301c29f0acb1ad89b94edcabb0e58ec4", size = 121547, upload-time = "2026-04-09T10:20:32.336Z" },
+]
+
+[[package]]
+name = "msal-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/99/5d239b6156eddf761a636bded1118414d161bd6b7b37a9335549ed159396/msal_extensions-1.3.1.tar.gz", hash = "sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4", size = 23315, upload-time = "2025-03-14T23:51:03.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/75/bd9b7bb966668920f06b200e84454c8f3566b102183bc55c5473d96cb2b9/msal_extensions-1.3.1-py3-none-any.whl", hash = "sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca", size = 20583, upload-time = "2025-03-14T23:51:03.016Z" },
+]
+
+[[package]]
 name = "openai"
-version = "2.31.0"
+version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -794,9 +854,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/fe/64b3d035780b3188f86c4f6f1bc202e7bb74757ef028802112273b9dcacf/openai-2.31.0.tar.gz", hash = "sha256:43ca59a88fc973ad1848d86b98d7fac207e265ebbd1828b5e4bdfc85f79427a5", size = 684772, upload-time = "2026-04-08T21:01:41.797Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/f4/4690ecb5d70023ce6bfcfeabfe717020f654bde59a775058ec6ac4692463/openai-2.15.0.tar.gz", hash = "sha256:42eb8cbb407d84770633f31bf727d4ffb4138711c670565a41663d9439174fba", size = 627383, upload-time = "2026-01-09T22:10:08.603Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/bc/a8f7c3aa03452fedbb9af8be83e959adba96a6b4a35e416faffcc959c568/openai-2.31.0-py3-none-any.whl", hash = "sha256:44e1344d87e56a493d649b17e2fac519d1368cbb0745f59f1957c4c26de50a0a", size = 1153479, upload-time = "2026-04-08T21:01:39.217Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/df/c306f7375d42bafb379934c2df4c2fa3964656c8c782bac75ee10c102818/openai-2.15.0-py3-none-any.whl", hash = "sha256:6ae23b932cd7230f7244e52954daa6602716d6b9bf235401a107af731baea6c3", size = 1067879, upload-time = "2026-01-09T22:10:06.446Z" },
 ]
 
 [[package]]
@@ -1028,20 +1088,20 @@ wheels = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.80.0"
+version = "1.56.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "genai-prices" },
-    { name = "griffelib" },
+    { name = "griffe" },
     { name = "httpx" },
     { name = "opentelemetry-api" },
     { name = "pydantic" },
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/27/aa309951a8973a8525fdf9e45b49960105bc78ebc8dba48366c2853538ae/pydantic_ai_slim-1.80.0.tar.gz", hash = "sha256:034f7f910dfce5d82528c74a717a99065ae548390f0b906165972cd13a87d2cf", size = 549153, upload-time = "2026-04-10T23:31:19.862Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/5c/3a577825b9c1da8f287be7f2ee6fe9aab48bc8a80e65c8518052c589f51c/pydantic_ai_slim-1.56.0.tar.gz", hash = "sha256:9f9f9c56b1c735837880a515ae5661b465b40207b25f3a3434178098b2137f05", size = 415265, upload-time = "2026-02-06T01:13:23.58Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/bf/ef273265ef3530cf432fd6d0014ceed57d1cc5b1550fd975bc91152633c8/pydantic_ai_slim-1.80.0-py3-none-any.whl", hash = "sha256:160ad31f522c3d091f3ce32b478d26034c05b6c2c84798a4c8b191c7f9f94bee", size = 703157, upload-time = "2026-04-10T23:31:12Z" },
+    { url = "https://files.pythonhosted.org/packages/62/4b/34682036528eeb9aaf093c2073540ddf399ab37b99d282a69ca41356f1aa/pydantic_ai_slim-1.56.0-py3-none-any.whl", hash = "sha256:d657e4113485020500b23b7390b0066e2a0277edc7577eaad2290735ca5dd7d5", size = 542270, upload-time = "2026-02-06T01:13:14.918Z" },
 ]
 
 [package.optional-dependencies]
@@ -1127,7 +1187,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "1.80.0"
+version = "1.56.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1135,9 +1195,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/7b/03a8791e4916cb0f841fcd77ef6b6bf504419bf03d1c16e4ef80bfd553ad/pydantic_graph-1.80.0.tar.gz", hash = "sha256:94b8c2dd20730ce3cd0fa544ca9c31011a7bb0c5b9f5ca1dade6a6bed7719e8c", size = 59243, upload-time = "2026-04-10T23:31:22.504Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/03/f92881cdb12d6f43e60e9bfd602e41c95408f06e2324d3729f7a194e2bcd/pydantic_graph-1.56.0.tar.gz", hash = "sha256:5e22972dbb43dbc379ab9944252ff864019abf3c7d465dcdf572fc8aec9a44a1", size = 58460, upload-time = "2026-02-06T01:13:26.708Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/12/483b7402d302021ff8537a746eebf018f4e0bb5892c7bef769ab968e03c1/pydantic_graph-1.80.0-py3-none-any.whl", hash = "sha256:60315c2042597d0377689ad48e9439760ec75d4ccda78830d2890ce9c94c6d84", size = 73065, upload-time = "2026-04-10T23:31:15.382Z" },
+    { url = "https://files.pythonhosted.org/packages/08/07/8c823eb4d196137c123d4d67434e185901d3cbaea3b0c2b7667da84e72c1/pydantic_graph-1.56.0-py3-none-any.whl", hash = "sha256:ec3f0a1d6fcedd4eb9c59fef45079c2ee4d4185878d70dae26440a9c974c6bb3", size = 72346, upload-time = "2026-02-06T01:13:18.792Z" },
 ]
 
 [[package]]
@@ -1397,74 +1457,74 @@ wheels = [
 
 [[package]]
 name = "regex"
-version = "2026.4.4"
+version = "2026.1.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cb/0e/3a246dbf05666918bd3664d9d787f84a9108f6f43cc953a077e4a7dfdb7e/regex-2026.4.4.tar.gz", hash = "sha256:e08270659717f6973523ce3afbafa53515c4dc5dcad637dc215b6fd50f689423", size = 416000, upload-time = "2026-04-03T20:56:28.155Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/86/07d5056945f9ec4590b518171c4254a5925832eb727b56d3c38a7476f316/regex-2026.1.15.tar.gz", hash = "sha256:164759aa25575cbc0651bef59a0b18353e54300d79ace8084c818ad8ac72b7d5", size = 414811, upload-time = "2026-01-14T23:18:02.775Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/7a/617356cbecdb452812a5d42f720d6d5096b360d4a4c1073af700ea140ad2/regex-2026.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b4c36a85b00fadb85db9d9e90144af0a980e1a3d2ef9cd0f8a5bef88054657c6", size = 489415, upload-time = "2026-04-03T20:53:11.645Z" },
-    { url = "https://files.pythonhosted.org/packages/20/e6/bf057227144d02e3ba758b66649e87531d744dda5f3254f48660f18ae9d8/regex-2026.4.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:dcb5453ecf9cd58b562967badd1edbf092b0588a3af9e32ee3d05c985077ce87", size = 291205, upload-time = "2026-04-03T20:53:13.289Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/3b/637181b787dd1a820ba1c712cee2b4144cd84a32dc776ca067b12b2d70c8/regex-2026.4.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6aa809ed4dc3706cc38594d67e641601bd2f36d5555b2780ff074edfcb136cf8", size = 289225, upload-time = "2026-04-03T20:53:16.002Z" },
-    { url = "https://files.pythonhosted.org/packages/05/21/bac05d806ed02cd4b39d9c8e5b5f9a2998c94c3a351b7792e80671fa5315/regex-2026.4.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:33424f5188a7db12958246a54f59a435b6cb62c5cf9c8d71f7cc49475a5fdada", size = 792434, upload-time = "2026-04-03T20:53:17.414Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/17/c65d1d8ae90b772d5758eb4014e1e011bb2db353fc4455432e6cc9100df7/regex-2026.4.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d346fccdde28abba117cc9edc696b9518c3307fbfcb689e549d9b5979018c6d", size = 861730, upload-time = "2026-04-03T20:53:18.903Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/64/933321aa082a2c6ee2785f22776143ba89840189c20d3b6b1d12b6aae16b/regex-2026.4.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:415a994b536440f5011aa77e50a4274d15da3245e876e5c7f19da349caaedd87", size = 906495, upload-time = "2026-04-03T20:53:20.561Z" },
-    { url = "https://files.pythonhosted.org/packages/01/ea/4c8d306e9c36ac22417336b1e02e7b358152c34dc379673f2d331143725f/regex-2026.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21e5eb86179b4c67b5759d452ea7c48eb135cd93308e7a260aa489ed2eb423a4", size = 799810, upload-time = "2026-04-03T20:53:22.961Z" },
-    { url = "https://files.pythonhosted.org/packages/29/ce/7605048f00e1379eba89d610c7d644d8f695dc9b26d3b6ecfa3132b872ff/regex-2026.4.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:312ec9dd1ae7d96abd8c5a36a552b2139931914407d26fba723f9e53c8186f86", size = 774242, upload-time = "2026-04-03T20:53:25.015Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/77/283e0d5023fde22cd9e86190d6d9beb21590a452b195ffe00274de470691/regex-2026.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a0d2b28aa1354c7cd7f71b7658c4326f7facac106edd7f40eda984424229fd59", size = 781257, upload-time = "2026-04-03T20:53:26.918Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/fb/7f3b772be101373c8626ed34c5d727dcbb8abd42a7b1219bc25fd9a3cc04/regex-2026.4.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:349d7310eddff40429a099c08d995c6d4a4bfaf3ff40bd3b5e5cb5a5a3c7d453", size = 854490, upload-time = "2026-04-03T20:53:29.065Z" },
-    { url = "https://files.pythonhosted.org/packages/85/30/56547b80f34f4dd2986e1cdd63b1712932f63b6c4ce2f79c50a6cd79d1c2/regex-2026.4.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e7ab63e9fe45a9ec3417509e18116b367e89c9ceb6219222a3396fa30b147f80", size = 763544, upload-time = "2026-04-03T20:53:30.917Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/2f/ce060fdfea8eff34a8997603532e44cdb7d1f35e3bc253612a8707a90538/regex-2026.4.4-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:fe896e07a5a2462308297e515c0054e9ec2dd18dfdc9427b19900b37dfe6f40b", size = 844442, upload-time = "2026-04-03T20:53:32.463Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/44/810cb113096a1dacbe82789fbfab2823f79d19b7f1271acecb7009ba9b88/regex-2026.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:eb59c65069498dbae3c0ef07bbe224e1eaa079825a437fb47a479f0af11f774f", size = 789162, upload-time = "2026-04-03T20:53:34.039Z" },
-    { url = "https://files.pythonhosted.org/packages/20/96/9647dd7f2ecf6d9ce1fb04dfdb66910d094e10d8fe53e9c15096d8aa0bd2/regex-2026.4.4-cp311-cp311-win32.whl", hash = "sha256:2a5d273181b560ef8397c8825f2b9d57013de744da9e8257b8467e5da8599351", size = 266227, upload-time = "2026-04-03T20:53:35.601Z" },
-    { url = "https://files.pythonhosted.org/packages/33/80/74e13262460530c3097ff343a17de9a34d040a5dc4de9cf3a8241faab51c/regex-2026.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:9542ccc1e689e752594309444081582f7be2fdb2df75acafea8a075108566735", size = 278399, upload-time = "2026-04-03T20:53:37.021Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/3c/39f19f47f19dcefa3403f09d13562ca1c0fd07ab54db2bc03148f3f6b46a/regex-2026.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:b5f9fb784824a042be3455b53d0b112655686fdb7a91f88f095f3fee1e2a2a54", size = 270473, upload-time = "2026-04-03T20:53:38.633Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/28/b972a4d3df61e1d7bcf1b59fdb3cddef22f88b6be43f161bb41ebc0e4081/regex-2026.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c07ab8794fa929e58d97a0e1796b8b76f70943fa39df225ac9964615cf1f9d52", size = 490434, upload-time = "2026-04-03T20:53:40.219Z" },
-    { url = "https://files.pythonhosted.org/packages/84/20/30041446cf6dc3e0eab344fc62770e84c23b6b68a3b657821f9f80cb69b4/regex-2026.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c785939dc023a1ce4ec09599c032cc9933d258a998d16ca6f2b596c010940eb", size = 292061, upload-time = "2026-04-03T20:53:41.862Z" },
-    { url = "https://files.pythonhosted.org/packages/62/c8/3baa06d75c98c46d4cc4262b71fd2edb9062b5665e868bca57859dadf93a/regex-2026.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1b1ce5c81c9114f1ce2f9288a51a8fd3aeea33a0cc440c415bf02da323aa0a76", size = 289628, upload-time = "2026-04-03T20:53:43.701Z" },
-    { url = "https://files.pythonhosted.org/packages/31/87/3accf55634caad8c0acab23f5135ef7d4a21c39f28c55c816ae012931408/regex-2026.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:760ef21c17d8e6a4fe8cf406a97cf2806a4df93416ccc82fc98d25b1c20425be", size = 796651, upload-time = "2026-04-03T20:53:45.379Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/0c/aaa2c83f34efedbf06f61cb1942c25f6cf1ee3b200f832c4d05f28306c2e/regex-2026.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7088fcdcb604a4417c208e2169715800d28838fefd7455fbe40416231d1d47c1", size = 865916, upload-time = "2026-04-03T20:53:47.064Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/f6/8c6924c865124643e8f37823eca845dc27ac509b2ee58123685e71cd0279/regex-2026.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:07edca1ba687998968f7db5bc355288d0c6505caa7374f013d27356d93976d13", size = 912287, upload-time = "2026-04-03T20:53:49.422Z" },
-    { url = "https://files.pythonhosted.org/packages/11/0e/a9f6f81013e0deaf559b25711623864970fe6a098314e374ccb1540a4152/regex-2026.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:993f657a7c1c6ec51b5e0ba97c9817d06b84ea5fa8d82e43b9405de0defdc2b9", size = 801126, upload-time = "2026-04-03T20:53:51.096Z" },
-    { url = "https://files.pythonhosted.org/packages/71/61/3a0cc8af2dc0c8deb48e644dd2521f173f7e6513c6e195aad9aa8dd77ac5/regex-2026.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2b69102a743e7569ebee67e634a69c4cb7e59d6fa2e1aa7d3bdbf3f61435f62d", size = 776788, upload-time = "2026-04-03T20:53:52.889Z" },
-    { url = "https://files.pythonhosted.org/packages/64/0b/8bb9cbf21ef7dee58e49b0fdb066a7aded146c823202e16494a36777594f/regex-2026.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6dac006c8b6dda72d86ea3d1333d45147de79a3a3f26f10c1cf9287ca4ca0ac3", size = 785184, upload-time = "2026-04-03T20:53:55.627Z" },
-    { url = "https://files.pythonhosted.org/packages/99/c2/d3e80e8137b25ee06c92627de4e4d98b94830e02b3e6f81f3d2e3f504cf5/regex-2026.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:50a766ee2010d504554bfb5f578ed2e066898aa26411d57e6296230627cdefa0", size = 859913, upload-time = "2026-04-03T20:53:57.249Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/e6/9d5d876157d969c804622456ef250017ac7a8f83e0e14f903b9e6df5ce95/regex-2026.4.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9e2f5217648f68e3028c823df58663587c1507a5ba8419f4fdfc8a461be76043", size = 765732, upload-time = "2026-04-03T20:53:59.428Z" },
-    { url = "https://files.pythonhosted.org/packages/82/80/b568935b4421388561c8ed42aff77247285d3ae3bb2a6ca22af63bae805e/regex-2026.4.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39d8de85a08e32632974151ba59c6e9140646dcc36c80423962b1c5c0a92e244", size = 852152, upload-time = "2026-04-03T20:54:01.505Z" },
-    { url = "https://files.pythonhosted.org/packages/39/29/f0f81217e21cd998245da047405366385d5c6072048038a3d33b37a79dc0/regex-2026.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:55d9304e0e7178dfb1e106c33edf834097ddf4a890e2f676f6c5118f84390f73", size = 789076, upload-time = "2026-04-03T20:54:03.323Z" },
-    { url = "https://files.pythonhosted.org/packages/49/1d/1d957a61976ab9d4e767dd4f9d04b66cc0c41c5e36cf40e2d43688b5ae6f/regex-2026.4.4-cp312-cp312-win32.whl", hash = "sha256:04bb679bc0bde8a7bfb71e991493d47314e7b98380b083df2447cda4b6edb60f", size = 266700, upload-time = "2026-04-03T20:54:05.639Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/5c/bf575d396aeb58ea13b06ef2adf624f65b70fafef6950a80fc3da9cae3bc/regex-2026.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:db0ac18435a40a2543dbb3d21e161a6c78e33e8159bd2e009343d224bb03bb1b", size = 277768, upload-time = "2026-04-03T20:54:07.312Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/27/049df16ec6a6828ccd72add3c7f54b4df029669bea8e9817df6fff58be90/regex-2026.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:4ce255cc05c1947a12989c6db801c96461947adb7a59990f1360b5983fab4983", size = 270568, upload-time = "2026-04-03T20:54:09.484Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/83/c4373bc5f31f2cf4b66f9b7c31005bd87fe66f0dce17701f7db4ee79ee29/regex-2026.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:62f5519042c101762509b1d717b45a69c0139d60414b3c604b81328c01bd1943", size = 490273, upload-time = "2026-04-03T20:54:11.202Z" },
-    { url = "https://files.pythonhosted.org/packages/46/f8/fe62afbcc3cf4ad4ac9adeaafd98aa747869ae12d3e8e2ac293d0593c435/regex-2026.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3790ba9fb5dd76715a7afe34dbe603ba03f8820764b1dc929dd08106214ed031", size = 291954, upload-time = "2026-04-03T20:54:13.412Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/92/4712b9fe6a33d232eeb1c189484b80c6c4b8422b90e766e1195d6e758207/regex-2026.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fae3c6e795d7678963f2170152b0d892cf6aee9ee8afc8c45e6be38d5107fe7", size = 289487, upload-time = "2026-04-03T20:54:15.824Z" },
-    { url = "https://files.pythonhosted.org/packages/88/2c/f83b93f85e01168f1070f045a42d4c937b69fdb8dd7ae82d307253f7e36e/regex-2026.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:298c3ec2d53225b3bf91142eb9691025bab610e0c0c51592dde149db679b3d17", size = 796646, upload-time = "2026-04-03T20:54:18.229Z" },
-    { url = "https://files.pythonhosted.org/packages/df/55/61a2e17bf0c4dc57e11caf8dd11771280d8aaa361785f9e3bc40d653f4a7/regex-2026.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e9638791082eaf5b3ac112c587518ee78e083a11c4b28012d8fe2a0f536dfb17", size = 865904, upload-time = "2026-04-03T20:54:20.019Z" },
-    { url = "https://files.pythonhosted.org/packages/45/32/1ac8ed1b5a346b5993a3d256abe0a0f03b0b73c8cc88d928537368ac65b6/regex-2026.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae3e764bd4c5ff55035dc82a8d49acceb42a5298edf6eb2fc4d328ee5dd7afae", size = 912304, upload-time = "2026-04-03T20:54:22.403Z" },
-    { url = "https://files.pythonhosted.org/packages/26/47/2ee5c613ab546f0eddebf9905d23e07beb933416b1246c2d8791d01979b4/regex-2026.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ffa81f81b80047ba89a3c69ae6a0f78d06f4a42ce5126b0eb2a0a10ad44e0b2e", size = 801126, upload-time = "2026-04-03T20:54:24.308Z" },
-    { url = "https://files.pythonhosted.org/packages/75/cd/41dacd129ca9fd20bd7d02f83e0fad83e034ac8a084ec369c90f55ef37e2/regex-2026.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f56ebf9d70305307a707911b88469213630aba821e77de7d603f9d2f0730687d", size = 776772, upload-time = "2026-04-03T20:54:26.319Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6d/5af0b588174cb5f46041fa7dd64d3fd5cd2fe51f18766703d1edc387f324/regex-2026.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:773d1dfd652bbffb09336abf890bfd64785c7463716bf766d0eb3bc19c8b7f27", size = 785228, upload-time = "2026-04-03T20:54:28.387Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/3b/f5a72b7045bd59575fc33bf1345f156fcfd5a8484aea6ad84b12c5a82114/regex-2026.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d51d20befd5275d092cdffba57ded05f3c436317ee56466c8928ac32d960edaf", size = 860032, upload-time = "2026-04-03T20:54:30.641Z" },
-    { url = "https://files.pythonhosted.org/packages/39/a4/72a317003d6fcd7a573584a85f59f525dfe8f67e355ca74eb6b53d66a5e2/regex-2026.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:0a51cdb3c1e9161154f976cb2bef9894bc063ac82f31b733087ffb8e880137d0", size = 765714, upload-time = "2026-04-03T20:54:32.789Z" },
-    { url = "https://files.pythonhosted.org/packages/25/1e/5672e16f34dbbcb2560cc7e6a2fbb26dfa8b270711e730101da4423d3973/regex-2026.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ae5266a82596114e41fb5302140e9630204c1b5f325c770bec654b95dd54b0aa", size = 852078, upload-time = "2026-04-03T20:54:34.546Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/0d/c813f0af7c6cc7ed7b9558bac2e5120b60ad0fa48f813e4d4bd55446f214/regex-2026.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c882cd92ec68585e9c1cf36c447ec846c0d94edd706fe59e0c198e65822fd23b", size = 789181, upload-time = "2026-04-03T20:54:36.642Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/6d/a344608d1adbd2a95090ddd906cec09a11be0e6517e878d02a5123e0917f/regex-2026.4.4-cp313-cp313-win32.whl", hash = "sha256:05568c4fbf3cb4fa9e28e3af198c40d3237cf6041608a9022285fe567ec3ad62", size = 266690, upload-time = "2026-04-03T20:54:38.343Z" },
-    { url = "https://files.pythonhosted.org/packages/31/07/54049f89b46235ca6f45cd6c88668a7050e77d4a15555e47dd40fde75263/regex-2026.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:3384df51ed52db0bea967e21458ab0a414f67cdddfd94401688274e55147bb81", size = 277733, upload-time = "2026-04-03T20:54:40.11Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/21/61366a8e20f4d43fb597708cac7f0e2baadb491ecc9549b4980b2be27d16/regex-2026.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:acd38177bd2c8e69a411d6521760806042e244d0ef94e2dd03ecdaa8a3c99427", size = 270565, upload-time = "2026-04-03T20:54:41.883Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/1e/3a2b9672433bef02f5d39aa1143ca2c08f311c1d041c464a42be9ae648dc/regex-2026.4.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f94a11a9d05afcfcfa640e096319720a19cc0c9f7768e1a61fceee6a3afc6c7c", size = 494126, upload-time = "2026-04-03T20:54:43.602Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/4b/c132a4f4fe18ad3340d89fcb56235132b69559136036b845be3c073142ed/regex-2026.4.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:36bcb9d6d1307ab629edc553775baada2aefa5c50ccc0215fbfd2afcfff43141", size = 293882, upload-time = "2026-04-03T20:54:45.41Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/5f/eaa38092ce7a023656280f2341dbbd4ad5f05d780a70abba7bb4f4bea54c/regex-2026.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261c015b3e2ed0919157046d768774ecde57f03d8fa4ba78d29793447f70e717", size = 292334, upload-time = "2026-04-03T20:54:47.051Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/f6/dd38146af1392dac33db7074ab331cec23cced3759167735c42c5460a243/regex-2026.4.4-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c228cf65b4a54583763645dcd73819b3b381ca8b4bb1b349dee1c135f4112c07", size = 811691, upload-time = "2026-04-03T20:54:49.074Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/f0/dc54c2e69f5eeec50601054998ec3690d5344277e782bd717e49867c1d29/regex-2026.4.4-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dd2630faeb6876fb0c287f664d93ddce4d50cd46c6e88e60378c05c9047e08ca", size = 871227, upload-time = "2026-04-03T20:54:51.035Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/af/cb16bd5dc61621e27df919a4449bbb7e5a1034c34d307e0a706e9cc0f3e3/regex-2026.4.4-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6a50ab11b7779b849472337191f3a043e27e17f71555f98d0092fa6d73364520", size = 917435, upload-time = "2026-04-03T20:54:52.994Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/71/8b260897f22996b666edd9402861668f45a2ca259f665ac029e6104a2d7d/regex-2026.4.4-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0734f63afe785138549fbe822a8cfeaccd1bae814c5057cc0ed5b9f2de4fc883", size = 816358, upload-time = "2026-04-03T20:54:54.884Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/60/775f7f72a510ef238254906c2f3d737fc80b16ca85f07d20e318d2eea894/regex-2026.4.4-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4ee50606cb1967db7e523224e05f32089101945f859928e65657a2cbb3d278b", size = 785549, upload-time = "2026-04-03T20:54:57.01Z" },
-    { url = "https://files.pythonhosted.org/packages/58/42/34d289b3627c03cf381e44da534a0021664188fa49ba41513da0b4ec6776/regex-2026.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6c1818f37be3ca02dcb76d63f2c7aaba4b0dc171b579796c6fbe00148dfec6b1", size = 801364, upload-time = "2026-04-03T20:54:58.981Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/20/f6ecf319b382a8f1ab529e898b222c3f30600fcede7834733c26279e7465/regex-2026.4.4-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:f5bfc2741d150d0be3e4a0401a5c22b06e60acb9aa4daa46d9e79a6dcd0f135b", size = 866221, upload-time = "2026-04-03T20:55:00.88Z" },
-    { url = "https://files.pythonhosted.org/packages/92/6a/9f16d3609d549bd96d7a0b2aee1625d7512ba6a03efc01652149ef88e74d/regex-2026.4.4-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:504ffa8a03609a087cad81277a629b6ce884b51a24bd388a7980ad61748618ff", size = 772530, upload-time = "2026-04-03T20:55:03.213Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/f6/aa9768bc96a4c361ac96419fbaf2dcdc33970bb813df3ba9b09d5d7b6d96/regex-2026.4.4-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:70aadc6ff12e4b444586e57fc30771f86253f9f0045b29016b9605b4be5f7dfb", size = 856989, upload-time = "2026-04-03T20:55:05.087Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/b4/c671db3556be2473ae3e4bb7a297c518d281452871501221251ea4ecba57/regex-2026.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f4f83781191007b6ef43b03debc35435f10cad9b96e16d147efe84a1d48bdde4", size = 803241, upload-time = "2026-04-03T20:55:07.162Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/5c/83e3b1d89fa4f6e5a1bc97b4abd4a9a97b3c1ac7854164f694f5f0ba98a0/regex-2026.4.4-cp313-cp313t-win32.whl", hash = "sha256:e014a797de43d1847df957c0a2a8e861d1c17547ee08467d1db2c370b7568baa", size = 269921, upload-time = "2026-04-03T20:55:09.62Z" },
-    { url = "https://files.pythonhosted.org/packages/28/07/077c387121f42cdb4d92b1301133c0d93b5709d096d1669ab847dda9fe2e/regex-2026.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:b15b88b0d52b179712632832c1d6e58e5774f93717849a41096880442da41ab0", size = 281240, upload-time = "2026-04-03T20:55:11.521Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/22/ead4a4abc7c59a4d882662aa292ca02c8b617f30b6e163bc1728879e9353/regex-2026.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:586b89cdadf7d67bf86ae3342a4dcd2b8d70a832d90c18a0ae955105caf34dbe", size = 272440, upload-time = "2026-04-03T20:55:13.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c9/0c80c96eab96948363d270143138d671d5731c3a692b417629bf3492a9d6/regex-2026.1.15-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1ae6020fb311f68d753b7efa9d4b9a5d47a5d6466ea0d5e3b5a471a960ea6e4a", size = 488168, upload-time = "2026-01-14T23:14:16.129Z" },
+    { url = "https://files.pythonhosted.org/packages/17/f0/271c92f5389a552494c429e5cc38d76d1322eb142fb5db3c8ccc47751468/regex-2026.1.15-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:eddf73f41225942c1f994914742afa53dc0d01a6e20fe14b878a1b1edc74151f", size = 290636, upload-time = "2026-01-14T23:14:17.715Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f9/5f1fd077d106ca5655a0f9ff8f25a1ab55b92128b5713a91ed7134ff688e/regex-2026.1.15-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e8cd52557603f5c66a548f69421310886b28b7066853089e1a71ee710e1cdc1", size = 288496, upload-time = "2026-01-14T23:14:19.326Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e1/8f43b03a4968c748858ec77f746c286d81f896c2e437ccf050ebc5d3128c/regex-2026.1.15-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5170907244b14303edc5978f522f16c974f32d3aa92109fabc2af52411c9433b", size = 793503, upload-time = "2026-01-14T23:14:20.922Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/4e/a39a5e8edc5377a46a7c875c2f9a626ed3338cb3bb06931be461c3e1a34a/regex-2026.1.15-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2748c1ec0663580b4510bd89941a31560b4b439a0b428b49472a3d9944d11cd8", size = 860535, upload-time = "2026-01-14T23:14:22.405Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/1c/9dce667a32a9477f7a2869c1c767dc00727284a9fa3ff5c09a5c6c03575e/regex-2026.1.15-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2f2775843ca49360508d080eaa87f94fa248e2c946bbcd963bb3aae14f333413", size = 907225, upload-time = "2026-01-14T23:14:23.897Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3c/87ca0a02736d16b6262921425e84b48984e77d8e4e572c9072ce96e66c30/regex-2026.1.15-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d9ea2604370efc9a174c1b5dcc81784fb040044232150f7f33756049edfc9026", size = 800526, upload-time = "2026-01-14T23:14:26.039Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ff/647d5715aeea7c87bdcbd2f578f47b415f55c24e361e639fe8c0cc88878f/regex-2026.1.15-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0dcd31594264029b57bf16f37fd7248a70b3b764ed9e0839a8f271b2d22c0785", size = 773446, upload-time = "2026-01-14T23:14:28.109Z" },
+    { url = "https://files.pythonhosted.org/packages/af/89/bf22cac25cb4ba0fe6bff52ebedbb65b77a179052a9d6037136ae93f42f4/regex-2026.1.15-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c08c1f3e34338256732bd6938747daa3c0d5b251e04b6e43b5813e94d503076e", size = 783051, upload-time = "2026-01-14T23:14:29.929Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f4/6ed03e71dca6348a5188363a34f5e26ffd5db1404780288ff0d79513bce4/regex-2026.1.15-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e43a55f378df1e7a4fa3547c88d9a5a9b7113f653a66821bcea4718fe6c58763", size = 854485, upload-time = "2026-01-14T23:14:31.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/9a/8e8560bd78caded8eb137e3e47612430a05b9a772caf60876435192d670a/regex-2026.1.15-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:f82110ab962a541737bd0ce87978d4c658f06e7591ba899192e2712a517badbb", size = 762195, upload-time = "2026-01-14T23:14:32.802Z" },
+    { url = "https://files.pythonhosted.org/packages/38/6b/61fc710f9aa8dfcd764fe27d37edfaa023b1a23305a0d84fccd5adb346ea/regex-2026.1.15-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:27618391db7bdaf87ac6c92b31e8f0dfb83a9de0075855152b720140bda177a2", size = 845986, upload-time = "2026-01-14T23:14:34.898Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/2e/fbee4cb93f9d686901a7ca8d94285b80405e8c34fe4107f63ffcbfb56379/regex-2026.1.15-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bfb0d6be01fbae8d6655c8ca21b3b72458606c4aec9bbc932db758d47aba6db1", size = 788992, upload-time = "2026-01-14T23:14:37.116Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/14/3076348f3f586de64b1ab75a3fbabdaab7684af7f308ad43be7ef1849e55/regex-2026.1.15-cp311-cp311-win32.whl", hash = "sha256:b10e42a6de0e32559a92f2f8dc908478cc0fa02838d7dbe764c44dca3fa13569", size = 265893, upload-time = "2026-01-14T23:14:38.426Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/19/772cf8b5fc803f5c89ba85d8b1870a1ca580dc482aa030383a9289c82e44/regex-2026.1.15-cp311-cp311-win_amd64.whl", hash = "sha256:e9bf3f0bbdb56633c07d7116ae60a576f846efdd86a8848f8d62b749e1209ca7", size = 277840, upload-time = "2026-01-14T23:14:39.785Z" },
+    { url = "https://files.pythonhosted.org/packages/78/84/d05f61142709474da3c0853222d91086d3e1372bcdab516c6fd8d80f3297/regex-2026.1.15-cp311-cp311-win_arm64.whl", hash = "sha256:41aef6f953283291c4e4e6850607bd71502be67779586a61472beacb315c97ec", size = 270374, upload-time = "2026-01-14T23:14:41.592Z" },
+    { url = "https://files.pythonhosted.org/packages/92/81/10d8cf43c807d0326efe874c1b79f22bfb0fb226027b0b19ebc26d301408/regex-2026.1.15-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4c8fcc5793dde01641a35905d6731ee1548f02b956815f8f1cab89e515a5bdf1", size = 489398, upload-time = "2026-01-14T23:14:43.741Z" },
+    { url = "https://files.pythonhosted.org/packages/90/b0/7c2a74e74ef2a7c32de724658a69a862880e3e4155cba992ba04d1c70400/regex-2026.1.15-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bfd876041a956e6a90ad7cdb3f6a630c07d491280bfeed4544053cd434901681", size = 291339, upload-time = "2026-01-14T23:14:45.183Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4d/16d0773d0c818417f4cc20aa0da90064b966d22cd62a8c46765b5bd2d643/regex-2026.1.15-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9250d087bc92b7d4899ccd5539a1b2334e44eee85d848c4c1aef8e221d3f8c8f", size = 289003, upload-time = "2026-01-14T23:14:47.25Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/e4/1fc4599450c9f0863d9406e944592d968b8d6dfd0d552a7d569e43bceada/regex-2026.1.15-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8a154cf6537ebbc110e24dabe53095e714245c272da9c1be05734bdad4a61aa", size = 798656, upload-time = "2026-01-14T23:14:48.77Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e6/59650d73a73fa8a60b3a590545bfcf1172b4384a7df2e7fe7b9aab4e2da9/regex-2026.1.15-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8050ba2e3ea1d8731a549e83c18d2f0999fbc99a5f6bd06b4c91449f55291804", size = 864252, upload-time = "2026-01-14T23:14:50.528Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ab/1d0f4d50a1638849a97d731364c9a80fa304fec46325e48330c170ee8e80/regex-2026.1.15-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0bf065240704cb8951cc04972cf107063917022511273e0969bdb34fc173456c", size = 912268, upload-time = "2026-01-14T23:14:52.952Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/df/0d722c030c82faa1d331d1921ee268a4e8fb55ca8b9042c9341c352f17fa/regex-2026.1.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c32bef3e7aeee75746748643667668ef941d28b003bfc89994ecf09a10f7a1b5", size = 803589, upload-time = "2026-01-14T23:14:55.182Z" },
+    { url = "https://files.pythonhosted.org/packages/66/23/33289beba7ccb8b805c6610a8913d0131f834928afc555b241caabd422a9/regex-2026.1.15-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d5eaa4a4c5b1906bd0d2508d68927f15b81821f85092e06f1a34a4254b0e1af3", size = 775700, upload-time = "2026-01-14T23:14:56.707Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/65/bf3a42fa6897a0d3afa81acb25c42f4b71c274f698ceabd75523259f6688/regex-2026.1.15-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:86c1077a3cc60d453d4084d5b9649065f3bf1184e22992bd322e1f081d3117fb", size = 787928, upload-time = "2026-01-14T23:14:58.312Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f5/13bf65864fc314f68cdd6d8ca94adcab064d4d39dbd0b10fef29a9da48fc/regex-2026.1.15-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:2b091aefc05c78d286657cd4db95f2e6313375ff65dcf085e42e4c04d9c8d410", size = 858607, upload-time = "2026-01-14T23:15:00.657Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/040e589834d7a439ee43fb0e1e902bc81bd58a5ba81acffe586bb3321d35/regex-2026.1.15-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:57e7d17f59f9ebfa9667e6e5a1c0127b96b87cb9cede8335482451ed00788ba4", size = 763729, upload-time = "2026-01-14T23:15:02.248Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/84/6921e8129687a427edf25a34a5594b588b6d88f491320b9de5b6339a4fcb/regex-2026.1.15-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:c6c4dcdfff2c08509faa15d36ba7e5ef5fcfab25f1e8f85a0c8f45bc3a30725d", size = 850697, upload-time = "2026-01-14T23:15:03.878Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/87/3d06143d4b128f4229158f2de5de6c8f2485170c7221e61bf381313314b2/regex-2026.1.15-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:cf8ff04c642716a7f2048713ddc6278c5fd41faa3b9cab12607c7abecd012c22", size = 789849, upload-time = "2026-01-14T23:15:06.102Z" },
+    { url = "https://files.pythonhosted.org/packages/77/69/c50a63842b6bd48850ebc7ab22d46e7a2a32d824ad6c605b218441814639/regex-2026.1.15-cp312-cp312-win32.whl", hash = "sha256:82345326b1d8d56afbe41d881fdf62f1926d7264b2fc1537f99ae5da9aad7913", size = 266279, upload-time = "2026-01-14T23:15:07.678Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/36/39d0b29d087e2b11fd8191e15e81cce1b635fcc845297c67f11d0d19274d/regex-2026.1.15-cp312-cp312-win_amd64.whl", hash = "sha256:4def140aa6156bc64ee9912383d4038f3fdd18fee03a6f222abd4de6357ce42a", size = 277166, upload-time = "2026-01-14T23:15:09.257Z" },
+    { url = "https://files.pythonhosted.org/packages/28/32/5b8e476a12262748851fa8ab1b0be540360692325975b094e594dfebbb52/regex-2026.1.15-cp312-cp312-win_arm64.whl", hash = "sha256:c6c565d9a6e1a8d783c1948937ffc377dd5771e83bd56de8317c450a954d2056", size = 270415, upload-time = "2026-01-14T23:15:10.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/2e/6870bb16e982669b674cce3ee9ff2d1d46ab80528ee6bcc20fb2292efb60/regex-2026.1.15-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e69d0deeb977ffe7ed3d2e4439360089f9c3f217ada608f0f88ebd67afb6385e", size = 489164, upload-time = "2026-01-14T23:15:13.962Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/9774542e203849b0286badf67199970a44ebdb0cc5fb739f06e47ada72f8/regex-2026.1.15-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3601ffb5375de85a16f407854d11cca8fe3f5febbe3ac78fb2866bb220c74d10", size = 291218, upload-time = "2026-01-14T23:15:15.647Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/87/b0cda79f22b8dee05f774922a214da109f9a4c0eca5da2c9d72d77ea062c/regex-2026.1.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4c5ef43b5c2d4114eb8ea424bb8c9cec01d5d17f242af88b2448f5ee81caadbc", size = 288895, upload-time = "2026-01-14T23:15:17.788Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/6a/0041f0a2170d32be01ab981d6346c83a8934277d82c780d60b127331f264/regex-2026.1.15-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:968c14d4f03e10b2fd960f1d5168c1f0ac969381d3c1fcc973bc45fb06346599", size = 798680, upload-time = "2026-01-14T23:15:19.342Z" },
+    { url = "https://files.pythonhosted.org/packages/58/de/30e1cfcdbe3e891324aa7568b7c968771f82190df5524fabc1138cb2d45a/regex-2026.1.15-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56a5595d0f892f214609c9f76b41b7428bed439d98dc961efafdd1354d42baae", size = 864210, upload-time = "2026-01-14T23:15:22.005Z" },
+    { url = "https://files.pythonhosted.org/packages/64/44/4db2f5c5ca0ccd40ff052ae7b1e9731352fcdad946c2b812285a7505ca75/regex-2026.1.15-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0bf650f26087363434c4e560011f8e4e738f6f3e029b85d4904c50135b86cfa5", size = 912358, upload-time = "2026-01-14T23:15:24.569Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b6/e6a5665d43a7c42467138c8a2549be432bad22cbd206f5ec87162de74bd7/regex-2026.1.15-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18388a62989c72ac24de75f1449d0fb0b04dfccd0a1a7c1c43af5eb503d890f6", size = 803583, upload-time = "2026-01-14T23:15:26.526Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/53/7cd478222169d85d74d7437e74750005e993f52f335f7c04ff7adfda3310/regex-2026.1.15-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6d220a2517f5893f55daac983bfa9fe998a7dbcaee4f5d27a88500f8b7873788", size = 775782, upload-time = "2026-01-14T23:15:29.352Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b5/75f9a9ee4b03a7c009fe60500fe550b45df94f0955ca29af16333ef557c5/regex-2026.1.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c9c08c2fbc6120e70abff5d7f28ffb4d969e14294fb2143b4b5c7d20e46d1714", size = 787978, upload-time = "2026-01-14T23:15:31.295Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b3/79821c826245bbe9ccbb54f6eadb7879c722fd3e0248c17bfc90bf54e123/regex-2026.1.15-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7ef7d5d4bd49ec7364315167a4134a015f61e8266c6d446fc116a9ac4456e10d", size = 858550, upload-time = "2026-01-14T23:15:33.558Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/85/2ab5f77a1c465745bfbfcb3ad63178a58337ae8d5274315e2cc623a822fa/regex-2026.1.15-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:6e42844ad64194fa08d5ccb75fe6a459b9b08e6d7296bd704460168d58a388f3", size = 763747, upload-time = "2026-01-14T23:15:35.206Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/84/c27df502d4bfe2873a3e3a7cf1bdb2b9cc10284d1a44797cf38bed790470/regex-2026.1.15-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:cfecdaa4b19f9ca534746eb3b55a5195d5c95b88cac32a205e981ec0a22b7d31", size = 850615, upload-time = "2026-01-14T23:15:37.523Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b7/658a9782fb253680aa8ecb5ccbb51f69e088ed48142c46d9f0c99b46c575/regex-2026.1.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:08df9722d9b87834a3d701f3fca570b2be115654dbfd30179f30ab2f39d606d3", size = 789951, upload-time = "2026-01-14T23:15:39.582Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2a/5928af114441e059f15b2f63e188bd00c6529b3051c974ade7444b85fcda/regex-2026.1.15-cp313-cp313-win32.whl", hash = "sha256:d426616dae0967ca225ab12c22274eb816558f2f99ccb4a1d52ca92e8baf180f", size = 266275, upload-time = "2026-01-14T23:15:42.108Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/16/5bfbb89e435897bff28cf0352a992ca719d9e55ebf8b629203c96b6ce4f7/regex-2026.1.15-cp313-cp313-win_amd64.whl", hash = "sha256:febd38857b09867d3ed3f4f1af7d241c5c50362e25ef43034995b77a50df494e", size = 277145, upload-time = "2026-01-14T23:15:44.244Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c1/a09ff7392ef4233296e821aec5f78c51be5e91ffde0d163059e50fd75835/regex-2026.1.15-cp313-cp313-win_arm64.whl", hash = "sha256:8e32f7896f83774f91499d239e24cebfadbc07639c1494bb7213983842348337", size = 270411, upload-time = "2026-01-14T23:15:45.858Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/38/0cfd5a78e5c6db00e6782fdae70458f89850ce95baa5e8694ab91d89744f/regex-2026.1.15-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ec94c04149b6a7b8120f9f44565722c7ae31b7a6d2275569d2eefa76b83da3be", size = 492068, upload-time = "2026-01-14T23:15:47.616Z" },
+    { url = "https://files.pythonhosted.org/packages/50/72/6c86acff16cb7c959c4355826bbf06aad670682d07c8f3998d9ef4fee7cd/regex-2026.1.15-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:40c86d8046915bb9aeb15d3f3f15b6fd500b8ea4485b30e1bbc799dab3fe29f8", size = 292756, upload-time = "2026-01-14T23:15:49.307Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/58/df7fb69eadfe76526ddfce28abdc0af09ffe65f20c2c90932e89d705153f/regex-2026.1.15-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:726ea4e727aba21643205edad8f2187ec682d3305d790f73b7a51c7587b64bdd", size = 291114, upload-time = "2026-01-14T23:15:51.484Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6c/a4011cd1cf96b90d2cdc7e156f91efbd26531e822a7fbb82a43c1016678e/regex-2026.1.15-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1cb740d044aff31898804e7bf1181cc72c03d11dfd19932b9911ffc19a79070a", size = 807524, upload-time = "2026-01-14T23:15:53.102Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/25/a53ffb73183f69c3e9f4355c4922b76d2840aee160af6af5fac229b6201d/regex-2026.1.15-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05d75a668e9ea16f832390d22131fe1e8acc8389a694c8febc3e340b0f810b93", size = 873455, upload-time = "2026-01-14T23:15:54.956Z" },
+    { url = "https://files.pythonhosted.org/packages/66/0b/8b47fc2e8f97d9b4a851736f3890a5f786443aa8901061c55f24c955f45b/regex-2026.1.15-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d991483606f3dbec93287b9f35596f41aa2e92b7c2ebbb935b63f409e243c9af", size = 915007, upload-time = "2026-01-14T23:15:57.041Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/fa/97de0d681e6d26fabe71968dbee06dd52819e9a22fdce5dac7256c31ed84/regex-2026.1.15-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:194312a14819d3e44628a44ed6fea6898fdbecb0550089d84c403475138d0a09", size = 812794, upload-time = "2026-01-14T23:15:58.916Z" },
+    { url = "https://files.pythonhosted.org/packages/22/38/e752f94e860d429654aa2b1c51880bff8dfe8f084268258adf9151cf1f53/regex-2026.1.15-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fe2fda4110a3d0bc163c2e0664be44657431440722c5c5315c65155cab92f9e5", size = 781159, upload-time = "2026-01-14T23:16:00.817Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a7/d739ffaef33c378fc888302a018d7f81080393d96c476b058b8c64fd2b0d/regex-2026.1.15-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:124dc36c85d34ef2d9164da41a53c1c8c122cfb1f6e1ec377a1f27ee81deb794", size = 795558, upload-time = "2026-01-14T23:16:03.267Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c4/542876f9a0ac576100fc73e9c75b779f5c31e3527576cfc9cb3009dcc58a/regex-2026.1.15-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:a1774cd1981cd212506a23a14dba7fdeaee259f5deba2df6229966d9911e767a", size = 868427, upload-time = "2026-01-14T23:16:05.646Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/0f/d5655bea5b22069e32ae85a947aa564912f23758e112cdb74212848a1a1b/regex-2026.1.15-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:b5f7d8d2867152cdb625e72a530d2ccb48a3d199159144cbdd63870882fb6f80", size = 769939, upload-time = "2026-01-14T23:16:07.542Z" },
+    { url = "https://files.pythonhosted.org/packages/20/06/7e18a4fa9d326daeda46d471a44ef94201c46eaa26dbbb780b5d92cbfdda/regex-2026.1.15-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:492534a0ab925d1db998defc3c302dae3616a2fc3fe2e08db1472348f096ddf2", size = 854753, upload-time = "2026-01-14T23:16:10.395Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/67/dc8946ef3965e166f558ef3b47f492bc364e96a265eb4a2bb3ca765c8e46/regex-2026.1.15-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c661fc820cfb33e166bf2450d3dadbda47c8d8981898adb9b6fe24e5e582ba60", size = 799559, upload-time = "2026-01-14T23:16:12.347Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/61/1bba81ff6d50c86c65d9fd84ce9699dd106438ee4cdb105bf60374ee8412/regex-2026.1.15-cp313-cp313t-win32.whl", hash = "sha256:99ad739c3686085e614bf77a508e26954ff1b8f14da0e3765ff7abbf7799f952", size = 268879, upload-time = "2026-01-14T23:16:14.049Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5e/cef7d4c5fb0ea3ac5c775fd37db5747f7378b29526cc83f572198924ff47/regex-2026.1.15-cp313-cp313t-win_amd64.whl", hash = "sha256:32655d17905e7ff8ba5c764c43cb124e34a9245e45b83c22e81041e1071aee10", size = 280317, upload-time = "2026-01-14T23:16:15.718Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/52/4317f7a5988544e34ab57b4bde0f04944c4786128c933fb09825924d3e82/regex-2026.1.15-cp313-cp313t-win_arm64.whl", hash = "sha256:b2a13dd6a95e95a489ca242319d18fc02e07ceb28fa9ad146385194d95b3c829", size = 271551, upload-time = "2026-01-14T23:16:17.533Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

  This PR adds a new plugin that enables Code Puppy to use Anthropic Claude models hosted on Microsoft Azure AI Foundry with Azure AD (Entra ID) authentication via `az login`.

  **Key Features:**
  - Uses `AsyncAnthropicFoundry` client from the `anthropic` SDK (native Anthropic API, not OpenAI format)
  - Azure AD authentication via `AzureCliCredential` - no API keys needed
  - Interactive `/foundry-setup` wizard for first-time configuration
  - `/foundry-status` command to check authentication and configured models
  - `/foundry-remove` command to clean up configurations
  - Support for context window suffixes in deployment names (e.g., `[1m]`, `[200k]`, `[500k]`)
  - Comprehensive test suite (52 tests, 92% coverage on utils module)

  ## Plugin Structure

  code_puppy/plugins/azure_foundry/
  ├── init.py              # Package marker
  ├── config.py                # Constants and configuration
  ├── token.py                 # Azure AD token provider
  ├── utils.py                 # Configuration utilities & context window parser
  ├── register_callbacks.py    # Plugin callbacks and slash commands
  └── README.md                # Documentation

  ## Usage

  ```bash
  # 1. Login to Azure
  az login

  # 2. Set resource name
  export ANTHROPIC_FOUNDRY_RESOURCE=your-resource-name

  # 3. Run setup wizard
  pup
  /foundry-setup

  # 4. Use Foundry models
  /model foundry-claude-opus

  Context Window Support

  Deployment names can include a context window suffix following the Claude Code format:
  - [1m] - 1 million tokens
  - [200k] - 200 thousand tokens

  The suffix is automatically stripped before sending to Azure, and the context length is set accordingly.

  Dependencies

  Adds azure-identity>=1.15.0 to dependencies (for AzureCliCredential and get_bearer_token_provider).

  Test plan

  - All 52 unit tests pass
  - Linting passes
  - Code formatted
  - Manual testing with actual Azure Foundry deployment
  - /foundry-status, /foundry-setup, /foundry-remove commands work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Azure AI Foundry plugin to connect to Azure-hosted Anthropic Claude models with interactive setup, status, and remove commands; supports Opus/Sonnet/Haiku selection and default deployments.
  * Deployment name suffixes (e.g., [1m], [200k]) are parsed to set model context windows.

* **Documentation**
  * Comprehensive plugin README with quick-start, auth, env vars, commands, troubleshooting, and architecture notes.

* **Tests**
  * Extensive tests for config, auth/token, utilities, model management, and command flows.

* **Chores**
  * Added Azure authentication dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->