### PR TITLE
feat(plugins): add context_indicator with prompt circle + /context command

### DIFF
--- a/code_puppy/plugins/context_indicator/__init__.py
+++ b/code_puppy/plugins/context_indicator/__init__.py
@@ -1,0 +1,13 @@
+"""Context-window usage indicator.
+
+Shows a colored circle in the terminal prompt reflecting how full the current
+agent's message history is relative to the active model's context window:
+
+* 🟢 — under 30% used
+* 🟡 — 30%-60% used
+* 🔴 — over 60% used
+
+Also exposes a ``/context`` slash command for a detailed breakdown.
+"""
+
+__all__: list[str] = []

--- a/code_puppy/plugins/context_indicator/register_callbacks.py
+++ b/code_puppy/plugins/context_indicator/register_callbacks.py
@@ -1,0 +1,157 @@
+"""Register callbacks for the ``context_indicator`` plugin.
+
+Hooks:
+
+* ``startup`` — wraps ``get_prompt_with_active_model`` to inject a colored
+  circle (🟢/🟡/🔴) reflecting current context-window usage.
+* ``custom_command`` / ``custom_command_help`` — exposes ``/context`` for a
+  detailed token-usage breakdown.
+
+Idempotent: re-installing the prompt patch is a no-op.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from code_puppy.callbacks import register_callback
+from code_puppy.plugins.context_indicator.usage import (
+    ContextUsage,
+    get_current_usage,
+)
+
+_COMMAND_NAME = "context"
+_PATCH_ATTR = "_context_indicator_original"
+
+
+# ---------------------------------------------------------------------------
+# Messaging helpers (lazy-imported to dodge circular imports at boot)
+# ---------------------------------------------------------------------------
+def _emit_info(message: str) -> None:
+    from code_puppy.messaging import emit_info
+
+    emit_info(message)
+
+
+def _emit_error(message: str) -> None:
+    from code_puppy.messaging import emit_error
+
+    emit_error(message)
+
+
+# ---------------------------------------------------------------------------
+# Prompt patching
+# ---------------------------------------------------------------------------
+def _build_indicator_tuple(usage: ContextUsage) -> Tuple[str, str]:
+    """Build the (style, text) tuple that gets inserted into the prompt."""
+    return ("class:context-indicator", f"{usage.indicator} ")
+
+
+def _inject_indicator(formatted_text):
+    """Return a new ``FormattedText`` with the usage indicator prepended.
+
+    Placed AFTER the dog emoji but BEFORE the puppy name so the colored
+    circle reads as a status badge for the prompt as a whole.
+    """
+    from prompt_toolkit.formatted_text import FormattedText
+
+    usage = get_current_usage()
+    if usage is None:
+        return formatted_text
+
+    try:
+        parts = list(formatted_text)
+        # Insert after the leading "🐶 " tuple (index 0) so the badge sits
+        # right next to the puppy. Fall back to prepend if shape changed.
+        insert_at = 1 if parts else 0
+        parts.insert(insert_at, _build_indicator_tuple(usage))
+        return FormattedText(parts)
+    except Exception:
+        return formatted_text
+
+
+def _install_prompt_patch() -> None:
+    """Monkey-patch ``get_prompt_with_active_model`` once."""
+    from code_puppy.command_line import prompt_toolkit_completion as ptc
+
+    if getattr(ptc, _PATCH_ATTR, None) is not None:
+        return  # Already patched
+
+    original = ptc.get_prompt_with_active_model
+    setattr(ptc, _PATCH_ATTR, original)
+
+    def patched(base: str = ">>> "):
+        result = original(base)
+        return _inject_indicator(result)
+
+    ptc.get_prompt_with_active_model = patched
+
+
+def _on_startup() -> None:
+    try:
+        _install_prompt_patch()
+    except Exception as exc:
+        _emit_error(f"context_indicator: failed to install prompt patch — {exc}")
+
+
+# ---------------------------------------------------------------------------
+# /context slash command
+# ---------------------------------------------------------------------------
+def _custom_help() -> List[Tuple[str, str]]:
+    return [
+        (
+            _COMMAND_NAME,
+            "Show context-window usage (tokens used vs. model capacity)",
+        )
+    ]
+
+
+def _format_usage_report(usage: ContextUsage) -> str:
+    bar_width = 30
+    filled = min(bar_width, max(0, int(round(usage.proportion * bar_width))))
+    bar = "█" * filled + "░" * (bar_width - filled)
+    return (
+        f"{usage.indicator} Context usage: {usage.percent:.1f}%\n"
+        f"  [{bar}]\n"
+        f"  Messages : {usage.used_tokens:,} tokens\n"
+        f"  Overhead : {usage.overhead_tokens:,} tokens (system prompt + tools)\n"
+        f"  Total    : {usage.total_tokens:,} / {usage.capacity:,} tokens\n"
+        f"  Buckets  : 🟢 <30%   🟡 30–60%   🔴 >60%"
+    )
+
+
+def _handle_context_command(command: str) -> bool:
+    usage = get_current_usage()
+    if usage is None:
+        _emit_info(
+            "🐶 No context info yet — load an agent and send a message first."
+        )
+        return True
+    _emit_info(_format_usage_report(usage))
+    return True
+
+
+def _handle_custom_command(command: str, name: str):
+    if name != _COMMAND_NAME:
+        return None
+    return _handle_context_command(command)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+register_callback("startup", _on_startup)
+register_callback("custom_command", _handle_custom_command)
+register_callback("custom_command_help", _custom_help)
+
+
+__all__ = [
+    "_build_indicator_tuple",
+    "_custom_help",
+    "_format_usage_report",
+    "_handle_context_command",
+    "_handle_custom_command",
+    "_inject_indicator",
+    "_install_prompt_patch",
+    "_on_startup",
+]

--- a/code_puppy/plugins/context_indicator/register_callbacks.py
+++ b/code_puppy/plugins/context_indicator/register_callbacks.py
@@ -116,7 +116,7 @@ def _format_usage_report(usage: ContextUsage) -> str:
         f"  Messages : {usage.used_tokens:,} tokens\n"
         f"  Overhead : {usage.overhead_tokens:,} tokens (system prompt + tools)\n"
         f"  Total    : {usage.total_tokens:,} / {usage.capacity:,} tokens\n"
-        f"  Buckets  : 🟢 <30%   🟡 30–60%   🔴 >60%"
+        f"  Buckets  : 🟢 <30%   🟡 30–<60%   🔴 ≥60%"
     )
 
 

--- a/code_puppy/plugins/context_indicator/register_callbacks.py
+++ b/code_puppy/plugins/context_indicator/register_callbacks.py
@@ -123,9 +123,7 @@ def _format_usage_report(usage: ContextUsage) -> str:
 def _handle_context_command(command: str) -> bool:
     usage = get_current_usage()
     if usage is None:
-        _emit_info(
-            "🐶 No context info yet — load an agent and send a message first."
-        )
+        _emit_info("🐶 No context info yet — load an agent and send a message first.")
         return True
     _emit_info(_format_usage_report(usage))
     return True

--- a/code_puppy/plugins/context_indicator/usage.py
+++ b/code_puppy/plugins/context_indicator/usage.py
@@ -10,7 +10,9 @@ from dataclasses import dataclass
 from typing import Optional
 
 # Thresholds (fractions of context window). Match the visual indicator buckets:
-#   <30% green, 30-60% yellow, >60% red.
+#   <30% green, 30–<60% yellow, ≥60% red.
+# Boundaries are exclusive on the upper end: e.g. exactly 0.30 → yellow,
+# exactly 0.60 → red. Keep ``_format_usage_report`` legend in sync.
 GREEN_THRESHOLD = 0.30
 YELLOW_THRESHOLD = 0.60
 
@@ -58,9 +60,11 @@ def pick_indicator(proportion: float) -> str:
 def get_current_usage() -> Optional[ContextUsage]:
     """Compute current context-window usage for the active agent.
 
