### PR TITLE
feat: add force_push_guard plugin to block accidental git force pushes

### DIFF
--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -409,8 +409,8 @@ async def run_with_mcp(
         except* Exception as other:
             unexpected = _collect_exceptions(
                 other,
-                lambda e: not isinstance(
-                    e, (asyncio.CancelledError, UsageLimitExceeded)
+                lambda e: (
+                    not isinstance(e, (asyncio.CancelledError, UsageLimitExceeded))
                 ),
             )
             for exc in unexpected:

--- a/code_puppy/plugins/force_push_guard/__init__.py
+++ b/code_puppy/plugins/force_push_guard/__init__.py
@@ -1,0 +1,5 @@
+"""Force push guard plugin.
+
+Blocks git force push commands and asks for explicit permission before
+allowing them through. Prevents the classic "oops I nuked main" scenario.
+"""

--- a/code_puppy/plugins/force_push_guard/detector.py
+++ b/code_puppy/plugins/force_push_guard/detector.py
@@ -1,0 +1,96 @@
+"""Pattern detection for git force push commands.
+
+Detects force push patterns in shell commands, covering all the sneaky
+ways git lets you wreck a remote branch.
+"""
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass
+class ForcePushMatch:
+    """Result of a force push pattern match."""
+
+    pattern_name: str
+    description: str
+
+
+# Matches shell operators that precede a new command in a pipeline/chain.
+# E.g. "cd foo && git push --force" or "true || git push -f"
+_SHELL_OPERATOR_RE = re.compile(r"(?:^|&&|\|\||;|\|)\s*git\s+push\b", re.MULTILINE)
+
+# Ordered by specificity — first match wins.
+# Each tuple: (compiled regex, human-readable name, what it catches)
+_FORCE_PUSH_PATTERNS: list[tuple[re.Pattern, str, str]] = [
+    (
+        re.compile(r"\bgit\s+push\b.*--force-with-lease"),
+        "--force-with-lease",
+        "force push with lease (safer, but still rewrites history)",
+    ),
+    (
+        re.compile(r"\bgit\s+push\b.*--force-if-includes"),
+        "--force-if-includes",
+        "force push with includes check (still rewrites history)",
+    ),
+    (
+        re.compile(r"\bgit\s+push\b.*--force"),
+        "--force",
+        "force push (rewrites remote history)",
+    ),
+    (
+        re.compile(r"\bgit\s+push\b.*\s-f\b"),
+        "-f",
+        "force push shorthand (rewrites remote history)",
+    ),
+    (
+        re.compile(r"\bgit\s+push\b.*\s-F\b"),
+        "-F",
+        "force push shorthand (rewrites remote history)",
+    ),
+    # The +refspec syntax: git push origin +main, git push origin +HEAD:main
+    (
+        re.compile(r"\bgit\s+push\b.*\s\+"),
+        "+refspec",
+        "force push via +refspec prefix (rewrites remote history)",
+    ),
+]
+
+
+def _is_git_push_a_command(command: str) -> bool:
+    """Check that 'git push' is an actual command, not a string argument.
+
+    Handles compound commands like "cd foo && git push --force" while
+    avoiding false positives like "echo 'git push --force'".
+
+    Args:
+        command: The shell command string to inspect.
+
+    Returns:
+        True if 'git push' appears as an actual command invocation.
+    """
+    return bool(_SHELL_OPERATOR_RE.search(command))
+
+
+def detect_force_push(command: str) -> ForcePushMatch | None:
+    """Check if a shell command contains a git force push.
+
+    Args:
+        command: The shell command string to inspect.
+
+    Returns:
+        ForcePushMatch if a force push pattern is found, None otherwise.
+    """
+    # Quick pre-filter: skip entirely if "push" isn't even in the command
+    if "push" not in command:
+        return None
+
+    # Ensure 'git push' is an actual command, not a string argument
+    if not _is_git_push_a_command(command):
+        return None
+
+    for pattern, name, description in _FORCE_PUSH_PATTERNS:
+        if pattern.search(command):
+            return ForcePushMatch(pattern_name=name, description=description)
+
+    return None

--- a/code_puppy/plugins/force_push_guard/register_callbacks.py
+++ b/code_puppy/plugins/force_push_guard/register_callbacks.py
@@ -1,15 +1,26 @@
 """Callback registration for the force push guard plugin.
 
-Hooks into the run_shell_command phase to intercept and block git force
-push commands before they execute. Returns {"blocked": True} to deny
-the command, which the command runner handles gracefully.
+Hooks into the run_shell_command phase to intercept git force push
+commands and prompt the user for approval before allowing them through.
+Returns {"blocked": True} to deny, None to allow.
 """
 
+import sys
 from typing import Any, Dict, Optional
 
+from rich.text import Text
+
 from code_puppy.callbacks import register_callback
-from code_puppy.messaging import emit_info
+from code_puppy.messaging import emit_error, emit_info, emit_warning
 from code_puppy.plugins.force_push_guard.detector import detect_force_push
+
+
+def _is_interactive() -> bool:
+    """Check if we're in an interactive terminal that can show prompts."""
+    try:
+        return sys.stdin.isatty()
+    except (AttributeError, OSError):
+        return False
 
 
 async def force_push_guard_callback(
@@ -17,8 +28,13 @@ async def force_push_guard_callback(
 ) -> Optional[Dict[str, Any]]:
     """Intercept shell commands containing git force push operations.
 
-    This runs on *every* shell command, so the heavy lifting (regex matching)
-    is gated behind a cheap "push" substring check inside detect_force_push().
+    When a force push is detected:
+    - Interactive TTY: prompt the user with approve/reject options.
+    - Non-interactive (CI, sub-agent, piped): hard-block with an error.
+
+    This runs on *every* shell command, but the heavy lifting (regex
+    matching) is gated behind a cheap "push" substring check inside
+    detect_force_push().
 
     Args:
         context: Execution context (unused).
@@ -27,13 +43,80 @@ async def force_push_guard_callback(
         timeout: Command timeout (unused).
 
     Returns:
-        None if the command is safe to proceed.
-        Dict with blocked=True if a force push pattern was detected.
+        None if the command is safe to proceed or user approved it.
+        Dict with blocked=True if a force push was detected and rejected.
     """
     match = detect_force_push(command)
     if match is None:
         return None
 
+    # --- Interactive TTY: ask the user ---
+    if _is_interactive():
+        return await _prompt_user_approval(command, match)
+
+    # --- Non-interactive: hard-block ---
+    return _block_command(command, match)
+
+
+async def _prompt_user_approval(command: str, match: Any) -> Optional[Dict[str, Any]]:
+    """Show an interactive approval prompt for the detected force push.
+
+    Args:
+        command: The original shell command.
+        match: The ForcePushMatch from the detector.
+
+    Returns:
+        None if user approves, Dict with blocked=True if rejected.
+    """
+    from code_puppy.tools.common import get_user_approval_async
+
+    panel_content = Text()
+    panel_content.append("⚠️  Force push detected: ", style="bold yellow")
+    panel_content.append(match.pattern_name, style="bold red")
+    panel_content.append("\n", style="")
+    panel_content.append(f"  {match.description}", style="dim")
+    panel_content.append("\n\n", style="")
+    panel_content.append("$ ", style="bold green")
+    panel_content.append(command, style="bold white")
+    panel_content.append(
+        "\n\nForce pushing rewrites remote history and can destroy others' work.",
+        style="yellow",
+    )
+
+    confirmed, user_feedback = await get_user_approval_async(
+        title="Force Push Guard 🛡️",
+        content=panel_content,
+        border_style="red",
+    )
+
+    if confirmed:
+        emit_info("⚠️  Force push approved — proceeding with caution.")
+        return None  # Allow the command through
+
+    # Rejected
+    reason = user_feedback or "User rejected force push"
+    return {
+        "blocked": True,
+        "reasoning": f"Force push rejected: {match.pattern_name} — {reason}",
+        "error_message": (
+            f"🛑 Force push rejected. Detected {match.pattern_name} "
+            f"in command:\n  {command}\n"
+            f"  {match.description}\n"
+            f"Feedback: {reason}"
+        ),
+    }
+
+
+def _block_command(command: str, match: Any) -> Dict[str, Any]:
+    """Hard-block a force push in non-interactive contexts.
+
+    Args:
+        command: The original shell command.
+        match: The ForcePushMatch from the detector.
+
+    Returns:
+        Dict with blocked=True and a descriptive error.
+    """
     error_message = (
         f"🛑 Force push blocked! Detected {match.pattern_name} "
         f"in command:\n  {command}\n"
@@ -43,7 +126,7 @@ async def force_push_guard_callback(
         f"in your terminal (outside code puppy) after double-checking the target branch."
     )
 
-    emit_info(error_message)
+    emit_warning(error_message)
 
     return {
         "blocked": True,

--- a/code_puppy/plugins/force_push_guard/register_callbacks.py
+++ b/code_puppy/plugins/force_push_guard/register_callbacks.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Optional
 from rich.text import Text
 
 from code_puppy.callbacks import register_callback
-from code_puppy.messaging import emit_error, emit_info, emit_warning
+from code_puppy.messaging import emit_info, emit_warning
 from code_puppy.plugins.force_push_guard.detector import detect_force_push
 
 

--- a/code_puppy/plugins/force_push_guard/register_callbacks.py
+++ b/code_puppy/plugins/force_push_guard/register_callbacks.py
@@ -1,0 +1,61 @@
+"""Callback registration for the force push guard plugin.
+
+Hooks into the run_shell_command phase to intercept and block git force
+push commands before they execute. Returns {"blocked": True} to deny
+the command, which the command runner handles gracefully.
+"""
+
+from typing import Any, Dict, Optional
+
+from code_puppy.callbacks import register_callback
+from code_puppy.messaging import emit_info
+from code_puppy.plugins.force_push_guard.detector import detect_force_push
+
+
+async def force_push_guard_callback(
+    context: Any, command: str, cwd: Optional[str] = None, timeout: int = 60
+) -> Optional[Dict[str, Any]]:
+    """Intercept shell commands containing git force push operations.
+
+    This runs on *every* shell command, so the heavy lifting (regex matching)
+    is gated behind a cheap "push" substring check inside detect_force_push().
+
+    Args:
+        context: Execution context (unused).
+        command: The shell command about to run.
+        cwd: Working directory (unused).
+        timeout: Command timeout (unused).
+
+    Returns:
+        None if the command is safe to proceed.
+        Dict with blocked=True if a force push pattern was detected.
+    """
+    match = detect_force_push(command)
+    if match is None:
+        return None
+
+    error_message = (
+        f"🛑 Force push blocked! Detected {match.pattern_name} "
+        f"in command:\n  {command}\n"
+        f"  {match.description}\n\n"
+        f"Force pushing rewrites remote history and can destroy others' work.\n"
+        f"If you *really* need to force push, use the exact command directly\n"
+        f"in your terminal (outside code puppy) after double-checking the target branch."
+    )
+
+    emit_info(error_message)
+
+    return {
+        "blocked": True,
+        "reasoning": f"Force push detected: {match.pattern_name} — {match.description}",
+        "error_message": error_message,
+    }
+
+
+def register() -> None:
+    """Register the force push guard callback."""
+    register_callback("run_shell_command", force_push_guard_callback)
+
+
+# Auto-register when this module is imported
+register()

--- a/code_puppy/plugins/force_push_guard/test_detector.py
+++ b/code_puppy/plugins/force_push_guard/test_detector.py
@@ -1,0 +1,143 @@
+"""Tests for the force push guard detector."""
+
+from code_puppy.plugins.force_push_guard.detector import detect_force_push
+
+
+class TestDetectForcePush:
+    """Test suite for force push pattern detection."""
+
+    # --- Should BLOCK these commands ---
+
+    def test_long_force_flag(self):
+        result = detect_force_push("git push --force origin main")
+        assert result is not None
+        assert result.pattern_name == "--force"
+
+    def test_short_f_flag(self):
+        result = detect_force_push("git push -f origin main")
+        assert result is not None
+        assert result.pattern_name == "-f"
+
+    def test_capital_f_flag(self):
+        result = detect_force_push("git push -F origin main")
+        assert result is not None
+        assert result.pattern_name == "-F"
+
+    def test_force_with_lease(self):
+        result = detect_force_push("git push --force-with-lease origin feature")
+        assert result is not None
+        assert result.pattern_name == "--force-with-lease"
+
+    def test_force_if_includes(self):
+        result = detect_force_push("git push --force-if-includes origin feature")
+        assert result is not None
+        assert result.pattern_name == "--force-if-includes"
+
+    def test_plus_refspec(self):
+        result = detect_force_push("git push origin +main")
+        assert result is not None
+        assert result.pattern_name == "+refspec"
+
+    def test_plus_refspec_head(self):
+        result = detect_force_push("git push origin +HEAD:refs/heads/main")
+        assert result is not None
+        assert result.pattern_name == "+refspec"
+
+    def test_force_before_remote(self):
+        result = detect_force_push(
+            "git push --force-with-lease --set-upstream origin foo"
+        )
+        assert result is not None
+        assert result.pattern_name == "--force-with-lease"
+
+    def test_force_after_remote(self):
+        result = detect_force_push("git push origin feature --force")
+        assert result is not None
+        assert result.pattern_name == "--force"
+
+    def test_force_flag_with_equals(self):
+        result = detect_force_push("git push --force=yes origin main")
+        assert result is not None
+        assert result.pattern_name == "--force"
+
+    def test_force_with_other_flags(self):
+        result = detect_force_push("git push -v -f origin main")
+        assert result is not None
+        assert result.pattern_name == "-f"
+
+    # --- Should ALLOW these commands ---
+
+    def test_normal_push(self):
+        assert detect_force_push("git push origin main") is None
+
+    def test_push_with_set_upstream(self):
+        assert detect_force_push("git push --set-upstream origin feature") is None
+
+    def test_push_with_tags(self):
+        assert detect_force_push("git push origin --tags") is None
+
+    def test_push_u(self):
+        assert detect_force_push("git push -u origin main") is None
+
+    def test_git_pull(self):
+        assert detect_force_push("git pull origin main") is None
+
+    def test_git_status(self):
+        assert detect_force_push("git status") is None
+
+    def test_unrelated_command(self):
+        assert detect_force_push("npm install --force") is None
+
+    def test_empty_string(self):
+        assert detect_force_push("") is None
+
+    def test_echo_push(self):
+        assert detect_force_push("echo 'git push --force'") is None
+
+    def test_push_dry_run(self):
+        assert detect_force_push("git push --dry-run origin main") is None
+
+    def test_git_push_all(self):
+        assert detect_force_push("git push --all origin") is None
+
+    def test_git_push_mirror(self):
+        """--mirror IS destructive, but it's not a 'force push' per se.
+        We don't block it — different safety concern."""
+        assert detect_force_push("git push --mirror") is None
+
+    def test_push_no_force_file(self):
+        """A file named '--force' in a weirdly structured command shouldn't match."""
+        # This is a contrived edge case — the regex should not match
+        assert detect_force_push("git push origin main") is None
+
+    def test_grep_push(self):
+        """grep containing 'push' should not trigger."""
+        assert detect_force_push("grep -r push src/") is None
+
+    # --- Compound commands (shell operators) ---
+
+    def test_compound_and_force(self):
+        result = detect_force_push("cd foo && git push --force origin main")
+        assert result is not None
+        assert result.pattern_name == "--force"
+
+    def test_compound_semicolon_force(self):
+        result = detect_force_push("echo hi; git push -f origin main")
+        assert result is not None
+        assert result.pattern_name == "-f"
+
+    def test_compound_or_force(self):
+        result = detect_force_push("git pull || git push --force origin main")
+        assert result is not None
+        assert result.pattern_name == "--force"
+
+    def test_compound_pipe_not_force(self):
+        """Piped git push (uncommon) should still be caught if forced."""
+        result = detect_force_push("cat file | git push --force")
+        # Note: piping to git push makes no sense, but regex should still match
+        assert result is not None
+        assert result.pattern_name == "--force"
+
+    def test_compound_and_normal_push(self):
+        """Compound with a normal push should be allowed."""
+        assert detect_force_push("cd foo && git push origin main") is None


### PR DESCRIPTION
Problem
───────

An LLM agent controlling code puppy can issue git push --force (or -f, +refspec, etc.) and nuke a remote branch — including main. This happened to me in practice, and the existing shell_safety plugin only catches this in yolo_mode via LLM-based risk assessment, which is probabilistic and can miss it.

Solution
────────

Add a deterministic force_push_guard plugin that intercepts shell commands containing force push patterns and prompts the user for approval before allowing them through.

Behavior

- Interactive (TTY) - Shows a red-bordered approval panel with the command, what was detected, and Approve/Reject/Reject-with-feedback options. User says yes → command runs. User says no → blocked.
- Non-interactive (CI, piped, sub-agent) - Hard-blocks with a descriptive error message telling the user to run the command directly in their terminal if they really need it.

This way, force pushes are never silent — but they're also not impossible when you actually need one (rebasing a feature branch you own, fixing a mistake on your own fork, etc.).

Detected patterns

│ Pattern │ Example │
| ------------- | ------------- |
│ --force │ git push --force origin main │
│ -f / -F │ git push -f origin main │
│ --force-with-lease │ git push --force-with-lease origin feature │
│ --force-if-includes │ git push --force-if-includes origin feature │
│ +refspec │ git push origin +main │

Not blocked (no false positives)

• Normal pushes (git push origin main)
• Push flags like -u, --tags, --set-upstream
• npm install --force (not a git push)
• String arguments (echo 'git push --force')
• Compound commands with safe pushes (cd foo && git push origin main)

Design decisions
────────────────

• Regex over LLM — force push patterns are deterministic and well-known; no need to burn a model call for this. The existing shell_safety plugin still runs and provides LLM-based coverage for other dangerous commands.
• Prompt, don't just block — force pushes have legitimate uses (rebasing a feature branch you own, fixing a mistake on your own fork). An interactive approval panel lets the user make the call. Non-interactive contexts hard-block since there's no one to ask.
• Composable — uses the same run_shell_command hook + {"blocked": True} contract as shell_safety. Multiple callbacks stack; first block wins. Uses the existing get_user_approval_async() TUI for a consistent approval UX.
• Cheap pre-filter — skips regex matching entirely if "push" isn't in the command string. Validates git push is an actual command (not a string arg) before pattern matching.
Files
─────

code_puppy/plugins/force_push_guard/
├── __init__.py                   # Package docstring
├── detector.py                  # Pattern matching (pure, no I/O)
├── register_callbacks.py  # Hook into run_shell_command
└── test_detector.py          # 30 tests, all passing

Testing
───────

$ uv run pytest code_puppy/plugins/force_push_guard/test_detector.py -v
30 passed in 1.1s

Covers all force push variants, safe pushes, compound commands (&&, ;, ||, |), and false-positive edge cases.