### PR TITLE
Autosave interrupted interactive sessions

### DIFF
--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -51,6 +51,13 @@ from code_puppy.version_checker import default_version_mismatch_behavior
 plugins.load_plugin_callbacks()
 
 
+def _save_autosave_snapshot() -> bool:
+    """Persist the current autosave snapshot if autosave is enabled."""
+    from code_puppy.config import auto_save_session_if_enabled
+
+    return auto_save_session_if_enabled()
+
+
 async def main():
     """Main async entry point for Code Puppy CLI."""
     parser = argparse.ArgumentParser(description="Code Puppy - A code generation agent")
@@ -332,6 +339,7 @@ async def main():
             # Default to interactive mode (no args = same as -i)
             await interactive_mode(message_renderer, initial_command=initial_command)
     finally:
+        _save_autosave_snapshot()
         if message_renderer:
             message_renderer.stop()
         if bus_renderer:
@@ -774,6 +782,7 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
                         from code_puppy.messaging import emit_warning
 
                         emit_warning("🍩 Wiggum loop stopped due to cancellation")
+                    _save_autosave_snapshot()
                     continue
                 # Get the structured response
                 agent_response = result.output
@@ -810,9 +819,7 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
                 get_queue_console().print_exception()
 
             # Auto-save session if enabled (moved outside the try block to avoid being swallowed)
-            from code_puppy.config import auto_save_session_if_enabled
-
-            auto_save_session_if_enabled()
+            _save_autosave_snapshot()
 
             # ================================================================
             # WIGGUM LOOP: Re-run prompt if wiggum mode is active
@@ -882,7 +889,7 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
                     await asyncio.sleep(0.1)
 
                     # Auto-save
-                    auto_save_session_if_enabled()
+                    _save_autosave_snapshot()
 
                 except KeyboardInterrupt:
                     emit_warning("\n🍩 Wiggum loop interrupted by Ctrl+C")
@@ -1046,6 +1053,8 @@ async def execute_single_prompt(prompt: str, message_renderer) -> None:
         from code_puppy.messaging import emit_error
 
         emit_error(f"Error executing prompt: {str(e)}")
+    finally:
+        _save_autosave_snapshot()
 
 
 def main_entry():

--- a/tests/test_cli_runner_full_coverage.py
+++ b/tests/test_cli_runner_full_coverage.py
@@ -677,6 +677,7 @@ class TestInteractiveMode:
     @pytest.mark.anyio
     async def test_prompt_returns_none_cancelled(self):
         call_count = 0
+        mock_autosave = MagicMock()
 
         async def fake_input(*a, **kw):
             nonlocal call_count
@@ -697,8 +698,10 @@ class TestInteractiveMode:
                 "code_puppy.cli_runner.parse_prompt_attachments": MagicMock(
                     return_value=_mock_parse_result("write hello")
                 ),
+                "code_puppy.cli_runner._save_autosave_snapshot": mock_autosave,
             },
         )
+        mock_autosave.assert_called()
 
     @pytest.mark.anyio
     async def test_prompt_cancelled_wiggum_active(self):


### PR DESCRIPTION
## Summary

Fixes autosave persistence for interrupted Code Puppy sessions.

If a user cancels an agent run with Ctrl-C and then exits, the interactive loop previously skipped the normal autosave path because cancelled runs return `None` and immediately continue to the next prompt. That could leave the autosave file missing the latest in-memory conversation history.

## What Changed

- Adds a small `_save_autosave_snapshot()` helper around `auto_save_session_if_enabled()`.
- Saves immediately before returning to the prompt after a cancelled agent run.
- Saves once during CLI shutdown so Ctrl-D, `/exit`, top-level interrupt, or process cleanup has a final persistence attempt.
- Saves from single-prompt mode in `finally` as a defensive cleanup path.
- Adds test coverage for the cancelled interactive prompt path.

## Validation

```bash
uv run pytest --no-cov tests/test_cli_runner_coverage.py tests/test_cli_runner_full_coverage.py -q
uv run ruff check code_puppy/cli_runner.py tests/test_cli_runner_full_coverage.py
uv run ruff format --check code_puppy/cli_runner.py tests/test_cli_runner_full_coverage.py
```

Results:

- `73 passed`
- Ruff check passed
- Ruff format check passed
