### PR TITLE
fix: emoji cursor spacing in terminal prompt

### DIFF
--- a/code_puppy/command_line/prompt_toolkit_completion.py
+++ b/code_puppy/command_line/prompt_toolkit_completion.py
@@ -512,6 +512,37 @@ class SlashCompleter(Completer):
             )
 
 
+def _strip_variation_selectors(text: str) -> str:
+    """Remove variation selectors (U+FE00-FE0F) from text.
+
+    These invisible characters modify emoji rendering but cause width
+    calculation mismatches between prompt_toolkit and terminal emulators.
+    """
+    return "".join(c for c in text if not (0xFE00 <= ord(c) <= 0xFE0F))
+
+
+def _normalize_emoji_spacing(text: str) -> str:
+    """Normalize emoji spacing for consistent terminal rendering.
+
+    Some emojis have East Asian Width 'N' (Neutral) which terminals render
+    inconsistently. This adds a space after such emojis to prevent
+    the following character from overlapping.
+    """
+    import unicodedata
+
+    result = []
+    text = _strip_variation_selectors(text)
+    for char in text:
+        result.append(char)
+        # Add padding after Neutral-width emoji to prevent overlap
+        if (
+            0x1F300 <= ord(char) <= 0x1FAFF
+            and unicodedata.east_asian_width(char) == "N"
+        ):
+            result.append(" ")  # Extra space buffer
+    return "".join(result)
+
+
 def get_prompt_with_active_model(base: str = ">>> "):
     from code_puppy.agents.agent_manager import get_current_agent
 
@@ -549,7 +580,7 @@ def get_prompt_with_active_model(base: str = ">>> "):
             ("bold", "🐶 "),
             ("class:puppy", f"{puppy}"),
             ("", " "),
-            ("class:agent", f"[{agent_display}] "),
+            ("class:agent", f"[{_normalize_emoji_spacing(agent_display)}] "),
             ("class:model", model_display + " "),
             ("class:cwd", "(" + str(cwd_display) + ") "),
             ("class:arrow", str(base)),
@@ -643,6 +674,7 @@ async def get_input_with_combined_completion(
         @bindings.add("c-enter", eager=True)
         def _(event):
             event.app.current_buffer.insert_text("\n")
+
     except Exception:
         pass
 

--- a/code_puppy/pydantic_patches.py
+++ b/code_puppy/pydantic_patches.py
@@ -344,6 +344,59 @@ def patch_tool_call_callbacks() -> None:
         pass
 
 
+def patch_prompt_toolkit_emoji_width() -> None:
+    """Patch prompt_toolkit's character width calculation for emojis.
+
+    Modern terminals render most emojis as 2 cells wide, but wcwidth often
+    returns 1 for many emoji codepoints. This causes cursor misalignment.
+
+    This patch:
+    1. Returns 0 for variation selectors (zero-width modifiers)
+    2. Returns 2 for emoji codepoints (terminals render them wide)
+    3. Falls back to wcwidth for non-emoji characters
+    """
+    try:
+        import wcwidth
+        from prompt_toolkit import utils as pt_utils
+
+        _original_get_cwidth = pt_utils.get_cwidth
+
+        def _patched_get_cwidth(char: str) -> int:
+            """Get character width with better emoji support."""
+            code = ord(char)
+
+            # Variation selectors are zero-width
+            if 0xFE00 <= code <= 0xFE0F:  # VS1-VS16
+                return 0
+
+            # Emoji codepoints - terminals render these as 2 cells wide
+            # even when wcwidth says 1
+            if (
+                0x1F300 <= code <= 0x1F9FF  # Misc Symbols/Pictographs, Emoticons
+                or 0x1F600 <= code <= 0x1F64F  # Emoticons
+                or 0x1F680 <= code <= 0x1F6FF  # Transport/Map symbols
+                or 0x1FA00 <= code <= 0x1FAFF  # Symbols/Pictographs Extended-A
+                or 0x2600 <= code <= 0x26FF  # Misc Symbols (☀️, ⚡, etc)
+                or 0x2700 <= code <= 0x27BF  # Dingbats (✂️, ✈️, etc)
+                or 0x1F1E0 <= code <= 0x1F1FF  # Regional indicators (flags)
+            ):
+                return 2
+
+            # Use wcwidth for non-emoji
+            w = wcwidth.wcwidth(char)
+            if w >= 0:
+                return w
+
+            return _original_get_cwidth(char)
+
+        pt_utils.get_cwidth = _patched_get_cwidth
+
+    except ImportError:
+        pass  # wcwidth or prompt_toolkit not available
+    except Exception:
+        pass  # Don't crash on patch failure
+
+
 def apply_all_patches() -> None:
     """Apply all pydantic-ai monkey patches.
 
@@ -354,3 +407,4 @@ def apply_all_patches() -> None:
     patch_process_message_history()
     patch_tool_call_json_repair()
     patch_tool_call_callbacks()
+    patch_prompt_toolkit_emoji_width()


### PR DESCRIPTION
Fix emoji cursor spacing in terminal prompt
───────────────────────────────────────────
<img width="510" height="62" alt="Screenshot 2026-04-29 at 11 36 47 AM" src="https://github.com/user-attachments/assets/d6deb662-c626-40c6-b93b-8864210d4439" />
<img width="548" height="68" alt="Screenshot 2026-04-29 at 11 37 01 AM" src="https://github.com/user-attachments/assets/508076a6-04a6-467f-b8d6-9cd2edd2b175" />

Fixes cursor misalignment when agent display names contain emojis like 🏗️ or 🛡️. The ] character was overlapping with emojis and the cursor appeared in the wrong position.

Changes

`prompt_toolkit_completion.py`
• Add _strip_variation_selectors() to remove invisible Unicode modifiers (U+FE00-FE0F)
• Add _normalize_emoji_spacing() to pad Neutral-width emojis with a buffer space
• Apply normalization to agent display names in the prompt

`pydantic_patches.py`
• Add patch_prompt_toolkit_emoji_width() to fix get_cwidth() for emoji codepoints
• Call patch in apply_all_patches()

Root Cause

Some emojis have East Asian Width "N" (Neutral) which terminals render inconsistently—sometimes 1 cell, sometimes 2. Combined with invisible variation selectors, this broke prompt_toolkit's cursor positioning.