### PR TITLE
fix(mcp): /mcp start auto-binds server to current agent

### DIFF
--- a/code_puppy/command_line/mcp/start_command.py
+++ b/code_puppy/command_line/mcp/start_command.py
@@ -95,8 +95,16 @@ class StartCommand(MCPCommandBase):
                 # Reload the agent to pick up the newly enabled server
                 # NOTE: We don't block or wait - the server will be ready
                 # when the next prompt runs (pydantic-ai handles connection)
+                #
+                # Auto-bind to the current agent if not already bound. The
+                # user just typed `/mcp start <name>` -- that's an explicit
+                # opt-in. Without this, get_servers_for_agent() will silently
+                # filter the new server out of the rebuilt toolset and the
+                # user gets a cheerful "started" message with zero tools.
+                # See CPUP-ne1 for the gory details.
                 try:
                     agent = get_current_agent()
+                    self._ensure_binding(agent.name, server_name, group_id)
                     agent.reload_code_generation_agent()
                     # Clear MCP tool cache - it will be repopulated on next run
                     agent.update_mcp_tool_cache_sync()
@@ -115,3 +123,35 @@ class StartCommand(MCPCommandBase):
         except Exception as e:
             logger.error(f"Error starting server '{server_name}': {e}")
             emit_error(f"Failed to start server: {e}", message_group=group_id)
+
+    @staticmethod
+    def _ensure_binding(
+        agent_name: str, server_name: str, group_id: Optional[str]
+    ) -> None:
+        """Bind ``server_name`` to ``agent_name`` if not already bound.
+
+        Idempotent and best-effort: any binding-layer exception is logged
+        but never propagated, so a flaky bindings file can't break
+        ``/mcp start``. Emits a single ``emit_info`` line when a new
+        binding is created so the user can see the cause and effect.
+        """
+        try:
+            from code_puppy.mcp_.agent_bindings import is_bound, set_binding
+
+            if is_bound(agent_name, server_name):
+                return
+            set_binding(agent_name, server_name, auto_start=True)
+            emit_info(
+                Text.from_markup(
+                    f"[dim]Also bound '{server_name}' to agent "
+                    f"'{agent_name}' (use /agents \u2192 B to manage).[/dim]"
+                ),
+                message_group=group_id,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(
+                "Auto-bind failed for server '%s' on agent '%s': %s",
+                server_name,
+                agent_name,
+                exc,
+            )

--- a/tests/command_line/mcp/test_start_command.py
+++ b/tests/command_line/mcp/test_start_command.py
@@ -145,3 +145,119 @@ class TestStartCommand:
         ):
             start_cmd.manager.start_server_sync.return_value = True
             start_cmd.execute(["myserver"], group_id="g1")
+
+    # ---- Auto-bind behaviour (CPUP-ne1) -------------------------------
+
+    def _make_agent(self, name="code-puppy"):
+        agent = MagicMock()
+        agent.name = name
+        return agent
+
+    def test_auto_binds_when_unbound(self, start_cmd):
+        """`/mcp start` on an unbound server creates the binding."""
+        agent = self._make_agent()
+        with (
+            patch(
+                "code_puppy.command_line.mcp.start_command.find_server_id_by_name",
+                return_value="id1",
+            ),
+            patch("code_puppy.command_line.mcp.start_command.emit_info"),
+            patch("code_puppy.command_line.mcp.start_command.emit_success"),
+            patch(
+                "code_puppy.command_line.mcp.start_command.get_current_agent",
+                return_value=agent,
+            ),
+            patch(
+                "code_puppy.mcp_.agent_bindings.is_bound", return_value=False
+            ) as mock_is_bound,
+            patch("code_puppy.mcp_.agent_bindings.set_binding") as mock_set_binding,
+        ):
+            start_cmd.manager.start_server_sync.return_value = True
+            start_cmd.execute(["myserver"], group_id="g1")
+
+            mock_is_bound.assert_called_once_with("code-puppy", "myserver")
+            mock_set_binding.assert_called_once_with(
+                "code-puppy", "myserver", auto_start=True
+            )
+            agent.reload_code_generation_agent.assert_called_once()
+
+    def test_no_rebind_when_already_bound(self, start_cmd):
+        """Already-bound server triggers no set_binding call (idempotent)."""
+        agent = self._make_agent()
+        with (
+            patch(
+                "code_puppy.command_line.mcp.start_command.find_server_id_by_name",
+                return_value="id1",
+            ),
+            patch("code_puppy.command_line.mcp.start_command.emit_info"),
+            patch("code_puppy.command_line.mcp.start_command.emit_success"),
+            patch(
+                "code_puppy.command_line.mcp.start_command.get_current_agent",
+                return_value=agent,
+            ),
+            patch("code_puppy.mcp_.agent_bindings.is_bound", return_value=True),
+            patch("code_puppy.mcp_.agent_bindings.set_binding") as mock_set_binding,
+        ):
+            start_cmd.manager.start_server_sync.return_value = True
+            start_cmd.execute(["myserver"], group_id="g1")
+
+            mock_set_binding.assert_not_called()
+            agent.reload_code_generation_agent.assert_called_once()
+
+    def test_auto_bind_failure_does_not_break_start(self, start_cmd):
+        """A binding-layer exception is swallowed; reload still happens."""
+        agent = self._make_agent()
+        with (
+            patch(
+                "code_puppy.command_line.mcp.start_command.find_server_id_by_name",
+                return_value="id1",
+            ),
+            patch("code_puppy.command_line.mcp.start_command.emit_info"),
+            patch("code_puppy.command_line.mcp.start_command.emit_success"),
+            patch(
+                "code_puppy.command_line.mcp.start_command.get_current_agent",
+                return_value=agent,
+            ),
+            patch(
+                "code_puppy.mcp_.agent_bindings.is_bound",
+                side_effect=RuntimeError("bindings file corrupted"),
+            ),
+        ):
+            start_cmd.manager.start_server_sync.return_value = True
+            start_cmd.execute(["myserver"], group_id="g1")
+
+            # Reload still happened even though bind blew up.
+            agent.reload_code_generation_agent.assert_called_once()
+
+    def test_bind_runs_before_reload(self, start_cmd):
+        """set_binding must be called BEFORE reload, or reload sees stale state."""
+        agent = self._make_agent()
+        call_order: list[str] = []
+        agent.reload_code_generation_agent.side_effect = lambda: call_order.append(
+            "reload"
+        )
+
+        def fake_set(*_a, **_kw):
+            call_order.append("bind")
+
+        with (
+            patch(
+                "code_puppy.command_line.mcp.start_command.find_server_id_by_name",
+                return_value="id1",
+            ),
+            patch("code_puppy.command_line.mcp.start_command.emit_info"),
+            patch("code_puppy.command_line.mcp.start_command.emit_success"),
+            patch(
+                "code_puppy.command_line.mcp.start_command.get_current_agent",
+                return_value=agent,
+            ),
+            patch("code_puppy.mcp_.agent_bindings.is_bound", return_value=False),
+            patch("code_puppy.mcp_.agent_bindings.set_binding", side_effect=fake_set),
+        ):
+            start_cmd.manager.start_server_sync.return_value = True
+            start_cmd.execute(["myserver"], group_id="g1")
+
+            assert call_order == ["bind", "reload"], (
+                "binding must be persisted before agent reload so the rebuilt "
+                "toolset actually picks up the new server"
+            )