-    Returns ``None`` if anything goes sideways (no agent loaded yet, model
-    config missing, etc.). Caller should treat ``None`` as "hide the
-    indicator" — never crash the prompt over a stat.
+    Returns ``None`` whenever any required piece of data is unavailable —
+    missing agent, missing model config, or *any* exception while estimating
+    history/used/overhead/capacity. We deliberately do **not** fall back to
+    zero on partial failures: a misleading 🟢 indicator is worse than no
+    indicator at all (the prompt simply hides the badge).
     """
     try:
         from code_puppy.agents.agent_manager import get_current_agent
@@ -76,23 +80,11 @@ def get_current_usage() -> Optional[ContextUsage]:
 
     try:
         history = agent.get_message_history() or []
-    except Exception:
-        history = []
-
-    try:
         used = sum(agent.estimate_tokens_for_message(m) for m in history)
-    except Exception:
-        used = 0
-
-    try:
         overhead = agent._estimate_context_overhead()
-    except Exception:
-        overhead = 0
-
-    try:
         capacity = agent._get_model_context_length()
     except Exception:
-        capacity = 0
+        return None
 
     if capacity <= 0:
         return None

--- a/code_puppy/plugins/context_indicator/usage.py
+++ b/code_puppy/plugins/context_indicator/usage.py
@@ -1,0 +1,104 @@
+"""Token usage calculation for the current agent's context window.
+
+Kept separate from ``register_callbacks.py`` so this stays unit-testable in
+isolation and so callbacks file remains thin.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+# Thresholds (fractions of context window). Match the visual indicator buckets:
+#   <30% green, 30-60% yellow, >60% red.
+GREEN_THRESHOLD = 0.30
+YELLOW_THRESHOLD = 0.60
+
+GREEN_CIRCLE = "🟢"
+YELLOW_CIRCLE = "🟡"
+RED_CIRCLE = "🔴"
+
+
+@dataclass(frozen=True)
+class ContextUsage:
+    """Snapshot of how full the current agent's context window is."""
+
+    used_tokens: int
+    overhead_tokens: int
+    capacity: int
+
+    @property
+    def total_tokens(self) -> int:
+        return self.used_tokens + self.overhead_tokens
+
+    @property
+    def proportion(self) -> float:
+        if self.capacity <= 0:
+            return 0.0
+        return self.total_tokens / self.capacity
+
+    @property
+    def percent(self) -> float:
+        return self.proportion * 100.0
+
+    @property
+    def indicator(self) -> str:
+        return pick_indicator(self.proportion)
+
+
+def pick_indicator(proportion: float) -> str:
+    """Pick the colored-circle emoji for a given usage proportion (0..1)."""
+    if proportion < GREEN_THRESHOLD:
+        return GREEN_CIRCLE
+    if proportion < YELLOW_THRESHOLD:
+        return YELLOW_CIRCLE
+    return RED_CIRCLE
+
+
+def get_current_usage() -> Optional[ContextUsage]:
+    """Compute current context-window usage for the active agent.
+
+    Returns ``None`` if anything goes sideways (no agent loaded yet, model
+    config missing, etc.). Caller should treat ``None`` as "hide the
+    indicator" — never crash the prompt over a stat.
+    """
+    try:
+        from code_puppy.agents.agent_manager import get_current_agent
+    except Exception:
+        return None
+
+    try:
+        agent = get_current_agent()
+    except Exception:
+        return None
+    if agent is None:
+        return None
+
+    try:
+        history = agent.get_message_history() or []
+    except Exception:
+        history = []
+
+    try:
+        used = sum(agent.estimate_tokens_for_message(m) for m in history)
+    except Exception:
+        used = 0
+
+    try:
+        overhead = agent._estimate_context_overhead()
+    except Exception:
+        overhead = 0
+
+    try:
+        capacity = agent._get_model_context_length()
+    except Exception:
+        capacity = 0
+
+    if capacity <= 0:
+        return None
+
+    return ContextUsage(
+        used_tokens=int(used),
+        overhead_tokens=int(overhead),
+        capacity=int(capacity),
+    )

