### PR TITLE
feat(commands): register /clear so it shows up in /help

### DIFF
--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -651,29 +651,11 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
             # The renderer is stopped in the finally block of main().
             break
 
-        # Check for clear command (supports both `clear` and `/clear`)
-        if task.strip().lower() in ("clear", "/clear"):
-            from code_puppy.command_line.clipboard import get_clipboard_manager
-            from code_puppy.messaging import (
-                emit_info,
-                emit_system_message,
-                emit_warning,
-            )
-
-            agent = get_current_agent()
-            new_session_id = finalize_autosave_session()
-            agent.clear_message_history()
-            emit_warning("Conversation history cleared!")
-            emit_system_message("The agent will not remember previous interactions.")
-            emit_info(f"Auto-save session rotated to: {new_session_id}")
-
-            # Also clear pending clipboard images
-            clipboard_manager = get_clipboard_manager()
-            clipboard_count = clipboard_manager.get_pending_count()
-            clipboard_manager.clear_pending()
-            if clipboard_count > 0:
-                emit_info(f"Cleared {clipboard_count} pending clipboard image(s)")
-            continue
+        # Backward-compat: bare `clear` (no slash) is rewritten to `/clear`
+        # so the registered handler in session_commands is the single source
+        # of truth. The slash form is dispatched normally below.
+        if task.strip().lower() == "clear":
+            task = "/clear"
 
         # Parse attachments first so leading paths aren't misread as commands
         processed_for_commands = parse_prompt_attachments(task)

--- a/code_puppy/command_line/session_commands.py
+++ b/code_puppy/command_line/session_commands.py
@@ -66,6 +66,47 @@ def handle_session_command(command: str) -> bool:
 
 
 @register_command(
+    name="clear",
+    description="Clear conversation history (rotates autosave; agent forgets prior turns)",
+    usage="/clear",
+    aliases=["cls"],
+    category="session",
+    detailed_help="""
+    Wipe the current conversation history so the agent starts fresh.
+
+    What it does:
+      - Finalizes & rotates the current autosave session (so prior history
+        is preserved on disk and recoverable via /autosave_load)
+      - Clears the in-memory message history for the active agent
+      - Drops any pending clipboard images queued for the next turn
+
+    The bare word `clear` (no slash) also works, for backward compatibility.
+    """,
+)
+def handle_clear_command(command: str) -> bool:
+    """Clear conversation history and rotate autosave session."""
+    from code_puppy.agents.agent_manager import get_current_agent
+    from code_puppy.command_line.clipboard import get_clipboard_manager
+    from code_puppy.config import finalize_autosave_session
+    from code_puppy.messaging import emit_info, emit_system_message, emit_warning
+
+    agent = get_current_agent()
+    new_session_id = finalize_autosave_session()
+    agent.clear_message_history()
+    emit_warning("Conversation history cleared!")
+    emit_system_message("The agent will not remember previous interactions.")
+    emit_info(f"Auto-save session rotated to: {new_session_id}")
+
+    # Also clear pending clipboard images so they don't leak into the next turn
+    clipboard_manager = get_clipboard_manager()
+    clipboard_count = clipboard_manager.get_pending_count()
+    clipboard_manager.clear_pending()
+    if clipboard_count > 0:
+        emit_info(f"Cleared {clipboard_count} pending clipboard image(s)")
+    return True
+
+
+@register_command(
     name="compact",
     description="Summarize and compact current chat history (uses compaction_strategy config)",
     usage="/compact",

--- a/tests/command_line/test_session_commands.py
+++ b/tests/command_line/test_session_commands.py
@@ -416,3 +416,78 @@ class TestHandleLoadContextCommand:
             patch("code_puppy.command_line.autosave_menu.display_resumed_history"),
         ):
             assert self._run("/load_context mysession") is True
