### PR TITLE
feat(bedrock): add AWS Bedrock provider plugin

### DIFF
--- a/code_puppy/command_line/add_model_menu.py
+++ b/code_puppy/command_line/add_model_menu.py
@@ -48,7 +48,7 @@ PROVIDER_ENDPOINTS = {
 # Providers that require custom SDK implementations we don't support yet.
 # These use non-OpenAI-compatible APIs or require special authentication (AWS SigV4, GCP, etc.)
 UNSUPPORTED_PROVIDERS = {
-    "amazon-bedrock": "Requires AWS SigV4 authentication",
+    "amazon-bedrock": "Use /bedrock-setup to configure (aws_bedrock plugin)",
     "google-vertex": "Requires GCP service account authentication",
     "google-vertex-anthropic": "Requires GCP service account authentication",
     "cloudflare-workers-ai": "Requires account ID in URL path",

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -530,14 +530,9 @@ def model_supports_setting(model_name: str, setting: str) -> bool:
             # For Anthropic/Claude models, include extended thinking settings
             if model_name.startswith("claude-") or model_name.startswith("anthropic-"):
                 base = ["temperature", "extended_thinking", "budget_tokens"]
-                # Opus 4-6 models also support the effort setting
-                lower = model_name.lower()
-                if (
-                    "opus-4-6" in lower
-                    or "4-6-opus" in lower
-                    or "opus-4-7" in lower
-                    or "4-7-opus" in lower
-                ):
+                from code_puppy.model_utils import supports_adaptive_thinking
+
+                if supports_adaptive_thinking(model_name):
                     base.append("effort")
                 return setting in base
             return setting in ["temperature", "seed"]

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -105,7 +105,7 @@ def get_api_key(env_var_name: str) -> str | None:
 
 # Model types that use the Anthropic Messages API under the hood.
 # These all need Anthropic-specific settings (thinking, effort, etc.).
-_ANTHROPIC_MODEL_TYPES = frozenset({"anthropic", "azure_foundry", "claude_code"})
+_ANTHROPIC_MODEL_TYPES = frozenset({"anthropic", "aws_bedrock", "azure_foundry", "claude_code"})
 
 
 def _is_anthropic_model(model_name: str, model_config: dict[str, Any]) -> bool:
@@ -261,7 +261,8 @@ def make_model_settings(
             should_use_anthropic_thinking_summary,
         )
 
-        default_thinking = get_default_extended_thinking(model_name)
+        actual_model_id = model_config.get("name", model_name)
+        default_thinking = get_default_extended_thinking(model_name, actual_model_id)
         extended_thinking = effective_settings.get(
             "extended_thinking", default_thinking
         )
@@ -278,7 +279,7 @@ def make_model_settings(
             }
             if (
                 extended_thinking == "adaptive"
-                and should_use_anthropic_thinking_summary(model_name)
+                and should_use_anthropic_thinking_summary(model_name, actual_model_id)
             ):
                 model_settings_dict["anthropic_thinking"]["display"] = "summarized"
             # Only send budget_tokens for classic "enabled" mode
@@ -297,7 +298,9 @@ def make_model_settings(
             model_supports_setting(model_name, "effort")
             and extended_thinking == "adaptive"
         ):
-            effort = effective_settings.get("effort", "high")
+            effort = effective_settings.get(
+                "effort", model_config.get("default_effort", "high")
+            )
             if "anthropic_thinking" in model_settings_dict:
                 extra_body = model_settings_dict.get("extra_body") or {}
                 extra_body["output_config"] = {"effort": effort}

--- a/code_puppy/model_utils.py
+++ b/code_puppy/model_utils.py
@@ -92,34 +92,65 @@ def prepare_prompt_for_model(
     )
 
 
-def get_default_extended_thinking(model_name: str) -> str:
-    """Return the default extended_thinking mode for an Anthropic model.
+def supports_adaptive_thinking(
+    model_name: str, actual_model_id: str | None = None
+) -> bool:
+    """Return whether a model should default to adaptive thinking.
 
-    Opus 4-6 and Opus 4-7 models default to ``"adaptive"`` thinking; all
-    other Anthropic models default to ``"enabled"``.
+    Opus 4-6, Opus 4-7, and Sonnet 4-6 models support adaptive thinking.
+    Checks both the alias/key and the real model ID to handle Bedrock-style
+    names like ``us.anthropic.claude-opus-4-7``.
 
     Args:
-        model_name: The model name string (e.g. ``"claude-opus-4-7"``).
+        model_name: The model alias/key (e.g. ``"bedrock-opus-4-7"``).
+        actual_model_id: The real model ID from config (e.g.
+            ``"us.anthropic.claude-opus-4-7"``).
+    """
+    candidates = [model_name.lower()]
+    if actual_model_id:
+        candidates.append(actual_model_id.lower())
+
+    _ADAPTIVE_TAGS = (
+        "opus-4-6",
+        "4-6-opus",
+        "opus-4-7",
+        "4-7-opus",
+        "sonnet-4-6",
+        "4-6-sonnet",
+    )
+    return any(tag in c for c in candidates for tag in _ADAPTIVE_TAGS)
+
+
+def get_default_extended_thinking(
+    model_name: str, actual_model_id: str | None = None
+) -> str:
+    """Return the default extended_thinking mode for an Anthropic model.
+
+    Opus 4-6, Opus 4-7, and Sonnet 4-6 models default to ``"adaptive"``
+    thinking; all other Anthropic models default to ``"enabled"``.
+
+    Args:
+        model_name: The model alias/key (e.g. ``"bedrock-opus-4-7"``).
+        actual_model_id: The real model ID from config (e.g.
+            ``"us.anthropic.claude-opus-4-7"``).
 
     Returns:
-        ``"adaptive"`` for Opus 4-6/4-7 variants, ``"enabled"`` otherwise.
+        ``"adaptive"`` for supported variants, ``"enabled"`` otherwise.
     """
-    lower = model_name.lower()
-    if (
-        "opus-4-6" in lower
-        or "4-6-opus" in lower
-        or "opus-4-7" in lower
-        or "4-7-opus" in lower
-    ):
+    if supports_adaptive_thinking(model_name, actual_model_id):
         return "adaptive"
     return "enabled"
 
 
-def should_use_anthropic_thinking_summary(model_name: str) -> bool:
+def should_use_anthropic_thinking_summary(
+    model_name: str, actual_model_id: str | None = None
+) -> bool:
     """Return whether Anthropic adaptive thinking should request summary display.
 
     Anthropic's newer Opus 4.7 models require ``display: \"summarized\"`` alongside
     ``thinking={"type": "adaptive"}``.
     """
-    lower = model_name.lower()
-    return "opus-4-7" in lower or "4-7-opus" in lower
+    candidates = [model_name.lower()]
+    if actual_model_id:
+        candidates.append(actual_model_id.lower())
+    return any("opus-4-7" in c or "4-7-opus" in c for c in candidates)

--- a/code_puppy/plugins/aws_bedrock/__init__.py
+++ b/code_puppy/plugins/aws_bedrock/__init__.py
@@ -1,0 +1,14 @@
+"""AWS Bedrock Plugin for Code Puppy.
+
+This plugin enables Code Puppy to use Anthropic Claude models hosted on
+AWS Bedrock with standard AWS credential chain authentication (env vars,
+profiles, IAM roles, SSO).
+
+Supported models:
+- Claude Opus 4.7 (1M context)
+- Claude Opus 4.6 (1M context)
+- Claude Sonnet 4.6 (1M context)
+- Claude Haiku 4.5 (200K context)
+"""
+
+__version__ = "0.1.0"

--- a/code_puppy/plugins/aws_bedrock/config.py
+++ b/code_puppy/plugins/aws_bedrock/config.py
@@ -1,0 +1,101 @@
+"""Configuration constants for the AWS Bedrock plugin."""
+
+from __future__ import annotations
+
+import functools
+import os
+from pathlib import Path
+
+from code_puppy.config import DATA_DIR
+
+ENV_AWS_REGION = "AWS_REGION"
+ENV_AWS_PROFILE = "AWS_PROFILE"
+ENV_BEDROCK_REGION = "BEDROCK_REGION"
+
+DEFAULT_REGION = "us-east-1"
+
+
+@functools.lru_cache(maxsize=1)
+def _detect_region() -> str | None:
+    """Detect region from boto3 session or EC2 instance metadata.
+
+    Result is cached for the process lifetime: on non-EC2 hosts with no
+    AWS config, the IMDS path below incurs two 1-second timeouts, and
+    this function is called on every model instantiation.
+    """
+    try:
+        import boto3
+
+        region = boto3.Session().region_name
+        if region:
+            return region
+    except Exception:
+        pass
+
+    try:
+        import urllib.request
+
+        token_req = urllib.request.Request(
+            "http://169.254.169.254/latest/api/token",
+            method="PUT",
+            headers={"X-aws-ec2-metadata-token-ttl-seconds": "30"},
+        )
+        token = urllib.request.urlopen(token_req, timeout=1).read().decode()
+        region_req = urllib.request.Request(
+            "http://169.254.169.254/latest/meta-data/placement/region",
+            headers={"X-aws-ec2-metadata-token": token},
+        )
+        return urllib.request.urlopen(region_req, timeout=1).read().decode()
+    except Exception:
+        return None
+
+
+MODELS: list[dict] = [
+    {
+        "base_key": "bedrock-opus-4-7",
+        "model_id": "us.anthropic.claude-opus-4-7",
+        "context_length": 1000000,
+        "variants": ["default", "low", "medium", "high", "xhigh", "max"],
+    },
+    {
+        "base_key": "bedrock-opus-4-6",
+        "model_id": "us.anthropic.claude-opus-4-6-v1:0",
+        "context_length": 1000000,
+        "variants": ["default", "low", "medium", "high", "max"],
+    },
+    {
+        "base_key": "bedrock-sonnet-4-6",
+        "model_id": "us.anthropic.claude-sonnet-4-6-v1:0",
+        "context_length": 1000000,
+        "variants": ["default", "low", "medium", "high", "max"],
+    },
+    {
+        "base_key": "bedrock-haiku",
+        "model_id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "context_length": 200000,
+        "variants": None,
+    },
+]
+
+
+def get_bedrock_region() -> str:
+    """Get the AWS region for Bedrock.
+
+    Precedence: BEDROCK_REGION > AWS_REGION > boto3 session > default.
+    """
+    return (
+        os.environ.get(ENV_BEDROCK_REGION)
+        or os.environ.get(ENV_AWS_REGION)
+        or _detect_region()
+        or DEFAULT_REGION
+    )
+
+
+def get_aws_profile() -> str | None:
+    """Get the AWS profile name from environment."""
+    return os.environ.get(ENV_AWS_PROFILE)
+
+
+def get_extra_models_path() -> Path:
+    """Get the path to the extra_models.json file."""
+    return Path(DATA_DIR) / "extra_models.json"

--- a/code_puppy/plugins/aws_bedrock/register_callbacks.py
+++ b/code_puppy/plugins/aws_bedrock/register_callbacks.py
@@ -1,0 +1,243 @@
+"""AWS Bedrock Plugin callbacks for Code Puppy CLI.
+
+This plugin enables Code Puppy to use Anthropic Claude models hosted on
+AWS Bedrock with standard AWS credential chain authentication.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from code_puppy.callbacks import register_callback
+from code_puppy.messaging import emit_error, emit_info, emit_success, emit_warning
+
+from .config import (
+    get_aws_profile,
+    get_bedrock_region,
+)
+from .utils import (
+    add_bedrock_models_to_config,
+    get_bedrock_models_from_config,
+    remove_bedrock_models_from_config,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Slash Command Handlers
+# ============================================================================
+
+
+def _handle_bedrock_status() -> None:
+    """Handle the /bedrock-status command."""
+    emit_info("")
+    emit_info("AWS Bedrock Status")
+    emit_info("=" * 40)
+
+    region = get_bedrock_region()
+    profile = get_aws_profile()
+
+    emit_info(f"Region: {region}")
+    if profile:
+        emit_info(f"Profile: {profile}")
+    else:
+        emit_info("Profile: (default credential chain)")
+
+    # Check AWS credentials
+    try:
+        import boto3
+
+        session = boto3.Session(profile_name=profile, region_name=region)
+        sts = session.client("sts")
+        identity = sts.get_caller_identity()
+        arn = identity.get("Arn", "unknown")
+        emit_success(f"Authenticated: {arn}")
+    except ImportError:
+        emit_warning("boto3 not installed - cannot verify credentials")
+    except Exception as e:
+        emit_warning(f"Authentication: {e}")
+
+    emit_info("")
+    bedrock_models = get_bedrock_models_from_config()
+    if bedrock_models:
+        emit_info(f"Configured Models ({len(bedrock_models)}):")
+        for model_key, config in bedrock_models.items():
+            model_id = config.get("name", "unknown")
+            emit_info(f"   - {model_key}: {model_id}")
+    else:
+        emit_info("Configured Models: None")
+        emit_info("   Run /bedrock-setup to configure models")
+
+    emit_info("")
+
+
+def _handle_bedrock_setup() -> None:
+    """Handle the /bedrock-setup command.
+
+    Region and credentials auto-resolve from the AWS environment
+    (IAM role, env vars, ~/.aws/config). No prompts needed.
+    """
+
+    added_models = add_bedrock_models_to_config(
+        aws_region=get_bedrock_region(),
+        aws_profile=get_aws_profile(),
+    )
+
+    if added_models:
+        emit_success(f"Bedrock: added {len(added_models)} model(s):")
+        for model_key in added_models:
+            emit_info(f"   - {model_key}")
+
+        from code_puppy.model_switching import set_model_and_reload_agent
+
+        set_model_and_reload_agent("bedrock-opus-4-7")
+        emit_info("Switched to bedrock-opus-4-7.")
+    else:
+        emit_warning("Bedrock: no models added — check configuration.")
+
+
+def _handle_bedrock_remove() -> None:
+    """Handle the /bedrock-remove command."""
+    removed = remove_bedrock_models_from_config()
+    if removed:
+        emit_success(f"Removed {len(removed)} Bedrock model(s):")
+        for model_key in removed:
+            emit_info(f"   - {model_key}")
+    else:
+        emit_info("No Bedrock models found in configuration.")
+
+
+# ============================================================================
+# Custom Command Registration
+# ============================================================================
+
+
+def _custom_help() -> list[tuple[str, str]]:
+    """Return help entries for custom commands."""
+    return [
+        ("bedrock-status", "Check AWS Bedrock authentication and configuration"),
+        ("bedrock-setup", "Auto-configure Bedrock Claude models"),
+        ("bedrock-remove", "Remove all Bedrock model configurations"),
+    ]
+
+
+def _handle_custom_command(command: str, name: str) -> bool | None:
+    """Handle custom slash commands for the AWS Bedrock plugin."""
+    handlers = {
+        "bedrock-status": _handle_bedrock_status,
+        "bedrock-setup": _handle_bedrock_setup,
+        "bedrock-remove": _handle_bedrock_remove,
+    }
+
+    handler = handlers.get(name)
+    if handler is None:
+        return None
+
+    try:
+        handler()
+        return True
+    except Exception as e:
+        logger.exception("Error handling /%s command: %s", name, e)
+        emit_error(f"Command /{name} failed: {e}")
+        return True
+
+
+# ============================================================================
+# Model Type Handler
+# ============================================================================
+
+
+def _create_aws_bedrock_model(model_name: str, model_config: dict, config: dict) -> Any:
+    """Create an AWS Bedrock model instance.
+
+    Uses AsyncAnthropicBedrock from the anthropic SDK with standard
+    AWS credential chain (env vars, profiles, IAM roles, SSO).
+    """
+    try:
+        from anthropic import AsyncAnthropicBedrock
+        from pydantic_ai.models.anthropic import AnthropicModel
+    except ImportError as e:
+        emit_error(
+            f"Failed to create Bedrock model '{model_name}': Missing dependency - {e}"
+        )
+        return None
+
+    from code_puppy.claude_cache_client import patch_anthropic_client_messages
+    from code_puppy.config import get_effective_model_settings
+    from code_puppy.model_factory import CONTEXT_1M_BETA
+    from code_puppy.provider_identity import (
+        make_anthropic_provider,
+        resolve_provider_identity,
+    )
+
+    model_id = model_config.get("name")
+    if not model_id:
+        emit_warning(f"Model ID not specified for '{model_name}'.")
+        return None
+
+    try:
+        effective_settings = get_effective_model_settings(model_name)
+        interleaved_thinking = effective_settings.get("interleaved_thinking", True)
+
+        beta_parts: list[str] = []
+        if interleaved_thinking:
+            beta_parts.append("interleaved-thinking-2025-05-14")
+
+        context_length = model_config.get("context_length", 200000)
+        if context_length >= 1_000_000:
+            beta_parts.append(CONTEXT_1M_BETA)
+
+        default_headers: dict[str, str] | None = None
+        if beta_parts:
+            default_headers = {"anthropic-beta": ",".join(beta_parts)}
+
+        client_kwargs: dict[str, Any] = {
+            "aws_region": model_config.get("aws_region") or get_bedrock_region(),
+        }
+
+        aws_profile = model_config.get("aws_profile") or get_aws_profile()
+        if aws_profile:
+            client_kwargs["aws_profile"] = aws_profile
+
+        if default_headers:
+            client_kwargs["default_headers"] = default_headers
+
+        anthropic_client = AsyncAnthropicBedrock(**client_kwargs)
+
+        patch_anthropic_client_messages(anthropic_client)
+
+        provider_identity = resolve_provider_identity(model_name, model_config)
+        provider = make_anthropic_provider(
+            provider_identity,
+            anthropic_client=anthropic_client,
+        )
+
+        model = AnthropicModel(model_name=model_id, provider=provider)
+        logger.info(
+            "Created Bedrock model: %s -> %s @ %s",
+            model_name,
+            model_id,
+            client_kwargs.get("aws_region", "auto"),
+        )
+        return model
+
+    except Exception as e:
+        emit_error(f"Failed to create Bedrock model '{model_name}': {e}")
+        logger.exception("Error creating Bedrock model: %s", e)
+        return None
+
+
+def _register_model_types() -> list[dict[str, Any]]:
+    """Register the aws_bedrock model type handler."""
+    return [{"type": "aws_bedrock", "handler": _create_aws_bedrock_model}]
+
+
+# ============================================================================
+# Callback Registration
+# ============================================================================
+
+register_callback("custom_command_help", _custom_help)
+register_callback("custom_command", _handle_custom_command)
+register_callback("register_model_type", _register_model_types)

--- a/code_puppy/plugins/aws_bedrock/utils.py
+++ b/code_puppy/plugins/aws_bedrock/utils.py
@@ -1,0 +1,155 @@
+"""Utility functions for the AWS Bedrock plugin."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from .config import (
+    MODELS,
+    get_extra_models_path,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def load_extra_models() -> dict[str, Any]:
+    """Load the extra_models.json configuration file."""
+    extra_models_path = get_extra_models_path()
+    if not extra_models_path.exists():
+        return {}
+
+    try:
+        with open(extra_models_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        logger.error("Error loading extra_models.json: %s", e)
+        return {}
+
+
+def save_extra_models(models: dict[str, Any]) -> bool:
+    """Save model configurations to extra_models.json (atomic write)."""
+    extra_models_path = get_extra_models_path()
+
+    try:
+        extra_models_path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = extra_models_path.with_suffix(".tmp")
+        with open(temp_path, "w", encoding="utf-8") as f:
+            json.dump(models, f, indent=2, ensure_ascii=False)
+        temp_path.replace(extra_models_path)
+        return True
+    except Exception as e:
+        logger.error("Error saving extra_models.json: %s", e)
+        return False
+
+
+def _build_model_entry(
+    model_id: str,
+    context_length: int,
+    has_effort: bool,
+    effort: str | None = None,
+    aws_region: str | None = None,
+    aws_profile: str | None = None,
+) -> dict[str, Any]:
+    """Build a single model config entry for extra_models.json."""
+    supported_settings = [
+        "temperature",
+        "extended_thinking",
+        "budget_tokens",
+        "interleaved_thinking",
+    ]
+    if has_effort:
+        supported_settings.append("effort")
+
+    config: dict[str, Any] = {
+        "type": "aws_bedrock",
+        "provider": "aws_bedrock",
+        "name": model_id,
+        "context_length": context_length,
+        "supported_settings": supported_settings,
+    }
+    if effort:
+        config["default_effort"] = effort
+    if aws_region:
+        config["aws_region"] = aws_region
+    if aws_profile:
+        config["aws_profile"] = aws_profile
+
+    return config
+
+
+def add_bedrock_models_to_config(
+    aws_region: str | None = None,
+    aws_profile: str | None = None,
+) -> list[str]:
+    """Add Bedrock model configurations (with effort variants) to extra_models.json."""
+    models = load_extra_models()
+    added: list[str] = []
+
+    for spec in MODELS:
+        base_key = spec["base_key"]
+        model_id = spec["model_id"]
+        context_length = spec["context_length"]
+        variants = spec.get("variants")
+
+        if variants:
+            for variant in variants:
+                if variant == "default":
+                    key = base_key
+                    effort = None
+                else:
+                    key = f"{base_key}-{variant}"
+                    effort = variant
+
+                models[key] = _build_model_entry(
+                    model_id=model_id,
+                    context_length=context_length,
+                    has_effort=True,
+                    effort=effort,
+                    aws_region=aws_region,
+                    aws_profile=aws_profile,
+                )
+                added.append(key)
+        else:
+            models[base_key] = _build_model_entry(
+                model_id=model_id,
+                context_length=context_length,
+                has_effort=False,
+                aws_region=aws_region,
+                aws_profile=aws_profile,
+            )
+            added.append(base_key)
+
+    if added and save_extra_models(models):
+        return added
+    return []
+
+
+def remove_bedrock_models_from_config() -> list[str]:
+    """Remove all Bedrock model configurations from extra_models.json."""
+    models = load_extra_models()
+    removed = [
+        key
+        for key, cfg in models.items()
+        if isinstance(cfg, dict) and cfg.get("type") == "aws_bedrock"
+    ]
+
+    for key in removed:
+        del models[key]
+
+    if removed and not save_extra_models(models):
+        logger.error("Failed to save extra_models.json after removing Bedrock models")
+        return []
+
+    return removed
+
+
+def get_bedrock_models_from_config() -> dict[str, Any]:
+    """Get all Bedrock model configurations from extra_models.json."""
+    models = load_extra_models()
+    return {
+        key: cfg
+        for key, cfg in models.items()
+        if isinstance(cfg, dict) and cfg.get("type") == "aws_bedrock"
+    }

--- a/code_puppy/provider_identity.py
+++ b/code_puppy/provider_identity.py
@@ -46,6 +46,7 @@ _TYPE_PROVIDER_OVERRIDES = {
     "chatgpt_oauth": "chatgpt",
     "gemini": "google",
     "gemini_oauth": "google",
+    "aws_bedrock": "aws_bedrock",
     "azure_openai": "azure_openai",
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ classifiers = [
     "Topic :: Software Development :: Code Generators",
 ]
 
+[project.optional-dependencies]
+bedrock = ["boto3>=1.35.0"]
+
 [project.urls]
 repository = "https://github.com/mpfaffenberger/code_puppy"
 HomePage = "https://github.com/mpfaffenberger/code_puppy"

--- a/tests/plugins/test_aws_bedrock.py
+++ b/tests/plugins/test_aws_bedrock.py
@@ -1,0 +1,435 @@
+"""Tests for the AWS Bedrock plugin.
+
+Covers config, utils (model entry building, config round-trip, variant
+expansion), register_callbacks (slash commands, custom command dispatch),
+and the shared adaptive-thinking helper in model_utils.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+# ============================================================================
+# FIXTURES
+# ============================================================================
+
+
+@pytest.fixture
+def tmp_extra_models(tmp_path):
+    """Return a path to a temporary extra_models.json and patch get_extra_models_path."""
+    p = tmp_path / "extra_models.json"
+    with patch(
+        "code_puppy.plugins.aws_bedrock.utils.get_extra_models_path", return_value=p
+    ):
+        yield p
+
+
+@pytest.fixture
+def extra_models_with_bedrock(tmp_extra_models):
+    """Create an extra_models.json that already contains some Bedrock entries."""
+    data = {
+        "bedrock-opus-4-7": {
+            "type": "aws_bedrock",
+            "provider": "aws_bedrock",
+            "name": "us.anthropic.claude-opus-4-7",
+            "context_length": 1000000,
+        },
+        "bedrock-haiku": {
+            "type": "aws_bedrock",
+            "provider": "aws_bedrock",
+            "name": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            "context_length": 200000,
+        },
+        "some-openai-model": {
+            "type": "openai",
+            "name": "gpt-4o",
+            "context_length": 128000,
+        },
+    }
+    tmp_extra_models.write_text(json.dumps(data, indent=2))
+    return tmp_extra_models
+
+
+# ============================================================================
+# CONFIG MODULE TESTS
+# ============================================================================
+
+
+class TestConfig:
+    """Test config.py constants and helpers."""
+
+    def test_models_list_has_expected_entries(self):
+        from code_puppy.plugins.aws_bedrock.config import MODELS
+
+        keys = [m["base_key"] for m in MODELS]
+        assert "bedrock-opus-4-7" in keys
+        assert "bedrock-opus-4-6" in keys
+        assert "bedrock-sonnet-4-6" in keys
+        assert "bedrock-haiku" in keys
+
+    def test_models_context_lengths(self):
+        from code_puppy.plugins.aws_bedrock.config import MODELS
+
+        by_key = {m["base_key"]: m for m in MODELS}
+        assert by_key["bedrock-opus-4-7"]["context_length"] == 1_000_000
+        assert by_key["bedrock-opus-4-6"]["context_length"] == 1_000_000
+        assert by_key["bedrock-sonnet-4-6"]["context_length"] == 1_000_000
+        assert by_key["bedrock-haiku"]["context_length"] == 200_000
+
+    def test_get_bedrock_region_env_override(self):
+        from code_puppy.plugins.aws_bedrock.config import get_bedrock_region
+
+        with patch.dict("os.environ", {"BEDROCK_REGION": "eu-west-1"}, clear=False):
+            assert get_bedrock_region() == "eu-west-1"
+
+    def test_get_bedrock_region_aws_region_fallback(self):
+        from code_puppy.plugins.aws_bedrock.config import get_bedrock_region
+
+        env = {"AWS_REGION": "us-west-2"}
+        with (
+            patch.dict("os.environ", env, clear=False),
+            patch.dict("os.environ", {"BEDROCK_REGION": ""}, clear=False),
+        ):
+            # Remove BEDROCK_REGION so it falls through
+            import os
+
+            os.environ.pop("BEDROCK_REGION", None)
+            assert get_bedrock_region() == "us-west-2"
+
+    def test_get_bedrock_region_default(self):
+        from code_puppy.plugins.aws_bedrock.config import get_bedrock_region
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"BEDROCK_REGION": "", "AWS_REGION": ""},
+                clear=False,
+            ),
+            patch(
+                "code_puppy.plugins.aws_bedrock.config._detect_region",
+                return_value=None,
+            ),
+        ):
+            import os
+
+            os.environ.pop("BEDROCK_REGION", None)
+            os.environ.pop("AWS_REGION", None)
+            assert get_bedrock_region() == "us-east-1"
+
+    def test_get_aws_profile_from_env(self):
+        from code_puppy.plugins.aws_bedrock.config import get_aws_profile
+
+        with patch.dict("os.environ", {"AWS_PROFILE": "dev-profile"}, clear=False):
+            assert get_aws_profile() == "dev-profile"
+
+    def test_get_aws_profile_none_when_unset(self):
+        from code_puppy.plugins.aws_bedrock.config import get_aws_profile
+
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+
+            os.environ.pop("AWS_PROFILE", None)
+            assert get_aws_profile() is None
+
+
+# ============================================================================
+# UTILS MODULE TESTS
+# ============================================================================
+
+
+class TestBuildModelEntry:
+    """Test _build_model_entry helper."""
+
+    def test_basic_entry(self):
+        from code_puppy.plugins.aws_bedrock.utils import _build_model_entry
+
+        entry = _build_model_entry(
+            model_id="us.anthropic.claude-opus-4-7",
+            context_length=1_000_000,
+            has_effort=False,
+        )
+        assert entry["type"] == "aws_bedrock"
+        assert entry["provider"] == "aws_bedrock"
+        assert entry["name"] == "us.anthropic.claude-opus-4-7"
+        assert entry["context_length"] == 1_000_000
+        assert "effort" not in entry.get("supported_settings", [])
+        assert "default_effort" not in entry
+
+    def test_entry_with_effort(self):
+        from code_puppy.plugins.aws_bedrock.utils import _build_model_entry
+
+        entry = _build_model_entry(
+            model_id="us.anthropic.claude-opus-4-7",
+            context_length=1_000_000,
+            has_effort=True,
+            effort="high",
+        )
+        assert "effort" in entry["supported_settings"]
+        assert entry["default_effort"] == "high"
+
+    def test_entry_with_aws_overrides(self):
+        from code_puppy.plugins.aws_bedrock.utils import _build_model_entry
+
+        entry = _build_model_entry(
+            model_id="us.anthropic.claude-opus-4-7",
+            context_length=1_000_000,
+            has_effort=False,
+            aws_region="eu-west-1",
+            aws_profile="prod",
+        )
+        assert entry["aws_region"] == "eu-west-1"
+        assert entry["aws_profile"] == "prod"
+
+
+class TestAddBedrockModelsToConfig:
+    """Test add_bedrock_models_to_config — variant expansion and persistence."""
+
+    def test_adds_all_models_and_variants(self, tmp_extra_models):
+        from code_puppy.plugins.aws_bedrock.utils import add_bedrock_models_to_config
+
+        added = add_bedrock_models_to_config(aws_region="us-east-1")
+        assert len(added) > 0
+
+        # Check that base keys exist
+        assert "bedrock-opus-4-7" in added
+        assert "bedrock-haiku" in added
+
+        # Check variant keys
+        assert "bedrock-opus-4-7-high" in added
+        assert "bedrock-sonnet-4-6-low" in added
+
+        # Verify file was written
+        data = json.loads(tmp_extra_models.read_text())
+        assert "bedrock-opus-4-7" in data
+        assert data["bedrock-opus-4-7"]["type"] == "aws_bedrock"
+
+    def test_preserves_existing_entries(self, tmp_extra_models):
+        from code_puppy.plugins.aws_bedrock.utils import add_bedrock_models_to_config
+
+        # Write a pre-existing model
+        existing = {"my-openai-model": {"type": "openai", "name": "gpt-4o"}}
+        tmp_extra_models.write_text(json.dumps(existing))
+
+        add_bedrock_models_to_config(aws_region="us-east-1")
+        data = json.loads(tmp_extra_models.read_text())
+        assert "my-openai-model" in data
+        assert "bedrock-opus-4-7" in data
+
+    def test_returns_empty_on_save_failure(self, tmp_extra_models):
+        from code_puppy.plugins.aws_bedrock.utils import add_bedrock_models_to_config
+
+        with patch(
+            "code_puppy.plugins.aws_bedrock.utils.save_extra_models",
+            return_value=False,
+        ):
+            result = add_bedrock_models_to_config()
+            assert result == []
+
+
+class TestRemoveBedrockModelsFromConfig:
+    """Test remove_bedrock_models_from_config."""
+
+    def test_removes_only_bedrock_entries(self, extra_models_with_bedrock):
+        from code_puppy.plugins.aws_bedrock.utils import (
+            remove_bedrock_models_from_config,
+        )
+
+        removed = remove_bedrock_models_from_config()
+        assert "bedrock-opus-4-7" in removed
+        assert "bedrock-haiku" in removed
+        assert "some-openai-model" not in removed
+
+        data = json.loads(extra_models_with_bedrock.read_text())
+        assert "some-openai-model" in data
+        assert "bedrock-opus-4-7" not in data
+
+    def test_returns_empty_when_nothing_to_remove(self, tmp_extra_models):
+        from code_puppy.plugins.aws_bedrock.utils import (
+            remove_bedrock_models_from_config,
+        )
+
+        tmp_extra_models.write_text(json.dumps({"gpt-4o": {"type": "openai"}}))
+        removed = remove_bedrock_models_from_config()
+        assert removed == []
+
+    def test_returns_empty_on_save_failure(self, extra_models_with_bedrock):
+        from code_puppy.plugins.aws_bedrock.utils import (
+            remove_bedrock_models_from_config,
+        )
+
+        with patch(
+            "code_puppy.plugins.aws_bedrock.utils.save_extra_models",
+            return_value=False,
+        ):
+            result = remove_bedrock_models_from_config()
+            assert result == []
+
+
+class TestGetBedrockModelsFromConfig:
+    """Test get_bedrock_models_from_config."""
+
+    def test_filters_bedrock_only(self, extra_models_with_bedrock):
+        from code_puppy.plugins.aws_bedrock.utils import (
+            get_bedrock_models_from_config,
+        )
+
+        models = get_bedrock_models_from_config()
+        assert "bedrock-opus-4-7" in models
+        assert "bedrock-haiku" in models
+        assert "some-openai-model" not in models
+
+
+# ============================================================================
+# REGISTER_CALLBACKS TESTS
+# ============================================================================
+
+
+class TestHandleCustomCommand:
+    """Test _handle_custom_command dispatch."""
+
+    def test_returns_none_for_unknown_command(self):
+        from code_puppy.plugins.aws_bedrock.register_callbacks import (
+            _handle_custom_command,
+        )
+
+        result = _handle_custom_command("/foo", "foo")
+        assert result is None
+
+    def test_returns_true_for_known_command(self):
+        from code_puppy.plugins.aws_bedrock.register_callbacks import (
+            _handle_custom_command,
+        )
+
+        with patch(
+            "code_puppy.plugins.aws_bedrock.register_callbacks._handle_bedrock_status"
+        ):
+            result = _handle_custom_command("/bedrock-status", "bedrock-status")
+            assert result is True
+
+    def test_returns_true_on_handler_error(self):
+        """Error path should return True (command was handled, just failed)."""
+        from code_puppy.plugins.aws_bedrock.register_callbacks import (
+            _handle_custom_command,
+        )
+
+        with patch(
+            "code_puppy.plugins.aws_bedrock.register_callbacks._handle_bedrock_status",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = _handle_custom_command("/bedrock-status", "bedrock-status")
+            assert result is True
+
+
+class TestCustomHelp:
+    """Test _custom_help entries."""
+
+    def test_help_entries(self):
+        from code_puppy.plugins.aws_bedrock.register_callbacks import _custom_help
+
+        entries = _custom_help()
+        names = [e[0] for e in entries]
+        assert "bedrock-status" in names
+        assert "bedrock-setup" in names
+        assert "bedrock-remove" in names
+
+    def test_setup_help_not_interactive(self):
+        from code_puppy.plugins.aws_bedrock.register_callbacks import _custom_help
+
+        entries = dict(_custom_help())
+        assert "interactive" not in entries["bedrock-setup"].lower()
+        assert "wizard" not in entries["bedrock-setup"].lower()
+
+
+# ============================================================================
+# MODEL_UTILS SHARED HELPER TESTS
+# ============================================================================
+
+
+class TestSupportsAdaptiveThinking:
+    """Test the shared supports_adaptive_thinking helper."""
+
+    def test_opus_4_7_by_alias(self):
+        from code_puppy.model_utils import supports_adaptive_thinking
+
+        assert supports_adaptive_thinking("claude-opus-4-7") is True
+
+    def test_opus_4_6_by_alias(self):
+        from code_puppy.model_utils import supports_adaptive_thinking
+
+        assert supports_adaptive_thinking("claude-opus-4-6") is True
+
+    def test_sonnet_4_6_by_alias(self):
+        from code_puppy.model_utils import supports_adaptive_thinking
+
+        assert supports_adaptive_thinking("claude-sonnet-4-6") is True
+
+    def test_haiku_not_adaptive(self):
+        from code_puppy.model_utils import supports_adaptive_thinking
+
+        assert supports_adaptive_thinking("claude-haiku-4-5") is False
+
+    def test_bedrock_opus_via_actual_model_id(self):
+        from code_puppy.model_utils import supports_adaptive_thinking
+
+        # The alias doesn't contain the tag, but the actual_model_id does
+        assert (
+            supports_adaptive_thinking(
+                "bedrock-opus", actual_model_id="us.anthropic.claude-opus-4-7"
+            )
+            is True
+        )
+
+    def test_unknown_model(self):
+        from code_puppy.model_utils import supports_adaptive_thinking
+
+        assert supports_adaptive_thinking("gpt-4o") is False
+
+
+class TestGetDefaultExtendedThinking:
+    """Test get_default_extended_thinking uses the shared helper."""
+
+    def test_adaptive_for_opus(self):
+        from code_puppy.model_utils import get_default_extended_thinking
+
+        assert get_default_extended_thinking("claude-opus-4-7") == "adaptive"
+
+    def test_enabled_for_haiku(self):
+        from code_puppy.model_utils import get_default_extended_thinking
+
+        assert get_default_extended_thinking("claude-haiku-4-5") == "enabled"
+
+    def test_adaptive_via_actual_model_id(self):
+        from code_puppy.model_utils import get_default_extended_thinking
+
+        result = get_default_extended_thinking(
+            "bedrock-opus", actual_model_id="us.anthropic.claude-opus-4-6-v1:0"
+        )
+        assert result == "adaptive"
+
+
+class TestShouldUseThinkingSummary:
+    """Test should_use_anthropic_thinking_summary."""
+
+    def test_true_for_opus_4_7(self):
+        from code_puppy.model_utils import should_use_anthropic_thinking_summary
+
+        assert should_use_anthropic_thinking_summary("claude-opus-4-7") is True
+
+    def test_false_for_opus_4_6(self):
+        from code_puppy.model_utils import should_use_anthropic_thinking_summary
+
+        assert should_use_anthropic_thinking_summary("claude-opus-4-6") is False
+
+    def test_true_via_actual_model_id(self):
+        from code_puppy.model_utils import should_use_anthropic_thinking_summary
+
+        assert (
+            should_use_anthropic_thinking_summary(
+                "bedrock-opus", actual_model_id="us.anthropic.claude-opus-4-7"
+            )
+            is True
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -91,6 +91,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.42.92"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/3b/84cafa37e85a57618554bd2bc21bd569417097f45f18c23ef488e6c69683/boto3-1.42.92.tar.gz", hash = "sha256:55ec6ef6fc81f46d567a7d1d398d1e5c375d468905d0ccd9e1f767f0c77dbe9b", size = 113207, upload-time = "2026-04-20T19:38:17.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/8f/350ffd50aaa515429464deb1dc85893a21a64cb41892feb6b22ce87304ad/boto3-1.42.92-py3-none-any.whl", hash = "sha256:c90d9a170faa0585755fa103a3cd9595e1f53443864e902c180f3d8177589125", size = 140555, upload-time = "2026-04-20T19:38:14.323Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.92"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/0a/6785ce224ba4483b3e1282d959e1dd2c2898823336f013464c43cb154036/botocore-1.42.92.tar.gz", hash = "sha256:f1193d3057a2d0267353d7ef4e136be37ea432336d097fcb1951fae566ca3a22", size = 15235239, upload-time = "2026-04-20T19:38:05.085Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/b8/41d4d7ba75a4fb4f11362e96371a12695bc6ba0bb7cc680137db0213f97e/botocore-1.42.92-py3-none-any.whl", hash = "sha256:09ddefddbb1565ceef4b44b4b6e61b1ca5f12701d1494ecc85c1133d1b1e81fb", size = 14916275, upload-time = "2026-04-20T19:38:01.684Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -247,6 +275,11 @@ dependencies = [
     { name = "websockets" },
 ]
 
+[package.optional-dependencies]
+bedrock = [
+    { name = "boto3" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pexpect" },
@@ -260,6 +293,7 @@ dev = [
 requires-dist = [
     { name = "anthropic", specifier = "==0.79.0" },
     { name = "azure-identity", specifier = ">=1.15.0" },
+    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.35.0" },
     { name = "dbos", specifier = ">=2.11.0" },
     { name = "fastapi", specifier = ">=0.109.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.24.1" },
@@ -283,6 +317,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27.0" },
     { name = "websockets", specifier = ">=12.0" },
 ]
+provides-extras = ["bedrock"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -744,6 +779,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/15/d6eb3b770f6a0d332675141ab3962fd4a7c270ede3515d9f3583e1d28276/jiter-0.12.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:89163163c0934854a668ed783a2546a0617f71706a2551a4a0666d91ab365d6b", size = 304233, upload-time = "2025-11-09T20:49:18.734Z" },
     { url = "https://files.pythonhosted.org/packages/8c/3e/e7e06743294eea2cf02ced6aa0ff2ad237367394e37a0e2b4a1108c67a36/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d96b264ab7d34bbb2312dedc47ce07cd53f06835eacbc16dde3761f47c3a9e7f", size = 338537, upload-time = "2025-11-09T20:49:20.317Z" },
     { url = "https://files.pythonhosted.org/packages/2f/9c/6753e6522b8d0ef07d3a3d239426669e984fb0eba15a315cdbc1253904e4/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c24e864cb30ab82311c6425655b0cdab0a98c5d973b065c66a3f020740c2324c", size = 346110, upload-time = "2025-11-09T20:49:21.817Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -1703,6 +1747,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/c5/abd840d4132fd51a12f594934af5eba1d5d27298a6f5b5d6c3be45301caf/ruff-0.14.13-py3-none-win32.whl", hash = "sha256:ef720f529aec113968b45dfdb838ac8934e519711da53a0456038a0efecbd680", size = 12919024, upload-time = "2026-01-15T20:14:43.647Z" },
     { url = "https://files.pythonhosted.org/packages/c2/55/6384b0b8ce731b6e2ade2b5449bf07c0e4c31e8a2e68ea65b3bafadcecc5/ruff-0.14.13-py3-none-win_amd64.whl", hash = "sha256:6070bd026e409734b9257e03e3ef18c6e1a216f0435c6751d7a8ec69cb59abef", size = 14097887, upload-time = "2026-01-15T20:15:01.48Z" },
     { url = "https://files.pythonhosted.org/packages/4d/e1/7348090988095e4e39560cfc2f7555b1b2a7357deba19167b600fdf5215d/ruff-0.14.13-py3-none-win_arm64.whl", hash = "sha256:7ab819e14f1ad9fe39f246cfcc435880ef7a9390d81a2b6ac7e01039083dd247", size = 13080224, upload-time = "2026-01-15T20:14:45.853Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds first-class support for Anthropic Claude models hosted on **AWS Bedrock**, implemented as a plugin under `code_puppy/plugins/aws_bedrock/` per the plugin-first contribution guide.

## What's new

### Plugin (`code_puppy/plugins/aws_bedrock/`)

- Registers a new `aws_bedrock` model type via the `register_model_type` callback
- Uses `AsyncAnthropicBedrock` from the `anthropic` SDK with the standard AWS credential chain (env vars, named profiles, IAM roles, SSO)
- Slash commands:
  - `/bedrock-status` — verify auth + list configured models
  - `/bedrock-setup` — auto-add Bedrock Claude models (Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5)
  - `/bedrock-remove` — clean up Bedrock entries
- Supports `interleaved-thinking-2025-05-14` and the 1M-context beta header when applicable
- Effort variants per model for power users (low/medium/high/max)

### Core integration (minimal, 5 files touched)

- **`model_utils.py`** — new `supports_adaptive_thinking()` shared helper; `get_default_extended_thinking` and `should_use_anthropic_thinking_summary` accept optional `actual_model_id` so Bedrock model IDs like `us.anthropic.claude-opus-4-7` resolve correctly; adds `sonnet-4-6` to the adaptive-thinking set
- **`model_factory.py`** — adds `aws_bedrock` to `_ANTHROPIC_MODEL_TYPES`; threads `actual_model_id` through thinking/summary helpers
- **`config.py`** — uses shared helper for effort setting support (replaces duplicated tag matching)
- **`provider_identity.py`** — one-line registration of `aws_bedrock`
- **`add_model_menu.py`** — updates `amazon-bedrock` entry in `UNSUPPORTED_PROVIDERS` to direct users to `/bedrock-setup`

### Dependency

- `boto3>=1.35.0` added as **optional dependency** (`[project.optional-dependencies] bedrock`) — non-Bedrock users are unaffected

## Auth

Zero config for users with a working AWS environment — `boto3`/`AsyncAnthropicBedrock` resolve credentials via the usual chain. Optional env overrides:

- `BEDROCK_REGION` — Bedrock-specific region (takes precedence)
- `AWS_REGION` / `AWS_DEFAULT_REGION`
- `AWS_PROFILE`

## Testing

- 34 new tests in `tests/plugins/test_aws_bedrock.py` covering config, utils (variant expansion, config round-trip), command dispatch, and the shared adaptive-thinking helper
- Existing test suite passes with no regressions

## Checklist

- [x] Plugin-first implementation (`register_callbacks.py`, registered hooks)
- [x] No new files over 600 lines
- [x] Existing tests pass
- [x] New plugin unit tests (34 tests)
- [x] `boto3` declared as optional dependency
- [x] DRY: shared `supports_adaptive_thinking()` helper