### PR TITLE
feat(models): add safe description overlays for model metadata + surface descriptions in model picker/settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ That's it. The plugin loader auto-discovers `register_callbacks.py` in subdirs.
 | `register_model_type` | Custom model type | `() -> list[dict]` with `{"type": str, "handler": callable}` |
 | `load_model_config` | Patch model config | `(*args, **kwargs) -> Any` |
 | `load_models_config` | Inject models | `() -> dict` |
+| `load_model_descriptions` | Inject description overlays | `() -> dict[str, str]` |
 | `get_model_system_prompt` | Per-model prompt | `(model_name, default_prompt, user_prompt) -> dict \| None` |
 | `stream_event` | Response streaming | `(event_type, event_data, agent_session_id=None) -> None` |
 | `pre_mcp_autostart` | Before bound MCP servers auto-start | `(agent_name, server_names) -> None` (refresh tokens / mint creds here) |

--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -17,6 +17,7 @@ PhaseType = Literal[
     "run_shell_command",
     "load_model_config",
     "load_models_config",
+    "load_model_descriptions",
     "load_prompt",
     "agent_reload",
     "custom_command",
@@ -64,6 +65,7 @@ _callbacks: Dict[PhaseType, List[CallbackFunc]] = {
     "run_shell_command": [],
     "load_model_config": [],
     "load_models_config": [],
+    "load_model_descriptions": [],
     "load_prompt": [],
     "agent_reload": [],
     "custom_command": [],
@@ -255,6 +257,19 @@ def on_load_models_config() -> List[Any]:
         List of model config dicts from all registered callbacks.
     """
     return _trigger_callbacks_sync("load_models_config")
+
+
+def on_load_model_descriptions() -> List[Any]:
+    """Trigger callbacks that provide description-only model overlays.
+
+    Plugins can return dictionaries mapping ``model_name -> description``.
+    These overlays are applied after config merges, so only missing
+    descriptions are injected and model configuration fields are untouched.
+
+    Returns:
+        List of description overlay dicts from all registered callbacks.
+    """
+    return _trigger_callbacks_sync("load_model_descriptions")
 
 
 def on_edit_file(*args, **kwargs) -> Any:

--- a/code_puppy/command_line/model_picker_completion.py
+++ b/code_puppy/command_line/model_picker_completion.py
@@ -22,11 +22,15 @@ from code_puppy.model_switching import set_model_and_reload_agent
 MODEL_PICKER_PAGE_SIZE = 15
 
 
-def load_model_names():
-    """Load model names from the config that's fetched from the endpoint."""
+def _load_models_config() -> dict:
     from code_puppy.model_factory import ModelFactory
 
-    models_config = ModelFactory.load_config()
+    return ModelFactory.load_config()
+
+
+def load_model_names():
+    """Load model names from the config that's fetched from the endpoint."""
+    models_config = _load_models_config()
     return list(models_config.keys())
 
 
@@ -74,6 +78,10 @@ class ModelNameCompleter(Completer):
         ].lstrip()
         start_position = -(len(text_after_trigger))
 
+        from code_puppy.model_descriptions import get_model_description
+
+        models_config = _load_models_config()
+
         # Filter model names based on what's typed after /model (case-insensitive)
         for model_name in self.model_names:
             if text_after_trigger and not query_matches_text(
@@ -81,11 +89,18 @@ class ModelNameCompleter(Completer):
             ):
                 continue  # Skip models that don't match the typed text
 
-            meta = (
-                "Model (selected)"
-                if model_name.lower() == get_active_model().lower()
-                else "Model"
-            )
+            description = get_model_description(models_config, model_name)
+            active_model_name = get_active_model()
+            if model_name.lower() == active_model_name.lower():
+                short = (
+                    description[:45] + "..." if len(description) > 48 else description
+                )
+                meta = f"✓ {short}"
+            else:
+                meta = (
+                    description[:48] + "..." if len(description) > 51 else description
+                )
+
             yield Completion(
                 model_name,
                 start_position=start_position,

--- a/code_puppy/command_line/model_settings_menu.py
+++ b/code_puppy/command_line/model_settings_menu.py
@@ -359,6 +359,10 @@ class ModelSettingsMenu:
                 self._add_model_nav_hints(lines)
                 return lines
 
+            from code_puppy.model_descriptions import get_model_description
+
+            models_config = ModelFactory.load_config()
+
             # Only render models on the current page
             for i, model_name in enumerate(self.models_on_page):
                 absolute_index = self.page_start + i
@@ -381,6 +385,10 @@ class ModelSettingsMenu:
                     lines.append(("fg:ansicyan", " ⚙"))
 
                 lines.append(("", "\n"))
+
+                if is_selected:
+                    description = get_model_description(models_config, model_name)
+                    lines.append(("fg:ansiyellow italic", f"      {description}\n"))
 
             lines.append(("", "\n"))
             self._add_model_nav_hints(lines)

--- a/code_puppy/model_descriptions.py
+++ b/code_puppy/model_descriptions.py
@@ -1,0 +1,62 @@
+"""Helpers for safe model description overlays.
+
+Model configs are assembled from multiple sources using shallow updates.
+These helpers keep description updates surgical so we don't clobber
+provider endpoints or other model settings.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+DEFAULT_MODEL_DESCRIPTION = "No description available."
+
+
+def apply_description_overlays(
+    models_config: dict[str, dict[str, Any]],
+    *overlays: Mapping[str, str],
+) -> dict[str, dict[str, Any]]:
+    """Apply description overlays to an existing merged models config.
+
+    Rules:
+    - Never create new models.
+    - Never overwrite non-description fields.
+    - Only set ``description`` when missing or blank.
+    """
+    for overlay in overlays:
+        for model_name, description in overlay.items():
+            if model_name not in models_config:
+                continue
+            if not isinstance(models_config.get(model_name), dict):
+                continue
+            if not isinstance(description, str):
+                continue
+
+            desc = description.strip()
+            if not desc:
+                continue
+
+            existing = models_config[model_name].get("description")
+            if isinstance(existing, str) and existing.strip():
+                continue
+
+            models_config[model_name]["description"] = desc
+
+    return models_config
+
+
+def get_model_description(
+    models_config: Mapping[str, Mapping[str, Any]],
+    model_name: str,
+    *,
+    default: str = DEFAULT_MODEL_DESCRIPTION,
+) -> str:
+    """Get a display-safe model description with fallback text."""
+    model_config = models_config.get(model_name, {})
+    description = (
+        model_config.get("description") if isinstance(model_config, Mapping) else None
+    )
+    if isinstance(description, str) and description.strip():
+        return description.strip()
+    return default

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -485,6 +485,43 @@ class ModelFactory:
                 f"Failed to load plugin models config: {exc}"
             )
 
+        # Final pass: apply description-only overlays from bundled + plugins.
+        # This avoids shallow update() calls clobbering remote model settings.
+        try:
+            from code_puppy.model_descriptions import apply_description_overlays
+
+            bundled_models = pathlib.Path(__file__).parent / "models.json"
+            with open(bundled_models, "r") as f:
+                bundled_config = json.load(f)
+
+            bundled_descriptions = {
+                name: (cfg.get("description") or "")
+                for name, cfg in bundled_config.items()
+                if isinstance(cfg, dict)
+            }
+
+            plugin_descriptions: dict[str, str] = {}
+            try:
+                from code_puppy.callbacks import on_load_model_descriptions
+
+                for result in on_load_model_descriptions():
+                    if isinstance(result, dict):
+                        plugin_descriptions.update(result)
+            except Exception as exc:
+                logging.getLogger(__name__).debug(
+                    f"Failed to load plugin model descriptions: {exc}"
+                )
+
+            apply_description_overlays(
+                config,
+                bundled_descriptions,
+                plugin_descriptions,
+            )
+        except Exception as exc:
+            logging.getLogger(__name__).debug(
+                f"Failed to apply model description overlays: {exc}"
+            )
+
         return config
 
     @staticmethod

--- a/code_puppy/models.json
+++ b/code_puppy/models.json
@@ -8,7 +8,12 @@
       "api_key": "$SYN_API_KEY"
     },
     "context_length": 200000,
-    "supported_settings": ["temperature", "seed", "top_p"]
+    "supported_settings": [
+      "temperature",
+      "seed",
+      "top_p"
+    ],
+    "description": "\ud83d\ude80 Synthetic-hosted GLM-5.1. Strong general coding and analysis with big context."
   },
   "synthetic-GLM-5": {
     "type": "custom_openai",
@@ -19,7 +24,12 @@
       "api_key": "$SYN_API_KEY"
     },
     "context_length": 200000,
-    "supported_settings": ["temperature", "seed", "top_p"]
+    "supported_settings": [
+      "temperature",
+      "seed",
+      "top_p"
+    ],
+    "description": "\u26a1 Synthetic-hosted GLM-5. Fast coding helper for day-to-day tasks."
   },
   "synthetic-MiniMax-M2.5": {
     "type": "custom_openai",
@@ -30,7 +40,12 @@
       "api_key": "$SYN_API_KEY"
     },
     "context_length": 195000,
-    "supported_settings": ["temperature", "seed", "top_p"]
+    "supported_settings": [
+      "temperature",
+      "seed",
+      "top_p"
+    ],
+    "description": "\ud83e\udde9 Synthetic-hosted MiniMax M2.5. Useful alternative model for mixed workloads."
   },
   "synthetic-qwen3.5-397b": {
     "type": "custom_openai",
@@ -41,7 +56,12 @@
       "api_key": "$SYN_API_KEY"
     },
     "context_length": 262144,
-    "supported_settings": ["temperature", "seed", "top_p"]
+    "supported_settings": [
+      "temperature",
+      "seed",
+      "top_p"
+    ],
+    "description": "\ud83e\udde0 Synthetic-hosted Qwen 3.5 397B. Big-model reasoning when you need extra depth."
   },
   "synthetic-Kimi-K2.5-Thinking": {
     "type": "custom_openai",
@@ -52,7 +72,12 @@
       "api_key": "$SYN_API_KEY"
     },
     "context_length": 256000,
-    "supported_settings": ["temperature", "seed", "top_p"]
+    "supported_settings": [
+      "temperature",
+      "seed",
+      "top_p"
+    ],
+    "description": "\ud83e\udd14 Synthetic-hosted Kimi K2.5 Thinking. Good for deliberate multi-step reasoning."
   },
   "synthetic-Kimi-K2.5-Thinking-NVFP4": {
     "type": "custom_openai",
@@ -63,7 +88,12 @@
       "api_key": "$SYN_API_KEY"
     },
     "context_length": 256000,
-    "supported_settings": ["temperature", "seed", "top_p"]
+    "supported_settings": [
+      "temperature",
+      "seed",
+      "top_p"
+    ],
+    "description": "\u2699\ufe0f Synthetic-hosted Kimi K2.5 NVFP4. Optimized variant for efficient throughput."
   },
   "synthetic-NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": {
     "type": "custom_openai",
@@ -74,7 +104,12 @@
       "api_key": "$SYN_API_KEY"
     },
     "context_length": 131072,
-    "supported_settings": ["temperature", "seed", "top_p"]
+    "supported_settings": [
+      "temperature",
+      "seed",
+      "top_p"
+    ],
+    "description": "\ud83d\udee0\ufe0f Synthetic-hosted Nemotron 120B NVFP4. Balanced speed and capability for coding."
   },
   "wafer.ai-glm-5.1": {
     "type": "custom_openai",
@@ -85,7 +120,13 @@
       "api_key": "$WAFER_API_KEY"
     },
     "context_length": 200000,
-    "supported_settings": ["temperature", "seed", "top_p", "max_tokens"]
+    "supported_settings": [
+      "temperature",
+      "seed",
+      "top_p",
+      "max_tokens"
+    ],
+    "description": "\ud83c\udf10 Wafer pass-through GLM-5.1. Handy if you route traffic through Wafer."
   },
   "wafer.ai-Qwen3.5-397B-A17B": {
     "type": "custom_openai",
@@ -96,9 +137,14 @@
       "api_key": "$WAFER_API_KEY"
     },
     "context_length": 262144,
-    "supported_settings": ["temperature", "seed", "top_p", "max_tokens"]
+    "supported_settings": [
+      "temperature",
+      "seed",
+      "top_p",
+      "max_tokens"
+    ],
+    "description": "\ud83d\udcda Wafer pass-through Qwen3.5-397B. Large-context option via Wafer gateway."
   },
-
   "firepass-kimi-k2p5-turbo": {
     "type": "custom_openai",
     "provider": "firepass",
@@ -108,7 +154,12 @@
       "api_key": "$FIREWORKS_API_KEY"
     },
     "context_length": 262144,
-    "supported_settings": ["temperature", "seed", "top_p"]
+    "supported_settings": [
+      "temperature",
+      "seed",
+      "top_p"
+    ],
+    "description": "\ud83d\udd25 Firepass Kimi K2.5 Turbo. Lower-latency Kimi route for quick responses."
   },
   "firepass-kimi-k2p6": {
     "type": "custom_openai",
@@ -119,7 +170,12 @@
       "api_key": "$FIREWORKS_API_KEY"
     },
     "context_length": 262144,
-    "supported_settings": ["temperature", "seed", "top_p"]
+    "supported_settings": [
+      "temperature",
+      "seed",
+      "top_p"
+    ],
+    "description": "\ud83d\udd25 Firepass Kimi K2.6. Newer Kimi router variant with solid coding quality."
   },
   "crof-kimi-k2.5-lightning": {
     "type": "custom_openai",
@@ -130,48 +186,77 @@
       "api_key": "$CROF_API_KEY"
     },
     "context_length": 131072,
-    "supported_settings": ["temperature", "seed", "top_p"]
+    "supported_settings": [
+      "temperature",
+      "seed",
+      "top_p"
+    ],
+    "description": "\u26a1 Crof Kimi K2.5 Lightning. Cost-aware and quick for iterative edits."
   },
   "zai-glm-5-coding": {
     "type": "zai_coding",
     "provider": "zai",
     "name": "glm-5",
     "context_length": 200000,
-    "supported_settings": ["temperature", "top_p"]
+    "supported_settings": [
+      "temperature",
+      "top_p"
+    ],
+    "description": "\u26a1 GLM-5 coding endpoint. Fast code generation and refactors without overthinking."
   },
   "zai-glm-5-api": {
     "type": "zai_api",
     "provider": "zai",
     "name": "glm-5",
     "context_length": 200000,
-    "supported_settings": ["temperature", "top_p"]
+    "supported_settings": [
+      "temperature",
+      "top_p"
+    ],
+    "description": "\ud83e\udd14 GLM-5 API variant. Better when you want richer reasoning behavior."
   },
   "zai-glm-5-turbo-coding": {
     "type": "zai_coding",
     "provider": "zai",
     "name": "glm-5-turbo",
     "context_length": 200000,
-    "supported_settings": ["temperature", "top_p"]
+    "supported_settings": [
+      "temperature",
+      "top_p"
+    ],
+    "description": "\ud83d\ude80 GLM-5 Turbo coding endpoint. Speed-first option for high-volume coding."
   },
   "zai-glm-5-turbo-api": {
     "type": "zai_api",
     "provider": "zai",
     "name": "glm-5-turbo",
     "context_length": 200000,
-    "supported_settings": ["temperature", "top_p"]
+    "supported_settings": [
+      "temperature",
+      "top_p"
+    ],
+    "description": "\ud83d\ude80 GLM-5 Turbo API endpoint. Fast general-purpose option with strong throughput."
   },
   "zai-glm-5.1-coding": {
     "type": "zai_coding",
     "provider": "zai",
     "name": "glm-5.1",
     "context_length": 200000,
-    "supported_settings": ["temperature", "top_p"]
+    "supported_settings": [
+      "temperature",
+      "top_p"
+    ],
+    "description": "\ud83c\udd95 GLM-5.1 coding endpoint. Latest coding-focused GLM flavor."
   },
   "zai-glm-5.1-api": {
     "type": "zai_api",
     "provider": "zai",
     "name": "glm-5.1",
     "context_length": 200000,
-    "supported_settings": ["temperature", "top_p"]
+    "supported_settings": [
+      "temperature",
+      "top_p"
+    ],
+    "description": "\ud83c\udd95 GLM-5.1 API endpoint. Latest general GLM option with broad capability."
   }
 }

--- a/tests/command_line/test_model_picker_completion.py
+++ b/tests/command_line/test_model_picker_completion.py
@@ -11,7 +11,7 @@ class TestLoadModelNames:
         from code_puppy.command_line.model_picker_completion import load_model_names
 
         with patch(
-            "code_puppy.model_factory.ModelFactory.load_config",
+            "code_puppy.command_line.model_picker_completion._load_models_config",
             return_value={"gpt-4": {}, "claude-3": {}},
         ):
             result = load_model_names()
@@ -51,7 +51,7 @@ class TestModelNameCompleter:
         from code_puppy.command_line.model_picker_completion import ModelNameCompleter
 
         with patch(
-            "code_puppy.model_factory.ModelFactory.load_config",
+            "code_puppy.command_line.model_picker_completion._load_models_config",
             return_value={"gpt-4": {}},
         ):
             c = ModelNameCompleter(trigger="/model")
@@ -63,8 +63,11 @@ class TestModelNameCompleter:
 
         with (
             patch(
-                "code_puppy.model_factory.ModelFactory.load_config",
-                return_value={"gpt-4": {}, "claude-3": {}},
+                "code_puppy.command_line.model_picker_completion._load_models_config",
+                return_value={
+                    "gpt-4": {"description": "Fast all-round model"},
+                    "claude-3": {"description": "Deep reasoning model"},
+                },
             ),
             patch(
                 "code_puppy.command_line.model_picker_completion.get_active_model",
@@ -74,17 +77,42 @@ class TestModelNameCompleter:
             c = ModelNameCompleter(trigger="/model")
             completions = list(c.get_completions(self._make_doc("/model "), None))
             assert len(completions) == 2
-            # Check that the active model has "(selected)" meta
-            metas = {c.text: str(c.display_meta) for c in completions}
-            assert "selected" in metas["gpt-4"]
-            assert "selected" not in metas["claude-3"]
+            metas = {
+                completion.text: str(completion.display_meta)
+                for completion in completions
+            }
+            assert "✓" in metas["gpt-4"]
+            assert "Fast all-round model" in metas["gpt-4"]
+            assert "Deep reasoning model" in metas["claude-3"]
+
+    def test_uses_fallback_description_when_missing(self):
+        from code_puppy.command_line.model_picker_completion import ModelNameCompleter
+
+        with (
+            patch(
+                "code_puppy.command_line.model_picker_completion._load_models_config",
+                return_value={"gpt-4": {}, "claude-3": {"description": ""}},
+            ),
+            patch(
+                "code_puppy.command_line.model_picker_completion.get_active_model",
+                return_value="gpt-4",
+            ),
+        ):
+            c = ModelNameCompleter(trigger="/model")
+            completions = list(c.get_completions(self._make_doc("/model "), None))
+            metas = {
+                completion.text: str(completion.display_meta)
+                for completion in completions
+            }
+            assert "No description available." in metas["gpt-4"]
+            assert "No description available." in metas["claude-3"]
 
     def test_filters_by_prefix(self):
         from code_puppy.command_line.model_picker_completion import ModelNameCompleter
 
         with (
             patch(
-                "code_puppy.model_factory.ModelFactory.load_config",
+                "code_puppy.command_line.model_picker_completion._load_models_config",
                 return_value={"gpt-4": {}, "claude-3": {}},
             ),
             patch(
@@ -163,7 +191,7 @@ class TestUpdateModelInInput:
 
         with (
             patch(
-                "code_puppy.model_factory.ModelFactory.load_config",
+                "code_puppy.command_line.model_picker_completion._load_models_config",
                 return_value={"gpt-4": {}},
             ),
             patch(
@@ -182,7 +210,7 @@ class TestUpdateModelInInput:
 
         with (
             patch(
-                "code_puppy.model_factory.ModelFactory.load_config",
+                "code_puppy.command_line.model_picker_completion._load_models_config",
                 return_value={"gpt-4": {}},
             ),
             patch(
@@ -205,7 +233,7 @@ class TestUpdateModelInInput:
         )
 
         with patch(
-            "code_puppy.model_factory.ModelFactory.load_config",
+            "code_puppy.command_line.model_picker_completion._load_models_config",
             return_value={"gpt-4": {}},
         ):
             assert update_model_in_input("/model xyz") is None
@@ -216,7 +244,7 @@ class TestUpdateModelInInput:
         )
 
         with patch(
-            "code_puppy.model_factory.ModelFactory.load_config",
+            "code_puppy.command_line.model_picker_completion._load_models_config",
             return_value={"gpt-4": {}},
         ):
             assert update_model_in_input("/m xyz") is None
@@ -228,7 +256,7 @@ class TestUpdateModelInInput:
 
         with (
             patch(
-                "code_puppy.model_factory.ModelFactory.load_config",
+                "code_puppy.command_line.model_picker_completion._load_models_config",
                 return_value={"gpt-4": {}},
             ),
             patch(
@@ -413,7 +441,7 @@ class TestGetInputWithModelCompletion:
 
         with (
             patch(
-                "code_puppy.model_factory.ModelFactory.load_config",
+                "code_puppy.command_line.model_picker_completion._load_models_config",
                 return_value={"gpt-4": {}},
             ),
             patch(
@@ -436,7 +464,7 @@ class TestGetInputWithModelCompletion:
 
         with (
             patch(
-                "code_puppy.model_factory.ModelFactory.load_config",
+                "code_puppy.command_line.model_picker_completion._load_models_config",
                 return_value={"gpt-4": {}},
             ),
             patch(
@@ -463,7 +491,7 @@ class TestGetInputWithModelCompletion:
         hfile = str(tmp_path / "history.txt")
         with (
             patch(
-                "code_puppy.model_factory.ModelFactory.load_config",
+                "code_puppy.command_line.model_picker_completion._load_models_config",
                 return_value={},
             ),
             patch(
@@ -488,7 +516,7 @@ class TestGetInputWithModelCompletion:
 
         with (
             patch(
-                "code_puppy.model_factory.ModelFactory.load_config",
+                "code_puppy.command_line.model_picker_completion._load_models_config",
                 return_value={"gpt-4": {}},
             ),
             patch(
@@ -515,7 +543,7 @@ class TestGetInputWithModelCompletion:
 
         with (
             patch(
-                "code_puppy.model_factory.ModelFactory.load_config",
+                "code_puppy.command_line.model_picker_completion._load_models_config",
                 return_value={"gpt-4": {}},
             ),
             patch(
@@ -532,7 +560,7 @@ class TestGetInputWithModelCompletion:
 
         with (
             patch(
-                "code_puppy.model_factory.ModelFactory.load_config",
+                "code_puppy.command_line.model_picker_completion._load_models_config",
                 return_value={"gpt-4": {}},
             ),
             patch(

--- a/tests/command_line/test_model_settings_menu_coverage.py
+++ b/tests/command_line/test_model_settings_menu_coverage.py
@@ -213,18 +213,44 @@ class TestFormatValue:
 
 class TestRenderMainList:
     @patch(
+        "code_puppy.command_line.model_settings_menu.ModelFactory.load_config",
+        return_value={"m1": {"description": "First model desc"}, "m2": {}},
+    )
+    @patch(
         "code_puppy.command_line.model_settings_menu.get_all_model_settings",
         return_value={},
     )
-    def test_render_models_view(self, mock_settings):
+    def test_render_models_view(self, mock_settings, mock_load_config):
         menu = _make_menu(models=["m1", "m2"])
         menu.view_mode = "models"
         lines = menu._render_main_list()
         text = "".join(t for _, t in lines)
         assert "Select a Model" in text
+        assert "First model desc" in text
 
+    @patch(
+        "code_puppy.command_line.model_settings_menu.ModelFactory.load_config",
+        return_value={"m1": {}},
+    )
+    @patch(
+        "code_puppy.command_line.model_settings_menu.get_all_model_settings",
+        return_value={},
+    )
+    def test_render_models_view_description_fallback(
+        self, mock_settings, mock_load_config
+    ):
+        menu = _make_menu(models=["m1"])
+        menu.view_mode = "models"
+        lines = menu._render_main_list()
+        text = "".join(t for _, t in lines)
+        assert "No description available." in text
+
+    @patch(
+        "code_puppy.command_line.model_settings_menu.ModelFactory.load_config",
+        return_value={"m1": {"description": "desc"}},
+    )
     @patch("code_puppy.command_line.model_settings_menu.get_all_model_settings")
-    def test_render_models_with_settings(self, mock_settings):
+    def test_render_models_with_settings(self, mock_settings, mock_load_config):
         mock_settings.return_value = {"temperature": 0.5}
         menu = _make_menu(models=["m1"])
         menu.current_model_name = "m1"
@@ -240,10 +266,14 @@ class TestRenderMainList:
         assert "No models" in text
 
     @patch(
+        "code_puppy.command_line.model_settings_menu.ModelFactory.load_config",
+        return_value={"m0": {"description": "desc"}},
+    )
+    @patch(
         "code_puppy.command_line.model_settings_menu.get_all_model_settings",
         return_value={},
     )
-    def test_render_models_pagination(self, mock_settings):
+    def test_render_models_pagination(self, mock_settings, mock_load_config):
         models = [f"m{i}" for i in range(MODELS_PER_PAGE + 5)]
         menu = _make_menu(models=models)
         lines = menu._render_main_list()

--- a/tests/test_model_descriptions.py
+++ b/tests/test_model_descriptions.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from code_puppy.model_descriptions import (
+    DEFAULT_MODEL_DESCRIPTION,
+    apply_description_overlays,
+    get_model_description,
+)
+
+
+def test_apply_description_overlays_injects_only_description() -> None:
+    base = {
+        "remote-model": {
+            "type": "custom_openai",
+            "name": "gpt-something",
+            "context_length": 123,
+        }
+    }
+
+    overlay = {"remote-model": "Hello I am a model."}
+    apply_description_overlays(base, overlay)
+
+    assert base["remote-model"]["description"] == "Hello I am a model."
+    assert base["remote-model"]["type"] == "custom_openai"
+    assert base["remote-model"]["name"] == "gpt-something"
+    assert base["remote-model"]["context_length"] == 123
+
+
+def test_apply_description_overlays_does_not_override_existing() -> None:
+    base = {"m": {"description": "Existing"}}
+    apply_description_overlays(base, {"m": "New"})
+    assert base["m"]["description"] == "Existing"
+
+
+def test_apply_description_overlays_does_not_create_new_models() -> None:
+    base = {"m": {"type": "x"}}
+    apply_description_overlays(base, {"new": "desc"})
+    assert "new" not in base
+
+
+def test_get_model_description_falls_back_for_missing_or_blank() -> None:
+    assert get_model_description({}, "missing") == DEFAULT_MODEL_DESCRIPTION
+    assert (
+        get_model_description({"m": {"description": "   "}}, "m")
+        == DEFAULT_MODEL_DESCRIPTION
+    )


### PR DESCRIPTION
## Summary

### What this changes

- Adds `code_puppy/model_descriptions.py` with:
  - `apply_description_overlays(...)`
  - `get_model_description(...)`
  - default fallback text

- Adds a new callback hook:
  - `load_model_descriptions` in `code_puppy/callbacks.py`

- Updates `ModelFactory.load_config()` to apply description overlays **after** config merges:
  - bundled `models.json` descriptions
  - plugin-provided description overlays
  - only fills missing/blank descriptions (no clobbering of model settings)

- Improves model UX:
  - `/model` completion now shows description metadata (with fallback)
  - model settings menu shows selected model description (with fallback)

- Updates `code_puppy/models.json` descriptions for current OSS models.

- Adds/updates tests:
  - new `tests/test_model_descriptions.py`
  - expanded picker + settings coverage for description/fallback behavior
  - updates docs hook table in `AGENTS.md` for `load_model_descriptions`

## Why

Model configs are merged from multiple sources using shallow updates.
Without a description-only overlay pass, metadata can be lost or overwritten unintentionally.
This keeps descriptions reliable while preserving all non-description model fields.

## Guardrails

`apply_description_overlays(...)` intentionally:

- does **not** create new models
- does **not** overwrite non-description fields
- only sets `description` when missing/blank
- ignores invalid/empty overlay values

## Validation

Ran formatting/lint on touched files:

- `isort --profile black ...`
- `ruff format ...`
- `ruff check --fix ...`
- `ruff check ...`

Ran targeted tests:

- `tests/test_model_descriptions.py`
- `tests/command_line/test_model_picker_completion.py`
- `tests/command_line/test_model_settings_menu_coverage.py`

All passed locally.