+
+
+class TestHandleClearCommand:
+    """Tests for the /clear command handler.
+
+    Lives in session_commands so it shows up in /help (single source of truth).
+    """
+
+    def _run(self, command="/clear"):
+        from code_puppy.command_line.session_commands import handle_clear_command
+
+        return handle_clear_command(command)
+
+    def test_clear_wipes_history_and_rotates_session(self):
+        agent = MagicMock()
+        clipboard = MagicMock()
+        clipboard.get_pending_count.return_value = 0
+        with (
+            patch(
+                "code_puppy.agents.agent_manager.get_current_agent",
+                return_value=agent,
+            ),
+            patch(
+                "code_puppy.command_line.clipboard.get_clipboard_manager",
+                return_value=clipboard,
+            ),
+            patch(
+                "code_puppy.config.finalize_autosave_session",
+                return_value="new-session-id",
+            ),
+            patch("code_puppy.messaging.emit_warning") as mock_warn,
+            patch("code_puppy.messaging.emit_system_message"),
+            patch("code_puppy.messaging.emit_info") as mock_info,
+        ):
+            assert self._run() is True
+            agent.clear_message_history.assert_called_once()
+            clipboard.clear_pending.assert_called_once()
+            mock_warn.assert_called_once()
+            # Info called once for the session-rotated message; no clipboard msg
+            assert mock_info.call_count == 1
+
+    def test_clear_reports_dropped_clipboard_images(self):
+        agent = MagicMock()
+        clipboard = MagicMock()
+        clipboard.get_pending_count.return_value = 3
+        with (
+            patch(
+                "code_puppy.agents.agent_manager.get_current_agent",
+                return_value=agent,
+            ),
+            patch(
+                "code_puppy.command_line.clipboard.get_clipboard_manager",
+                return_value=clipboard,
+            ),
+            patch(
+                "code_puppy.config.finalize_autosave_session",
+                return_value="sid",
+            ),
+            patch("code_puppy.messaging.emit_warning"),
+            patch("code_puppy.messaging.emit_system_message"),
+            patch("code_puppy.messaging.emit_info") as mock_info,
+        ):
+            assert self._run() is True
+            # One info for session rotation, one for the dropped clipboard count
+            assert mock_info.call_count == 2
+            assert any("3" in str(c) for c in mock_info.call_args_list)
+
+    def test_clear_is_registered_and_appears_in_help(self):
+        """Regression: /clear must show up in /help (was previously hidden)."""
+        # Trigger registration via import side-effects
+        import code_puppy.command_line.session_commands  # noqa: F401
+        from code_puppy.command_line.command_registry import get_unique_commands
+
+        names = {c.name for c in get_unique_commands()}
+        assert "clear" in names


### PR DESCRIPTION
## Summary

The `clear` / `/clear` command was hardcoded as a special-case input intercept in `cli_runner.py` (~line 654-676), which meant it **never appeared in `/help`** output and wasn't tab-completable. Every other command lives in the registry via `@register_command`, but `/clear` was invisible to the help generator — a single-source-of-truth violation.

This PR moves `/clear` into the registry alongside its sibling session commands (`/compact`, `/truncate`, `/dump_context`).

## Changes

- **`code_puppy/command_line/session_commands.py`** — new `handle_clear_command` decorated with `@register_command(name="clear", aliases=["cls"], category="session")`. Logic is byte-for-byte equivalent to the old hardcoded block.
- **`code_puppy/cli_runner.py`** — replace the 24-line duplicated block with a 5-line backward-compat shim that rewrites bare `clear` (no slash) into `/clear` and lets the normal command dispatcher route it.
- **`tests/command_line/test_session_commands.py`** — 3 new tests: the registered handler's happy path, the dropped-clipboard-images branch, and a **regression test** asserting `/clear` is in the registry so it can never silently disappear from `/help` again.

## User-visible impact

| Before | After |
|---|---|
| `clear` works, `/clear` works, but neither shows up in `/help` | Both still work, `/clear` shows in `/help` and tab-completes |
| Logic duplicated in 2 places | Single source of truth in `session_commands.py` |

No behavior change. The autosave session still rotates, history still gets wiped, pending clipboard images still get cleared.

## Test results

- ✅ All 33 `test_session_commands.py` tests pass (30 existing + 3 new)
- ✅ All 59 `test_cli_runner_full_coverage.py` tests pass (including the existing `test_clear_command`)
- ✅ Verified `/clear` appears in `get_commands_help()` output

## Zen check 🧘

- ✅ "There should be one — and preferably only one — obvious way to do it."
- ✅ "Special cases aren't special enough to break the rules."
- ✅ DRY

## Follow-up suggestion

The `wiggum` command at `cli_runner.py:847` suffers from the same hidden-special-case pattern. Happy to tackle it in a follow-up PR if you'd like.
