### PR TITLE
fix(frontend-emitter): preserve ToolCallPart metadata in stream events

### DIFF
--- a/code_puppy/plugins/frontend_emitter/emitter.py
+++ b/code_puppy/plugins/frontend_emitter/emitter.py
@@ -42,7 +42,9 @@ from code_puppy.config import (
     get_frontend_emitter_max_recent_events,
     get_frontend_emitter_queue_size,
 )
-from code_puppy.plugins.frontend_emitter.session_context import current_emitter_session_id
+from code_puppy.plugins.frontend_emitter.session_context import (
+    current_emitter_session_id,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/code_puppy/plugins/frontend_emitter/register_callbacks.py
+++ b/code_puppy/plugins/frontend_emitter/register_callbacks.py
@@ -289,6 +289,7 @@ def _sanitize_event_data(data: Any) -> Any:
             "args_delta": _truncate_string(args_delta, max_length=1000),
             "tool_call_id": _safe_getattr_str(data, "tool_call_id"),
             "tool_name": _safe_getattr_str(data, "tool_name"),
+            "tool_name_delta": _safe_getattr_str(data, "tool_name_delta"),
         }
 
     # 3. part-wrapping events (PartStartEvent / PartEndEvent / etc.) --
@@ -300,7 +301,17 @@ def _sanitize_event_data(data: Any) -> Any:
             inner = f"<{type_name}.part>"
         return {"type": type_name, "part": inner}
 
