### PR TITLE
fix: correct misleading comment in get_allow_recursion()

### DIFF
--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -263,7 +263,7 @@ def get_allow_recursion() -> bool:
     """
     val = get_value("allow_recursion")
     if val is None:
-        return True  # Default to False for safety
+        return True  # Default to True to allow recursion unless explicitly disabled
     return str(val).lower() in ("1", "true", "yes", "on")
 
 


### PR DESCRIPTION
## Summary

The inline comment on the default return value said `"Default to False for safety"` but the function returns `True` when no config value is set. The `True` default is the correct and intentional behavior — it is explicitly asserted by existing tests (`test_get_allow_recursion_defaults_to_true`). This corrects the comment to match the actual behavior.

Fixes #238

## Test plan

- [ ] `uv run pytest tests/test_config_and_storage_edge_cases.py -k "allow_recursion" -v --no-cov` — all 6 tests pass before and after the change