### PR TITLE
fix(display): disable clipboard features in termflow rendering

### DIFF
--- a/code_puppy/agents/event_stream_handler.py
+++ b/code_puppy/agents/event_stream_handler.py
@@ -107,6 +107,7 @@ async def event_stream_handler(
 
     from termflow import Parser as TermflowParser
     from termflow import Renderer as TermflowRenderer
+    from termflow.render.style import RenderFeatures
 
     # Use the module-level console (set via set_streaming_console)
     console = get_streaming_console()
@@ -191,7 +192,9 @@ async def event_stream_handler(
                 # Initialize termflow streaming for this text part
                 termflow_parsers[event.index] = TermflowParser()
                 termflow_renderers[event.index] = TermflowRenderer(
-                    output=console.file, width=console.width
+                    output=console.file,
+                    width=console.width,
+                    features=RenderFeatures(clipboard=False),
                 )
                 termflow_line_buffers[event.index] = ""
                 # Handle initial content if present

--- a/code_puppy/tools/agent_tools.py
+++ b/code_puppy/tools/agent_tools.py
@@ -437,9 +437,7 @@ def register_invoke_agent(agent):
                 bound_agent_name = getattr(agent_config, "name", None)
                 if bound_agent_name:
                     await autostart_bound_servers_async(manager, bound_agent_name)
-                mcp_servers = manager.get_servers_for_agent(
-                    agent_name=bound_agent_name
-                )
+                mcp_servers = manager.get_servers_for_agent(agent_name=bound_agent_name)
 
             from code_puppy.agents._compaction import make_history_processor
 

--- a/code_puppy/tools/display.py
+++ b/code_puppy/tools/display.py
@@ -43,6 +43,7 @@ def display_non_streamed_result(
     from rich.text import Text
     from termflow import Parser as TermflowParser
     from termflow import Renderer as TermflowRenderer
+    from termflow.render.style import RenderFeatures
 
     from code_puppy.messaging.spinner import pause_all_spinners, resume_all_spinners
 
@@ -66,7 +67,11 @@ def display_non_streamed_result(
 
     # Use termflow for markdown rendering
     parser = TermflowParser()
-    renderer = TermflowRenderer(output=console.file, width=console.width)
+    renderer = TermflowRenderer(
+        output=console.file,
+        width=console.width,
+        features=RenderFeatures(clipboard=False),
+    )
 
     # Process content line by line
     for line in content.split("\n"):

--- a/tests/tools/test_display.py
+++ b/tests/tools/test_display.py
@@ -70,9 +70,13 @@ class TestDisplayNonStreamedResult:
         # Verify parser was instantiated
         mock_parser_class.assert_called_once()
 
-        # Verify renderer was instantiated
+        # Verify renderer was instantiated (clipboard=False prevents OSC 52 overwrite)
+        from termflow.render.style import RenderFeatures
+
         mock_renderer_class.assert_called_once_with(
-            output=mock_console.file, width=mock_console.width
+            output=mock_console.file,
+            width=mock_console.width,
+            features=RenderFeatures(clipboard=False),
         )
 
     @patch("code_puppy.messaging.spinner.pause_all_spinners")
@@ -511,8 +515,14 @@ class TestDisplayNonStreamedResult:
         # Call the function
         display_non_streamed_result(content="test", console=mock_console)
 
-        # Verify renderer was created with the correct console.file
-        mock_renderer_class.assert_called_once_with(output=test_file, width=100)
+        # Verify renderer was created with the correct console.file (clipboard=False prevents OSC 52 overwrite)
+        from termflow.render.style import RenderFeatures
+
+        mock_renderer_class.assert_called_once_with(
+            output=test_file,
+            width=100,
+            features=RenderFeatures(clipboard=False),
+        )
 
     @patch("code_puppy.messaging.spinner.pause_all_spinners")
     @patch("code_puppy.messaging.spinner.resume_all_spinners")


### PR DESCRIPTION
- Prevent termflow from enabling clipboard-related render features in both streamed and non-streamed markdown output
- Reduce the risk of terminal side effects when rendering assistant responses in the console
- Keep display behavior focused on text rendering while avoiding unnecessary clipboard integration