### PR TITLE
build(deps): add 7-day exclusion window to prevent supply chain attacks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ omit = ["code_puppy/main.py"]
 
 [tool.uv]
 python-preference = "only-managed"
+exclude-newer = "7 days"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
- Configure uv to exclude packages newer than 7 days via exclude-newer setting
- Mitigates 0-day supply chain attack vectors by preventing immediate adoption of newly published packages
- Enhances dependency security posture while maintaining access to stable, vetted packages