### PR TITLE
feat(frontend_emitter): per-session event channel + lossless delta sa…

### DIFF
--- a/code_puppy/plugins/frontend_emitter/emitter.py
+++ b/code_puppy/plugins/frontend_emitter/emitter.py
@@ -1,13 +1,40 @@
 """Event emitter for frontend integration.
 
 Provides a global event queue that WebSocket handlers can subscribe to.
-Events are JSON-serializable dicts with type, timestamp, and data.
+Events are JSON-serializable dicts with type, timestamp, data, and an
+optional ``session_id`` channel for multi-tenant routing.
+
+Session-channel model
+---------------------
+- Producers may attach a ``session_id`` to an event in two ways:
+    1. Explicit kwarg:  ``emit_event(type, data, session_id="abc")``
+    2. ContextVar:      set ``code_puppy.plugins.frontend_emitter.session_context.current_emitter_session_id``
+                        before calling ``emit_event``; the value is
+                        picked up automatically.
+  The explicit kwarg always wins over the ContextVar.
+
+- Consumers may subscribe in two ways:
+    1. ``subscribe()``                        -> wildcard (all events)
+    2. ``subscribe(session_id="abc")``        -> only events whose
+                                                  ``session_id`` matches
+                                                  ``"abc"``.
+  Wildcard subscribers also receive session-tagged events. Session
+  subscribers only receive events whose ``session_id`` exactly matches
+  their filter (events with ``session_id is None`` are NOT delivered
+  to session subscribers).
+
+This design is fully backward compatible: existing 2-arg callers of
+``emit_event`` and bare ``subscribe()`` calls behave identically to
+before -- they just see ``session_id: None`` on emitted events.
 """
