### PR TITLE
ci(publish): add automatic git tagging on successful release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,6 +102,13 @@ jobs:
       - name: Bump version
         run: uv version --bump patch
 
+      - name: Capture new version
+        id: version
+        run: |
+          NEW_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "New version: $NEW_VERSION"
+
       - name: Build package
         run: |
           uv build
@@ -112,7 +119,7 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: uv run twine upload --verbose dist/*
 
-      - name: Push version bump to GitHub
+      - name: Push version bump and tag to GitHub
         if: ${{ success() }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -121,4 +128,7 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add .
           git commit -m "chore: bump version [ci skip]" || echo "No changes to commit"
+          TAG="v${{ steps.version.outputs.version }}"
+          git tag -a "$TAG" -m "Release $TAG"
           git push
+          git push origin "$TAG"


### PR DESCRIPTION
- Capture version from pyproject.toml after bumping
- Create annotated Git tag when release succeeds
- Push both version bump commit and tag to GitHub
- Ensure tags are only pushed after successful PyPI upload