--- a/tests/plugins/test_context_indicator_plugin.py
+++ b/tests/plugins/test_context_indicator_plugin.py
@@ -1,0 +1,245 @@
+"""Tests for the context_indicator plugin."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _plugin_module():
+    sys.modules.setdefault("dbos", MagicMock())
+    _ensure_agent_manager_stub()
+    return importlib.import_module(
+        "code_puppy.plugins.context_indicator.register_callbacks"
+    )
+
+
+def _ensure_agent_manager_stub():
+    """Stub ``code_puppy.agents.agent_manager`` so ``patch()`` can target it.
+
+    Importing the real module pulls in MCP dependencies that aren't installed
+    in the test environment. The plugin only ever calls
+    ``get_current_agent`` — a stub with that attribute is plenty.
+    """
+    if "code_puppy.agents.agent_manager" in sys.modules:
+        return
+    stub = MagicMock()
+    stub.get_current_agent = MagicMock(side_effect=RuntimeError("unstubbed"))
+    sys.modules["code_puppy.agents.agent_manager"] = stub
+    # Also ensure parent ``code_puppy.agents`` namespace knows about it.
+    agents_pkg = sys.modules.get("code_puppy.agents")
+    if agents_pkg is not None:
+        setattr(agents_pkg, "agent_manager", stub)
+
+
+def _usage_module():
+    _ensure_agent_manager_stub()
+    return importlib.import_module("code_puppy.plugins.context_indicator.usage")
+
+
+# ---------------------------------------------------------------------------
+# pick_indicator threshold logic
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "proportion,expected",
+    [
+        (0.0, "🟢"),
+        (0.05, "🟢"),
+        (0.299, "🟢"),
+        (0.30, "🟡"),
+        (0.45, "🟡"),
+        (0.599, "🟡"),
+        (0.60, "🔴"),
+        (0.85, "🔴"),
+        (1.50, "🔴"),
+    ],
+)
+def test_pick_indicator_buckets(proportion, expected):
+    assert _usage_module().pick_indicator(proportion) == expected
+
+
+# ---------------------------------------------------------------------------
+# ContextUsage dataclass
+# ---------------------------------------------------------------------------
+def test_context_usage_proportion_and_percent():
+    usage = _usage_module().ContextUsage(
+        used_tokens=4000, overhead_tokens=1000, capacity=10000
+    )
+    assert usage.total_tokens == 5000
+    assert usage.proportion == 0.5
+    assert usage.percent == 50.0
+    assert usage.indicator == "🟡"
+
+
+def test_context_usage_zero_capacity_safe():
+    usage = _usage_module().ContextUsage(
+        used_tokens=10, overhead_tokens=10, capacity=0
+    )
+    assert usage.proportion == 0.0
+    assert usage.indicator == "🟢"
+
+
+# ---------------------------------------------------------------------------
+# get_current_usage — defensive paths
+# ---------------------------------------------------------------------------
+def test_get_current_usage_returns_none_when_agent_missing():
+    mod = _usage_module()
+    with patch(
+        "code_puppy.agents.agent_manager.get_current_agent",
+        side_effect=RuntimeError("nope"),
+    ):
+        assert mod.get_current_usage() is None
+
+
+def test_get_current_usage_returns_none_when_capacity_zero():
+    mod = _usage_module()
+    fake_agent = MagicMock()
+    fake_agent.get_message_history.return_value = []
+    fake_agent.estimate_tokens_for_message.return_value = 0
+    fake_agent._estimate_context_overhead.return_value = 0
+    fake_agent._get_model_context_length.return_value = 0
+    with patch(
+        "code_puppy.agents.agent_manager.get_current_agent",
+        return_value=fake_agent,
+    ):
+        assert mod.get_current_usage() is None
+
+
+def test_get_current_usage_computes_totals():
+    mod = _usage_module()
+    fake_agent = MagicMock()
+    fake_agent.get_message_history.return_value = ["m1", "m2", "m3"]
+    fake_agent.estimate_tokens_for_message.side_effect = lambda m: 1000
+    fake_agent._estimate_context_overhead.return_value = 500
+    fake_agent._get_model_context_length.return_value = 10000
+    with patch(
+        "code_puppy.agents.agent_manager.get_current_agent",
+        return_value=fake_agent,
+    ):
+        usage = mod.get_current_usage()
+    assert usage is not None
+    assert usage.used_tokens == 3000
+    assert usage.overhead_tokens == 500
+    assert usage.capacity == 10000
+    assert usage.total_tokens == 3500
+    assert usage.indicator == "🟡"  # 35%
+
+
+# ---------------------------------------------------------------------------
+# Prompt patch
+# ---------------------------------------------------------------------------
+def test_install_prompt_patch_is_idempotent():
+    module = _plugin_module()
+    from code_puppy.command_line import prompt_toolkit_completion as ptc
+
+    original = ptc.get_prompt_with_active_model
+    try:
+        module._install_prompt_patch()
+        first = ptc.get_prompt_with_active_model
+        module._install_prompt_patch()
+        second = ptc.get_prompt_with_active_model
+        assert first is second
+        assert getattr(ptc, "_context_indicator_original") is original
+    finally:
+        ptc.get_prompt_with_active_model = original
+        if hasattr(ptc, "_context_indicator_original"):
+            delattr(ptc, "_context_indicator_original")
+
+
+def test_inject_indicator_returns_unchanged_when_usage_none():
+    module = _plugin_module()
+    from prompt_toolkit.formatted_text import FormattedText
+
+    original = FormattedText([("bold", "🐶 "), ("class:arrow", ">>> ")])
+    with patch(
+        "code_puppy.plugins.context_indicator.register_callbacks.get_current_usage",
+        return_value=None,
+    ):
+        result = module._inject_indicator(original)
+    assert result is original
+
+
+def test_inject_indicator_inserts_circle_after_dog():
+    module = _plugin_module()
+    from prompt_toolkit.formatted_text import FormattedText
+
+    fake_usage = _usage_module().ContextUsage(
+        used_tokens=100, overhead_tokens=0, capacity=10000
+    )
+    original = FormattedText([("bold", "🐶 "), ("class:arrow", ">>> ")])
+    with patch(
+        "code_puppy.plugins.context_indicator.register_callbacks.get_current_usage",
+        return_value=fake_usage,
+    ):
+        result = module._inject_indicator(original)
+
+    parts = list(result)
+    assert parts[0] == ("bold", "🐶 ")
+    assert parts[1][0] == "class:context-indicator"
+    assert "🟢" in parts[1][1]
+
+
+# ---------------------------------------------------------------------------
+# /context slash command
+# ---------------------------------------------------------------------------
+def test_custom_help_lists_command():
+    entries = dict(_plugin_module()._custom_help())
+    assert "context" in entries
+
+
+def test_handle_custom_command_ignores_unrelated_names():
+    assert _plugin_module()._handle_custom_command("/nope", "nope") is None
+
+
+def test_handle_context_command_emits_info_when_usage_present():
+    module = _plugin_module()
+    fake_usage = _usage_module().ContextUsage(
+        used_tokens=2000, overhead_tokens=500, capacity=10000
+    )
+    with (
+        patch(
+            "code_puppy.plugins.context_indicator.register_callbacks.get_current_usage",
+            return_value=fake_usage,
+        ),
+        patch(
+            "code_puppy.plugins.context_indicator.register_callbacks._emit_info"
+        ) as mock_info,
+    ):
+        result = module._handle_custom_command("/context", "context")
+    assert result is True
+    mock_info.assert_called_once()
+    msg = mock_info.call_args[0][0]
+    assert "25.0%" in msg
+    assert "🟢" in msg
+
+
+def test_handle_context_command_emits_friendly_message_when_no_usage():
+    module = _plugin_module()
+    with (
+        patch(
+            "code_puppy.plugins.context_indicator.register_callbacks.get_current_usage",
+            return_value=None,
+        ),
+        patch(
+            "code_puppy.plugins.context_indicator.register_callbacks._emit_info"
+        ) as mock_info,
+    ):
+        result = module._handle_custom_command("/context", "context")
+    assert result is True
+    mock_info.assert_called_once()
+    assert "No context info" in mock_info.call_args[0][0]
+
+
+def test_format_usage_report_includes_progress_bar():
+    module = _plugin_module()
+    usage = _usage_module().ContextUsage(
+        used_tokens=6000, overhead_tokens=1000, capacity=10000
+    )
+    report = module._format_usage_report(usage)
+    assert "🔴" in report
+    assert "70.0%" in report
+    assert "█" in report
+    assert "░" in report

--- a/tests/plugins/test_context_indicator_plugin.py
+++ b/tests/plugins/test_context_indicator_plugin.py
@@ -75,9 +75,7 @@ def test_context_usage_proportion_and_percent():
 
 
 def test_context_usage_zero_capacity_safe():
-    usage = _usage_module().ContextUsage(
-        used_tokens=10, overhead_tokens=10, capacity=0
-    )
+    usage = _usage_module().ContextUsage(used_tokens=10, overhead_tokens=10, capacity=0)
     assert usage.proportion == 0.0
     assert usage.indicator == "🟢"
 

--- a/tests/plugins/test_context_indicator_plugin.py
+++ b/tests/plugins/test_context_indicator_plugin.py
@@ -79,9 +79,7 @@ def test_context_usage_proportion_and_percent():
 
 
 def test_context_usage_zero_capacity_safe():
-    usage = _usage_module().ContextUsage(
-        used_tokens=10, overhead_tokens=10, capacity=0
-    )
+    usage = _usage_module().ContextUsage(used_tokens=10, overhead_tokens=10, capacity=0)
     assert usage.proportion == 0.0
     assert usage.indicator == "🟢"
 
@@ -92,6 +90,31 @@ def test_context_usage_zero_capacity_safe():
 def test_get_current_usage_returns_none_when_agent_missing(stub_agent_manager):
     mod = _usage_module()
     stub_agent_manager.get_current_agent.side_effect = RuntimeError("nope")
+    assert mod.get_current_usage() is None
+
+
+def test_get_current_usage_returns_none_when_estimator_raises(stub_agent_manager):
+    """If *any* estimator blows up we hide the indicator rather than lying."""
+    mod = _usage_module()
+    fake_agent = MagicMock()
+    fake_agent.get_message_history.return_value = ["m1"]
+    fake_agent.estimate_tokens_for_message.side_effect = RuntimeError("boom")
+    fake_agent._estimate_context_overhead.return_value = 0
+    fake_agent._get_model_context_length.return_value = 10000
+    stub_agent_manager.get_current_agent.side_effect = None
+    stub_agent_manager.get_current_agent.return_value = fake_agent
+    assert mod.get_current_usage() is None
+
+
+def test_get_current_usage_returns_none_when_overhead_raises(stub_agent_manager):
+    mod = _usage_module()
+    fake_agent = MagicMock()
+    fake_agent.get_message_history.return_value = []
+    fake_agent.estimate_tokens_for_message.return_value = 0
+    fake_agent._estimate_context_overhead.side_effect = RuntimeError("boom")
+    fake_agent._get_model_context_length.return_value = 10000
+    stub_agent_manager.get_current_agent.side_effect = None
+    stub_agent_manager.get_current_agent.return_value = fake_agent
     assert mod.get_current_usage() is None
 
 

--- a/tests/plugins/test_context_indicator_plugin.py
+++ b/tests/plugins/test_context_indicator_plugin.py
@@ -1,4 +1,14 @@
-"""Tests for the context_indicator plugin."""
+"""Tests for the context_indicator plugin.
+
+Important: we do **not** permanently inject a stub for
+``code_puppy.agents.agent_manager`` into ``sys.modules``. Doing so at import
+time would leak the MagicMock to every other test that imports the real
+``agent_manager`` afterwards, causing order-dependent failures.
+
+Instead, the ``stub_agent_manager`` fixture below uses ``monkeypatch`` so the
+stub is automatically torn down after the test. Tests that don't actually
+exercise ``get_current_agent`` don't take the fixture at all.
+"""
 
 from __future__ import annotations
 
@@ -10,34 +20,28 @@ import pytest
 
 
 def _plugin_module():
-    sys.modules.setdefault("dbos", MagicMock())
-    _ensure_agent_manager_stub()
     return importlib.import_module(
         "code_puppy.plugins.context_indicator.register_callbacks"
     )
 
 
-def _ensure_agent_manager_stub():
-    """Stub ``code_puppy.agents.agent_manager`` so ``patch()`` can target it.
+def _usage_module():
+    return importlib.import_module("code_puppy.plugins.context_indicator.usage")
 
