### PR TITLE
fix(autocomplete): register /clear command to enable autocomplete suggestions (#254)

### DIFF
--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -625,8 +625,8 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
             # The renderer is stopped in the finally block of main().
             break
 
-        # Check for clear command (supports both `clear` and `/clear`)
-        if task.strip().lower() in ("clear", "/clear"):
+        # Check for clear command (supports only `clear`)
+        if task.strip().lower() in ("clear"):
             from code_puppy.command_line.clipboard import get_clipboard_manager
             from code_puppy.messaging import (
                 emit_info,

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -626,7 +626,7 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
             break
 
         # Check for clear command (supports only `clear`)
-        if task.strip().lower() in ("clear"):
+        if task.strip().lower() == "clear":
             from code_puppy.command_line.clipboard import get_clipboard_manager
             from code_puppy.messaging import (
                 emit_info,

--- a/code_puppy/command_line/core_commands.py
+++ b/code_puppy/command_line/core_commands.py
@@ -170,7 +170,7 @@ def handle_paste_command(command: str) -> bool:
 @register_command(
     name="clear",
     description="Clear conversation history and rotate autosave session",
-    usage="/clear, clear",
+    usage="/clear",
     aliases=[],
     category="core",
 )

--- a/code_puppy/command_line/core_commands.py
+++ b/code_puppy/command_line/core_commands.py
@@ -175,6 +175,12 @@ def handle_paste_command(command: str) -> bool:
     category="core",
 )
 def handle_clear_command(command: str) -> bool:
+    """Clear conversation history, rotate autosave session, and clear pending clipboard images.
+
+    Resets the agent's context so it starts fresh, persists the current session
+    to autosave, and notifies the user of the cleanup.
+    """
+
     from code_puppy.command_line.clipboard import get_clipboard_manager
     from code_puppy.messaging import emit_warning, emit_system_message, emit_info
     from code_puppy.agents import get_current_agent

--- a/code_puppy/command_line/core_commands.py
+++ b/code_puppy/command_line/core_commands.py
@@ -168,6 +168,35 @@ def handle_paste_command(command: str) -> bool:
 
 
 @register_command(
+    name="clear",
+    description="Clear conversation history and rotate autosave session",
+    usage="/clear, clear",
+    aliases=[],
+    category="core",
+)
+def handle_clear_command(command: str) -> bool:
+    from code_puppy.command_line.clipboard import get_clipboard_manager
+    from code_puppy.messaging import emit_warning, emit_system_message, emit_info
+    from code_puppy.agents import get_current_agent
+    from code_puppy.config import finalize_autosave_session
+
+    agent = get_current_agent()
+    new_session_id = finalize_autosave_session()
+    agent.clear_message_history()
+    emit_warning("Conversation history cleared!")
+    emit_system_message("The agent will not remember previous interactions.")
+    emit_info(f"Auto-save session rotated to: {new_session_id}")
+
+    # Also clear pending clipboard images
+    clipboard_manager = get_clipboard_manager()
+    clipboard_count = clipboard_manager.get_pending_count()
+    clipboard_manager.clear_pending()
+    if clipboard_count > 0:
+        emit_info(f"Cleared {clipboard_count} pending clipboard image(s)")
+    return True
+
+
+@register_command(
     name="tutorial",
     description="Run the interactive tutorial wizard",
     usage="/tutorial",


### PR DESCRIPTION
## Summary
Fixes #254: The `/clear` command now appears in autocomplete suggestions when typing `/cl`.

## Root Cause
The `/clear` command was previously handled via an inline conditional check in the main interactive loop rather than being registered through the `@register_command` decorator. Since `SlashCompleter` only yields suggestions from commands in the registry (`get_unique_commands()`), `/clear` was invisible to tab-completion.

## Changes
- Added `@register_command` decorator to the clear handler in `code_puppy/command_line/core_commands.py`
- Implemented `handle_clear_command()` preserving original behavior:
  - Clears conversation history via `agent.clear_message_history()`
  - Rotates autosave session via `finalize_autosave_session()`
  - Clears pending clipboard images
  - Emits appropriate user feedback messages
- Removed `/clear` from the inline handler in `cli_runner.py`; the bare `clear` 
  (without slash) is retained there for backwards compatibility
- `/clear` is now fully owned by the registry — autocomplete, `/help` listing, 
  and execution all go through `handle_clear_command()`
  
## Out of Scope: `/exit` and `/quit`
Applying the same split to `/exit` and `/quit` is not straightforward. The inline handler for these commands needs to `break` out of the interactive loop — a side effect that cannot be expressed in the current registry return protocol (`True`/`str`/`False`). 
Moving them to the registry would require either introducing a sentinel return value or restructuring the loop exit mechanism, both of which are beyond the scope of this fix. 
Flagged for a follow-up.

## Testing
- [x] Autocomplete: Typing `/cl` + TAB now shows both `/clear` and `/clipboard`
- [x] Execution: `/clear` properly resets conversation history and rotates autosave sessions
- [x] Clipboard: Pending clipboard images are cleared on execution
- [x] Backwards compatibility: Plain `clear` (without `/`) continues to work
- [x] Tests & Linting: `uv run pytest tests/command_line/ -v` & `uv run ruff check . && uv run ruff format .`

## Notes
- No breaking changes; only adds missing registration metadata
- Follows the same registration pattern as other core commands (`/clipboard`, `/cd`, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clear command to wipe the in-memory conversation and rotate to a new autosave session.
  * After clearing, the app warns that prior interactions won’t be remembered and shows the new session id.
  * Clears any pending clipboard image attachments and reports how many were removed.

* **Refactor**
  * Clear activation narrowed to the plain "clear" input (previous alternate form no longer triggers).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->