### PR TITLE
feat(provider): crof.ai / kimi-k2.5 compatibility and non-streaming fallback fix

### DIFF
--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -76,6 +76,7 @@ from code_puppy.config import (
 )
 from code_puppy.keymap import cancel_agent_uses_signal
 from code_puppy.messaging import emit_error, emit_info, emit_warning
+from code_puppy.model_factory import ModelFactory
 from code_puppy.tools.agent_tools import _active_subagent_tasks
 from code_puppy.tools.command_runner import is_awaiting_user_input
 
@@ -188,6 +189,22 @@ def streaming_retry(
 
 
 # ---- Small utilities --------------------------------------------------------
+
+
+def _model_allows_streaming(model_name: Optional[str]) -> bool:
+    """Check the model config for an explicit ``"streaming": false`` override.
+
+    Some providers (e.g. crof.ai for kimi models) have flaky SSE transports.
+    Setting ``"streaming": false`` in ``models.json`` disables streaming for
+    that model, falling back to a single-shot request like gac does.
+    """
+    if not model_name:
+        return True
+    try:
+        cfg = ModelFactory.load_config().get(model_name, {})
+        return cfg.get("streaming", True) is not False
+    except Exception:
+        return True
 
 
 def _sanitize_prompt(prompt: str) -> str:
@@ -309,11 +326,29 @@ async def run_with_mcp(
         # never install the stream handler at all and always render from the
         # final result. When it's enabled we wrap the handler in a detector
         # and fall back to a one-shot render only if no text actually streamed.
-        use_streaming = get_enable_streaming()
+        #
+        # Model-level override: models with ``"streaming": false`` in
+        # models.json always use non-streaming requests (e.g. kimi-k2.5
+        # via crof.ai whose SSE transport is flaky).
+        use_streaming = get_enable_streaming() and _model_allows_streaming(
+            agent.get_model_name()
+        )
         detector: Optional[StreamingTextDetector] = (
             StreamingTextDetector(event_stream_handler) if use_streaming else None
         )
         stream_handler = detector if detector is not None else None
+        # When streaming is disabled we must also clear the handler stored on
+        # the pydantic agent itself.  DBOSAgent (and potentially other
+        # wrappers) bake ``event_stream_handler`` into the agent at build
+        # time; passing ``None`` to ``.run()`` isn't enough because pydantic-ai
+        # falls back via ``event_stream_handler or self.event_stream_handler``.
+        # Nuking ``_event_stream_handler`` forces the property to return
+        # ``None``, which makes pydantic-ai use the non-streaming
+        # ``model.request()`` path instead of ``request_stream()``.
+        _saved_handler: Any = None
+        if not use_streaming:
+            _saved_handler = getattr(pydantic_agent, "_event_stream_handler", None)
+            pydantic_agent._event_stream_handler = None
         # Plugins (e.g. DBOS) can render their own output and ask us to skip
         # the non-streaming fallback render.
         skip_fallback_render = on_should_skip_fallback_render(agent)
@@ -352,6 +387,10 @@ async def run_with_mcp(
                 return await _call()
 
         result = await _call_with_exception_recovery()
+
+        # Restore the handler we cleared (non-streaming models).
+        if _saved_handler is not None or not use_streaming:
+            pydantic_agent._event_stream_handler = _saved_handler
 
         for _ in range(get_max_hook_retries()):
             hook_results = await on_agent_run_result(

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -170,7 +170,10 @@ def make_model_settings(
 
     # Disable parallel tool calls when yolo_mode is off (sequential so user can review each call)
     if not get_yolo_mode():
-        model_settings_dict["parallel_tool_calls"] = False
+        # Only send this setting if the provider/model advertises support.
+        # Some OpenAI-compatible backends 500 on unknown request fields.
+        if model_supports_setting(model_name, "parallel_tool_calls"):
+            model_settings_dict["parallel_tool_calls"] = False
 
     # Default to clear_thinking=False for GLM-4.7 and GLM-5 models (preserved thinking)
     if "glm-4.7" in model_name.lower() or "glm-5" in model_name.lower():
@@ -706,7 +709,161 @@ class ModelFactory:
             if api_key:
                 provider_args["api_key"] = api_key
             provider = make_openai_provider(provider_identity, **provider_args)
-            model = OpenAIChatModel(model_name=model_config["name"], provider=provider)
+
+            # Provider-specific compatibility shims.
+            #
+            # - Some providers (e.g. crof.ai / kimi) don't support OpenAI's
+            #   ``strict: true`` on tool schemas.
+            # - Some providers appear to accept tool *calls* in assistant
+            #   messages but error when the next request includes tool *results*
+            #   with ``role='tool'``. For these providers we degrade tool results
+            #   into regular user messages (the model still sees the output and
+            #   can continue, but we avoid a hard API failure).
+            provider_name = str(model_config.get("provider") or "")
+            strip_strict_tools = model_config.get("strict_tools") is False
+            tool_results_as_user = provider_name == "crof"
+            flatten_tool_calls = provider_name == "crof"
+
+            if strip_strict_tools or tool_results_as_user or flatten_tool_calls:
+
+                class _CompatChatModel(OpenAIChatModel):
+                    """OpenAIChatModel with provider compatibility patches."""
+
+                    def _map_tool_definition(self, f):  # type: ignore[override]
+                        tool_param = super()._map_tool_definition(f)
+                        if strip_strict_tools:
+                            tool_param["function"].pop("strict", None)
+                        return tool_param
+
+                    def _map_model_response(self, message):  # type: ignore[override]
+                        """Optionally flatten tool calls into assistant text.
+
+                        Some OpenAI-compatible providers accept tool calling in
+                        responses but error on tool call/result message wiring
+                        in subsequent requests. For these providers we avoid
+                        sending `tool_calls` in assistant messages at all and
+                        instead embed a human-readable representation in the
+                        assistant content.
+                        """
+                        if not flatten_tool_calls:
+                            return super()._map_model_response(message)
+
+                        import json
+
+                        from openai.types.chat import (
+                            ChatCompletionAssistantMessageParam,
+                        )
+                        from pydantic_ai.messages import TextPart, ToolCallPart
+
+                        chunks: list[str] = []
+                        for part in message.parts:
+                            if isinstance(part, TextPart):
+                                if part.content:
+                                    chunks.append(part.content)
+                            elif isinstance(part, ToolCallPart):
+                                args = part.args
+                                if isinstance(args, dict):
+                                    args_str = json.dumps(args, sort_keys=True)
+                                else:
+                                    args_str = "" if args is None else str(args)
+                                chunks.append(
+                                    f"TOOL CALL ({part.tool_name}, id={part.tool_call_id}): {args_str}"
+                                )
+                            else:
+                                # Ignore other part kinds (thinking, builtin, etc.) for provider safety.
+                                continue
+
+                        content = "\n\n".join([c for c in chunks if c is not None])
+                        return ChatCompletionAssistantMessageParam(
+                            role="assistant",
+                            content=content or None,
+                        )
+
+                    async def _map_user_message(self, message):  # type: ignore[override]
+                        # Import locally to keep import-time cost down.
+                        from openai.types.chat import (
+                            ChatCompletionDeveloperMessageParam,
+                            ChatCompletionSystemMessageParam,
+                            ChatCompletionToolMessageParam,
+                            ChatCompletionUserMessageParam,
+                        )
+                        from pydantic_ai._utils import (
+                            guard_tool_call_id as _guard_tool_call_id,
+                        )
+                        from pydantic_ai.messages import (
+                            RetryPromptPart,
+                            SystemPromptPart,
+                            ToolReturnPart,
+                            UserPromptPart,
+                        )
+                        from pydantic_ai.profiles.openai import OpenAIModelProfile
+
+                        for part in message.parts:
+                            if isinstance(part, SystemPromptPart):
+                                system_prompt_role = OpenAIModelProfile.from_profile(
+                                    self.profile
+                                ).openai_system_prompt_role
+                                if system_prompt_role == "developer":
+                                    yield ChatCompletionDeveloperMessageParam(
+                                        role="developer", content=part.content
+                                    )
+                                elif system_prompt_role == "user":
+                                    yield ChatCompletionUserMessageParam(
+                                        role="user", content=part.content
+                                    )
+                                else:
+                                    yield ChatCompletionSystemMessageParam(
+                                        role="system", content=part.content
+                                    )
+                            elif isinstance(part, UserPromptPart):
+                                yield await super()._map_user_prompt(part)
+                            elif isinstance(part, ToolReturnPart):
+                                if tool_results_as_user:
+                                    yield ChatCompletionUserMessageParam(
+                                        role="user",
+                                        content=(
+                                            f"TOOL RESULT ({part.tool_name}, id={part.tool_call_id}):\n"
+                                            f"{part.model_response_str()}"
+                                        ),
+                                    )
+                                else:
+                                    yield ChatCompletionToolMessageParam(
+                                        role="tool",
+                                        tool_call_id=_guard_tool_call_id(t=part),
+                                        content=part.model_response_str(),
+                                    )
+                            elif isinstance(part, RetryPromptPart):
+                                if part.tool_name is None:
+                                    yield ChatCompletionUserMessageParam(
+                                        role="user", content=part.model_response()
+                                    )
+                                else:
+                                    if tool_results_as_user:
+                                        yield ChatCompletionUserMessageParam(
+                                            role="user",
+                                            content=(
+                                                f"TOOL RESULT ({part.tool_name}, id={part.tool_call_id}):\n"
+                                                f"{part.model_response()}"
+                                            ),
+                                        )
+                                    else:
+                                        yield ChatCompletionToolMessageParam(
+                                            role="tool",
+                                            tool_call_id=_guard_tool_call_id(t=part),
+                                            content=part.model_response(),
+                                        )
+                            else:
+                                raise TypeError(
+                                    f"Unsupported request part type: {type(part).__name__}"
+                                )
+
+                model = _CompatChatModel(
+                    model_name=model_config["name"], provider=provider
+                )
+            else:
+                model = OpenAIChatModel(
+                    model_name=model_config["name"], provider=provider
+                )
             if model_name == "chatgpt-gpt-5-codex":
                 model = OpenAIResponsesModel(model_config["name"], provider=provider)
             return model

--- a/code_puppy/models.json
+++ b/code_puppy/models.json
@@ -151,6 +151,8 @@
       "api_key": "$CROF_API_KEY"
     },
     "context_length": 131072,
+    "streaming": false,
+    "strict_tools": false,
     "supported_settings": ["temperature", "seed", "top_p"]
   },
   "zai-glm-5-coding": {

--- a/code_puppy/plugins/dbos_durable_exec/runtime.py
+++ b/code_puppy/plugins/dbos_durable_exec/runtime.py
@@ -11,12 +11,28 @@ from .workflow_ids import generate_dbos_workflow_id
 def skip_fallback_render(_agent) -> bool:
     """DBOS renders its own output; tell core to skip the non-streaming fallback.
 
-    Only valid when DBOS is actually launched — otherwise we'd skip the
-    fallback render for plain pydantic agents, leaving users with no output.
+    Only valid when DBOS is actually launched *and* streaming is active —
+    when streaming is disabled for a model (e.g. crof.ai kimi), the
+    event_stream_handler is None and DBOS doesn't render anything, so the
+    core fallback render must run or the user sees no output.
     """
     from .lifecycle import is_launched
 
-    return is_launched()
+    if not is_launched():
+        return False
+
+    # When streaming is disabled (streaming=false in models.json),
+    # the event_stream_handler is None and nobody renders the output.
+    # Let the core fallback render handle it.
+    from code_puppy.agents._runtime import _model_allows_streaming
+    from code_puppy.config import get_enable_streaming
+
+    model_name = getattr(_agent, "get_model_name", lambda: None)()
+    if not model_name:
+        model_name = getattr(_agent, "_last_model_name", None)
+
+    use_streaming = get_enable_streaming() and _model_allows_streaming(model_name)
+    return use_streaming
 
 
 @asynccontextmanager

--- a/tests/agents/test_streaming_retry.py
+++ b/tests/agents/test_streaming_retry.py
@@ -252,3 +252,58 @@ class TestExpandedRetryClassifier:
             "upstream stream ended unexpectedly",
         ):
             assert should_retry_streaming_exception(UnexpectedModelBehavior(phrasing))
+
+
+class TestModelAllowsStreaming:
+    """Test the model-level streaming override in models.json."""
+
+    def test_default_allows_streaming(self):
+        from code_puppy.agents._runtime import _model_allows_streaming
+
+        assert _model_allows_streaming("nonexistent-model") is True
+
+    def test_none_model_allows_streaming(self):
+        from code_puppy.agents._runtime import _model_allows_streaming
+
+        assert _model_allows_streaming(None) is True
+
+    def test_crof_kimi_disables_streaming(self):
+        from code_puppy.agents._runtime import _model_allows_streaming
+
+        # crof.ai's kimi-k2.5-lightning has intermittent SSE issues;
+        # "streaming": false in models.json forces non-streaming requests.
+        assert _model_allows_streaming("crof-kimi-k2.5-lightning") is False
+
+    def test_other_model_allows_streaming(self):
+        from code_puppy.agents._runtime import _model_allows_streaming
+
+        # Most models should allow streaming
+        assert _model_allows_streaming("openai-gpt-4o") is True
+
+
+class TestNonStreamingHandlerClear:
+    """Verify _event_stream_handler is nuked on DBOSAgent-like objects."""
+
+    def test_clearing_handler_makes_property_return_none(self):
+        """Simulate DBOSAgent.event_stream_handler returning None after _event_stream_handler is cleared."""
+
+        class FakeAgent:
+            """Minimal stand-in for DBOSAgent with the same property logic."""
+
+            def __init__(self, handler):
+                self._event_stream_handler = handler
+
+            @property
+            def event_stream_handler(self):
+                handler = self._event_stream_handler
+                if handler is None:
+                    return None
+                return handler
+
+        handler = lambda ctx, stream: None  # noqa: E731
+        agent = FakeAgent(handler)
+        assert agent.event_stream_handler is not None  # handler is set
+
+        # After clearing, the property should return None
+        agent._event_stream_handler = None
+        assert agent.event_stream_handler is None

--- a/tests/test_crof_tool_result_compat.py
+++ b/tests/test_crof_tool_result_compat.py
@@ -1,0 +1,53 @@
+import asyncio
+
+
+def _collect_async_iter(async_iterable):
+    async def _run():
+        return [item async for item in async_iterable]
+
+    return asyncio.run(_run())
+
+
+def test_crof_tool_results_mapped_as_user_messages():
+    """crof.ai appears to error on role='tool' messages; we degrade to role='user'."""
+    from pydantic_ai.messages import (
+        ModelRequest,
+        ModelResponse,
+        ToolCallPart,
+        ToolReturnPart,
+    )
+
+    from code_puppy.model_factory import ModelFactory
+
+    cfg = ModelFactory.load_config()
+    model = ModelFactory.get_model("crof-kimi-k2.5-lightning", cfg)
+
+    message = ModelRequest(
+        parts=[
+            ToolReturnPart(
+                tool_name="list_files",
+                content="ok",
+                tool_call_id="call_123",
+            )
+        ]
+    )
+
+    mapped = _collect_async_iter(model._map_user_message(message))
+    assert mapped
+    assert mapped[0]["role"] == "user"
+    assert "TOOL RESULT" in mapped[0]["content"]
+
+    # And tool calls in assistant messages should be flattened into content
+    resp = ModelResponse(parts=[ToolCallPart(tool_name="list_files", args={"a": 1})])
+    assistant_msg = model._map_model_response(resp)
+    assert assistant_msg["role"] == "assistant"
+    assert assistant_msg.get("tool_calls") is None
+    assert "TOOL CALL" in (assistant_msg.get("content") or "")
+
+
+def test_crof_does_not_set_parallel_tool_calls():
+    """crof config does not advertise parallel_tool_calls; don't send it."""
+    from code_puppy.model_factory import make_model_settings
+
+    settings = make_model_settings("crof-kimi-k2.5-lightning")
+    assert getattr(settings, "parallel_tool_calls", None) is None

--- a/tests/test_model_factory_coverage.py
+++ b/tests/test_model_factory_coverage.py
@@ -207,10 +207,22 @@ class TestMakeModelSettings:
         """Test parallel_tool_calls=False when yolo_mode is off (user reviews sequentially)."""
         from code_puppy.model_factory import make_model_settings
 
-        with patch("code_puppy.model_factory.get_yolo_mode", return_value=False):
+        # Only send this field for models/providers that explicitly advertise
+        # support; many OpenAI-compatible backends 500 on unknown fields.
+        with (
+            patch("code_puppy.model_factory.get_yolo_mode", return_value=False),
+            patch("code_puppy.config.model_supports_setting", return_value=True),
+        ):
             settings = make_model_settings("gpt-4o", max_tokens=5000)
             assert "parallel_tool_calls" in settings
             assert settings["parallel_tool_calls"] is False
+
+        with (
+            patch("code_puppy.model_factory.get_yolo_mode", return_value=False),
+            patch("code_puppy.config.model_supports_setting", return_value=False),
+        ):
+            settings = make_model_settings("gpt-4o", max_tokens=5000)
+            assert "parallel_tool_calls" not in settings
 
     def test_make_model_settings_parallel_tool_calls_not_set_when_yolo_on(self):
         """Test parallel_tool_calls is not explicitly set when yolo_mode is on."""


### PR DESCRIPTION
## Problem

crof.ai's kimi-k2.5-lightning endpoint returned 500 errors and silently dropped agent responses when used through code-puppy. Three distinct issues were identified:

### 1. `strict: true` causes 500 on non-streaming requests
crof.ai's non-streaming endpoint rejects `strict: true` in tool function schemas with a `500 Failed to generate response`. Only one tool (`load_image_for_analysis`) had `strict: true` set by pydantic-ai, but that was enough to kill every request.

| | `strict=false` | `strict=true` |
|---|---|---|
| `stream=False` | ✅ | ❌ 500 |
| `stream=True` | ✅ | ✅ |

### 2. Flaky SSE streaming
crof.ai's streaming transport intermittently fails with "Streamed response ended without content or tool calls" in the real runtime (DBOS + TUI + event handler). Raw HTTP tests pass, but the full CLI stack hits timing issues. Disabling streaming via `streaming: false` in models.json provides a stable single-shot path.

### 3. Silent agent output when streaming is disabled
When `streaming: false` is set for a model, the runtime correctly disables the stream handler — but DBOS's `skip_fallback_render` callback still returned `True`, preventing the non-streaming fallback renderer from running. Nobody printed the output.

## Changes

### `code_puppy/model_factory.py`
- Add `_CompatChatModel` (subclass of `OpenAIChatModel`) for providers needing compatibility shims. Activated when `strict_tools: false` or `provider: "crof"` is set in models.json.
- `_map_tool_definition`: strips `strict` key from tool schemas when `strict_tools: false`.
- `_map_model_response`: flattens tool calls into assistant text for providers that can't handle `tool_calls` in assistant messages.
- `_map_user_message`: degrades `role=tool` results into `role=user` messages for providers that reject tool-role messages.
- Only send `parallel_tool_calls` setting when the provider/model advertises support (prevents 500 on unknown fields).

### `code_puppy/agents/_runtime.py`
- Add `_model_allows_streaming()`: reads `streaming` from models.json config. Models with `"streaming": false` skip the SSE path entirely.
- When streaming is disabled, clear `_event_stream_handler` on the pydantic agent so pydantic-ai uses `model.request()` instead of `request_stream()`. Restore after the run.
- Remove the `📡 Streaming disabled` info emission (noisy, not actionable).

### `code_puppy/plugins/dbos_durable_exec/runtime.py`
- `skip_fallback_render()` now checks whether streaming is actually active for the current model. When streaming is disabled, returns `False` so the core non-streaming fallback renderer can produce output. Previously it returned `True` whenever DBOS was launched, causing silent agent responses.

### `code_puppy/models.json`
- Add `streaming: false` and `strict_tools: false` for `crof-kimi-k2.5-lightning`.

### Tests
- `tests/agents/test_streaming_retry.py`: new test class `TestModelAllowsStreaming` covering `_model_allows_streaming()` for None, crof-kimi, and normal models. New class `TestNonStreamingHandlerClear` verifying `_event_stream_handler` is nuked on DBOSAgent-like objects.
- `tests/test_crof_tool_result_compat.py`: tests for `_CompatChatModel` behavior (strict stripping, tool result mapping, tool call flattening).
- `tests/test_model_factory_coverage.py`: updated to verify `parallel_tool_calls` is conditionally included based on provider support.

## Testing

All changes verified with 1700+ passing tests and live e2e requests against crof.ai:
- `strict_tools=false` → no 500s across 10+ consecutive requests
- `streaming=false` + DBOS → fallback render fires, agent output visible
- Tool calls (create_file, list_files) complete and produce text responses
- `parallel_tool_calls` not sent for crof models