-    Importing the real module pulls in MCP dependencies that aren't installed
-    in the test environment. The plugin only ever calls
-    ``get_current_agent`` — a stub with that attribute is plenty.
+
+@pytest.fixture
+def stub_agent_manager(monkeypatch):
+    """Provide a scoped stub for ``code_puppy.agents.agent_manager``.
+
+    The plugin only ever calls ``get_current_agent`` from that module, so a
+    bare ``MagicMock`` with that attribute is enough. ``monkeypatch.setitem``
+    guarantees ``sys.modules`` is restored to its previous state when the
+    test ends — no leakage to siblings.
     """
-    if "code_puppy.agents.agent_manager" in sys.modules:
-        return
     stub = MagicMock()
     stub.get_current_agent = MagicMock(side_effect=RuntimeError("unstubbed"))
-    sys.modules["code_puppy.agents.agent_manager"] = stub
-    # Also ensure parent ``code_puppy.agents`` namespace knows about it.
-    agents_pkg = sys.modules.get("code_puppy.agents")
-    if agents_pkg is not None:
-        setattr(agents_pkg, "agent_manager", stub)
-
-
-def _usage_module():
-    _ensure_agent_manager_stub()
-    return importlib.import_module("code_puppy.plugins.context_indicator.usage")
+    monkeypatch.setitem(sys.modules, "code_puppy.agents.agent_manager", stub)
+    return stub
 
 
 # ---------------------------------------------------------------------------
