### PR TITLE
Fix: #259 Windows grep backslash handling in _grep

### DIFF
--- a/code_puppy/tools/file_operations.py
+++ b/code_puppy/tools/file_operations.py
@@ -583,10 +583,32 @@ def _sanitize_string(text: str) -> str:
         )
 
 
+def _split_grep_search_string(search_string: str) -> list[str]:
+    """Split grep arguments without corrupting Windows backslashes.
+
+    `_grep` accepts ripgrep-style flags in `search_string`, so we still need
+    shell-like tokenization. On Windows, POSIX parsing treats backslashes as
+    escapes and mangles common regexes and paths, so use non-POSIX tokenization
+    and then trim any matching quote wrappers from the resulting tokens.
+    """
+
+    import shlex
+
+    try:
+        if os.name == "nt":
+            lexer = shlex.shlex(search_string, posix=False)
+            lexer.whitespace_split = True
+            lexer.commenters = ""
+            return [part.strip("\"'") for part in lexer]
+        return shlex.split(search_string)
+    except ValueError:
+        # Keep the full string intact when quotes are unmatched.
+        return [search_string]
+
+
 def _grep(context: RunContext, search_string: str, directory: str = ".") -> GrepOutput:
     import json
     import os
-    import shlex
     import shutil
     import subprocess
     import sys
@@ -651,12 +673,8 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
 
         cmd.extend(["--ignore-file", ignore_file])
         # Split search_string to support ripgrep flags like --ignore-case
-        try:
-            parts = shlex.split(search_string)
-        except ValueError:
-            # Fallback for unmatched quotes (e.g., apostrophes in search terms)
-            parts = [search_string]
-        cmd.extend(parts)
+        # without corrupting Windows backslashes in regexes or file paths.
+        cmd.extend(_split_grep_search_string(search_string))
         cmd.append(directory)
         # Use encoding with error handling to handle files with invalid UTF-8
         result = subprocess.run(
@@ -667,6 +685,15 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
             encoding="utf-8",
             errors="replace",  # Replace invalid chars instead of crashing
         )
+
+        if result.returncode not in (0, 1):
+            stderr = _sanitize_string(result.stderr.strip()) if result.stderr else ""
+            error_message = stderr or f"ripgrep exited with code {result.returncode}"
+        elif result.returncode == 1 and result.stderr.strip():
+            error_message = _sanitize_string(result.stderr.strip())
+
+        if error_message is not None:
+            return GrepOutput(matches=[], error=error_message)
 
         # Parse the JSON output from ripgrep
         for line in result.stdout.strip().split("\n"):

--- a/tests/tools/test_file_operations_coverage.py
+++ b/tests/tools/test_file_operations_coverage.py
@@ -252,6 +252,46 @@ class TestGrepFunction:
         result = _grep(None, "content", str(tmp_path))
         assert isinstance(result, GrepOutput)
 
+    @patch("code_puppy.tools.file_operations.os.name", "nt")
+    @patch("shutil.which", return_value="rg")
+    @patch("subprocess.run")
+    def test_grep_preserves_backslashes_on_windows(
+        self, mock_run, _mock_which, tmp_path
+    ):
+        """Test Windows grep preserves backslashes in regex and path arguments."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="",
+            stderr="",
+        )
+
+        patterns = [r"\bdef\b", r"\d+", r"C:\Users\me", r"foo\.bar"]
+
+        for pattern in patterns:
+            result = _grep(None, pattern, str(tmp_path))
+
+            assert result.error is None
+            invoked_cmd = mock_run.call_args[0][0]
+            assert pattern in invoked_cmd
+
+    @patch("shutil.which", return_value="rg")
+    @patch("subprocess.run")
+    def test_grep_reports_ripgrep_errors(self, mock_run, _mock_which, tmp_path):
+        """Test ripgrep failures are surfaced instead of looking like no matches."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=2,
+            stdout="",
+            stderr="regex parse error:\n    foo(\n       ^\nerror: unclosed group",
+        )
+
+        result = _grep(None, "foo(", str(tmp_path))
+
+        assert result.matches == []
+        assert result.error is not None
+        assert "regex parse error" in result.error
+
 
 class TestListFilesRipgrepHandling:
     """Test _list_files handling of ripgrep edge cases."""


### PR DESCRIPTION
## Summary
This fixes a Windows bug in code_puppy.tools.file_operations._grep where search strings containing backslashes were corrupted before being passed to ripgrep.

The root cause was POSIX shlex.split(search_string), which treats \ as an escape character. On Windows that broke common searches like \bhello\b, \d+, foo\.bar, and path-like input such as C:\Users\me.

## Changes
use Windows-safe argument splitting for _grep
preserve backslashes in regex and path-like input
surface ripgrep errors instead of silently returning zero matches
add regression tests for Windows backslash handling and ripgrep error propagation
Notes
grep is still regex-based by default. A raw search like C:\Users\me now returns the real ripgrep regex error instead of looking like “no matches”. For literal path searches, use -F "C:\Users\me".


## Passed:
pytest tests/tools/test_file_operations_coverage.py -q
pytest tests/tools/test_file_operations_coverage.py -q -k grep

## Manual Windows smoke test:

\bhello_world\b matched
\d+ matched
-F "C:\Users\me" matched literal Windows paths