### PR TITLE
fix(mcp): initialise ManagedMCPServer._enabled from ServerConfig.enabled

### DIFF
--- a/code_puppy/mcp_/managed_server.py
+++ b/code_puppy/mcp_/managed_server.py
@@ -130,8 +130,7 @@ class ManagedMCPServer:
             Union[MCPServerSSE, MCPServerStdio, MCPServerStreamableHTTP]
         ] = None
         self._state = ServerState.STOPPED
-        # Always start disabled - servers must be explicitly started with /mcp start
-        self._enabled = False
+        self._enabled = server_config.enabled
         self._quarantine_until: Optional[datetime] = None
         self._start_time: Optional[datetime] = None
         self._stop_time: Optional[datetime] = None

--- a/tests/mcp/test_managed_server.py
+++ b/tests/mcp/test_managed_server.py
@@ -10,6 +10,7 @@ import pytest
 from code_puppy.mcp_.managed_server import (
     ManagedMCPServer,
     ServerConfig,
+    ServerState,
     _expand_env_vars,
 )
 
@@ -164,3 +165,57 @@ def test_expand_env_vars_non_string():
     assert _expand_env_vars(3.14) == 3.14
     assert _expand_env_vars(True) is True
     assert _expand_env_vars(None) is None
+
+
+class TestManagedMCPServerEnableFromConfig:
+    """ManagedMCPServer._enabled should be initialised from ServerConfig.enabled.
+
+    Before this fix, __init__ hardcoded ``self._enabled = False`` regardless
+    of ``server_config.enabled``.  Every server therefore required an explicit
+    ``/mcp start`` command before ``get_servers_for_agent()`` would include it.
+    """
+
+    def _make_config(self, enabled: bool) -> ServerConfig:
+        return ServerConfig(
+            id="test-id",
+            name="test-server",
+            type="stdio",
+            enabled=enabled,
+            config={"command": "echo", "args": []},
+        )
+
+    def test_enabled_true_in_config_makes_server_enabled(self):
+        """ServerConfig(enabled=True) → is_enabled() is True right after construction."""
+        server = ManagedMCPServer(self._make_config(enabled=True))
+        assert server.is_enabled() is True
+
+    def test_enabled_false_in_config_makes_server_disabled(self):
+        """ServerConfig(enabled=False) → is_enabled() is False right after construction."""
+        server = ManagedMCPServer(self._make_config(enabled=False))
+        assert server.is_enabled() is False
+
+    def test_enabled_flag_and_tracker_state_are_independent(self):
+        """is_enabled() can be True while tracker state stays STOPPED.
+
+        The enabled flag gates get_servers_for_agent() — it makes the server
+        visible to pydantic-ai immediately on launch.  The tracker state only
+        advances to RUNNING after start_server() actually spawns a subprocess
+        and calls record_start_time().  Conflating the two caused
+        ``/mcp status`` to show ``State: ✓ Run, Uptime: -`` because
+        record_start_time() was never called.
+        """
+        server = ManagedMCPServer(self._make_config(enabled=True))
+        assert server.is_enabled() is True
+        # Internal _state is set in __init__ — it should still be STOPPED
+        assert server._state == ServerState.STOPPED
+
+    def test_enable_disable_still_work_as_runtime_overrides(self):
+        """enable()/disable() remain valid for explicit runtime control."""
+        server = ManagedMCPServer(self._make_config(enabled=False))
+        assert server.is_enabled() is False
+
+        server.enable()
+        assert server.is_enabled() is True
+
+        server.disable()
+        assert server.is_enabled() is False

--- a/tests/mcp/test_managed_server_coverage.py
+++ b/tests/mcp/test_managed_server_coverage.py
@@ -143,7 +143,7 @@ class TestManagedMCPServerInit:
             server = ManagedMCPServer(config)
 
         assert server._state == ServerState.STOPPED
-        assert server._enabled is False  # Always starts disabled
+        assert server._enabled is True  # Reflects ServerConfig.enabled (default True)
         assert server._quarantine_until is None
         assert server._start_time is None
         assert server._stop_time is None