+
+from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List, Optional, Set
 from uuid import uuid4
 
 from code_puppy.config import (
@@ -15,32 +42,101 @@ from code_puppy.config import (
     get_frontend_emitter_max_recent_events,
     get_frontend_emitter_queue_size,
 )
+from code_puppy.plugins.frontend_emitter.session_context import current_emitter_session_id
 
 logger = logging.getLogger(__name__)
 
-# Global state for event distribution
-_subscribers: Set[asyncio.Queue[Dict[str, Any]]] = set()
+
+# Sentinel used for "no explicit kwarg was passed".  We can't use ``None``
+# because ``None`` is a meaningful explicit value meaning "this event has
+# no session context, even if a ContextVar is set".  This lets a caller
+# opt OUT of the ContextVar fallback by explicitly passing ``session_id=None``.
+class _Unset:
+    def __repr__(self) -> str:
+        return "<unset>"
+
+
+_UNSET: Any = _Unset()
+
+
+@dataclass(eq=False)
+class _Subscriber:
+    """A subscription handle. Wraps an asyncio.Queue plus an optional filter."""
+
+    queue: "asyncio.Queue[Dict[str, Any]]"
+    session_id: Optional[str] = None  # None == wildcard (all events)
+
+
+# Global state for event distribution.
+#
+# We keep two parallel data structures:
+#   * ``_subscribers``: the legacy "set of queues" used by callers that
+#     have a raw queue reference (back-compat for unsubscribe(queue)).
+#   * ``_subscriber_records``: the richer set with filter metadata,
+#     iterated during fan-out.
+#
+# Both are kept in sync by ``subscribe`` / ``unsubscribe``.
+_subscribers: Set["asyncio.Queue[Dict[str, Any]]"] = set()
+_subscriber_records: Set[_Subscriber] = set()
 _recent_events: List[Dict[str, Any]] = []  # Keep last N events for new subscribers
 
 
-def emit_event(event_type: str, data: Any = None) -> None:
-    """Emit an event to all subscribers.
+def _resolve_session_id(explicit: Any) -> Optional[str]:
+    """Resolve the effective session_id for an emit call.
 
-    Creates a structured event dict with unique ID, type, timestamp, and data,
-    then broadcasts it to all active subscriber queues.
+    Precedence: explicit kwarg > ContextVar > None.
+
+    Passing ``session_id=None`` *explicitly* opts out of the ContextVar
+    fallback (the resolved value is ``None``).  Only the ``_UNSET``
+    sentinel triggers the ContextVar lookup.
+    """
+    if explicit is _UNSET:
+        try:
+            return current_emitter_session_id.get()
+        except LookupError:
+            return None
+    return explicit
+
+
+def emit_event(
+    event_type: str,
+    data: Any = None,
+    session_id: Any = _UNSET,
+) -> None:
+    """Emit an event to all matching subscribers.
+
+    Creates a structured event dict with unique ID, type, timestamp,
+    data, and ``session_id`` channel, then broadcasts it to all active
+    subscribers whose filter matches.
 
     Args:
-        event_type: Type of event (e.g., "tool_call_start", "stream_token")
-        data: Event data payload - should be JSON-serializable
+        event_type: Type of event (e.g., "tool_call_start", "stream_token").
+        data: Event data payload - should be JSON-serializable.
+        session_id: Optional session identifier. If omitted, the value of
+            the ``code_puppy.plugins.frontend_emitter.session_context.current_emitter_session_id`` ContextVar is
+            used (or ``None`` if no ContextVar is set). Pass
+            ``session_id=None`` explicitly to bypass the ContextVar
+            fallback.
+
+    Routing rules:
+        - A wildcard subscriber (``subscribe()`` with no filter) receives
+          ALL events regardless of their ``session_id``.
+        - A session-filtered subscriber (``subscribe(session_id="x")``)
+          receives ONLY events whose resolved ``session_id == "x"``.
+          Events with ``session_id is None`` are NOT delivered to
+          session-filtered subscribers.
     """
     # Early return if emitter is disabled
     if not get_frontend_emitter_enabled():
         return
 
+    resolved_sid = _resolve_session_id(session_id)
+
     event: Dict[str, Any] = {
         "id": str(uuid4()),
         "type": event_type,
         "timestamp": datetime.now(timezone.utc).isoformat(),
+        "session_id": resolved_sid,
         "data": data or {},
     }
 
@@ -50,52 +146,98 @@ def emit_event(event_type: str, data: Any = None) -> None:
     if len(_recent_events) > max_recent:
         _recent_events.pop(0)
 
-    # Broadcast to all active subscribers
-    for subscriber_queue in _subscribers.copy():
+    # Build the set of queues that are managed via the public subscribe()
+    # API.  Anything in the legacy ``_subscribers`` set that is NOT here is
+    # an "orphan" -- a queue someone added directly, which we still want
+    # to honour as a wildcard subscriber for back-compat.
+    managed_qids = {id(sub.queue) for sub in _subscriber_records}
+
+    # 1. Deliver to filter-matching managed subscribers.
+    for sub in list(_subscriber_records):
+        # Filter logic:
+        #   - sub.session_id is None  -> wildcard, deliver everything
+        #   - sub.session_id == sid   -> exact match
+        #   - otherwise               -> skip
+        if sub.session_id is not None and sub.session_id != resolved_sid:
+            continue
         try:
-            subscriber_queue.put_nowait(event)
+            sub.queue.put_nowait(event)
+        except asyncio.QueueFull:
+            logger.warning(f"Subscriber queue full, dropping event: {event_type}")
+        except Exception as e:
+            logger.error(f"Failed to emit event to subscriber: {e}")
+
+    # 2. Back-compat: deliver to any queue someone added DIRECTLY to the
+    # legacy ``_subscribers`` set without going through ``subscribe()``.
+    # These orphan queues are treated as unconditional wildcards.  Queues
+    # owned by ``subscribe()`` are excluded here so they don't double-fire
+    # and so session filtering above is respected.
+    for orphan_q in list(_subscribers):
+        if id(orphan_q) in managed_qids:
+            continue
+        try:
+            orphan_q.put_nowait(event)
         except asyncio.QueueFull:
             logger.warning(f"Subscriber queue full, dropping event: {event_type}")
         except Exception as e:
             logger.error(f"Failed to emit event to subscriber: {e}")
 
 
-def subscribe() -> asyncio.Queue[Dict[str, Any]]:
+def subscribe(
+    session_id: Optional[str] = None,
+) -> "asyncio.Queue[Dict[str, Any]]":
     """Subscribe to events.
 
-    Creates and returns a new async queue that will receive all future events.
+    Creates and returns a new async queue that will receive future events.
     The queue has a configurable max size (via frontend_emitter_queue_size)
-    to prevent unbounded memory growth if the subscriber is slow to process events.
+    to prevent unbounded memory growth if the subscriber is slow.
+
+    Args:
+        session_id: If provided, the queue will ONLY receive events whose
+            ``session_id`` exactly matches this value.  If omitted (or
+            ``None``), the queue acts as a wildcard and receives every
+            emitted event.
 
     Returns:
-        An asyncio.Queue that will receive event dictionaries.
+        An ``asyncio.Queue`` that will receive matching event dictionaries.
     """
     queue_size = get_frontend_emitter_queue_size()
-    queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue(maxsize=queue_size)
+    queue: "asyncio.Queue[Dict[str, Any]]" = asyncio.Queue(maxsize=queue_size)
     _subscribers.add(queue)
-    logger.debug(f"New subscriber added, total subscribers: {len(_subscribers)}")
+    _subscriber_records.add(_Subscriber(queue=queue, session_id=session_id))
+    logger.debug(
+        f"New subscriber added (session_id={session_id!r}), "
+        f"total subscribers: {len(_subscriber_records)}"
+    )
     return queue
 
 
-def unsubscribe(queue: asyncio.Queue[Dict[str, Any]]) -> None:
+def unsubscribe(queue: "asyncio.Queue[Dict[str, Any]]") -> None:
     """Unsubscribe from events.
 
-    Removes the queue from the subscriber set. Safe to call even if the queue
-    was never subscribed or already unsubscribed.
+    Removes the queue from the subscriber set. Safe to call even if the
+    queue was never subscribed or already unsubscribed.
 
     Args:
-        queue: The queue returned from subscribe()
+        queue: The queue returned from ``subscribe()``.
     """
     _subscribers.discard(queue)
-    logger.debug(f"Subscriber removed, remaining subscribers: {len(_subscribers)}")
+    # Drop matching record(s) from the rich set as well.  We compare by
+    # queue identity since the same queue object can only correspond to
+    # one _Subscriber record (subscribe always allocates a fresh queue).
+    to_drop = {sub for sub in _subscriber_records if sub.queue is queue}
+    _subscriber_records.difference_update(to_drop)
+    logger.debug(
+        f"Subscriber removed, remaining subscribers: {len(_subscriber_records)}"
+    )
 
 
 def get_recent_events() -> List[Dict[str, Any]]:
     """Get recent events for new subscribers.
 
-    Returns a copy of the most recent events (up to frontend_emitter_max_recent_events).
-    Useful for allowing new WebSocket connections to "catch up" on
-    recent activity.
+    Returns a copy of the most recent events (up to
+    ``frontend_emitter_max_recent_events``).  Useful for letting new
+    WebSocket connections "catch up" on recent activity.
 
     Returns:
         A list of recent event dictionaries.
@@ -109,7 +251,7 @@ def get_subscriber_count() -> int:
     Returns:
         Number of active subscriber queues.
     """
-    return len(_subscribers)
+    return len(_subscriber_records)
 
 
 def clear_recent_events() -> None:

--- a/code_puppy/plugins/frontend_emitter/register_callbacks.py
+++ b/code_puppy/plugins/frontend_emitter/register_callbacks.py
@@ -2,8 +2,23 @@
 
 This module registers callbacks for various agent events and emits them
 to subscribed WebSocket handlers via the emitter module.
+
+Session channel
+---------------
+None of the emit-sites below pass an explicit ``session_id`` to
+``emit_event``.  Instead they rely on the implicit fallback to
+``code_puppy.plugins.frontend_emitter.session_context.current_emitter_session_id`` -- so any embedder (e.g. a
+WebSocket backend handling multiple sessions concurrently) just needs
+to set the ContextVar at the start of an agent run and every event
+emitted by code-puppy during that run will be tagged with the
+correct session_id automatically.  No imports from
+``code_puppy.api.*`` are added here; the contract is purely through
+the ContextVar primitive in ``code_puppy.plugins.frontend_emitter.session_context``.
 """
 
+from __future__ import annotations
+
+import json
 import logging
 import time
 from typing import Any, Dict, Optional
@@ -14,15 +29,27 @@ from code_puppy.plugins.frontend_emitter.emitter import emit_event
 logger = logging.getLogger(__name__)
 
 
+# Maximum serialized size we allow for a structured tool-args payload
+# before we fall back to a truncated string representation.  Chosen to
+# fit comfortably in a typical 16-64 KB WebSocket frame after JSON
+# wrapping while still being large enough to carry real file paths,
+# small code snippets, and config blobs verbatim.
+_MAX_ARGS_SERIALIZED_BYTES = 4096
+
+# Maximum length for the textual representation we attach when a value
+# can't be JSON-serialised or exceeds the size cap above.
+_MAX_ARGS_TRUNCATED_STR = 4000
+
+
 async def on_pre_tool_call(
     tool_name: str, tool_args: Dict[str, Any], context: Any = None
 ) -> None:
     """Emit an event when a tool call starts.
 
     Args:
-        tool_name: Name of the tool being called
-        tool_args: Arguments being passed to the tool
-        context: Optional context data for the tool call
+        tool_name: Name of the tool being called.
+        tool_args: Arguments being passed to the tool.
+        context: Optional context data for the tool call.
     """
     try:
         emit_event(
@@ -48,11 +75,11 @@ async def on_post_tool_call(
     """Emit an event when a tool call completes.
 
     Args:
-        tool_name: Name of the tool that was called
-        tool_args: Arguments that were passed to the tool
-        result: The result returned by the tool
-        duration_ms: Execution time in milliseconds
-        context: Optional context data for the tool call
+        tool_name: Name of the tool that was called.
+        tool_args: Arguments that were passed to the tool.
+        result: The result returned by the tool.
+        duration_ms: Execution time in milliseconds.
+        context: Optional context data for the tool call.
     """
     try:
         emit_event(
@@ -78,9 +105,13 @@ async def on_stream_event(
     """Emit streaming events from the agent.
 
     Args:
-        event_type: Type of the streaming event
-        event_data: Data associated with the event
-        agent_session_id: Optional session ID of the agent emitting the event
+        event_type: Type of the streaming event.
+        event_data: Data associated with the event.
+        agent_session_id: Optional session ID of the agent emitting the
+            event.  This is a *callback-supplied* identifier from the
+            agent layer; it is independent of the WebSocket-session
+            ContextVar used by the emitter and is preserved verbatim
+            inside the event payload.
     """
     try:
         emit_event(
@@ -100,8 +131,8 @@ async def on_invoke_agent(*args: Any, **kwargs: Any) -> None:
     """Emit an event when an agent is invoked.
 
     Args:
-        *args: Positional arguments from the invoke_agent callback
-        **kwargs: Keyword arguments from the invoke_agent callback
+        *args: Positional arguments from the invoke_agent callback.
+        **kwargs: Keyword arguments from the invoke_agent callback.
     """
     try:
         # Extract relevant info from args/kwargs
@@ -119,16 +150,28 @@ async def on_invoke_agent(*args: Any, **kwargs: Any) -> None:
         logger.error(f"Failed to emit invoke_agent event: {e}")
 
 
+# ─── sanitizers ─────────────────────────────────────────────────────────
+
+
 def _sanitize_args(args: Dict[str, Any]) -> Dict[str, Any]:
     """Sanitize tool arguments for safe emission.
 
-    Truncates large values and removes potentially sensitive data.
+    Strategy:
+      * Primitives (str / int / float / bool / None) round-trip directly,
+        with strings capped at 500 chars.
+      * Structured values (list / dict) are JSON-serialised and kept
+        verbatim if the serialised form fits within ``_MAX_ARGS_SERIALIZED_BYTES``;
+        otherwise replaced by a truncated string representation (NOT the
+        opaque ``<list[N]>`` stub the previous implementation produced).
+      * Anything that can't be JSON-serialised falls back to ``repr()``,
+        capped at ``_MAX_ARGS_TRUNCATED_STR`` chars.
 
     Args:
-        args: The raw tool arguments
+        args: The raw tool arguments dict (or any value -- non-dicts are
+            normalised to an empty dict for back-compat).
 
     Returns:
-        Sanitized arguments safe for emission
+        Sanitized arguments safe for emission over a WebSocket.
     """
     if not isinstance(args, dict):
         return {}
@@ -137,25 +180,75 @@ def _sanitize_args(args: Dict[str, Any]) -> Dict[str, Any]:
     for key, value in args.items():
         if isinstance(value, str):
             sanitized[key] = _truncate_string(value, max_length=500)
-        elif isinstance(value, (int, float, bool, type(None))):
+        elif isinstance(value, bool) or value is None:
+            # Note: must check ``bool`` before ``int`` because bool is a subclass of int.
             sanitized[key] = value
-        elif isinstance(value, (list, dict)):
-            # Just indicate the type and length for complex types
-            sanitized[key] = f"<{type(value).__name__}[{len(value)}]>"
+        elif isinstance(value, (int, float)):
+            sanitized[key] = value
+        elif isinstance(value, (list, dict, tuple)):
+            sanitized[key] = _preserve_structured(value)
         else:
-            sanitized[key] = f"<{type(value).__name__}>"
+            # Unknown type: best-effort textual representation.
+            try:
+                sanitized[key] = _truncate_string(
+                    repr(value), max_length=_MAX_ARGS_TRUNCATED_STR
+                )
+            except Exception:
+                sanitized[key] = f"<{type(value).__name__}>"
 
     return sanitized
+
+
+def _preserve_structured(value: Any) -> Any:
+    """Round-trip a structured value through JSON if it fits within budget.
+
+    Returns the original value (so it serialises naturally downstream)
+    when the serialised form is <= ``_MAX_ARGS_SERIALIZED_BYTES`` bytes,
+    otherwise a truncated string preview.  This replaces the previous
+    behaviour of emitting an opaque ``<list[N]>`` stub.
+    """
+    try:
+        serialised = json.dumps(value, default=str, ensure_ascii=False)
+    except (TypeError, ValueError):
+        # Not JSON-serialisable at all -- fall back to a short repr.
+        try:
+            return _truncate_string(repr(value), max_length=_MAX_ARGS_TRUNCATED_STR)
+        except Exception:
+            return f"<{type(value).__name__}>"
+
+    if len(serialised.encode("utf-8")) <= _MAX_ARGS_SERIALIZED_BYTES:
+        # Small enough -- return the original Python value so it
+        # round-trips cleanly through whatever JSON encoder runs later.
+        return value
+
+    # Too big: return a truncated preview string so the consumer at
+    # least sees the shape and the first portion of the content.
+    return _truncate_string(serialised, max_length=_MAX_ARGS_TRUNCATED_STR)
 
 
 def _sanitize_event_data(data: Any) -> Any:
     """Sanitize event data for safe emission.
 
+    Special-cased for pydantic-ai delta-style objects:
+      * Anything carrying a ``content_delta`` attribute (text streaming)
+        is normalised to ``{"type": <class_name>, "content_delta": <str>}``.
+      * Anything carrying an ``args_delta`` attribute (tool-call streaming)
+        is normalised to ``{"type": <class_name>, "args_delta": <str>,
+        "tool_call_id": <id|None>, "tool_name": <name|None>}``.
+      * Anything carrying a ``part`` attribute (part_start / part_end
+        wrappers) is unwrapped recursively into its part.
+      * Plain dicts / lists / scalars retain the previous behaviour
+        (capped recursion, capped length).
+
+    Without this normalisation, ``repr()`` of a pydantic-ai delta produces
+    something like ``<TextPartDelta>`` and downstream consumers (browsers,
+    GUI clients) lose the actual streamed content.
+
     Args:
-        data: The raw event data
+        data: The raw event data.
 
     Returns:
-        Sanitized data safe for emission
+        Sanitized data safe for emission.
     """
     if data is None:
         return None
@@ -172,17 +265,69 @@ def _sanitize_event_data(data: Any) -> Any:
     if isinstance(data, (list, tuple)):
         return [_sanitize_event_data(item) for item in data[:20]]
 
-    return f"<{type(data).__name__}>"
+    # ── pydantic-ai delta extraction ────────────────────────────────
+    #
+    # We use duck-typing (hasattr) rather than isinstance() so we don't
+    # have to import pydantic-ai here and we stay compatible with any
+    # future delta subclass that adheres to the same attribute names.
+
+    type_name = type(data).__name__
+
+    # 1. content_delta (TextPartDelta)
+    if hasattr(data, "content_delta"):
+        content = getattr(data, "content_delta", "")
+        return {
+            "type": type_name,
+            "content_delta": _truncate_string(content, max_length=1000),
+        }
+
+    # 2. args_delta (ToolCallPartDelta)
+    if hasattr(data, "args_delta"):
+        args_delta = getattr(data, "args_delta", "")
+        return {
+            "type": type_name,
+            "args_delta": _truncate_string(args_delta, max_length=1000),
+            "tool_call_id": _safe_getattr_str(data, "tool_call_id"),
+            "tool_name": _safe_getattr_str(data, "tool_name"),
+        }
+
+    # 3. part-wrapping events (PartStartEvent / PartEndEvent / etc.) --
+    #    unwrap the inner ``part`` so its content is reachable too.
+    if hasattr(data, "part"):
+        try:
+            inner = _sanitize_event_data(data.part)
+        except Exception:
+            inner = f"<{type_name}.part>"
+        return {"type": type_name, "part": inner}
+
+    # 4. Anything with a usable content/text attribute on the top level
+    #    (e.g. fully-formed TextPart, ThinkingPart).
+    if hasattr(data, "content"):
+        return {
+            "type": type_name,
+            "content": _truncate_string(getattr(data, "content", ""), max_length=1000),
+        }
+
+    return f"<{type_name}>"
+
+
+def _safe_getattr_str(obj: Any, name: str) -> Optional[str]:
+    """Return ``str(getattr(obj, name))`` or ``None`` if missing / failing."""
+    try:
+        val = getattr(obj, name, None)
+        return None if val is None else str(val)
+    except Exception:
+        return None
 
 
 def _is_successful_result(result: Any) -> bool:
     """Determine if a tool result indicates success.
 
     Args:
-        result: The tool result
+        result: The tool result.
 
     Returns:
-        True if the result appears successful
+        True if the result appears successful.
     """
     if result is None:
         return True  # No result often means success
@@ -205,10 +350,10 @@ def _summarize_result(result: Any) -> str:
     """Create a brief summary of a tool result.
 
     Args:
-        result: The tool result
+        result: The tool result.
 
     Returns:
-        A string summary of the result
+        A string summary of the result.
     """
     if result is None:
         return "<no result>"
@@ -230,14 +375,14 @@ def _summarize_result(result: Any) -> str:
 
 
 def _truncate_string(value: Any, max_length: int = 100) -> Optional[str]:
-    """Truncate a string value if it exceeds max_length.
+    """Truncate a string value if it exceeds ``max_length``.
 
     Args:
-        value: The value to truncate (will be converted to str)
-        max_length: Maximum length before truncation
+        value: The value to truncate (will be converted to str).
+        max_length: Maximum length before truncation.
 
     Returns:
-        Truncated string or None if value is None
+        Truncated string or ``None`` if value is ``None``.
     """
     if value is None:
         return None

--- a/code_puppy/plugins/frontend_emitter/session_context.py
+++ b/code_puppy/plugins/frontend_emitter/session_context.py
@@ -1,0 +1,57 @@
+"""Session-id ContextVar used by the frontend_emitter plugin.
+
+This module defines a single ``contextvars.ContextVar`` that carries
+the *current agent invocation's* session identifier across the asyncio
+call graph without requiring every callable to take an explicit kwarg.
+
+The primary use case is letting embedders (e.g. a WebSocket backend
+hosting multiple concurrent agent sessions) tag every event emitted
+during an agent run with a session identifier, so subscribers can
+filter events by session without monkey-patching the emitter.
+
+Usage::
+
+    from code_puppy.plugins.frontend_emitter.session_context import (
+        current_emitter_session_id,
+    )
+
+    token = current_emitter_session_id.set("my-session-id")
+    try:
+        await some_agent_work()  # any emit_event() inside picks up the sid
+    finally:
+        current_emitter_session_id.reset(token)
+
+Because ``ContextVar`` values are copied into each new asyncio Task at
+creation time, sessions are naturally isolated across concurrent tasks
+without explicit propagation.
+
+Scope note
+----------
+This ContextVar is intentionally scoped to the ``frontend_emitter``
+plugin.  It is not a general-purpose ``code_puppy.context.session_id``
+because the only consumer is the emitter's session-channel fan-out
+logic.  Other subsystems that need session-level metadata should
+introduce their own ContextVar with a clearly-scoped name.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import Optional
+
+# The session_id of the currently running agent invocation, if any.
+#
+# Set by embedders (e.g. a backend WebSocket session handler) before
+# kicking off agent work, and read by ``emit_event()`` (and helpers
+# in ``register_callbacks``) to tag every emitted event with the
+# current session.
+#
+# ``None`` is the legitimate "no session context" value -- callers
+# should treat it as "this event is not associated with any particular
+# session" rather than as an error.
+current_emitter_session_id: ContextVar[Optional[str]] = ContextVar(
+    "code_puppy_frontend_emitter_session_id", default=None
+)
+
+
+__all__ = ["current_emitter_session_id"]

--- a/tests/plugins/test_frontend_emitter_coverage.py
+++ b/tests/plugins/test_frontend_emitter_coverage.py
@@ -269,14 +269,36 @@ class TestSanitizeArgs:
         result = _sanitize_args({"i": 1, "f": 2.0, "b": True, "n": None})
         assert result == {"i": 1, "f": 2.0, "b": True, "n": None}
 
-    def test_complex_types(self):
+    def test_complex_types_preserved_when_small(self):
+        """Small structured args round-trip verbatim (no opaque <list[N]> stub).
+
+        This is the Phase 1 ``_sanitize_args`` contract: list / dict
+        values that JSON-serialise to <= 4 KB are returned unchanged so
+        downstream consumers see the real shape.
+        """
         from code_puppy.plugins.frontend_emitter.register_callbacks import (
             _sanitize_args,
         )
 
         result = _sanitize_args({"lst": [1, 2], "dct": {"a": 1}})
-        assert "list[2]" in result["lst"]
-        assert "dict[1]" in result["dct"]
+        assert result["lst"] == [1, 2]
+        assert result["dct"] == {"a": 1}
+
+    def test_complex_types_truncated_when_oversize(self):
+        """A structured value whose JSON form exceeds the size cap is replaced
+        by a truncated string preview (not silently dropped)."""
+        from code_puppy.plugins.frontend_emitter.register_callbacks import (
+            _sanitize_args,
+        )
+
+        # Big enough to definitely exceed the cap when JSON-serialised.
+        big = {"items": ["x" * 200] * 100}
+        result = _sanitize_args(big)
+        assert isinstance(result["items"], str)
+        # Preview should be non-trivial -- it carries real content, not an
+        # opaque type stub.
+        assert len(result["items"]) > 100
+        assert "x" in result["items"]
 
     def test_other_types(self):
         from code_puppy.plugins.frontend_emitter.register_callbacks import (

--- a/tests/plugins/test_frontend_emitter_session_channel.py
+++ b/tests/plugins/test_frontend_emitter_session_channel.py
@@ -1,0 +1,322 @@
+"""Tests for the session-channel feature of frontend_emitter.
+
+Covers:
+  * ``code_puppy.plugins.frontend_emitter.session_context.current_emitter_session_id`` ContextVar isolation
+  * ``emit_event(session_id=...)`` explicit-kwarg precedence
+  * ``emit_event`` ContextVar fallback
+  * ``emit_event(session_id=None)`` opt-out of ContextVar fallback
+  * ``subscribe(session_id=...)`` per-session routing filter
+  * Wildcard subscriber still sees session-tagged events
+  * Multi-session isolation under concurrent asyncio Tasks
+  * Backward compatibility of the legacy 2-arg ``emit_event`` call shape
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+from code_puppy.plugins.frontend_emitter.session_context import current_emitter_session_id
+from code_puppy.plugins.frontend_emitter.emitter import (
+    _recent_events,
+    _subscriber_records,
+    emit_event,
+    get_subscriber_count,
+    subscribe,
+    unsubscribe,
+)
+
+# ─── helpers ─────────────────────────────────────────────────────────────
+
+
+def _reset_emitter_state() -> None:
+    """Wipe in-process subscriber and recent-event state between tests."""
+    _subscriber_records.clear()
+    _recent_events.clear()
+
+
+def _drain(q: "asyncio.Queue[Dict[str, Any]]") -> List[Dict[str, Any]]:
+    """Drain everything currently in ``q`` without awaiting."""
+    out: List[Dict[str, Any]] = []
+    while not q.empty():
+        out.append(q.get_nowait())
+    return out
+
+
+@pytest.fixture(autouse=True)
+def _emitter_enabled_and_reset():
+    """Ensure the emitter is enabled and state is clean for each test."""
+    _reset_emitter_state()
+    with patch(
+        "code_puppy.plugins.frontend_emitter.emitter.get_frontend_emitter_enabled",
+        return_value=True,
+    ), patch(
+        "code_puppy.plugins.frontend_emitter.emitter.get_frontend_emitter_max_recent_events",
+        return_value=1000,
+    ), patch(
+        "code_puppy.plugins.frontend_emitter.emitter.get_frontend_emitter_queue_size",
+        return_value=1000,
+    ):
+        yield
+    _reset_emitter_state()
+
+
+# ─── ContextVar primitive ────────────────────────────────────────────────
+
+
+class TestContextVar:
+    def test_default_is_none(self):
+        # Fresh ContextVar in a fresh asyncio Context defaults to None.
+        ctx = __import__("contextvars").copy_context()
+
+        def _read() -> Any:
+            return current_emitter_session_id.get()
+
+        assert ctx.run(_read) is None
+
+    @pytest.mark.asyncio
+    async def test_set_and_reset_roundtrip(self):
+        assert current_emitter_session_id.get() is None
+        token = current_emitter_session_id.set("sid-1")
+        try:
+            assert current_emitter_session_id.get() == "sid-1"
+        finally:
+            current_emitter_session_id.reset(token)
+        assert current_emitter_session_id.get() is None
+
+    @pytest.mark.asyncio
+    async def test_isolation_across_concurrent_tasks(self):
+        """Each asyncio Task gets its own ContextVar snapshot."""
+
+        async def worker(sid: str) -> str:
+            token = current_emitter_session_id.set(sid)
+            try:
+                # Yield to the loop so other workers run in between -- if
+                # the ContextVar leaks across tasks, this is where it'd show.
+                await asyncio.sleep(0.01)
+                seen = current_emitter_session_id.get()
+                # Yield again post-read for good measure.
+                await asyncio.sleep(0.01)
+                assert seen == sid, f"leak: expected {sid}, got {seen}"
+                return seen
+            finally:
+                current_emitter_session_id.reset(token)
+
+        results = await asyncio.gather(*[worker(f"sid-{i}") for i in range(10)])
+        assert results == [f"sid-{i}" for i in range(10)]
+        # Outer context unchanged.
+        assert current_emitter_session_id.get() is None
+
+    @pytest.mark.asyncio
+    async def test_reset_runs_even_on_exception(self):
+        async def boom() -> None:
+            token = current_emitter_session_id.set("doomed")
+            try:
+                raise RuntimeError("kaboom")
+            finally:
+                current_emitter_session_id.reset(token)
+
+        with pytest.raises(RuntimeError):
+            await boom()
+        assert current_emitter_session_id.get() is None
+
+
+# ─── emit_event session_id precedence ────────────────────────────────────
+
+
+class TestEmitEventSessionId:
+    @pytest.mark.asyncio
+    async def test_explicit_kwarg_wins_over_contextvar(self):
+        q = subscribe()
+        token = current_emitter_session_id.set("ctx-sid")
+        try:
+            emit_event("explicit-kwarg", {}, session_id="explicit-sid")
+        finally:
+            current_emitter_session_id.reset(token)
+        events = _drain(q)
+        assert len(events) == 1
+        assert events[0]["session_id"] == "explicit-sid"
+        unsubscribe(q)
+
+    @pytest.mark.asyncio
+    async def test_contextvar_used_when_kwarg_unset(self):
+        q = subscribe()
+        token = current_emitter_session_id.set("ctx-sid")
+        try:
+            emit_event("ctx-fallback", {})
+        finally:
+            current_emitter_session_id.reset(token)
+        events = _drain(q)
+        assert len(events) == 1
+        assert events[0]["session_id"] == "ctx-sid"
+        unsubscribe(q)
+
+    @pytest.mark.asyncio
+    async def test_explicit_none_opts_out_of_contextvar_fallback(self):
+        """Passing session_id=None explicitly disables the ContextVar fallback."""
+        q = subscribe()
+        token = current_emitter_session_id.set("ctx-sid")
+        try:
+            emit_event("opt-out", {}, session_id=None)
+        finally:
+            current_emitter_session_id.reset(token)
+        events = _drain(q)
+        assert len(events) == 1
+        assert events[0]["session_id"] is None
+        unsubscribe(q)
+
+    @pytest.mark.asyncio
+    async def test_no_kwarg_no_contextvar_means_none(self):
+        q = subscribe()
+        emit_event("neither", {})  # no kwarg, no ContextVar set
+        events = _drain(q)
+        assert events[0]["session_id"] is None
+        unsubscribe(q)
+
+
+# ─── subscribe filter behaviour ──────────────────────────────────────────
+
+
+class TestSubscribeFilter:
+    @pytest.mark.asyncio
+    async def test_session_subscriber_receives_only_matching(self):
+        q_alice = subscribe(session_id="alice")
+        emit_event("e1", {}, session_id="alice")
+        emit_event("e2", {}, session_id="bob")
+        emit_event("e3", {}, session_id="alice")
+        emit_event("e4", {})  # session_id=None
+        events = _drain(q_alice)
+        assert [e["type"] for e in events] == ["e1", "e3"]
+        assert all(e["session_id"] == "alice" for e in events)
+        unsubscribe(q_alice)
+
+    @pytest.mark.asyncio
+    async def test_wildcard_subscriber_receives_everything(self):
+        q_all = subscribe()
+        emit_event("e1", {}, session_id="alice")
+        emit_event("e2", {}, session_id="bob")
+        emit_event("e3", {})  # session_id=None
+        events = _drain(q_all)
+        assert [e["type"] for e in events] == ["e1", "e2", "e3"]
+        assert [e["session_id"] for e in events] == ["alice", "bob", None]
+        unsubscribe(q_all)
+
+    @pytest.mark.asyncio
+    async def test_session_subscriber_does_not_receive_untagged(self):
+        """An untagged event (session_id=None) must NOT leak to a session subscriber."""
+        q_alice = subscribe(session_id="alice")
+        emit_event("untagged", {})  # session_id will resolve to None
+        assert q_alice.empty()
+        unsubscribe(q_alice)
+
+    @pytest.mark.asyncio
+    async def test_multiple_session_subscribers_for_same_sid(self):
+        """Two independent subscribers for the same session_id both receive."""
+        q1 = subscribe(session_id="shared")
+        q2 = subscribe(session_id="shared")
+        emit_event("shared-evt", {}, session_id="shared")
+        assert _drain(q1)[0]["type"] == "shared-evt"
+        assert _drain(q2)[0]["type"] == "shared-evt"
+        unsubscribe(q1)
+        unsubscribe(q2)
+
+
+# ─── multi-session isolation (the integration acceptance test) ───────────
+
+
+class TestMultiSessionIsolation:
+    @pytest.mark.asyncio
+    async def test_concurrent_sessions_do_not_cross_leak(self):
+        """Many concurrent agent-style runs, each in its own ContextVar
+        scope, must NEVER deliver events to another session's subscriber."""
+
+        n_sessions = 8
+        events_per_session = 25
+        subscribers = {
+            sid: subscribe(session_id=sid)
+            for sid in (f"sess-{i}" for i in range(n_sessions))
+        }
+        q_wild = subscribe()  # observer
+
+        async def run_session(sid: str) -> None:
+            token = current_emitter_session_id.set(sid)
+            try:
+                for i in range(events_per_session):
+                    # Interleave to maximise scheduler context-switches.
+                    await asyncio.sleep(0)
+                    emit_event(f"evt-{i}", {"who": sid, "i": i})
+            finally:
+                current_emitter_session_id.reset(token)
+
+        await asyncio.gather(*[run_session(sid) for sid in subscribers])
+
+        # 1. Each session subscriber received exactly its own events.
+        for sid, q in subscribers.items():
+            events = _drain(q)
+            assert len(events) == events_per_session, (
+                f"session {sid} got {len(events)} events, "
+                f"expected {events_per_session}"
+            )
+            assert all(e["session_id"] == sid for e in events), (
+                f"CROSS-SESSION LEAK detected for {sid}: "
+                f"{[e['session_id'] for e in events if e['session_id'] != sid]}"
+            )
+            assert all(e["data"]["who"] == sid for e in events)
+
+        # 2. Wildcard subscriber saw every event from every session.
+        wild_events = _drain(q_wild)
+        assert len(wild_events) == n_sessions * events_per_session
+        sid_counts = {sid: 0 for sid in subscribers}
+        for e in wild_events:
+            sid_counts[e["session_id"]] += 1
+        assert all(c == events_per_session for c in sid_counts.values())
+
+        for q in subscribers.values():
+            unsubscribe(q)
+        unsubscribe(q_wild)
+
+    @pytest.mark.asyncio
+    async def test_event_count_matches_after_unsubscribe(self):
+        """unsubscribe() actually stops delivery to that queue."""
+        q = subscribe(session_id="A")
+        emit_event("e1", {}, session_id="A")
+        assert q.qsize() == 1
+        unsubscribe(q)
+        emit_event("e2", {}, session_id="A")
+        # q is unsubscribed -- size must NOT increase.
+        assert q.qsize() == 1
+
+
+# ─── backward compatibility ──────────────────────────────────────────────
+
+
+class TestBackwardCompat:
+    @pytest.mark.asyncio
+    async def test_legacy_two_arg_emit_event_still_works(self):
+        q = subscribe()  # legacy bare subscribe
+        emit_event("legacy.type", {"foo": "bar"})  # legacy 2-arg emit
+        events = _drain(q)
+        assert len(events) == 1
+        e = events[0]
+        assert e["type"] == "legacy.type"
+        assert e["data"] == {"foo": "bar"}
+        assert "id" in e
+        assert "timestamp" in e
+        assert e["session_id"] is None
+        unsubscribe(q)
+
+    @pytest.mark.asyncio
+    async def test_get_subscriber_count_tracks_session_subscribers(self):
+        assert get_subscriber_count() == 0
+        q1 = subscribe()
+        q2 = subscribe(session_id="x")
+        q3 = subscribe(session_id="y")
+        assert get_subscriber_count() == 3
+        unsubscribe(q2)
+        assert get_subscriber_count() == 2
+        unsubscribe(q1)
+        unsubscribe(q3)
+        assert get_subscriber_count() == 0


### PR DESCRIPTION
…nitisers

Two composable improvements to the frontend_emitter plugin that let embedders (e.g. a WebSocket backend hosting multiple concurrent agent sessions) tag every emitted event with a session identifier and stream real per-token text to subscribers.

**Feature: session-id channel**

Adds a per-plugin ContextVar plus matching emit/subscribe APIs so the
same in-process emitter can serve N concurrent sessions, each with its
own filtered subscriber.

-  code_puppy/plugins/frontend_emitter/session_context.py (new)
   Defines current_emitter_session_id: ContextVar[Optional[str]] with key "code_puppy_frontend_emitter_session_id".    Scoped to the plugin on purpose -- it is not a general-purpose code_puppy.context primitive. Other subsystems that want session-scoped metadata should introduce their own ContextVar with a clearly-scoped name.

-  emitter.emit_event() gains an optional session_id kwarg.
    Precedence: explicit kwarg > current_emitter_session_id ContextVar None. Passing session_id=None explicitly opts out of the ContextVar fallback. Every emitted event now carries a top-level "session_id" field.

- emitter.subscribe() gains an optional session_id filter.
    Wildcard subscribers (no filter) still see everything; session subscribers receive only events whose resolved session_id matches. Untagged events (session_id=None) are NOT delivered to session-filtered subscribers.

- Fan-out preserves back-compat with code that pokes the legacy _subscribers set directly; orphan queues are treated as wildcards.

Because ContextVar values are copied into each new asyncio Task at creation time, sessions are isolated across concurrent agent runs with no explicit propagation required.

**Fix: lossy event sanitisation dropped streamed content**

- register_callbacks._sanitize_event_data previously fell through to a f"<{type(data).__name__}>" stub for any non-primitive value, so every part_delta event arrived at subscribers with its delta field clobbered to the literal "<TextPartDelta>" and the actual streamed text (the content_delta attribute) thrown away. This made the emitter unusable for token-by-token WS streaming and forced embedders (e.g. puppy-desk-be's event_bridge.py) to register raw callbacks that bypassed emit_event() entirely.

- _sanitize_event_data: pydantic-ai delta objects are duck-typed  normalised (content_delta / args_delta / part wrapping /
    top-level content), preserving the real streamed text.

- _sanitize_args: list/dict/tuple values are JSON-round-tripped and kept verbatim if the serialised form fits in 4 KB; oversize
    values fall back to a truncated string preview instead of the previous opaque "<list[N]>" / "<dict[K]>" stub.

- All four callback emit-sites rely on the implicit ContextVar fallback for session_id -- no explicit code_puppy.api.* coupling.
