### PR TITLE
fix(tests): don't stomp real mcp with MagicMocks when mcp is installed

### DIFF
--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -409,8 +409,8 @@ async def run_with_mcp(
         except* Exception as other:
             unexpected = _collect_exceptions(
                 other,
-                lambda e: not isinstance(
-                    e, (asyncio.CancelledError, UsageLimitExceeded)
+                lambda e: (
+                    not isinstance(e, (asyncio.CancelledError, UsageLimitExceeded))
                 ),
             )
             for exc in unexpected:

--- a/tests/plugins/conftest.py
+++ b/tests/plugins/conftest.py
@@ -9,11 +9,23 @@ from unittest.mock import MagicMock
 def pytest_configure(config):
     """Configure pytest with compatibility workarounds.
 
-    Pre-patch sys.modules to provide a mock ``mcp.types`` during collection.
-    This prevents a ValueError in pydantic's RootModel metaclass when MCP
-    is not installed in the test environment.
+    Pre-patch sys.modules to provide a mock ``mcp.types`` during collection,
+    but only when the real ``mcp`` package is not importable. Previously we
+    checked ``"mcp" not in sys.modules`` which is true on a clean start —
+    that installed MagicMocks for ``mcp.client`` etc. and then, when other
+    tests (e.g. ``tests/agents/test_compaction.py``) transitively imported
+    ``pydantic_ai.mcp``, its ``from mcp.client.sse import sse_client`` blew
+    up with "'mcp.client' is not a package" because the MagicMock had no
+    ``__path__``.
+
+    Real ``mcp`` is installed in this project's dev environment, so the
+    mock path is only needed in bare CI images. Probe with a real import
+    first; only fall back to mocks if that fails.
     """
-    if "mcp" not in sys.modules:
+    try:
+        import mcp  # noqa: F401
+        import mcp.types  # noqa: F401
+    except ImportError:
         mcp_mock = MagicMock()
         mcp_mock.types = MagicMock()
         sys.modules["mcp"] = mcp_mock


### PR DESCRIPTION
## Problem

Running any two test files together where one is under \`tests/plugins/\` and another transitively imports \`pydantic_ai.mcp\` fails during collection:

\`\`\`
ModuleNotFoundError: No module named 'mcp.client.sse'; 'mcp.client' is not a package
\`\`\`

Reproducer (requires \`pydantic-ai-slim[mcp]\` to be installed — it is, via the main dependency):

\`\`\`bash
uv run pytest tests/agents/test_compaction.py tests/plugins/test_azure_foundry.py -q
# → ERROR at collection, 1 error
\`\`\`

Run either file on its own and it passes.

## Root cause

\`tests/plugins/conftest.py::pytest_configure\` unconditionally installs \`MagicMock\`s into \`sys.modules\` for \`mcp\`, \`mcp.client\`, and \`mcp.client.session\` whenever \`"mcp" not in sys.modules\`. Pytest starts with \`mcp\` not yet imported, so the mock path always wins — even when the real \`mcp\` package is installed.

Then when collection reaches a test module that transitively imports \`pydantic_ai.mcp\` (e.g. via \`code_puppy.agents._builder\` → \`pydantic_ai.durable_exec.dbos\`), the line \`from mcp.client.sse import sse_client\` tries to look up \`.sse\` as a submodule of the MagicMock-\`mcp.client\`, which has no \`__path__\`, and Python raises _"mcp.client is not a package"_. That gets re-raised as the helpful "please install mcp" error.

Single-file runs of either affected test worked because \`tests/plugins/conftest.py\` wasn't loaded for them.

## Fix

Probe with a real import of \`mcp\` / \`mcp.types\` first. Only install the mocks if the real import fails. Real dev envs (including this repo's own) skip the mocks entirely; bare CI images without \`mcp\` still get the compatibility shim.

## Test plan

- [x] \`uv run pytest tests/agents/test_compaction.py tests/plugins/test_azure_foundry.py -q --no-cov\` → 99 pass (was: collection error)
- [x] \`uv run pytest tests/plugins/test_azure_foundry.py tests/plugins/test_aws_bedrock.py -q --no-cov\` → 103 pass (no regression on plugin-only runs)
- [x] \`ruff format --check\` + \`ruff check\` clean