### PR TITLE
feat(plugins): Ollama support

### DIFF
--- a/code_puppy/plugins/ollama/__init__.py
+++ b/code_puppy/plugins/ollama/__init__.py
@@ -1,0 +1,1 @@
+"""Ollama plugin — registers the 'ollama' model type for local OpenAI Chat Completions-compatible endpoints."""

--- a/code_puppy/plugins/ollama/register_callbacks.py
+++ b/code_puppy/plugins/ollama/register_callbacks.py
@@ -1,0 +1,127 @@
+"""Ollama model type handler for OpenAI Chat Completions-compatible endpoints.
+
+Registers the 'ollama' model type so users can connect Code Puppy to local
+inference servers (Ollama, LM Studio, vLLM, llama.cpp, etc.) via
+~/.code_puppy/extra_models.json.
+
+Minimal config (Ollama on localhost with defaults):
+{
+    "ollama-qwen3": {
+        "type": "ollama",
+        "name": "qwen3:30b",
+        "context_length": 131072
+    }
+}
+
+Full config (remote server, same custom_endpoint format as custom_openai):
+{
+    "lmstudio-codellama": {
+        "type": "ollama",
+        "name": "codellama:34b",
+        "context_length": 16384,
+        "custom_endpoint": {
+            "url": "http://192.168.1.50:1234/v1",
+            "api_key": "$LM_STUDIO_KEY"
+        }
+    }
+}
+
+Note: Code Puppy requires models with strong tool/function calling support.
+Models without tool calling will notwork properly.
+"""
+
+import logging
+import os
+from typing import Any
+
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+from code_puppy.callbacks import register_callback
+from code_puppy.http_utils import create_async_client
+from code_puppy.model_factory import get_custom_config
+
+logger = logging.getLogger(__name__)
+
+# Ollama defaults
+_DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434/v1"
+_DEFAULT_OLLAMA_API_KEY = "ollama"
+
+
+def create_ollama_model(
+    model_name: str,
+    model_config: dict[str, Any],
+    config: dict[str, Any],
+) -> OpenAIChatModel | None:
+    """Create a model for an OpenAI Chat Completions-compatible endpoint.
+
+    When ``custom_endpoint`` is present in *model_config*, the standard
+    ``get_custom_config()`` helper is used (same path as ``custom_openai``
+    and ``codex`` model types).
+
+    When ``custom_endpoint`` is absent, sensible Ollama defaults are applied:
+    - base URL from ``OLLAMA_HOST`` env var, or ``http://localhost:11434/v1``
+    - api_key ``"ollama"`` (required non-empty by OpenAIProvider, not validated by Ollama)
+
+    Args:
+        model_name: The config key name of the model.
+        model_config: The model's configuration dict.
+        config: The full models configuration (unused, kept for API compat).
+
+    Returns:
+        OpenAIChatModel instance, or None if creation fails.
+    """
+    try:
+        if "custom_endpoint" in model_config:
+            url, headers, verify, api_key = get_custom_config(model_config)
+        else:
+            # Derive base URL: OLLAMA_HOST env var → default
+            ollama_host = os.environ.get("OLLAMA_HOST", "").rstrip("/")
+            if ollama_host:
+                url = (
+                    ollama_host if ollama_host.endswith("/v1") else f"{ollama_host}/v1"
+                )
+            else:
+                url = _DEFAULT_OLLAMA_BASE_URL
+            headers = {}
+            verify = None
+            api_key = _DEFAULT_OLLAMA_API_KEY
+
+        client = create_async_client(headers=headers, verify=verify)
+
+        provider_args: dict[str, Any] = {
+            "base_url": url,
+            "http_client": client,
+        }
+        if api_key:
+            provider_args["api_key"] = api_key
+        else:
+            provider_args["api_key"] = _DEFAULT_OLLAMA_API_KEY
+
+        provider = OpenAIProvider(**provider_args)
+
+        actual_model_name = model_config.get("name", model_name)
+        model = OpenAIChatModel(actual_model_name, provider=provider)
+        model.provider = (
+            provider  # Expose for connection-pooling cleanup (project convention)
+        )
+
+        logger.info("Created ollama model: %s -> %s", actual_model_name, url)
+        return model
+
+    except Exception as e:
+        logger.error("Failed to create ollama model '%s': %s", model_name, e)
+        return None
+
+
+def _get_ollama_model_types():
+    """Return the ollama model type handler for the register_model_type hook."""
+    return [
+        {
+            "type": "ollama",
+            "handler": create_ollama_model,
+        },
+    ]
+
+
+register_callback("register_model_type", _get_ollama_model_types)