### PR DESCRIPTION
## Problem

When an MCP server is added to `~/.code_puppy/mcp_servers.json` outside the install wizard — by hand-editing, by a third-party tool, or by an agent helpfully writing the config — no corresponding entry is created in `~/.code_puppy/mcp_agent_bindings.json`. The server is registered but bound to nothing.

Running `/mcp start <name>` then gives the user a perfectly cheerful response:

```
🚀 Starting server: nu (subprocess starting in background)
Agent reloaded with updated servers
```

...with zero new tools available, because `get_servers_for_agent(agent_name=...)` silently filters out the unbound server (the skip is a `logger.debug`, invisible at default log level).

### Reproduction

1. Add to `~/.code_puppy/mcp_servers.json`:
   ```json
   {"mcp_servers": {"nu": {"type": "stdio", "command": "/opt/homebrew/bin/nu", "args": ["--mcp"], "enabled": true}}}
   ```
2. Restart Code Puppy.
3. Run `/mcp start nu`.
4. **Expected:** agent has `nu`'s tools available.
5. **Actual:** start message looks fine, but no tools are injected. `mcp_agent_bindings.json` is never written.

The current workaround is `/agents → B` to manually bind the server, which is undiscoverable for most users.

## Fix

Treat `/mcp start <name>` as the user's explicit binding intent. After a successful `start_server_sync`, and **before** the agent reload (so the rebuilt toolset actually picks up the new server), check `is_bound(current_agent, server_name)` and call `set_binding(..., auto_start=True)` if the binding is missing. A single `emit_info` line tells the user what just happened and how to manage it later:

```
Also bound 'nu' to agent 'code-puppy' (use /agents → B to manage).
```

The helper is best-effort: any exception from the binding layer is logged but never propagated, so a corrupted bindings file can't break `/mcp start`.

### Why this approach

This is **additive**, not redefinitive. It doesn't change the meaning of strict opt-in anywhere else in the codebase — it adds one new path *into* the bindings system, justified by the fact that typing `/mcp start <name>` is an unambiguous signal of "yes, I want this." Existing users with curated `mcp_agent_bindings.json` see no behavior change (the new branch only fires when a binding is missing).

An alternative considered and rejected: redefining "no entry for agent X" to mean "all servers visible" until the user creates their first binding. That design is more invasive, has no equivalent of the explicit user-facing notice, and is harder to defend in review. Happy to revisit if maintainers prefer it.

### Optional escape hatch

Not implemented in this PR, but trivial to add if desired: a `--no-bind` flag on `/mcp start` to preserve pure strict-opt-in behavior on demand. Suggesting we leave that for follow-up unless requested here.

## Testing

- 4 new tests in `tests/command_line/mcp/test_start_command.py`:
  - `test_auto_binds_when_unbound` — happy path
  - `test_no_rebind_when_already_bound` — idempotency
  - `test_auto_bind_failure_does_not_break_start` — corrupted bindings file doesn't break start
  - `test_bind_runs_before_reload` — ordering invariant (binding must persist before agent reload)
- Full file: 14/14 passing
- `tests/command_line/mcp/` + `tests/mcp/` regression: **1241 passed, 6 skipped, 0 failed**
- `ruff check --fix` and `ruff format` both clean

## Scope

This PR fixes the most common manifestation. Two related follow-ups exist as ideas worth tracking separately:

- A warning when `get_servers_for_agent` skips a registered-but-unbound server, for the user who hand-edits and never runs `/mcp start` at all. (Belt-and-suspenders; today's fix covers everyone who *does* run `/mcp start`.)
- A look at the MCP install wizard UX, which is what pushes users toward hand-editing in the first place.

Both intentionally out of scope here to keep this PR small and reviewable.
