### PR TITLE
fix(dbos): remove leading slash from command name in help text

### DIFF
--- a/code_puppy/plugins/dbos_durable_exec/commands.py
+++ b/code_puppy/plugins/dbos_durable_exec/commands.py
@@ -28,4 +28,4 @@ def handle_dbos_command(command: str, name: str):
 
 
 def dbos_command_help():
-    return [("/dbos", "Toggle DBOS durable execution: /dbos on|off|status")]
+    return [("dbos", "Toggle DBOS durable execution: /dbos on|off|status")]

--- a/tests/plugins/test_dbos_durable_exec.py
+++ b/tests/plugins/test_dbos_durable_exec.py
@@ -20,24 +20,12 @@ from code_puppy.callbacks import (
     count_callbacks,
     get_callbacks,
 )
-from code_puppy.plugins.dbos_durable_exec import (
-    cancel as cancel_mod,
-)
-from code_puppy.plugins.dbos_durable_exec import (
-    commands as commands_mod,
-)
-from code_puppy.plugins.dbos_durable_exec import (
-    config as config_mod,
-)
-from code_puppy.plugins.dbos_durable_exec import (
-    runtime as runtime_mod,
-)
-from code_puppy.plugins.dbos_durable_exec import (
-    workflow_ids as workflow_ids_mod,
-)
-from code_puppy.plugins.dbos_durable_exec import (
-    wrapper as wrapper_mod,
-)
+from code_puppy.plugins.dbos_durable_exec import cancel as cancel_mod
+from code_puppy.plugins.dbos_durable_exec import commands as commands_mod
+from code_puppy.plugins.dbos_durable_exec import config as config_mod
+from code_puppy.plugins.dbos_durable_exec import runtime as runtime_mod
+from code_puppy.plugins.dbos_durable_exec import workflow_ids as workflow_ids_mod
+from code_puppy.plugins.dbos_durable_exec import wrapper as wrapper_mod
 
 # ─────────────────────── config.is_enabled ────────────────────────────
 
@@ -378,7 +366,7 @@ class TestHandleDbosCommand:
 
     def test_help_entries(self):
         entries = commands_mod.dbos_command_help()
-        assert any(name == "/dbos" for name, _ in entries)
+        assert any(name == "dbos" for name, _ in entries)
 
 
 # ─────────────────────── register_callbacks wiring ────────────────────


### PR DESCRIPTION
- Update command name in help entry from "/dbos" to "dbos"
- Fix corresponding test assertion to match the updated command name