@@ -75,7 +79,9 @@ def test_context_usage_proportion_and_percent():
 
 
 def test_context_usage_zero_capacity_safe():
-    usage = _usage_module().ContextUsage(used_tokens=10, overhead_tokens=10, capacity=0)
+    usage = _usage_module().ContextUsage(
+        used_tokens=10, overhead_tokens=10, capacity=0
+    )
     assert usage.proportion == 0.0
     assert usage.indicator == "🟢"
 
@@ -83,41 +89,34 @@ def test_context_usage_zero_capacity_safe():
 # ---------------------------------------------------------------------------
 # get_current_usage — defensive paths
 # ---------------------------------------------------------------------------
-def test_get_current_usage_returns_none_when_agent_missing():
+def test_get_current_usage_returns_none_when_agent_missing(stub_agent_manager):
     mod = _usage_module()
-    with patch(
-        "code_puppy.agents.agent_manager.get_current_agent",
-        side_effect=RuntimeError("nope"),
-    ):
-        assert mod.get_current_usage() is None
+    stub_agent_manager.get_current_agent.side_effect = RuntimeError("nope")
+    assert mod.get_current_usage() is None
 
 
-def test_get_current_usage_returns_none_when_capacity_zero():
+def test_get_current_usage_returns_none_when_capacity_zero(stub_agent_manager):
     mod = _usage_module()
     fake_agent = MagicMock()
     fake_agent.get_message_history.return_value = []
     fake_agent.estimate_tokens_for_message.return_value = 0
     fake_agent._estimate_context_overhead.return_value = 0
     fake_agent._get_model_context_length.return_value = 0
