### PR TITLE
Fail closed non-interactive approval prompts

### DIFF
--- a/code_puppy/tools/common.py
+++ b/code_puppy/tools/common.py
@@ -52,6 +52,28 @@ def _get_approval_async_lock() -> asyncio.Lock:
     return _APPROVAL_ASYNC_LOCK
 
 
+def _stdin_supports_interactive_approval() -> bool:
+    """Return True only when stdin can accept interactive approval input."""
+    stdin = getattr(sys, "stdin", None)
+    if stdin is None:
+        return False
+
+    isatty = getattr(stdin, "isatty", None)
+    if isatty is None:
+        return False
+
+    try:
+        return bool(isatty())
+    except Exception:
+        return False
+
+
+def _deny_noninteractive_approval(title: str) -> tuple[bool, None]:
+    """Fail closed when approval is requested without an interactive stdin."""
+    emit_warning(f"Approval for '{title}' rejected: stdin is not interactive.")
+    return False, None
+
+
 # Syntax highlighting imports for "syntax" diff mode
 try:
     from pygments import lex
@@ -1116,6 +1138,9 @@ def _get_user_approval_impl(
 
     from code_puppy.tools.command_runner import set_awaiting_user_input
 
+    if not _stdin_supports_interactive_approval():
+        return _deny_noninteractive_approval(title)
+
     if puppy_name is None:
         from code_puppy.config import get_puppy_name
 
@@ -1309,6 +1334,9 @@ async def _get_user_approval_async_impl(
 ) -> tuple[bool, str | None]:
     """Inner implementation of get_user_approval_async (lock-free)."""
     from code_puppy.tools.command_runner import set_awaiting_user_input
+
+    if not _stdin_supports_interactive_approval():
+        return _deny_noninteractive_approval(title)
 
     if puppy_name is None:
         from code_puppy.config import get_puppy_name

--- a/tests/tools/test_common_full_coverage.py
+++ b/tests/tools/test_common_full_coverage.py
@@ -656,6 +656,12 @@ class TestArrowSelect:
 
 
 class TestGetUserApproval:
+    @pytest.fixture(autouse=True)
+    def _interactive_stdin(self):
+        with patch("code_puppy.tools.common.sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = True
+            yield mock_stdin
+
     def test_approve(self):
         from code_puppy.tools.common import get_user_approval
 
@@ -806,6 +812,12 @@ class TestGetUserApproval:
 
 
 class TestGetUserApprovalAsync:
+    @pytest.fixture(autouse=True)
+    def _interactive_stdin(self):
+        with patch("code_puppy.tools.common.sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = True
+            yield mock_stdin
+
     @pytest.mark.asyncio
     async def test_approve(self):
         from code_puppy.tools.common import get_user_approval_async

--- a/tests/tools/test_common_missing.py
+++ b/tests/tools/test_common_missing.py
@@ -192,6 +192,12 @@ class TestFormatDiffWithColors:
 
 
 class TestGetUserApproval:
+    @pytest.fixture(autouse=True)
+    def _interactive_stdin(self):
+        with patch("code_puppy.tools.common.sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = True
+            yield mock_stdin
+
     @patch("code_puppy.tools.common.arrow_select", return_value="\u2713 Approve")
     @patch("code_puppy.tools.common.Console")
     @patch("code_puppy.tools.common.emit_info")
@@ -299,6 +305,12 @@ class TestGetUserApproval:
 
 
 class TestGetUserApprovalAsync:
+    @pytest.fixture(autouse=True)
+    def _interactive_stdin(self):
+        with patch("code_puppy.tools.common.sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = True
+            yield mock_stdin
+
     @pytest.mark.asyncio
     @patch("code_puppy.tools.common.arrow_select_async", return_value="\u2713 Approve")
     @patch("code_puppy.tools.common.Console")

--- a/tests/tools/test_noninteractive_approval.py
+++ b/tests/tools/test_noninteractive_approval.py
@@ -1,0 +1,75 @@
+from unittest.mock import MagicMock, patch
+
+from code_puppy.callbacks import _callbacks, clear_callbacks, register_callback
+from code_puppy.plugins.file_permission_handler.register_callbacks import (
+    handle_file_permission,
+)
+from code_puppy.tools.file_modifications import write_to_file
+
+
+class _NonTtyStdin:
+    def isatty(self) -> bool:
+        return False
+
+
+def test_get_user_approval_fails_closed_without_tty():
+    from code_puppy.tools.common import get_user_approval
+
+    with (
+        patch("code_puppy.tools.common.sys.stdin", new=_NonTtyStdin()),
+        patch("code_puppy.tools.common.arrow_select") as mock_select,
+        patch("code_puppy.tools.common.Console"),
+        patch("code_puppy.tools.common.time.sleep", return_value=None),
+    ):
+        approved, feedback = get_user_approval("Test", "content", puppy_name="Rex")
+
+    assert approved is False
+    assert feedback is None
+    mock_select.assert_not_called()
+
+
+async def test_get_user_approval_async_fails_closed_without_tty():
+    from code_puppy.tools.common import get_user_approval_async
+
+    with (
+        patch("code_puppy.tools.common.sys.stdin", new=_NonTtyStdin()),
+        patch("code_puppy.tools.common.arrow_select_async") as mock_select,
+        patch("code_puppy.tools.common.Console"),
+    ):
+        approved, feedback = await get_user_approval_async(
+            "Test", "content", puppy_name="Rex"
+        )
+
+    assert approved is False
+    assert feedback is None
+    mock_select.assert_not_called()
+
+
+def test_write_to_file_fails_closed_without_tty(tmp_path):
+    target = tmp_path / "probe.txt"
+    original_callbacks = _callbacks["file_permission"].copy()
+
+    try:
+        clear_callbacks("file_permission")
+        register_callback("file_permission", handle_file_permission)
+
+        with (
+            patch("code_puppy.tools.common.sys.stdin", new=_NonTtyStdin()),
+            patch("code_puppy.tools.common.arrow_select") as mock_select,
+            patch(
+                "code_puppy.plugins.file_permission_handler.register_callbacks.get_yolo_mode",
+                return_value=False,
+            ),
+            patch("code_puppy.tools.common.Console"),
+            patch("code_puppy.tools.common.time.sleep", return_value=None),
+        ):
+            result = write_to_file(MagicMock(), str(target), "changed by test\n", False)
+    finally:
+        _callbacks["file_permission"] = original_callbacks
+
+    assert result["success"] is False
+    assert result["changed"] is False
+    assert result["user_rejection"] is True
+    assert result["user_feedback"] is None
+    assert target.exists() is False
+    mock_select.assert_not_called()


### PR DESCRIPTION
## Summary
- fail closed when approval is requested without an interactive stdin
- centralize the non-TTY guard in `code_puppy.tools.common` so both sync and async approval helpers behave consistently
- ensure file writes inherit the same fail-closed behavior through the existing file-permission flow

## Why
Shell-command approval already guards on `stdin.isatty()`, but the shared approval helpers did not. In non-interactive contexts, that could lead to attempted approval UI/input instead of a fast deterministic denial.

In a local pre-fix probe against this repo, a child process calling `get_user_approval()` with `stdin=/dev/null` timed out after 3 seconds instead of returning a denial, which matches the concern that Code Puppy could block waiting for approval input the user never actually sees.

## What changed
- added a shared stdin interactivity helper
- added a centralized fail-closed denial path for approval requests without interactive stdin
- guarded both `get_user_approval()` and `get_user_approval_async()` before any UI/input attempt
- added focused regression coverage for non-TTY sync/async approval and file-write denial
- updated existing approval tests to explicitly mock interactive stdin so existing expectations remain valid

## Validation
- `uv run --frozen pytest tests/tools/test_common_full_coverage.py::TestGetUserApproval tests/tools/test_common_full_coverage.py::TestGetUserApprovalAsync tests/tools/test_common_missing.py tests/test_file_permissions.py tests/plugins/test_file_permission_coverage.py tests/tools/test_noninteractive_approval.py -q --no-cov`
- result: `119 passed`

## Notes
I also refreshed a local manual probe script to match the current repo seams (sync helper, async helper, and `write_to_file` via the real file-permission callback). I left that probe out of this PR to keep the change set focused, but I can provide the script and/or the results if that would be helpful during review.