--- a/tests/plugins/test_ollama_plugin.py
+++ b/tests/plugins/test_ollama_plugin.py
@@ -1,0 +1,199 @@
+"""Tests for the Ollama plugin model type handler."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic_ai.models.openai import OpenAIChatModel, OpenAIResponsesModel
+
+from code_puppy.plugins.ollama.register_callbacks import (
+    _DEFAULT_OLLAMA_API_KEY,
+    _DEFAULT_OLLAMA_BASE_URL,
+    _get_ollama_model_types,
+    create_ollama_model,
+)
+
+MODULE = "code_puppy.plugins.ollama.register_callbacks"
+
+
+@pytest.fixture
+def mock_async_client():
+    with patch(f"{MODULE}.create_async_client") as mock:
+        mock.return_value = MagicMock()
+        yield mock
+
+
+@pytest.fixture
+def mock_get_custom_config():
+    with patch(f"{MODULE}.get_custom_config") as mock:
+        mock.return_value = (
+            "http://remote:8080/v1",
+            {"X-Key": "val"},
+            None,
+            "custom-key",
+        )
+        yield mock
+
+
+@pytest.fixture
+def mock_provider():
+    with patch(f"{MODULE}.OpenAIProvider") as mock:
+        mock.return_value = MagicMock()
+        yield mock
+
+
+def test_custom_endpoint_uses_get_custom_config(
+    mock_async_client, mock_get_custom_config, mock_provider
+):
+    model_config = {
+        "name": "codellama:34b",
+        "custom_endpoint": {
+            "url": "http://remote:8080/v1",
+            "api_key": "custom-key",
+        },
+    }
+    result = create_ollama_model("my-model", model_config, {})
+
+    mock_get_custom_config.assert_called_once_with(model_config)
+    assert isinstance(result, OpenAIChatModel)
+
+
+def test_no_custom_endpoint_defaults_to_localhost(
+    mock_async_client, mock_provider, monkeypatch
+):
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    model_config = {"name": "llama3:8b"}
+    result = create_ollama_model("my-model", model_config, {})
+
+    assert isinstance(result, OpenAIChatModel)
+    # Verify the client was created with empty headers and no verify
+    mock_async_client.assert_called_once_with(headers={}, verify=None)
+
+
+def test_ollama_host_env_appends_v1(mock_async_client, mock_provider, monkeypatch):
+    monkeypatch.setenv("OLLAMA_HOST", "http://myserver:11434")
+    model_config = {"name": "gpt3:30b"}
+    create_ollama_model("my-model", model_config, {})
+
+    # Check the provider was called with /v1 appended
+    call_kwargs = mock_provider.call_args[1]
+    assert call_kwargs["base_url"] == "http://myserver:11434/v1"
+
+
+def test_ollama_host_already_ends_with_v1(
+    mock_async_client, mock_provider, monkeypatch
+):
+    monkeypatch.setenv("OLLAMA_HOST", "http://myserver:11434/v1")
+    model_config = {"name": "gpt3:30b"}
+    create_ollama_model("my-model", model_config, {})
+
+    call_kwargs = mock_provider.call_args[1]
+    assert call_kwargs["base_url"] == "http://myserver:11434/v1"
+
+
+def test_ollama_host_trailing_slash_stripped(
+    mock_async_client, mock_provider, monkeypatch
+):
+    monkeypatch.setenv("OLLAMA_HOST", "http://myserver:11434/")
+    model_config = {"name": "gpt3:30b"}
+    create_ollama_model("my-model", model_config, {})
+
+    call_kwargs = mock_provider.call_args[1]
+    assert call_kwargs["base_url"] == "http://myserver:11434/v1"
+
+
+def test_ollama_host_empty_string_uses_default(
+    mock_async_client, mock_provider, monkeypatch
+):
+    monkeypatch.setenv("OLLAMA_HOST", "")
+    model_config = {"name": "llama3:8b"}
+    create_ollama_model("my-model", model_config, {})
+
+    call_kwargs = mock_provider.call_args[1]
+    assert call_kwargs["base_url"] == _DEFAULT_OLLAMA_BASE_URL
+
+
+def test_returns_open_ai_chat_model_not_responses(
+    mock_async_client, mock_provider, monkeypatch
+):
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    model_config = {"name": "llama3:8b"}
+    result = create_ollama_model("my-model", model_config, {})
+
+    assert isinstance(result, OpenAIChatModel)
+    assert not isinstance(result, OpenAIResponsesModel)
+
+
+def test_provider_is_set_on_model(mock_async_client, mock_provider, monkeypatch):
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    model_config = {"name": "llama3:8b"}
+    result = create_ollama_model("my-model", model_config, {})
+
+    assert result is not None
+    assert hasattr(result, "provider")
+    assert result.provider is not None
+
+
+def test_uses_model_config_name(mock_async_client, mock_provider, monkeypatch):
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    model_config = {"name": "gpt3:30b"}
+    result = create_ollama_model("config-key", model_config, {})
+
+    assert result is not None
+    assert result.model_name == "gpt3:30b"
+
+
+def test_falls_back_to_model_name_key(mock_async_client, mock_provider, monkeypatch):
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    model_config = {}  # No "name" key
+    result = create_ollama_model("fallback-name", model_config, {})
+
+    assert result is not None
+    assert result.model_name == "fallback-name"
+
+
+def test_returns_none_on_exception(monkeypatch):
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    model_config = {
+        "name": "test",
+        "custom_endpoint": {"url": "http://x", "api_key": "k"},
+    }
+    with patch(f"{MODULE}.get_custom_config", side_effect=RuntimeError("boom")):
+        result = create_ollama_model("bad-model", model_config, {})
+    assert result is None
+
+
+def test_get_ollama_model_types_structure():
+    result = _get_ollama_model_types()
+    assert isinstance(result, list)
+    assert len(result) == 1
+    entry = result[0]
+    assert entry["type"] == "ollama"
+    assert callable(entry["handler"])
+    assert entry["handler"] is create_ollama_model
+
+
+def test_api_key_defaults_to_ollama(mock_async_client, mock_provider, monkeypatch):
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    model_config = {"name": "llama3:8b"}
+    create_ollama_model("my-model", model_config, {})
+
+    call_kwargs = mock_provider.call_args[1]
+    assert call_kwargs["api_key"] == _DEFAULT_OLLAMA_API_KEY
+
+
+def test_api_key_fallback_when_custom_returns_none(mock_async_client, mock_provider):
+    with patch(f"{MODULE}.get_custom_config") as mock_gcc:
+        mock_gcc.return_value = ("http://x/v1", {}, None, None)
+        create_ollama_model(
+            "m",
+            {"name": "t", "custom_endpoint": {"url": "http://x/v1"}},
+            {},
+        )
+
+    call_kwargs = mock_provider.call_args[1]
+    assert call_kwargs["api_key"] == _DEFAULT_OLLAMA_API_KEY
+
+
+def test_default_constants():
+    assert _DEFAULT_OLLAMA_BASE_URL == "http://localhost:11434/v1"
+    assert _DEFAULT_OLLAMA_API_KEY == "ollama"


### PR DESCRIPTION
## Summary

Adds a new plugin that lets Code Puppy connect to local inference servers — Ollama, LM Studio, vLLM, llama.cpp, and any other OpenAI Chat Completions-compatible endpoint — without sending requests to remote model providers.

The plugin is auto-discovered by the existing plugin loader. Zero existing files were modified.

## User Story
As a user, I want to run Code Puppy with local models through Ollama (or any OpenAI Chat Completions-compatible endpoint), so that I don't connect with remote model providers, use the hardware on my machine to process requests, and reduce costs.

## Acceptance Criteria
- [x] A new plugin `code_puppy/plugins/ollama/` is created following the plugin architecture
- [x] The plugin registers an `"ollama"` model type via the `register_model_type` callback hook
- [x] Users can configure Ollama models in `~/.code_puppy/extra_models.json` using the existing `custom_endpoint` config format
- [x] When no `custom_endpoint` is provided, the plugin defaults to `http://localhost:11434/v1` with api_key `"ollama"`
- [x] The `OLLAMA_HOST` environment variable overrides the default base URL
- [x] The handler creates `OpenAIChatModel` (Chat Completions API), NOT `OpenAIResponsesModel` (Responses API)
- [x] All existing Code Puppy features (tools, agents, sub-agents, plugins, streaming) work with Ollama models that support tool/function calling
- [x] The plugin fails gracefully — never crashes the app
- [x] Unit tests cover all paths with 95%+ coverage
- [x] No existing files are modified — plugin loader auto-discovers the new directory
- [x] Code passes `ruff format` and `ruff check`

## Test Plan
| # | Test Case | Expected Result |
|---|-----------|-----------------|
| 1 | Handler with `custom_endpoint` config | Uses provided URL, api_key, headers via `get_custom_config()` |
| 2 | Handler without `custom_endpoint` | Defaults to `http://localhost:11434/v1`, api_key `"ollama"` |
| 3 | `OLLAMA_HOST` env var set | Overrides default URL, appends `/v1` if missing |
| 4 | Handler returns `OpenAIChatModel` | NOT `OpenAIResponsesModel` — verified via isinstance check |
| 5 | Handler failure (e.g., bad config) | Returns `None`, does not raise |
| 6 | `get_ollama_model_types()` return structure | Returns `[{"type": "ollama", "handler": callable}]` |
| 7 | `ModelFactory.get_model` integration | Type `"ollama"` routes to the handler via callback |
| 8 | Plugin auto-discovery | `register_callbacks.py` is found by plugin loader |

### How to Use

#### 1 — Install Ollama

```bash
brew install ollama
```

#### 2 — Pull a model with tool calling support

```bash
ollama pull qwen3:8b         # ~6 GB VRAM  — good for testing
ollama pull qwen3:14b        # ~10 GB VRAM — better quality
ollama pull qwen3:30b        # ~20 GB VRAM — recommended
```

#### 3 — Start the Ollama server

```bash
brew services start ollama
```

```bash
curl http://localhost:11434/api/tags
```

#### 4 — Configure the model in Code Puppy

Create or edit ~/.code_puppy/extra_models.json:

```json
{
  "ollama-qwen3": {
    "type": "ollama",
    "name": "qwen3:8b",
    "context_length": 32768
  }
}
```

Multiple models can be registered at once:

```json
{
  "ollama-qwen3-8b": {
    "type": "ollama",
    "name": "qwen3:8b",
    "context_length": 32768
  },
  "ollama-qwen3-30b": {
    "type": "ollama",
    "name": "qwen3:30b",
    "context_length": 131072
  }
}
```

Custom host (different port, remote machine, LM Studio):

```json
{
  "lmstudio-codellama": {
    "type": "ollama",
    "name": "codellama:34b",
    "context_length": 16384,
    "custom_endpoint": {
      "url": "http://192.168.1.50:1234/v1",
      "api_key": "lm-studio"
    }
  }
}
```

Alternatively, set OLLAMA_HOST to override the default endpoint without editing the config:

```bash
export OLLAMA_HOST=http://myserver:11434
```

#### 5 — Run Code Puppy and switch to the local model

```bash
./code-puppy-dev --interactive
```

Inside the session:

```bash
/model ollama-qwen3
```

Or start directly on the model:

```bash
./code-puppy-dev --interactive --model ollama-qwen3
```

### Testing

#### Unit tests (no Ollama required — fully mocked)

```bash
pytest tests/test_ollama_plugin.py -v
```

Coverage: 100% on plugin files across 15 test cases covering:
- custom_endpoint path (uses get_custom_config())
- Default localhost path
- OLLAMA_HOST env var — append /v1, already ends with /v1, trailing slash, empty string
- Returns OpenAIChatModel not OpenAIResponsesModel
- model_config["name"] resolution with fallback to config key
- Graceful None return on exception
- Handler registration structure

Verified End-to-End

- ollama serve + qwen3:8b on localhost
- Model appears in /model picker after configuring extra_models.json
- File read/write tool calls work
- Multi-step agentic tasks complete successfully
- No remote API calls made during local model session