-    with patch(
-        "code_puppy.agents.agent_manager.get_current_agent",
-        return_value=fake_agent,
-    ):
-        assert mod.get_current_usage() is None
+    stub_agent_manager.get_current_agent.side_effect = None
+    stub_agent_manager.get_current_agent.return_value = fake_agent
+    assert mod.get_current_usage() is None
 
 
-def test_get_current_usage_computes_totals():
+def test_get_current_usage_computes_totals(stub_agent_manager):
     mod = _usage_module()
     fake_agent = MagicMock()
     fake_agent.get_message_history.return_value = ["m1", "m2", "m3"]
     fake_agent.estimate_tokens_for_message.side_effect = lambda m: 1000
     fake_agent._estimate_context_overhead.return_value = 500
     fake_agent._get_model_context_length.return_value = 10000
-    with patch(
-        "code_puppy.agents.agent_manager.get_current_agent",
-        return_value=fake_agent,
-    ):
-        usage = mod.get_current_usage()
+    stub_agent_manager.get_current_agent.side_effect = None
+    stub_agent_manager.get_current_agent.return_value = fake_agent
+    usage = mod.get_current_usage()
     assert usage is not None
     assert usage.used_tokens == 3000
     assert usage.overhead_tokens == 500


### PR DESCRIPTION
## Summary

