### PR TITLE
Add ChatGPT GPT-5.5 OAuth model

### DIFF
--- a/code_puppy/plugins/chatgpt_oauth/utils.py
+++ b/code_puppy/plugins/chatgpt_oauth/utils.py
@@ -344,6 +344,7 @@ def exchange_code_for_tokens(
 # These are the known models that work with ChatGPT OAuth tokens
 # Based on codex-rs CLI and shell-scripts/codex-call.sh
 DEFAULT_CODEX_MODELS = [
+    "gpt-5.5",
     "gpt-5.4",
     "gpt-5.3-instant",
     "gpt-5.3-codex-spark",
@@ -356,6 +357,7 @@ DEFAULT_CODEX_MODELS = [
 # doesn't return them (e.g. newly launched, not yet in the API catalogue).
 # These are merged into whatever the endpoint returns.
 REQUIRED_CODEX_MODELS = [
+    "gpt-5.5",
     "gpt-5.4",
     "gpt-5.3-instant",
     "gpt-5.3-codex",
@@ -478,12 +480,12 @@ def add_models_to_extra_config(models: List[str]) -> bool:
             # reasoning effort, reasoning summaries, and text verbosity.
             supported_settings = ["reasoning_effort", "summary", "verbosity"]
 
-            # xhigh reasoning is supported by codex models and GPT-5.4 variants.
+            # xhigh reasoning is supported by codex models and GPT-5.4+ variants.
             # Older non-codex GPT-5.x models like gpt-5.2 stay capped at "high".
             normalized_model_name = model_name.lower()
             supports_xhigh_reasoning = (
                 "codex" in normalized_model_name
-                or normalized_model_name.startswith("gpt-5.4")
+                or normalized_model_name.startswith(("gpt-5.4", "gpt-5.5"))
             )
 
             chatgpt_models[prefixed] = {

--- a/tests/plugins/test_chatgpt_oauth_integration.py
+++ b/tests/plugins/test_chatgpt_oauth_integration.py
@@ -86,12 +86,18 @@ class TestModelManagement:
         models_file = tmp_path / "models.json"
         mock_path.return_value = models_file
 
-        result = add_models_to_extra_config(["gpt-5.2", "gpt-5.2-codex"])
+        result = add_models_to_extra_config([
+            "gpt-5.5",
+            "gpt-5.2",
+            "gpt-5.2-codex",
+        ])
 
         assert result is True
         models = json.loads(models_file.read_text())
+        assert "chatgpt-gpt-5.5" in models
         assert "chatgpt-gpt-5.2" in models
         assert "chatgpt-gpt-5.2-codex" in models
+        assert models["chatgpt-gpt-5.5"]["supports_xhigh_reasoning"] is True
 
     @patch("code_puppy.plugins.chatgpt_oauth.utils.get_chatgpt_models_path")
     def test_add_models_with_context_settings(self, mock_path, tmp_path):
@@ -169,6 +175,7 @@ class TestModelManagement:
         models = fetch_chatgpt_models("test_token", "test_account")
 
         # Required models are prepended if not in API response
+        assert "gpt-5.5" in models
         assert "gpt-5.4" in models
         assert "gpt-5.3-instant" in models
         assert "gpt-5.2" in models

--- a/tests/plugins/test_chatgpt_oauth_utils.py
+++ b/tests/plugins/test_chatgpt_oauth_utils.py
@@ -1075,24 +1075,25 @@ class TestAddModelsToConfig:
 
     @patch("code_puppy.plugins.chatgpt_oauth.utils.save_chatgpt_models")
     @patch("code_puppy.plugins.chatgpt_oauth.utils.load_chatgpt_models")
-    def test_add_models_to_extra_config_gpt54_supports_xhigh(
+    def test_add_models_to_extra_config_gpt54_and_newer_support_xhigh(
         self, mock_load, mock_save
     ):
-        """Test GPT-5.4 models expose xhigh reasoning in model settings."""
+        """Test GPT-5.4+ models expose xhigh reasoning in model settings."""
         mock_load.return_value = {}
         mock_save.return_value = True
 
-        result = add_models_to_extra_config(["gpt-5.4"])
+        result = add_models_to_extra_config(["gpt-5.5", "gpt-5.4"])
 
         assert result is True
         saved_config = mock_save.call_args[0][0]
-        gpt54_config = saved_config["chatgpt-gpt-5.4"]
-        assert gpt54_config["supported_settings"] == [
-            "reasoning_effort",
-            "summary",
-            "verbosity",
-        ]
-        assert gpt54_config["supports_xhigh_reasoning"] is True
+        for model_name in ("chatgpt-gpt-5.5", "chatgpt-gpt-5.4"):
+            model_config = saved_config[model_name]
+            assert model_config["supported_settings"] == [
+                "reasoning_effort",
+                "summary",
+                "verbosity",
+            ]
+            assert model_config["supports_xhigh_reasoning"] is True
 
     @patch("code_puppy.plugins.chatgpt_oauth.utils.save_chatgpt_models")
     @patch("code_puppy.plugins.chatgpt_oauth.utils.load_chatgpt_models")


### PR DESCRIPTION
## Summary
- add gpt-5.5 to the ChatGPT OAuth default and required model lists
- allow GPT-5.5 models to use xhigh reasoning settings like GPT-5.4
- update ChatGPT OAuth tests to cover GPT-5.5 registration and required-model injection

## Tests
- uv run pytest tests/plugins/test_chatgpt_oauth_integration.py tests/plugins/test_chatgpt_oauth_utils.py -q
- uv run ruff check code_puppy/plugins/chatgpt_oauth/utils.py tests/plugins/test_chatgpt_oauth_integration.py tests/plugins/test_chatgpt_oauth_utils.py