### PR TITLE
fix: handle asyncio.CancelledError in interactive prompt loop

### DIFF
--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -549,7 +549,7 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
                 # Fall back to basic input if prompt_toolkit is not available
                 task = input(">>> ")
 
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, asyncio.CancelledError):
             # Handle Ctrl+C - cancel input and continue
             # Windows-specific: Reset terminal state after interrupt to prevent
             # the terminal from becoming unresponsive (can't type characters)


### PR DESCRIPTION
## Summary

- `prompt_toolkit`'s `prompt_async` can raise `asyncio.CancelledError` when the event loop is left in a cancelled state after a prior Ctrl+C (e.g. cancelling an MCP server install)
- The existing handler only caught `KeyboardInterrupt`, causing the interactive loop to crash on the next prompt
- Expanded the except clause to catch both `KeyboardInterrupt` and `asyncio.CancelledError`

Fixes #233

## Test plan

- [ ] Run interactive mode
- [ ] Trigger an MCP server installation, press Ctrl+C during setup
- [ ] Confirm the next prompt appears normally without a traceback