Adds a tiny ergonomics plugin that surfaces context-window usage:

* A colored circle in the terminal prompt right after 🐶:
  * 🟢 under 30% used
  * 🟡 30–60% used
  * 🔴 over 60% used
* A new `/context` slash command that prints a token-usage breakdown
  (messages vs. system/tools overhead vs. total / capacity) plus a
  little progress bar.

## Demo

```
🐶 🟡 puppy [code-puppy] [openai:gpt-5] (~/proj) >>>

> /context
🟡 Context usage: 50.0%
  [███████████████░░░░░░░░░░░░░░░]
  Messages : 4,500 tokens
  Overhead : 500 tokens (system prompt + tools)
  Total    : 5,000 / 10,000 tokens
  Buckets  : 🟢 <30%   🟡 30–60%   🔴 >60%
```

## Design

* **Plugin-only.** No edits to `code_puppy/command_line/` or anywhere
  in core. Uses the documented `startup`, `custom_command`, and
  `custom_command_help` hooks per `CONTRIBUTING.md`.
* **Idempotent prompt patch** on `get_prompt_with_active_model` —
  original is stashed on the module so re-installation is a no-op
  (mirrors the pattern from `prompt_newline`).
* **Token math reuses the agent's own helpers**
  (`estimate_tokens_for_message`, `_estimate_context_overhead`,
  `_get_model_context_length`) so the indicator stays in lockstep with
  the numbers the compaction subsystem already computes.
* **Defensive everywhere.** Any exception inside usage computation
  hides the indicator instead of crashing the prompt — the colored
  circle is a status badge, not a load-bearing dependency.
* **Single Responsibility split:** `usage.py` knows tokens,
  `register_callbacks.py` knows prompt-toolkit and slash commands. ~100
  lines each, well under the 600-line cap.

## Tests

`tests/plugins/test_context_indicator_plugin.py` — **22 cases** covering:

* All three threshold buckets at edge values (0%, 29.9%, 30%, 59.9%, 60%, 150%)
* `ContextUsage` proportion / percent / indicator math
* Defensive `None` returns when no agent / capacity is zero / imports fail
* Idempotent prompt patching (re-install is no-op, original is preserved)
* Indicator placement (after the 🐶 tuple, before the puppy name)
* `/context` command (success path, no-usage path, ignores unrelated names)
* Progress-bar rendering

## Files

```
code_puppy/plugins/context_indicator/
├── __init__.py              # docstring + sentinel
├── usage.py                 # token-counting + ContextUsage dataclass (~100 LOC)
└── register_callbacks.py    # prompt patch + /context command (~150 LOC)
tests/plugins/test_context_indicator_plugin.py
```

No new dependencies. No core file modifications.
