### PR TITLE
feat(models): add crof Kimi K2.5 Lightning model

### DIFF
--- a/code_puppy/models.json
+++ b/code_puppy/models.json
@@ -131,6 +131,17 @@
     "context_length": 262144,
     "supported_settings": ["temperature", "seed", "top_p"]
   },
+  "crof-kimi-k2.5-lightning": {
+    "type": "custom_openai",
+    "provider": "crof",
+    "name": "kimi-k2.5-lightning",
+    "custom_endpoint": {
+      "url": "https://api.crof.ai/v1",
+      "api_key": "$CROF_API_KEY"
+    },
+    "context_length": 131072,
+    "supported_settings": ["temperature", "seed", "top_p"]
+  },
   "zai-glm-5-coding": {
     "type": "zai_coding",
     "provider": "zai",


### PR DESCRIPTION
- Introduce new model entry "crof-kimi-k2.5-lightning" with custom OpenAI endpoint.
- Configure endpoint URL and API key placeholder for CROF.
- Set context length to 131072 and support common generation settings.
- Enables users to leverage Kimi K2.5 Lightning via the CROF provider.