@@ -201,6 +201,7 @@ class TestGetPydanticServer:
             id="test-id",
             name="test-server",
             type="sse",
+            enabled=False,
             config={"url": "http://localhost:8080"},
         )
 
@@ -208,7 +209,7 @@ class TestGetPydanticServer:
             mock_sse.return_value = MagicMock()
             server = ManagedMCPServer(config)
 
-        # Server starts disabled by default
+        # Explicitly disabled via ServerConfig.enabled=False
         assert server._enabled is False
 
         with pytest.raises(RuntimeError, match="disabled or quarantined"):
@@ -677,6 +678,7 @@ class TestEnableDisable:
             id="test-id",
             name="test-server",
             type="sse",
+            enabled=False,
             config={"url": "http://localhost:8080"},
         )
 
@@ -685,7 +687,7 @@ class TestEnableDisable:
             server = ManagedMCPServer(config)
 
         assert server._state == ServerState.STOPPED
-        assert server._enabled is False
+        assert server._enabled is False  # Explicitly disabled via config
 
         server.enable()
 
@@ -721,6 +723,7 @@ class TestEnableDisable:
             id="test-id",
             name="test-server",
             type="sse",
+            enabled=False,
             config={"url": "http://localhost:8080"},
         )
 
@@ -728,7 +731,7 @@ class TestEnableDisable:
             mock_sse.return_value = MagicMock()
             server = ManagedMCPServer(config)
 
-        assert server.is_enabled() is False
+        assert server.is_enabled() is False  # Explicitly disabled via config
         server.enable()
         assert server.is_enabled() is True
         server.disable()
@@ -806,6 +809,7 @@ class TestQuarantine:
             id="test-id",
             name="test-server",
             type="sse",
+            enabled=False,
             config={"url": "http://localhost:8080"},
         )
 
@@ -813,7 +817,7 @@ class TestQuarantine:
             mock_sse.return_value = MagicMock()
             server = ManagedMCPServer(config)
 
-        # Don't enable - stay disabled
+        # Explicitly disabled via config - stays disabled
         server._quarantine_until = datetime.now() - timedelta(seconds=1)
         server._state = ServerState.QUARANTINED
 
@@ -1014,6 +1018,7 @@ class TestGetStatus:
             id="test-id",
             name="test-server",
             type="sse",
+            enabled=False,
             config={"url": "http://localhost:8080"},
         )
 
@@ -1027,7 +1032,7 @@ class TestGetStatus:
         assert status["name"] == "test-server"
         assert status["type"] == "sse"
         assert status["state"] == "stopped"
-        assert status["enabled"] is False
+        assert status["enabled"] is False  # Explicitly disabled via config
         assert status["quarantined"] is False
         assert status["quarantine_remaining_seconds"] is None
         assert status["uptime_seconds"] is None


### PR DESCRIPTION
 ### Problem

 ManagedMCPServer.__init__ hardcodes self._enabled = False regardless of the
 enabled field on ServerConfig. Since ServerConfig.enabled defaults to True for
 every server in mcp_servers.json, this field was silently ignored on every
 startup. Every server required an explicit /mcp start <name> command before
 get_servers_for_agent() would include it — a silent UX regression for anyone with
 servers configured.

 ### Fix

 One line in __init__:
 `python
 # Before
 self._enabled = False

 # After
 self._enabled = server_config.enabled
 `

 enable() and disable() remain valid for explicit runtime control and now operate
 on top of the configured default rather than always starting from False.

 ### The enabled flag and tracker state are intentionally separate

 - is_enabled() — gates get_servers_for_agent(); set from config at construction;
 makes servers visible to pydantic-ai immediately on launch
 - tracker state — stays STOPPED until start_server() actually spawns a subprocess
 and calls record_start_time()

 Conflating the two (setting tracker to RUNNING at init) causes /mcp status to
 display State: ✓ Run, Uptime: - because record_start_time() is never called
 during flag initialisation.

 ### Tests

 Added TestManagedMCPServerEnableFromConfig to tests/mcp/test_managed_server.py (4
 cases). Also corrected 5 pre-existing assertions in
 test_managed_server_coverage.py that had been codifying the buggy False default.