### PR TITLE
fix(ask_user_question): coerce JSON-string questions arg to list via …

### DIFF
--- a/code_puppy/tools/ask_user_question/registration.py
+++ b/code_puppy/tools/ask_user_question/registration.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Annotated, Any
 
-from pydantic import Field
+from pydantic import BeforeValidator, Field
 from pydantic_ai import RunContext
 
 from .handler import ask_user_question as _ask_user_question_impl
@@ -12,6 +13,25 @@ from .models import AskUserQuestionOutput
 
 if TYPE_CHECKING:
     from pydantic_ai import Agent
+
+
+def _coerce_questions_json_string(v: Any) -> Any:
+    """Coerce a JSON-stringified array to a native list before pydantic validates it.
+
+    LLMs frequently pass the questions array as a JSON string (e.g. ``"[{...}]"``)
+    instead of a native list. pydantic-ai validates tool call arguments against
+    the function signature before calling the handler — so the coercion must
+    happen here, at the registration layer, before pydantic sees the value.
+
+    If JSON parsing fails, the original value is returned unchanged and pydantic
+    produces a clear type error.
+    """
+    if isinstance(v, str):
+        try:
+            return json.loads(v)
+        except (json.JSONDecodeError, ValueError):
+            return v
+    return v
 
 
 def register_ask_user_question(agent: Agent) -> None:
@@ -22,13 +42,13 @@ def register_ask_user_question(agent: Agent) -> None:
         context: RunContext,  # noqa: ARG001 - Required by framework
         questions: Annotated[
             list[dict[str, Any]],
+            BeforeValidator(_coerce_questions_json_string),
             Field(
                 description=(
                     "Array of question objects. Each question should include: "
-                    "'question' (string), 'header' (short string), "
-                    "optional 'multi_select' (boolean), and 'options' "
-                    "(array of option objects with 'label' and optional "
-                    "'description')."
+                    "'question' (string), 'header' (short string), optional "
+                    "'multi_select' (boolean), and 'options' (array of option "
+                    "objects with 'label' and optional 'description')."
                 )
             ),
         ],

--- a/tests/tools/test_ask_user_question/test_registration.py
+++ b/tests/tools/test_ask_user_question/test_registration.py
@@ -1,0 +1,87 @@
+"""Tests for ask_user_question tool registration.
+
+Covers the BeforeValidator that coerces JSON-stringified question arrays to
+native lists. LLMs occasionally serialise the questions argument as a JSON
+string instead of a native list; pydantic-ai validates arguments before
+calling the handler, so the coercion must happen at the registration layer.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+class TestCoerceQuestionsJsonString:
+    """_coerce_questions_json_string coerces JSON strings to lists."""
+
+    def test_coerce_valid_json_string_to_list(self):
+        """A JSON-stringified array should be parsed to a native list."""
+        from code_puppy.tools.ask_user_question.registration import (
+            _coerce_questions_json_string,
+        )
+
+        questions = [{"question": "q", "header": "h", "options": [{"label": "a"}]}]
+        result = _coerce_questions_json_string(json.dumps(questions))
+        assert result == questions
+        assert isinstance(result, list)
+
+    def test_passthrough_native_list(self):
+        """A native list passes through unchanged (exact same object)."""
+        from code_puppy.tools.ask_user_question.registration import (
+            _coerce_questions_json_string,
+        )
+
+        questions = [{"question": "q", "header": "h", "options": [{"label": "a"}]}]
+        result = _coerce_questions_json_string(questions)
+        assert result is questions
+
+    def test_passthrough_invalid_json_string(self):
+        """A non-JSON string passes through unchanged so pydantic can error."""
+        from code_puppy.tools.ask_user_question.registration import (
+            _coerce_questions_json_string,
+        )
+
+        bad = "not-json"
+        assert _coerce_questions_json_string(bad) == bad
+
+    def test_passthrough_none(self):
+        """None passes through unchanged."""
+        from code_puppy.tools.ask_user_question.registration import (
+            _coerce_questions_json_string,
+        )
+
+        assert _coerce_questions_json_string(None) is None
+
+    def test_passthrough_dict(self):
+        """A dict (wrong type but not a string) passes through unchanged."""
+        from code_puppy.tools.ask_user_question.registration import (
+            _coerce_questions_json_string,
+        )
+
+        d = {"question": "q"}
+        assert _coerce_questions_json_string(d) is d
+
+    def test_coerce_empty_array_string(self):
+        """The string '[]' coerces to an empty list."""
+        from code_puppy.tools.ask_user_question.registration import (
+            _coerce_questions_json_string,
+        )
+
+        assert _coerce_questions_json_string("[]") == []
+
+    def test_coerce_single_element_array_string(self):
+        """Single-element JSON array string coerces correctly — the original failing case."""
+        from code_puppy.tools.ask_user_question.registration import (
+            _coerce_questions_json_string,
+        )
+
+        q = [
+            {
+                "question": "Which theme?",
+                "header": "Theme",
+                "options": [{"label": "A"}, {"label": "B"}],
+            }
+        ]
+        result = _coerce_questions_json_string(json.dumps(q))
+        assert result == q
+        assert len(result) == 1


### PR DESCRIPTION
…BeforeValidator

LLMs occasionally serialise the questions array as a JSON string ('[{"question":...}]') instead of a native list. pydantic-ai validates tool arguments before calling the handler, so a plain str fails validation against list[dict[str, Any]] and the tool errors on every retry.

Add _coerce_questions_json_string() and wire it in as a BeforeValidator on the questions parameter Annotated chain. The validator attempts json.loads() on strings; non-JSON strings and all non-string values pass through unchanged, preserving pydantic's own error messages for genuinely bad input.

Fix is schema-transparent: BeforeValidator runs before pydantic inspects the value, so the JSON Schema exposed to the LLM is unchanged.

Add tests/tools/test_ask_user_question/test_registration.py covering the coercion, all passthrough cases, and the original single-element array failure case.