### PR TITLE
fix(skills): align /skills command handler with advertised subcommands

### DIFF
--- a/code_puppy/plugins/agent_skills/register_callbacks.py
+++ b/code_puppy/plugins/agent_skills/register_callbacks.py
@@ -141,6 +141,9 @@ def _handle_skills_command(command: str, name: str) -> Optional[Any]:
         /skills install  – Browse & install from remote catalog
         /skills enable   – Enable skills integration globally
         /skills disable  – Disable skills integration globally
+        /skills toggle   – Toggle skills integration globally
+        /skills refresh  – Force skill re-discovery and refresh local cache
+        /skills help     – Show skills command help
     """
     if name not in (_COMMAND_NAME, *_ALIASES):
         return None
@@ -151,7 +154,10 @@ def _handle_skills_command(command: str, name: str) -> Optional[Any]:
         get_skills_enabled,
         set_skills_enabled,
     )
-    from code_puppy.plugins.agent_skills.discovery import discover_skills
+    from code_puppy.plugins.agent_skills.discovery import (
+        discover_skills,
+        refresh_skill_cache,
+    )
     from code_puppy.plugins.agent_skills.metadata import parse_skill_metadata
     from code_puppy.plugins.agent_skills.skills_menu import show_skills_menu
 
@@ -220,9 +226,40 @@ def _handle_skills_command(command: str, name: str) -> Optional[Any]:
             emit_warning("\U0001f534 Skills integration disabled globally")
             return True
 
+        elif subcommand == "toggle":
+            new_state = not get_skills_enabled()
+            set_skills_enabled(new_state)
+            if new_state:
+                emit_success("✅ Skills integration enabled globally")
+            else:
+                emit_warning("🔴 Skills integration disabled globally")
+            return True
+
+        elif subcommand == "refresh":
+            refreshed = refresh_skill_cache()
+            valid_skills = [skill for skill in refreshed if skill.has_skill_md]
+            emit_success(
+                f"🔄 Refreshed skills cache: {len(refreshed)} discovered "
+                f"({len(valid_skills)} with SKILL.md)"
+            )
+            return True
+
+        elif subcommand == "help":
+            emit_info("Available /skills subcommands:")
+            emit_info("  /skills list     - List all installed skills")
+            emit_info("  /skills install  - Browse & install from catalog")
+            emit_info("  /skills enable   - Enable skills integration globally")
+            emit_info("  /skills disable  - Disable skills integration globally")
+            emit_info("  /skills toggle   - Toggle skills integration globally")
+            emit_info("  /skills refresh  - Refresh skill cache")
+            emit_info("  /skills          - Open interactive skills menu")
+            return True
+
         else:
             emit_error(f"Unknown subcommand: {subcommand}")
-            emit_info("Usage: /skills [list|install|enable|disable]")
+            emit_info(
+                "Usage: /skills [list|install|enable|disable|toggle|refresh|help]"
+            )
             return True
 
     # No subcommand – launch TUI menu

--- a/tests/plugins/test_agent_skills_callbacks_coverage.py
+++ b/tests/plugins/test_agent_skills_callbacks_coverage.py
@@ -257,6 +257,50 @@ class TestHandleSkillsCommand:
         ):
             assert _handle_skills_command("/skills disable", "skills") is True
 
+    def test_skills_toggle(self):
+        from code_puppy.plugins.agent_skills.register_callbacks import (
+            _handle_skills_command,
+        )
+
+        with (
+            patch(f"{_CFG}.get_skills_enabled", return_value=False),
+            patch(f"{_CFG}.set_skills_enabled") as mock_set,
+            patch(f"{_MSG}.emit_success") as mock_success,
+        ):
+            assert _handle_skills_command("/skills toggle", "skills") is True
+            mock_set.assert_called_once_with(True)
+            mock_success.assert_called_once()
+
+    def test_skills_help(self):
+        from code_puppy.plugins.agent_skills.register_callbacks import (
+            _handle_skills_command,
+        )
+
+        with patch(f"{_MSG}.emit_info") as mock_info:
+            assert _handle_skills_command("/skills help", "skills") is True
+            assert mock_info.call_count >= 2
+            assert "toggle" in str(mock_info.call_args_list)
+
+    def test_skills_refresh(self):
+        from code_puppy.plugins.agent_skills.register_callbacks import (
+            _handle_skills_command,
+        )
+
+        refreshed = [
+            MagicMock(name="valid", has_skill_md=True),
+            MagicMock(name="invalid", has_skill_md=False),
+        ]
+
+        with (
+            patch(f"{_DISC}.refresh_skill_cache", return_value=refreshed),
+            patch(f"{_MSG}.emit_success") as mock_success,
+        ):
+            assert _handle_skills_command("/skills refresh", "skills") is True
+            mock_success.assert_called_once()
+            assert "Refreshed skills cache" in str(mock_success.call_args)
+            assert "2 discovered" in str(mock_success.call_args)
+            assert "1 with SKILL.md" in str(mock_success.call_args)
+
     def test_skills_unknown_subcommand(self):
         from code_puppy.plugins.agent_skills.register_callbacks import (
             _handle_skills_command,
@@ -264,9 +308,11 @@ class TestHandleSkillsCommand:
 
         with (
             patch(f"{_MSG}.emit_error"),
-            patch(f"{_MSG}.emit_info"),
+            patch(f"{_MSG}.emit_info") as mock_info,
         ):
             assert _handle_skills_command("/skills bogus", "skills") is True
+            assert "toggle" in str(mock_info.call_args)
+            assert "help" in str(mock_info.call_args)
 
     def test_skills_no_subcommand_launches_menu(self):
         from code_puppy.plugins.agent_skills.register_callbacks import (


### PR DESCRIPTION
## 🐶 What’s fixed

`/skills` autocomplete/help advertised subcommands (`toggle`, `help`, `refresh`) that the active slash-command handler did not actually support. Users would see errors like:

- `Unknown subcommand: toggle`

This PR aligns implementation with the advertised UX and keeps behavior consistent.

## ✅ Changes

- Added `/skills toggle` handling in `agent_skills` slash callback
  - Toggles global skills integration state
  - Emits clear enabled/disabled status output
- Added `/skills refresh` handling
  - Forces skill re-discovery and reports discovered/valid counts
- Added `/skills help` handling
  - Prints available subcommands and descriptions
- Updated unknown-subcommand usage text to include all supported options
- Updated callback tests to cover:
  - toggle path
  - refresh path
  - help path
  - usage text expectations

## 🧪 Test evidence

Ran targeted tests:

- `uv run pytest -q tests/plugins/test_agent_skills_callbacks_coverage.py`
- `uv run pytest -q tests/command_line/test_skills_completion.py tests/test_hook_manager.py -k "skills or /skills or test_custom_command"`
- `uv run pytest -q tests/plugins/test_agent_skills_callbacks_coverage.py tests/command_line/test_skills_completion.py -k "skills"`

All passing in local run.

## Why this matters

This removes command-surface inconsistency and avoids user confusion where completion/help claims a command exists but execution rejects it.