-    # 4. Anything with a usable content/text attribute on the top level
+    # 4. ToolCallPart payloads: preserve structured tool metadata for
+    #    downstream stream bridges (/ws/chat typed event parser).
+    if hasattr(data, "tool_name") and hasattr(data, "args"):
+        return {
+            "type": type_name,
+            "tool_call_id": _safe_getattr_str(data, "tool_call_id"),
+            "tool_name": _safe_getattr_str(data, "tool_name"),
+            "args": _sanitize_args(getattr(data, "args", {})),
+        }
+
+    # 5. Anything with a usable content/text attribute on the top level
     #    (e.g. fully-formed TextPart, ThinkingPart).
     if hasattr(data, "content"):
         return {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,41 @@ import asyncio
 import inspect
 import os
 import subprocess
+from copy import deepcopy
 from unittest.mock import MagicMock
 
 import pytest
 
 from code_puppy import config as cp_config
+from code_puppy import callbacks as cp_callbacks
+
+
+def _ensure_builtin_plugin_callback_registrations() -> None:
+    """Re-register builtin plugin callbacks that tests assert are wired.
+
+    Some callback unit tests intentionally clear the global callback registry.
+    Importing a plugin module a second time does not re-run module-scope
+    registrations, so restore the key builtin registrations explicitly.
+    ``register_callback`` deduplicates, making this safe to call per test.
+    """
+    from code_puppy.plugins.agent_steering import register_callbacks as steering
+    from code_puppy.plugins.azure_foundry import register_callbacks as foundry
+    from code_puppy.plugins.claude_code_hooks import register_callbacks as hooks
+    from code_puppy.plugins.universal_constructor import register_callbacks as uc
+
+    cp_callbacks.register_callback(
+        "agent_pause_requested", steering._on_pause_requested
+    )
+    cp_callbacks.register_callback("custom_command_help", foundry._custom_help)
+    cp_callbacks.register_callback("custom_command", foundry._handle_custom_command)
+    cp_callbacks.register_callback("register_model_type", foundry._register_model_types)
+    # Keep hook callbacks registered for wiring tests, but do not let local
+    # ~/.code_puppy or project .claude hook configuration affect test runs.
+    hooks._hook_engine = None
+    cp_callbacks.register_callback("pre_tool_call", hooks.on_pre_tool_call_hook)
+    cp_callbacks.register_callback("post_tool_call", hooks.on_post_tool_call_hook)
+    cp_callbacks.register_callback("startup", uc._on_startup)
+
 
 # Integration test fixtures - only import if pexpect.spawn is available (Unix)
 # On Windows, pexpect doesn't have spawn attribute, so skip these imports
@@ -35,52 +65,58 @@ except (ImportError, AttributeError):
 
 
 @pytest.fixture(autouse=True)
-def isolate_config_between_tests(tmp_path_factory):
-    """Isolate config file changes between tests.
+def isolate_global_state_between_tests(tmp_path_factory):
+    """Isolate mutable global state between tests.
 
-    This prevents tests from modifying the user's real config file
-    (e.g., changing the selected model). Each test gets its own
-    temporary config file in a separate directory from tmp_path.
+    Tests must be deterministic locally and in CI. Do not seed test config from
+    the developer's real ``~/.code_puppy/puppy.cfg`` because user defaults such
+    as ``default_agent`` or ``compaction_threshold`` change expected defaults.
+    Also snapshot callback registrations so tests exercising callback mutation
+    cannot wipe plugin registrations needed by later tests.
     """
     import shutil
     import tempfile
 
-    # Save original config path
+    # Ensure lazy plugin imports are represented in the snapshot.
+    _ensure_builtin_plugin_callback_registrations()
+
+    # Save original config path and callback registry.
     original_config_file = cp_config.CONFIG_FILE
     original_config_dir = cp_config.CONFIG_DIR
+    original_callbacks = deepcopy(cp_callbacks._callbacks)
 
     # Create a completely separate temp directory for config isolation
-    # (not using tmp_path which tests may use for their own purposes)
+    # (not using tmp_path which tests may use for their own purposes).
     config_temp_dir = tempfile.mkdtemp(prefix="code_puppy_test_config_")
     temp_config_dir = os.path.join(config_temp_dir, ".code_puppy")
     os.makedirs(temp_config_dir, exist_ok=True)
     temp_config_file = os.path.join(temp_config_dir, "puppy.cfg")
 
-    # Copy existing config if it exists (so tests start with real settings)
-    if os.path.exists(original_config_file):
-        shutil.copy(original_config_file, temp_config_file)
-
-    # Redirect config to temp location
+    # Redirect config to an empty temp file so defaults are true product
+    # defaults, not the local developer's personal settings.
     cp_config.CONFIG_FILE = temp_config_file
     cp_config.CONFIG_DIR = temp_config_dir
 
-    # Clear model cache to ensure fresh state
+    # Clear model cache to ensure fresh state.
     cp_config.clear_model_cache()
-    # Clear session-local model cache (required for /model session sticky behavior)
+    # Clear session-local model cache (required for /model session sticky behavior).
     cp_config.reset_session_model()
 
     yield
 
-    # Restore original config paths
+    # Restore original config paths and callback registrations.
     cp_config.CONFIG_FILE = original_config_file
     cp_config.CONFIG_DIR = original_config_dir
+    cp_callbacks._callbacks.clear()
+    cp_callbacks._callbacks.update(original_callbacks)
+    _ensure_builtin_plugin_callback_registrations()
 
-    # Clear cache again after test
+    # Clear cache again after test.
     cp_config.clear_model_cache()
-    # Clear session-local model cache
+    # Clear session-local model cache.
     cp_config.reset_session_model()
 
-    # Clean up the temp directory
+    # Clean up the temp directory.
     try:
         shutil.rmtree(config_temp_dir)
     except Exception:

--- a/tests/plugins/test_frontend_emitter_coverage.py
+++ b/tests/plugins/test_frontend_emitter_coverage.py
@@ -373,6 +373,39 @@ class TestSanitizeEventData:
         result = _sanitize_event_data(object())
         assert "object" in result
 
+    def test_tool_call_part_preserves_tool_metadata(self):
+        from code_puppy.plugins.frontend_emitter.register_callbacks import (
+            _sanitize_event_data,
+        )
+
+        class _ToolCallPart:
+            tool_call_id = "tc_1"
+            tool_name = "list_files"
+            args = {"directory": "."}
+
+        result = _sanitize_event_data(_ToolCallPart())
+        assert isinstance(result, dict)
+        assert result["tool_call_id"] == "tc_1"
+        assert result["tool_name"] == "list_files"
+        assert result["args"] == {"directory": "."}
+
+    def test_tool_call_part_delta_preserves_name_delta(self):
+        from code_puppy.plugins.frontend_emitter.register_callbacks import (
+            _sanitize_event_data,
+        )
+
+        class _ToolCallPartDelta:
+            tool_call_id = "tc_2"
+            tool_name = None
+            tool_name_delta = "run_shell_command"
+            args_delta = '{"command":"git status"}'
+
+        result = _sanitize_event_data(_ToolCallPartDelta())
+        assert isinstance(result, dict)
+        assert result["tool_call_id"] == "tc_2"
+        assert result["tool_name_delta"] == "run_shell_command"
+        assert result["args_delta"] == '{"command":"git status"}'
+
 
 class TestIsSuccessfulResult:
     def test_none(self):

--- a/tests/plugins/test_frontend_emitter_session_channel.py
+++ b/tests/plugins/test_frontend_emitter_session_channel.py
@@ -19,7 +19,9 @@ from unittest.mock import patch
 
 import pytest
 
-from code_puppy.plugins.frontend_emitter.session_context import current_emitter_session_id
+from code_puppy.plugins.frontend_emitter.session_context import (
+    current_emitter_session_id,
+)
 from code_puppy.plugins.frontend_emitter.emitter import (
     _recent_events,
     _subscriber_records,
@@ -50,15 +52,19 @@ def _drain(q: "asyncio.Queue[Dict[str, Any]]") -> List[Dict[str, Any]]:
 def _emitter_enabled_and_reset():
     """Ensure the emitter is enabled and state is clean for each test."""
     _reset_emitter_state()
-    with patch(
-        "code_puppy.plugins.frontend_emitter.emitter.get_frontend_emitter_enabled",
-        return_value=True,
-    ), patch(
-        "code_puppy.plugins.frontend_emitter.emitter.get_frontend_emitter_max_recent_events",
-        return_value=1000,
-    ), patch(
-        "code_puppy.plugins.frontend_emitter.emitter.get_frontend_emitter_queue_size",
-        return_value=1000,
+    with (
+        patch(
+            "code_puppy.plugins.frontend_emitter.emitter.get_frontend_emitter_enabled",
+            return_value=True,
+        ),
+        patch(
+            "code_puppy.plugins.frontend_emitter.emitter.get_frontend_emitter_max_recent_events",
+            return_value=1000,
+        ),
+        patch(
+            "code_puppy.plugins.frontend_emitter.emitter.get_frontend_emitter_queue_size",
+            return_value=1000,
+        ),
     ):
         yield
     _reset_emitter_state()
@@ -257,8 +263,7 @@ class TestMultiSessionIsolation:
         for sid, q in subscribers.items():
             events = _drain(q)
             assert len(events) == events_per_session, (
-                f"session {sid} got {len(events)} events, "
-                f"expected {events_per_session}"
+                f"session {sid} got {len(events)} events, expected {events_per_session}"
             )
             assert all(e["session_id"] == sid for e in events), (
                 f"CROSS-SESSION LEAK detected for {sid}: "


### PR DESCRIPTION
What changed
• Preserves structured ToolCallPart metadata during event sanitization:
  ◦ tool_call_id
  ◦ tool_name
  ◦ args
• Preserves ToolCallPartDelta metadata:
  ◦ args_delta
  ◦ tool_call_id
  ◦ tool_name
  ◦ tool_name_delta
• Updates frontend emitter coverage tests to lock in these behaviors.

Why
Previously, sanitizer output could collapse tool-call parts into lossy placeholders, which caused downstream consumers (like Puppy Desk BE) to lose tool-call identity and argument deltas. This merge ensures tool-call streams remain high-fidelity and parseable end-to-end.

Validation
• Updated emitter coverage tests pass (tests/plugins/test_frontend_emitter_coverage.py).
• No API surface changes; behavior is backward-compatible for existing event consumers that already handle structured metadata.