### PR TITLE
Support loading AGENTS.md from .code_puppy/ directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,25 @@ Please review this code for security issues." > .claude/commands/review.md
 - Ollama endpoint available
 
 ## Agent Rules
-We support AGENT.md files for defining coding standards and styles that your code should comply with. These rules can cover various aspects such as formatting, naming conventions, and even design guidelines.
+
+Code Puppy supports `AGENTS.md` files for defining coding standards, project conventions, and behavioral guidelines that the AI should follow. These rules can cover formatting, naming conventions, architectural patterns, and project-specific instructions.
 
 For examples and more information about agent rules, visit [https://agent.md](https://agent.md)
+
+### AGENTS.md Search Order
+
+Code Puppy loads rules from multiple locations, combining them in order:
+
+| Priority | Location | Purpose |
+|----------|----------|----------|
+| 1 | `~/.code_puppy/AGENTS.md` | Global rules (applied to all projects) |
+| 2 | `.code_puppy/AGENTS.md` | Project rules (preferred location) |
+| 3 | `./AGENTS.md` | Project rules (alternate location) |
+
+**Key behaviors:**
+- Global and project rules are **combined** (global first, then project)
+- `.code_puppy/` directory takes **precedence** over project root
+- All filename variants are supported: `AGENTS.md`, `AGENT.md`, `agents.md`, `agent.md`
 
 ## Using MCP Servers for External Tools
 

--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -33,14 +33,21 @@ from code_puppy.model_factory import ModelFactory, make_model_settings
 _reload_count = 0
 
 _AGENT_RULE_FILES = ("AGENTS.md", "AGENT.md", "agents.md", "agent.md")
+_CODE_PUPPY_DIR = ".code_puppy"
 
 
 def load_puppy_rules() -> Optional[str]:
     """Load AGENT(S).md from global config dir and/or the current project dir.
 
     Global rules (``~/.code_puppy/AGENTS.md``) come first; project-local rules
-    are appended, allowing projects to override/extend global ones. Returns
-    ``None`` if neither exists.
+    are appended, allowing projects to override/extend global ones.
+
+    **Search order for project rules:**
+
+    1. ``.code_puppy/AGENTS.md`` (preferred — keeps root clean)
+    2. ``./AGENTS.md`` (alternate location)
+
+    Returns ``None`` if neither exists.
     """
     global_rules: Optional[str] = None
     for name in _AGENT_RULE_FILES:
@@ -50,11 +57,23 @@ def load_puppy_rules() -> Optional[str]:
             break
 
     project_rules: Optional[str] = None
-    for name in _AGENT_RULE_FILES:
-        candidate = Path(name)
-        if candidate.exists():
-            project_rules = candidate.read_text(encoding="utf-8-sig")
-            break
+
+    # Priority 1: Check .code_puppy/ directory (preferred location)
+    code_puppy_dir = Path(_CODE_PUPPY_DIR)
+    if code_puppy_dir.is_dir():
+        for name in _AGENT_RULE_FILES:
+            candidate = code_puppy_dir / name
+            if candidate.exists():
+                project_rules = candidate.read_text(encoding="utf-8-sig")
+                break
+
+    # Priority 2: Fallback to project root
+    if project_rules is None:
+        for name in _AGENT_RULE_FILES:
+            candidate = Path(name)
+            if candidate.exists():
+                project_rules = candidate.read_text(encoding="utf-8-sig")
+                break
 
     rules = [r for r in (global_rules, project_rules) if r]
     return "\n\n".join(rules) if rules else None

--- a/tests/agents/test_builder_load_puppy_rules.py
+++ b/tests/agents/test_builder_load_puppy_rules.py
@@ -1,0 +1,194 @@
+"""Tests for load_puppy_rules() in code_puppy.agents._builder.
+
+Covers the .code_puppy/ directory feature (PUP-34):
+- Loading from .code_puppy/AGENTS.md (preferred)
+- Precedence: .code_puppy/ over project root
+- Backwards compatibility with root AGENTS.md
+- Combining global + project rules
+- Edge cases (dir is file, empty dir, etc.)
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+class TestLoadPuppyRulesCodePuppyDir:
+    """Tests for .code_puppy/ directory support in load_puppy_rules()."""
+
+    @pytest.fixture
+    def temp_project(self, tmp_path, monkeypatch):
+        """Set up a temporary project directory and cd into it."""
+        monkeypatch.chdir(tmp_path)
+        return tmp_path
+
+    @pytest.fixture
+    def mock_config_dir(self, tmp_path):
+        """Create a mock global config directory."""
+        config_dir = tmp_path / "global_config"
+        config_dir.mkdir()
+        return config_dir
+
+    def test_load_from_code_puppy_dir(self, temp_project, mock_config_dir):
+        """Load AGENTS.md from .code_puppy/ directory."""
+        from code_puppy.agents._builder import load_puppy_rules
+
+        # Create .code_puppy/AGENTS.md
+        code_puppy_dir = temp_project / ".code_puppy"
+        code_puppy_dir.mkdir()
+        agents_file = code_puppy_dir / "AGENTS.md"
+        agents_file.write_text("# Rules from .code_puppy dir")
+
+        with patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)):
+            result = load_puppy_rules()
+
+        assert result == "# Rules from .code_puppy dir"
+
+    def test_precedence_code_puppy_over_root(self, temp_project, mock_config_dir):
+        """Files in .code_puppy/ take precedence over project root."""
+        from code_puppy.agents._builder import load_puppy_rules
+
+        # Create both locations
+        code_puppy_dir = temp_project / ".code_puppy"
+        code_puppy_dir.mkdir()
+        (code_puppy_dir / "AGENTS.md").write_text("# Preferred rules")
+        (temp_project / "AGENTS.md").write_text("# Root rules")
+
+        with patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)):
+            result = load_puppy_rules()
+
+        # Should use .code_puppy/ version, NOT root
+        assert result == "# Preferred rules"
+        assert "Root rules" not in (result or "")
+
+    def test_fallback_to_root(self, temp_project, mock_config_dir):
+        """Fall back to root AGENTS.md if .code_puppy/ doesn't exist."""
+        from code_puppy.agents._builder import load_puppy_rules
+
+        # Only create root AGENTS.md
+        (temp_project / "AGENTS.md").write_text("# Root rules")
+
+        with patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)):
+            result = load_puppy_rules()
+
+        assert result == "# Root rules"
+
+    def test_global_and_code_puppy_combined(self, temp_project, mock_config_dir):
+        """Global rules and .code_puppy rules are combined."""
+        from code_puppy.agents._builder import load_puppy_rules
+
+        # Create global rules
+        (mock_config_dir / "AGENTS.md").write_text("# Global rules")
+
+        # Create .code_puppy rules
+        code_puppy_dir = temp_project / ".code_puppy"
+        code_puppy_dir.mkdir()
+        (code_puppy_dir / "AGENTS.md").write_text("# Project rules")
+
+        with patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)):
+            result = load_puppy_rules()
+
+        # Both should be present, global first
+        assert "# Global rules" in result
+        assert "# Project rules" in result
+        assert result.index("# Global rules") < result.index("# Project rules")
+
+    def test_global_and_root_combined(self, temp_project, mock_config_dir):
+        """Global rules + root rules work together."""
+        from code_puppy.agents._builder import load_puppy_rules
+
+        # Create global rules
+        (mock_config_dir / "AGENTS.md").write_text("# Global rules")
+
+        # Create root rules
+        (temp_project / "AGENTS.md").write_text("# Root rules")
+
+        with patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)):
+            result = load_puppy_rules()
+
+        # Both should be combined
+        assert "# Global rules" in result
+        assert "# Root rules" in result
+
+    def test_code_puppy_is_file_not_dir(self, temp_project, mock_config_dir):
+        """If .code_puppy is a file (not directory), fall back to root."""
+        from code_puppy.agents._builder import load_puppy_rules
+
+        # Create .code_puppy as a FILE, not directory
+        (temp_project / ".code_puppy").write_text("I'm a file, not a dir!")
+
+        # Create root AGENTS.md as fallback
+        (temp_project / "AGENTS.md").write_text("# Root fallback")
+
+        with patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)):
+            result = load_puppy_rules()
+
+        # Should use root fallback
+        assert result == "# Root fallback"
+
+    def test_code_puppy_dir_exists_but_empty(self, temp_project, mock_config_dir):
+        """Empty .code_puppy/ dir falls back to root AGENTS.md."""
+        from code_puppy.agents._builder import load_puppy_rules
+
+        # Create empty .code_puppy directory
+        (temp_project / ".code_puppy").mkdir()
+
+        # Create root AGENTS.md as fallback
+        (temp_project / "AGENTS.md").write_text("# Root fallback")
+
+        with patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)):
+            result = load_puppy_rules()
+
+        # Should use root fallback
+        assert result == "# Root fallback"
+
+    def test_no_agents_files_anywhere(self, temp_project, mock_config_dir):
+        """Returns None if no AGENTS.md files exist anywhere."""
+        from code_puppy.agents._builder import load_puppy_rules
+
+        with patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)):
+            result = load_puppy_rules()
+
+        assert result is None
+
+    def test_agent_md_variant_in_code_puppy_dir(self, temp_project, mock_config_dir):
+        """Also supports AGENT.md (singular) in .code_puppy/."""
+        from code_puppy.agents._builder import load_puppy_rules
+
+        code_puppy_dir = temp_project / ".code_puppy"
+        code_puppy_dir.mkdir()
+        # Use singular AGENT.md instead of AGENTS.md
+        (code_puppy_dir / "AGENT.md").write_text("# Singular agent rules")
+
+        with patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)):
+            result = load_puppy_rules()
+
+        assert result == "# Singular agent rules"
+
+    def test_agents_md_takes_precedence_over_agent_md(
+        self, temp_project, mock_config_dir
+    ):
+        """AGENTS.md (plural) takes precedence over AGENT.md (singular)."""
+        from code_puppy.agents._builder import load_puppy_rules
+
+        code_puppy_dir = temp_project / ".code_puppy"
+        code_puppy_dir.mkdir()
+        (code_puppy_dir / "AGENTS.md").write_text("# Plural wins")
+        (code_puppy_dir / "AGENT.md").write_text("# Singular loses")
+
+        with patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)):
+            result = load_puppy_rules()
+
+        assert result == "# Plural wins"
+
+    def test_only_global_rules(self, temp_project, mock_config_dir):
+        """Only global rules loaded when no project rules exist."""
+        from code_puppy.agents._builder import load_puppy_rules
+
+        # Create only global rules
+        (mock_config_dir / "AGENTS.md").write_text("# Global only")
+
+        with patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)):
+            result = load_puppy_rules()
+
+        assert result == "# Global only"


### PR DESCRIPTION
- Add .code_puppy/ as preferred location for project AGENTS.md
- Fall back to root AGENTS.md if .code_puppy/ not found
- Both locations are valid (no deprecation warnings)
- Update README with search order documentation
- Add comprehensive test coverage (11 tests)