### PR TITLE
feat(theming): terminal-native theming — respect the user's color scheme

### DIFF
--- a/code_puppy/__init__.py
+++ b/code_puppy/__init__.py
@@ -8,3 +8,16 @@ try:
 except Exception:
     # Fallback for dev environments where metadata might not be available
     __version__ = "0.0.0-dev"
+
+# Patch Rich's hardcoded `markdown.code` style (cyan-on-black) with an
+# accessible bold+reverse equivalent. Must run before any `Console` is
+# instantiated so every console inherits the patched theme. Deferred until
+# AFTER `__version__` is set because the messaging subpackage transitively
+# imports plugins that read `code_puppy.__version__` at import time —
+# importing messaging first would race that read. See
+# `messaging.terminal_theme.install_accessible_markdown_styles` for the why.
+from code_puppy.messaging.terminal_theme import (  # noqa: E402
+    install_accessible_markdown_styles,
+)
+
+install_accessible_markdown_styles()

--- a/code_puppy/command_line/colors_menu.py
+++ b/code_puppy/command_line/colors_menu.py
@@ -61,54 +61,35 @@ BANNER_SAMPLE_CONTENT = {
     "llm_judge": "🎯 Verdict: Complete ✅\nGoal verified — all tests pass.",
 }
 
-# Available background colors grouped by theme
+# Banner background colors offered by the interactive picker.
+#
+# ANSI 16-slot vocabulary only — the user's terminal palette (Catppuccin,
+# Solarized, Modus Vivendi/Operandi, Gruvbox, ...) controls the actual
+# pixels, so picker entries blend with whatever scheme the user runs.
+#
+# Notes:
+#   * `black` and `white` are omitted: they collide with terminal bg
+#     defaults on dark or light themes respectively.
+#   * `bright_*` variants are offered as a separate group; they read as
+#     more vivid backgrounds in most palettes.
+#   * Keys are the human-readable label shown in the picker; values are
+#     the ANSI color names Rich consumes.
 BANNER_COLORS = {
-    # Cool colors
+    # Base 8 ANSI colors
+    "red": "red",
+    "green": "green",
+    "yellow": "yellow",
     "blue": "blue",
-    "dark blue": "dark_blue",
-    "navy blue": "navy_blue",
-    "deep sky blue": "deep_sky_blue4",
-    "steel blue": "steel_blue",
-    "dodger blue": "dodger_blue3",
-    # Cyans & Teals
-    "dark cyan": "dark_cyan",
-    "cyan": "cyan4",
-    "teal": "dark_turquoise",
-    "aquamarine": "aquamarine1",
-    # Greens
-    "green": "green4",
-    "dark green": "dark_green",
-    "sea green": "dark_sea_green4",
-    "spring green": "spring_green4",
-    "chartreuse": "chartreuse4",
-    # Purples & Magentas
-    "purple": "purple",
-    "dark magenta": "dark_magenta",
-    "medium purple": "medium_purple4",
-    "dark violet": "dark_violet",
-    "plum": "plum4",
-    "orchid": "dark_orchid",
-    # Reds & Oranges
-    "red": "red3",
-    "dark red": "dark_red",
-    "indian red": "indian_red",
-    "orange red": "orange_red1",
-    "orange": "dark_orange3",
-    # Yellows & Golds
-    "gold": "gold3",
-    "dark goldenrod": "dark_goldenrod",
-    "olive": "dark_olive_green3",
-    # Grays
-    "grey30": "grey30",
-    "grey37": "grey37",
-    "grey42": "grey42",
-    "grey50": "grey50",
-    "grey58": "grey58",
-    "dark slate gray": "dark_slate_gray3",
-    # Pink tones
-    "hot pink": "hot_pink3",
-    "deep pink": "deep_pink4",
-    "pale violet red": "pale_violet_red1",
+    "magenta": "magenta",
+    "cyan": "cyan",
+    "grey": "bright_black",  # ANSI "bright black" == the grey slot
+    # Bright variants
+    "bright red": "bright_red",
+    "bright green": "bright_green",
+    "bright yellow": "bright_yellow",
+    "bright blue": "bright_blue",
+    "bright magenta": "bright_magenta",
+    "bright cyan": "bright_cyan",
 }
 
 

--- a/code_puppy/command_line/diff_menu.py
+++ b/code_puppy/command_line/diff_menu.py
@@ -620,81 +620,36 @@ async def _split_panel_selector(
     return result[0]
 
 
+# Diff line-background colors offered by the interactive picker.
+#
+# ANSI 16-slot vocabulary only — the user's terminal palette controls the
+# actual pixels, so picker entries blend with whatever scheme the user runs
+# (Catppuccin, Solarized, Modus Vivendi/Operandi, Gruvbox, ...).
+#
+# Note: addition/deletion line color is *redundant* with the +/- glyphs
+# (WCAG 1.4.1: color is decoration, not the sole signal), so red/green is
+# defensible here even though red/green is CVD-hostile in isolation. Users
+# with red-green CVD still get correct diff semantics from the glyphs.
+#
+# Keys are the human-readable label shown in the picker; values are the
+# ANSI color names Rich consumes. The default ("green" / "red") matches
+# config._DEFAULT_DIFF_ADDITION / _DELETION.
 ADDITION_COLORS = {
-    # primary first (darkened)
-    "dark green": "#0b3e0b",
-    "darker green": "#0b1f0b",
-    "dark aqua": "#164952",
-    "deep teal": "#143f3c",
-    # blues (darkened)
-    "sky blue": "#406884",
-    "soft blue": "#315c78",
-    "steel blue": "#20394e",
-    "forest teal": "#124831",
-    "cool teal": "#1b4b54",
-    "marine aqua": "#275860",
-    "slate blue": "#304f69",
-    "deep steel": "#1e3748",
-    "shadow olive": "#2f3a15",
-    "deep moss": "#1f3310",
-    # G
-    "midnight spruce": "#0f3a29",
-    "shadow jade": "#0d4a3a",
-    # B
-    "abyss blue": "#0d2f4d",
-    "midnight fjord": "#133552",
-    # I
-    "dusky indigo": "#1a234d",
-    "nocturne indigo": "#161d3f",
-    # V
-    "midnight violet": "#2a1a3f",
-    "deep amethyst": "#3a2860",
+    "green": "green",
+    "bright green": "bright_green",
+    "cyan": "cyan",
+    "bright cyan": "bright_cyan",
+    "blue": "blue",
+    "bright blue": "bright_blue",
 }
 
 DELETION_COLORS = {
-    # primary first (darkened)
-    "dark red": "#4a0f0f",
-    # pinks / reds (darkened)
-    "pink": "#7f143b",
-    "soft red": "#741f3c",
-    "salmon": "#842848",
-    "rose": "#681c35",
-    "deep rose": "#4f1428",
-    # oranges (darkened)
-    "burnt orange": "#753b10",
-    "deep orange": "#5b2b0d",
-    # yellows (darkened)
-    "amber": "#69551c",
-    # reds (darkened)
-    "red": "#5d0b0b",
-    "ruby": "#5b141f",
-    "wine": "#390e1a",
-    # purples (darkened)
-    "purple": "#5a4284",
-    "soft purple": "#503977",
-    "violet": "#432758",
-    # ROYGBIV deletions (unchanged)
-    # R
-    "ember crimson": "#5a0e12",
-    "smoked ruby": "#4b0b16",
-    # O
-    "molten orange": "#70340c",
-    "baked amber": "#5c2b0a",
-    # Y
-    "burnt ochre": "#5a4110",
-    "tawny umber": "#4c3810",
-    # G
-    "swamp olive": "#3c3a14",
-    "bog green": "#343410",
-    # B
-    "dusky petrol": "#2a3744",
-    "warm slate": "#263038",
-    # I
-    "wine indigo": "#311b3f",
-    "mulberry dusk": "#3f1f52",
-    # V
-    "garnet plum": "#4a1e3a",
-    "dusky magenta": "#5a1f4c",
+    "red": "red",
+    "bright red": "bright_red",
+    "magenta": "magenta",
+    "bright magenta": "bright_magenta",
+    "yellow": "yellow",
+    "bright yellow": "bright_yellow",
 }
 
 

--- a/code_puppy/command_line/mcp/logs_command.py
+++ b/code_puppy/command_line/mcp/logs_command.py
@@ -171,11 +171,13 @@ class LogsCommand(MCPCommandBase):
             # Format log content with syntax highlighting
             log_content = "\n".join(log_lines)
 
+            from code_puppy.messaging.terminal_theme import current_code_theme
+
             # Create a panel with the logs
             syntax = Syntax(
                 log_content,
                 "log",
-                theme="monokai",
+                theme=current_code_theme(),
                 word_wrap=True,
                 line_numbers=False,
             )

--- a/code_puppy/command_line/uc_menu.py
+++ b/code_puppy/command_line/uc_menu.py
@@ -564,10 +564,12 @@ def _show_source_code(tool: UCToolInfo) -> None:
 
     try:
         source_code = Path(tool.source_path).read_text()
+        from code_puppy.messaging.terminal_theme import current_code_theme
+
         syntax = Syntax(
             source_code,
             "python",
-            theme="monokai",
+            theme=current_code_theme(),
             line_numbers=True,
             word_wrap=True,
         )

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -1482,36 +1482,45 @@ def set_diff_deletion_color(color: str):
 # =============================================================================
 
 # Default banner colors (Rich color names)
-# A beautiful jewel-tone palette with semantic meaning:
-#   - Blues/Teals: Reading & navigation (calm, informational)
-#   - Warm tones: Actions & changes (edits, shell commands)
-#   - Purples: AI thinking & reasoning (the "brain" colors)
-#   - Greens: Completions & success
-#   - Neutrals: Search & listings
+# Banner background colors. ANSI base names only — the user's terminal
+# palette (Catppuccin, Solarized, Modus, Gruvbox, ...) decides the actual
+# pixels, so banners blend with whatever the user has chosen.
+#
+# Banner-color semantics are kept ("thinking is bluish", "file edits are
+# warm", "reasoning is purplish") but expressed in the ANSI 16-slot
+# vocabulary instead of the old 256-color jewel-tone names. Notes:
+#
+#   * No `bright_*` variants in defaults: brights tend to be highly
+#     saturated in most terminal palettes and read as garish backgrounds
+#     even on dark themes. Plain `red`/`blue`/etc. behave better as bg.
+#   * `black` and `white` are deliberately avoided: they collide with
+#     terminal background defaults on either dark or light themes.
+#   * Users can still override per-banner via `set_banner_color(...)` if
+#     they want a bright variant.
 DEFAULT_BANNER_COLORS = {
-    "thinking": "deep_sky_blue4",  # Sapphire - contemplation
-    "agent_response": "medium_purple4",  # Amethyst - main AI output
-    "shell_command": "dark_orange3",  # Amber - system commands
-    "read_file": "steel_blue",  # Steel - reading files
-    "edit_file": "dark_goldenrod",  # Gold - modifications (legacy)
-    "create_file": "dark_goldenrod",  # Gold - file creation
-    "replace_in_file": "dark_goldenrod",  # Gold - file modifications
-    "delete_snippet": "dark_goldenrod",  # Gold - snippet removal
-    "grep": "grey37",  # Silver - search results
-    "directory_listing": "dodger_blue2",  # Sky - navigation
-    "agent_reasoning": "dark_violet",  # Violet - deep thought
-    "invoke_agent": "deep_pink4",  # Ruby - agent invocation
-    "subagent_response": "sea_green3",  # Emerald - sub-agent success
-    "list_agents": "dark_slate_gray3",  # Slate - neutral listing
-    "universal_constructor": "dark_cyan",  # Teal - constructing tools
-    # Browser/Terminal tools - same color as edit_file (gold)
-    "terminal_tool": "dark_goldenrod",  # Gold - browser terminal operations
-    # MCP tools - distinct from builtin tools
-    "mcp_tool_call": "dark_cyan",  # Teal - external MCP tool calls
-    # User-initiated shell pass-through (! prefix) - distinct from agent's shell_command
-    "shell_passthrough": "medium_sea_green",  # Green - user's own shell commands
-    # LLM Judge - goal-mode verdict (distinct from agent reasoning)
-    "llm_judge": "gold3",  # Gold - judicial authority / gavel
+    "thinking": "blue",  # contemplation
+    "agent_response": "magenta",  # main AI output (purple-ish slot)
+    "shell_command": "yellow",  # system commands (warm)
+    "read_file": "blue",  # reading files
+    "edit_file": "yellow",  # modifications (warm)
+    "create_file": "yellow",  # file creation
+    "replace_in_file": "yellow",  # file modifications
+    "delete_snippet": "yellow",  # snippet removal
+    "grep": "bright_black",  # search results (neutral)
+    "directory_listing": "blue",  # navigation
+    "agent_reasoning": "magenta",  # deep thought
+    "invoke_agent": "red",  # agent invocation (attention)
+    "subagent_response": "green",  # sub-agent success
+    "list_agents": "cyan",  # neutral listing
+    "universal_constructor": "cyan",  # constructing tools
+    # Browser/Terminal tools - same color slot as edit_file
+    "terminal_tool": "yellow",  # browser terminal operations
+    # MCP tools - distinct slot from builtin tools (still cool-ish)
+    "mcp_tool_call": "cyan",  # external MCP tool calls
+    # User-initiated shell pass-through (! prefix) - distinct from agent's
+    "shell_passthrough": "green",  # user's own shell commands
+    # LLM Judge - goal-mode verdict
+    "llm_judge": "yellow",  # judicial authority / gavel
 }
 
 
@@ -1528,7 +1537,7 @@ def get_banner_color(banner_name: str) -> str:
     val = get_value(config_key)
     if val:
         return val
-    return DEFAULT_BANNER_COLORS.get(banner_name, "blue")
+        return DEFAULT_BANNER_COLORS.get(banner_name, "blue")
 
 
 def set_banner_color(banner_name: str, color: str):

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -1537,7 +1537,7 @@ def get_banner_color(banner_name: str) -> str:
     val = get_value(config_key)
     if val:
         return val
-        return DEFAULT_BANNER_COLORS.get(banner_name, "blue")
+    return DEFAULT_BANNER_COLORS.get(banner_name, "blue")
 
 
 def set_banner_color(banner_name: str, color: str):

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -1433,89 +1433,48 @@ def set_diff_highlight_style(style: str):
     pass
 
 
-# Defaults for diff highlight colors — single source of truth.
-_DEFAULT_DIFF_ADDITION_HEX = "#0b1f0b"  # darker green
-_DEFAULT_DIFF_DELETION_HEX = "#390e1a"  # wine
-
-
-def _coerce_to_hex(value: Optional[str], fallback: str) -> str:
-    """Normalize any color string to '#RRGGBB'.
-
-    Accepts:
-      - '#RRGGBB' hex strings (any case) — returned lowercased.
-      - Rich color names like 'green', 'orange1', 'bright_red'.
-      - 'rgb(r,g,b)' forms that Rich understands.
-
-    Anything Rich can't parse (including None/empty) falls back to ``fallback``.
-    This keeps downstream consumers like ``brighten_hex`` happy — they only
-    ever see a well-formed #RRGGBB string.
-    """
-    if not value:
-        return fallback
-    candidate = value.strip()
-    # Fast-path: already a valid #RRGGBB.
-    if (
-        len(candidate) == 7
-        and candidate.startswith("#")
-        and all(c in "0123456789abcdefABCDEF" for c in candidate[1:])
-    ):
-        return candidate.lower()
-    # Otherwise try Rich's parser (handles named colors, rgb(), etc.).
-    try:
-        from rich.color import Color  # local import keeps module import cheap
-
-        triplet = Color.parse(candidate).get_truecolor()
-        return f"#{triplet.red:02x}{triplet.green:02x}{triplet.blue:02x}"
-    except Exception:
-        return fallback
+# Defaults for diff highlight colors — ANSI color names so the user's
+# terminal palette governs how they actually render.
+_DEFAULT_DIFF_ADDITION = "green"
+_DEFAULT_DIFF_DELETION = "red"
 
 
 def get_diff_addition_color() -> str:
-    """Get the base color for diff additions, always as a valid '#RRGGBB' hex.
+    """Get the color for diff additions (ANSI name, hex, or any Rich color).
 
-    Falls back to the default darker green if the configured value is missing
-    or unparseable.
+    Falls back to ``"green"`` if unset. The value is returned verbatim so
+    Rich can interpret it per the user's terminal palette — we don't coerce
+    ANSI names into truecolor hex (that would silently override Catppuccin,
+    Solarized, etc.).
     """
-    return _coerce_to_hex(
-        get_value("highlight_addition_color"), _DEFAULT_DIFF_ADDITION_HEX
-    )
+    return get_value("highlight_addition_color") or _DEFAULT_DIFF_ADDITION
 
 
 def set_diff_addition_color(color: str):
     """Set the color for diff additions.
 
-    Accepts '#RRGGBB' hex, Rich color names ('green', 'bright_green', ...), or
-    'rgb(r,g,b)'. The value is normalized to '#RRGGBB' before being written so
-    downstream renderers never see a raw name.
+    Stored verbatim. Recommended values are ANSI names like ``"green"`` or
+    ``"bright_green"`` so the user's terminal theme stays in control.
     """
-    set_config_value(
-        "highlight_addition_color",
-        _coerce_to_hex(color, _DEFAULT_DIFF_ADDITION_HEX),
-    )
+    set_config_value("highlight_addition_color", color)
 
 
 def get_diff_deletion_color() -> str:
-    """Get the base color for diff deletions, always as a valid '#RRGGBB' hex.
+    """Get the color for diff deletions (ANSI name, hex, or any Rich color).
 
-    Falls back to the default wine if the configured value is missing or
-    unparseable.
+    Falls back to ``"red"`` if unset. The value is returned verbatim so
+    Rich can interpret it per the user's terminal palette.
     """
-    return _coerce_to_hex(
-        get_value("highlight_deletion_color"), _DEFAULT_DIFF_DELETION_HEX
-    )
+    return get_value("highlight_deletion_color") or _DEFAULT_DIFF_DELETION
 
 
 def set_diff_deletion_color(color: str):
     """Set the color for diff deletions.
 
-    Accepts '#RRGGBB' hex, Rich color names ('red', 'orange1', ...), or
-    'rgb(r,g,b)'. The value is normalized to '#RRGGBB' before being written so
-    downstream renderers never see a raw name.
+    Stored verbatim. Recommended values are ANSI names like ``"red"`` or
+    ``"bright_red"`` so the user's terminal theme stays in control.
     """
-    set_config_value(
-        "highlight_deletion_color",
-        _coerce_to_hex(color, _DEFAULT_DIFF_DELETION_HEX),
-    )
+    set_config_value("highlight_deletion_color", color)
 
 
 # =============================================================================

--- a/code_puppy/messaging/renderers.py
+++ b/code_puppy/messaging/renderers.py
@@ -138,7 +138,9 @@ def _print_message(console: Console, message: UIMessage) -> None:
     if isinstance(content, str):
         if message.type == MessageType.AGENT_RESPONSE:
             try:
-                console.print(Markdown(content))
+                from code_puppy.messaging.terminal_theme import current_code_theme
+
+                console.print(Markdown(content, code_theme=current_code_theme()))
             except Exception:
                 console.print(escape_rich_markup(content))
         elif style:

--- a/code_puppy/messaging/rich_renderer.py
+++ b/code_puppy/messaging/rich_renderer.py
@@ -18,6 +18,8 @@ from rich.rule import Rule
 # Note: Syntax import removed - file content not displayed, only header
 from rich.table import Table
 
+from code_puppy.messaging.terminal_theme import current_code_theme
+
 from code_puppy.config import get_subagent_verbose
 from code_puppy.tools.common import format_diff_with_colors
 from code_puppy.tools.subagent_context import is_subagent
@@ -774,13 +776,13 @@ class RichConsoleRenderer:
         # Current reasoning
         self._console.print("[bold cyan]Current reasoning:[/bold cyan]")
         # Render reasoning as markdown
-        md = Markdown(msg.reasoning)
+        md = Markdown(msg.reasoning, code_theme=current_code_theme())
         self._console.print(md)
 
         # Next steps (if any)
         if msg.next_steps and msg.next_steps.strip():
             self._console.print("\n[bold cyan]Planned next steps:[/bold cyan]")
-            md_steps = Markdown(msg.next_steps)
+            md_steps = Markdown(msg.next_steps, code_theme=current_code_theme())
             self._console.print(md_steps)
 
         # Trailing newline for spinner separation
@@ -794,7 +796,7 @@ class RichConsoleRenderer:
 
         # Content (markdown or plain)
         if msg.is_markdown:
-            md = Markdown(msg.content)
+            md = Markdown(msg.content, code_theme=current_code_theme())
             self._console.print(md)
         else:
             self._console.print(msg.content)
@@ -826,7 +828,7 @@ class RichConsoleRenderer:
             msg.prompt[:200] + "..." if len(msg.prompt) > 200 else msg.prompt
         )
         self._console.print("[dim]Prompt:[/dim]")
-        md_prompt = Markdown(prompt_display)
+        md_prompt = Markdown(prompt_display, code_theme=current_code_theme())
         self._console.print(md_prompt)
 
     def _render_subagent_response(self, msg: SubAgentResponseMessage) -> None:
@@ -836,7 +838,7 @@ class RichConsoleRenderer:
         self._console.print(f"\n{banner} [bold cyan]{msg.agent_name}[/bold cyan]")
 
         # Render response as markdown
-        md = Markdown(msg.response)
+        md = Markdown(msg.response, code_theme=current_code_theme())
         self._console.print(md)
 
         # Footer with session info

--- a/code_puppy/messaging/terminal_theme.py
+++ b/code_puppy/messaging/terminal_theme.py
@@ -38,6 +38,7 @@ __all__ = [
     "TerminalBackground",
     "detect_terminal_bg",
     "resolve_code_theme",
+    "current_code_theme",
 ]
 
 TerminalBackground = Literal["light", "dark"]
@@ -116,3 +117,19 @@ def resolve_code_theme(configured: Optional[str] = None) -> str:
         return configured.strip()
     bg = detect_terminal_bg()
     return "ansi_light" if bg == "light" else "ansi_dark"
+
+
+def current_code_theme() -> str:
+    """Convenience wrapper: read the ``code_theme`` config key and resolve.
+
+    Imports ``code_puppy.config`` lazily to avoid circular imports (config
+    already pulls in ``code_puppy.messaging``). Falls back to pure detection
+    if config isn't importable for any reason.
+    """
+    try:
+        from code_puppy.config import get_value
+
+        configured = get_value("code_theme")
+    except Exception:
+        configured = None
+    return resolve_code_theme(configured)

--- a/code_puppy/messaging/terminal_theme.py
+++ b/code_puppy/messaging/terminal_theme.py
@@ -39,6 +39,7 @@ __all__ = [
     "detect_terminal_bg",
     "resolve_code_theme",
     "current_code_theme",
+    "install_accessible_markdown_styles",
 ]
 
 TerminalBackground = Literal["light", "dark"]
@@ -117,6 +118,43 @@ def resolve_code_theme(configured: Optional[str] = None) -> str:
         return configured.strip()
     bg = detect_terminal_bg()
     return "ansi_light" if bg == "light" else "ansi_dark"
+
+
+def install_accessible_markdown_styles() -> None:
+    """Patch Rich's default ``markdown.code`` / ``markdown.kbd`` styles.
+
+    Rich ships ``markdown.code`` as ``bold cyan on black`` and
+    ``markdown.kbd`` as ``bold bright_yellow``. Both bake in specific ANSI
+    slots that can collide with the user's theme. Concrete failure mode:
+    Catppuccin Latte renders ANSI ``cyan`` as a greenish teal and ANSI
+    ``black`` as a soft grey, which together produce an unreadable
+    green-on-grey — catastrophic for users with red–green color vision
+    deficiency (deuteranopia / protanopia, ~8% of men).
+
+    The fix: replace both with ``Style(bold=True, reverse=True)``. Reverse
+    swaps the terminal's *own* foreground/background pair, which is
+    readable by construction (the user already chose a legible default).
+    No color slot is selected, so no theme can mismatch it. Bold provides
+    a redundant non-color signal that this region is code, satisfying
+    WCAG 1.4.1 ("use of color").
+
+    Idempotent. Mutates ``rich.themes.DEFAULT.styles`` directly so every
+    subsequently-created ``Console`` inherits the patched values without
+    each call site having to know.
+
+    Must be called *before* any ``rich.console.Console`` is instantiated
+    if you want existing-process consoles to pick up the new styles
+    (Consoles snapshot a reference to ``themes.DEFAULT`` at construction
+    time, but since they consult ``.styles`` lazily at render time,
+    mutating the dict in place propagates anyway). Practically: call from
+    package ``__init__.py``.
+    """
+    from rich import themes
+    from rich.style import Style
+
+    accessible = Style(bold=True, reverse=True)
+    themes.DEFAULT.styles["markdown.code"] = accessible
+    themes.DEFAULT.styles["markdown.kbd"] = accessible
 
 
 def current_code_theme() -> str:

--- a/code_puppy/messaging/terminal_theme.py
+++ b/code_puppy/messaging/terminal_theme.py
@@ -1,0 +1,118 @@
+"""Terminal-native theme resolution.
+
+Code Puppy renders code blocks via Rich's ``Markdown`` and ``Syntax``. Both
+accept a ``code_theme`` argument naming a Pygments style. Most Pygments styles
+emit truecolor (``\\e[38;2;R;G;Bm``) escape sequences, which silently override
+the user's terminal palette — exactly the contract we want to *respect*, not
+ignore. Rich ships two ANSI-named Pygments styles for this very reason:
+
+* ``ansi_dark``  — uses ANSI color names; reads well on dark terminals
+* ``ansi_light`` — uses ANSI color names; reads well on light terminals
+
+This module picks between them by sniffing the terminal's background. The
+detection itself is best-effort:
+
+1. ``COLORFGBG`` env var (set by many terminals, including rxvt/urxvt,
+   konsole, and Terminal.app via the user's profile). Format is
+   ``"<fg>;<bg>"`` with ANSI color indices; indices 0–6 and 8 mean dark
+   background, the rest mean light.
+2. (deliberately not implemented) OSC 11 query — would require writing to
+   ``/dev/tty`` and reading back with a timeout. YAGNI for v1. If users on
+   exotic terminals need it, they can set ``CODE_PUPPY_TERMINAL_BG=light``
+   or override ``code_theme`` directly.
+
+The resolver also honors two escape hatches:
+
+* ``CODE_PUPPY_TERMINAL_BG`` env (``light`` / ``dark``) — forces detection.
+* ``code_theme`` config key — bypasses detection entirely; pass any
+  Pygments style name (``monokai``, ``github-dark``, etc.) for the old
+  fixed-palette behavior.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal, Optional
+
+__all__ = [
+    "TerminalBackground",
+    "detect_terminal_bg",
+    "resolve_code_theme",
+]
+
+TerminalBackground = Literal["light", "dark"]
+
+# ANSI palette indices that the COLORFGBG convention treats as "dark"
+# backgrounds. Anything outside this set (typically 7 = white, 15 = bright
+# white, 9–14 = brights) is treated as a light background.
+_DARK_BG_INDICES = frozenset({"0", "1", "2", "3", "4", "5", "6", "8"})
+
+
+def _bg_from_colorfgbg(raw: Optional[str]) -> Optional[TerminalBackground]:
+    """Parse a ``COLORFGBG`` value into a background classification.
+
+    Returns ``None`` if the value is missing or unparseable so callers can
+    decide their own fallback.
+    """
+    if not raw:
+        return None
+    parts = raw.split(";")
+    if not parts:
+        return None
+    # Last segment is the background index per the de-facto convention.
+    bg_token = parts[-1].strip()
+    if not bg_token:
+        return None
+    return "dark" if bg_token in _DARK_BG_INDICES else "light"
+
+
+def _bg_from_env_override() -> Optional[TerminalBackground]:
+    """Honor an explicit ``CODE_PUPPY_TERMINAL_BG`` env override."""
+    forced = (os.environ.get("CODE_PUPPY_TERMINAL_BG") or "").strip().lower()
+    if forced in ("light", "dark"):
+        return forced  # type: ignore[return-value]
+    return None
+
+
+def detect_terminal_bg(default: TerminalBackground = "dark") -> TerminalBackground:
+    """Best-effort terminal background detection.
+
+    Priority:
+      1. ``CODE_PUPPY_TERMINAL_BG`` env (``light`` / ``dark``).
+      2. ``COLORFGBG`` env, parsed per the rxvt convention.
+      3. ``default`` argument (defaults to ``"dark"`` — the safer assumption
+         since dark themes dominate, and dim-on-dark is more readable than
+         bright-on-light).
+
+    Args:
+        default: fallback when no signal is available.
+
+    Returns:
+        Either ``"light"`` or ``"dark"``.
+    """
+    forced = _bg_from_env_override()
+    if forced is not None:
+        return forced
+    from_env = _bg_from_colorfgbg(os.environ.get("COLORFGBG"))
+    if from_env is not None:
+        return from_env
+    return default
+
+
+def resolve_code_theme(configured: Optional[str] = None) -> str:
+    """Resolve the Pygments style name to hand to Rich.
+
+    Args:
+        configured: value from the ``code_theme`` config key (or ``None``).
+            Special value ``"system"`` (the default) triggers terminal-bg
+            detection. Anything else is passed through unchanged so users
+            can opt back into fixed palettes like ``monokai``.
+
+    Returns:
+        A Pygments style name suitable for Rich's
+        ``Markdown(code_theme=...)`` / ``Syntax(theme=...)`` arguments.
+    """
+    if configured and configured.strip().lower() != "system":
+        return configured.strip()
+    bg = detect_terminal_bg()
+    return "ansi_light" if bg == "light" else "ansi_dark"

--- a/code_puppy/tools/common.py
+++ b/code_puppy/tools/common.py
@@ -552,20 +552,19 @@ def should_ignore_dir_path(path: str) -> bool:
 # SYNTAX HIGHLIGHTING FOR DIFFS ("syntax" mode)
 # ============================================================================
 
-# Monokai color scheme - because we have taste 🎨
-TOKEN_COLORS = (
-    {
-        Token.Keyword: "#f92672" if PYGMENTS_AVAILABLE else "magenta",
-        Token.Name.Builtin: "#66d9ef" if PYGMENTS_AVAILABLE else "cyan",
-        Token.Name.Function: "#a6e22e" if PYGMENTS_AVAILABLE else "green",
-        Token.String: "#e6db74" if PYGMENTS_AVAILABLE else "yellow",
-        Token.Number: "#ae81ff" if PYGMENTS_AVAILABLE else "magenta",
-        Token.Comment: "#75715e" if PYGMENTS_AVAILABLE else "bright_black",
-        Token.Operator: "#f92672" if PYGMENTS_AVAILABLE else "magenta",
-    }
-    if PYGMENTS_AVAILABLE
-    else {}
-)
+# Token → ANSI color name mapping. Pure ANSI so that whatever palette the
+# user has loaded in their terminal (Catppuccin, Solarized, Gruvbox, a
+# high-contrast / color-blind preset, ...) is what actually shows up. No
+# truecolor hex, no "taste" — we trust the user's terminal.
+TOKEN_COLORS = {
+    Token.Keyword: "magenta",
+    Token.Name.Builtin: "cyan",
+    Token.Name.Function: "green",
+    Token.String: "yellow",
+    Token.Number: "magenta",
+    Token.Comment: "bright_black",
+    Token.Operator: "magenta",
+}
 
 EXTENSION_TO_LEXER_NAME = {
     ".py": "python",
@@ -627,21 +626,19 @@ def _get_lexer_for_extension(extension: str):
 
 
 def _get_token_color(token_type) -> str:
-    """Get color for a token type from our Monokai scheme.
+    """Get the ANSI color name for a Pygments token type.
 
-    Args:
-        token_type: Pygments token type
-
-    Returns:
-        Hex color string or color name
+    Returns ``"default"`` (i.e. the terminal's default foreground) for
+    unmatched tokens — this keeps prose / unknown tokens readable on both
+    light and dark backgrounds.
     """
     if not PYGMENTS_AVAILABLE:
-        return "#cccccc"
+        return "default"
 
     for ttype, color in TOKEN_COLORS.items():
         if token_type in ttype:
             return color
-    return "#cccccc"  # Default light-grey for unmatched tokens
+    return "default"
 
 
 def _highlight_code_line(code: str, bg_color: str | None, lexer) -> Text:
@@ -708,27 +705,34 @@ def _extract_file_extension_from_diff(diff_text: str) -> str:
 # COLOR PAIR OPTIMIZATION (for "highlighted" mode)
 # ============================================================================
 
+# ANSI base → bright variant. Used to pick a foreground marker color that
+# stays readable against the matching background block (e.g. the "+" on a
+# green-tinted added line uses bright_green for emphasis). Anything we don't
+# recognize — hex strings, exotic Rich names — is returned unchanged so the
+# user can still opt into custom values via config without us mangling them.
+_ANSI_BRIGHT_MAP = {
+    "black": "bright_black",
+    "red": "bright_red",
+    "green": "bright_green",
+    "yellow": "bright_yellow",
+    "blue": "bright_blue",
+    "magenta": "bright_magenta",
+    "cyan": "bright_cyan",
+    "white": "bright_white",
+}
 
-def brighten_hex(hex_color: str, factor: float) -> str:
+
+def _brighten_ansi(color: str) -> str:
+    """Return the bright ANSI counterpart of ``color`` if there is one.
+
+    For non-ANSI values (hex, ``bright_*`` already, ``default``, anything
+    exotic) the input is returned unchanged. The intent is to give marker
+    glyphs a touch more pop than the background — not to police what the
+    user configured.
     """
-    Darken a hex color by multiplying each RGB channel by `factor`.
-    factor=1.0 -> no change
-    factor=0.0 -> black
-    factor=0.18 -> good for diff backgrounds (recommended)
-    """
-    hex_color = hex_color.lstrip("#")
-    if len(hex_color) != 6:
-        raise ValueError(f"Expected #RRGGBB, got {hex_color!r}")
-
-    r = int(hex_color[0:2], 16)
-    g = int(hex_color[2:4], 16)
-    b = int(hex_color[4:6], 16)
-
-    r = max(0, min(255, int(r * (1 + factor))))
-    g = max(0, min(255, int(g * (1 + factor))))
-    b = max(0, min(255, int(b * (1 + factor))))
-
-    return f"#{r:02x}{g:02x}{b:02x}"
+    if not color:
+        return color
+    return _ANSI_BRIGHT_MAP.get(color.strip().lower(), color)
 
 
 def _format_diff_with_syntax_highlighting(
@@ -759,9 +763,9 @@ def _format_diff_with_syntax_highlighting(
     extension = _extract_file_extension_from_diff(diff_text)
     lexer = _get_lexer_for_extension(extension)
 
-    # Generate background colors from foreground colors
-    add_fg = brighten_hex(addition_color, 0.6)
-    del_fg = brighten_hex(deletion_color, 0.6)
+    # Marker foreground: brighten the base ANSI color so the +/- glyphs pop.
+    add_fg = _brighten_ansi(addition_color)
+    del_fg = _brighten_ansi(deletion_color)
 
     # Background colors for different line types
     # Context lines have no background (None) for clean, minimal diffs

--- a/code_puppy/tools/common.py
+++ b/code_puppy/tools/common.py
@@ -553,17 +553,32 @@ def should_ignore_dir_path(path: str) -> bool:
 # ============================================================================
 
 # Token → ANSI color name mapping. Pure ANSI so that whatever palette the
-# user has loaded in their terminal (Catppuccin, Solarized, Gruvbox, a
-# high-contrast / color-blind preset, ...) is what actually shows up. No
-# truecolor hex, no "taste" — we trust the user's terminal.
+# user has loaded in their terminal (Catppuccin, Solarized, Gruvbox, Modus
+# Operandi/Vivendi, ...) is what actually shows up. No truecolor hex, no
+# "taste" — we trust the user's terminal.
+#
+# Color choices prioritize colorblind accessibility (WCAG 1.4.1):
+#   1. Bias toward the blue/yellow axis, which survives every common form
+#      of color vision deficiency (deuter-, prot-, trit-anopia).
+#   2. Avoid red/green as a primary contrast (CVD-hostile pair).
+#   3. Don't reuse the same color for unrelated token types. The previous
+#      map had `magenta` doing triple duty (Keyword, Number, Operator),
+#      collapsing three distinct semantic categories into one visual one.
+#   4. Let Operator fall back to `default` — the terminal's default fg
+#      has guaranteed contrast against the bg by construction, and most
+#      operators are syntactic noise that doesn't benefit from coloring.
+#
+# Note: line-level diff coloring still uses red/green, but that's defensible
+# because the +/- glyphs provide the primary signal; color is redundant
+# decoration there (satisfies WCAG 1.4.1).
 TOKEN_COLORS = {
-    Token.Keyword: "magenta",
+    Token.Keyword: "blue",
     Token.Name.Builtin: "cyan",
-    Token.Name.Function: "green",
+    Token.Name.Function: "bright_blue",
     Token.String: "yellow",
-    Token.Number: "magenta",
+    Token.Number: "bright_cyan",
     Token.Comment: "bright_black",
-    Token.Operator: "magenta",
+    Token.Operator: "default",
 }
 
 EXTENSION_TO_LEXER_NAME = {

--- a/scripts/visual_theme_demo.py
+++ b/scripts/visual_theme_demo.py
@@ -1,0 +1,92 @@
+"""Visual smoke test for the new ANSI code-theme resolver.
+
+Renders the same Markdown block under three conditions so you can
+eyeball-verify Catppuccin Latte (light) actually stays readable:
+
+  1. Whatever the terminal autodetects (CODE_PUPPY_TERMINAL_BG / COLORFGBG)
+  2. Forced 'ansi_dark'
+  3. Forced 'ansi_light'
+
+Run with:
+
+    .venv/bin/python scripts/visual_theme_demo.py
+
+Not part of the test suite; just a one-shot eyeball check.
+"""
+
+from __future__ import annotations
+
+import os
+
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.rule import Rule
+
+from code_puppy.messaging.terminal_theme import (
+    detect_terminal_bg,
+    resolve_code_theme,
+)
+
+SAMPLE_MD = """\
+# Theming smoke test 🐶
+
+Some inline `code` should be visible without straining — this used to be
+`cyan on black` in Rich, which rendered as **green on grey** under
+Catppuccin Latte (a red–green CVD nightmare). It is now `bold reverse`,
+which respects the terminal's own fg/bg pair.
+
+Keyboard shortcuts like <kbd>Ctrl+C</kbd> get the same treatment.
+
+```python
+def greet(name: str) -> str:
+    \"\"\"Return a friendly greeting for the given name.\"\"\"
+    pieces = ["Hello", name, "—", "have", "a", "great", "day!"]
+    return " ".join(pieces)
+
+
+if __name__ == "__main__":
+    for who in ("Jeff", "Tizzy", "the world"):
+        print(greet(who))
+```
+
+```bash
+# Shell highlighting too
+grep -rn "monokai" code_puppy/ || echo "no truecolor lock-in here"
+```
+
+A regular paragraph with **bold**, *italic*, and ~~strikethrough~~ — these
+should all use the terminal palette, not hard-coded RGB.
+"""
+
+
+def _render(console: Console, label: str, theme: str) -> None:
+    """Render the sample markdown with a fixed pygments theme + a label."""
+    console.print(
+        Rule(f"[bold]{label}[/bold]  ([cyan]code_theme={theme}[/cyan])"),
+    )
+    console.print(Markdown(SAMPLE_MD, code_theme=theme))
+    console.print()
+
+
+def main() -> None:
+    console = Console()
+    console.print(
+        Panel.fit(
+            f"COLORFGBG={os.environ.get('COLORFGBG', '<unset>')!r}\n"
+            f"CODE_PUPPY_TERMINAL_BG={os.environ.get('CODE_PUPPY_TERMINAL_BG', '<unset>')!r}\n"
+            f"detect_terminal_bg() => {detect_terminal_bg()!r}\n"
+            f"resolve_code_theme(None) => {resolve_code_theme(None)!r}",
+            title="terminal_theme detection",
+            border_style="dim",
+        )
+    )
+
+    auto_theme = resolve_code_theme(None)
+    _render(console, "AUTODETECTED", auto_theme)
+    _render(console, "FORCED ansi_dark", "ansi_dark")
+    _render(console, "FORCED ansi_light", "ansi_light")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/command_line/test_colors_menu.py
+++ b/tests/command_line/test_colors_menu.py
@@ -144,10 +144,22 @@ class TestBannerColors:
     def test_palette_uses_ansi_names_only(self):
         """All palette values must be ANSI names (no truecolor hex, no 256-color names)."""
         allowed_ansi = {
-            "black", "red", "green", "yellow",
-            "blue", "magenta", "cyan", "white",
-            "bright_black", "bright_red", "bright_green", "bright_yellow",
-            "bright_blue", "bright_magenta", "bright_cyan", "bright_white",
+            "black",
+            "red",
+            "green",
+            "yellow",
+            "blue",
+            "magenta",
+            "cyan",
+            "white",
+            "bright_black",
+            "bright_red",
+            "bright_green",
+            "bright_yellow",
+            "bright_blue",
+            "bright_magenta",
+            "bright_cyan",
+            "bright_white",
             "default",
         }
         for label, value in BANNER_COLORS.items():

--- a/tests/command_line/test_colors_menu.py
+++ b/tests/command_line/test_colors_menu.py
@@ -88,51 +88,73 @@ class TestBannerSampleContent:
 
 
 class TestBannerColors:
-    """Test available banner colors."""
+    """Test available banner colors.
+
+    The picker palette is the ANSI 16-slot vocabulary so the user's terminal
+    theme controls the actual pixels. These tests assert each ANSI semantic
+    family is represented; specific compound names ("dodger blue",
+    "spring green", etc.) are intentionally NOT included — those would
+    bake in 256-color lock-in we explicitly avoid.
+    """
 
     def test_cool_colors_defined(self):
-        """Test that cool colors (blue, cyan, etc.) are defined."""
+        """Test that cool ANSI slots (blue, cyan) are defined."""
         cool_colors = [
             "blue",
-            "dark blue",
             "cyan",
-            "teal",
-            "dodger blue",
+            "bright blue",
+            "bright cyan",
         ]
         for color in cool_colors:
             assert color in BANNER_COLORS
 
     def test_warm_colors_defined(self):
-        """Test that warm colors (red, orange, etc.) are defined."""
+        """Test that warm ANSI slots (red, yellow) are defined."""
         warm_colors = [
             "red",
-            "orange",
+            "yellow",
+            "bright red",
+            "bright yellow",
         ]
         for color in warm_colors:
-            if color in BANNER_COLORS:  # Optional warm colors
-                assert BANNER_COLORS[color]
+            assert color in BANNER_COLORS
 
     def test_green_colors_defined(self):
-        """Test that green colors are defined."""
+        """Test that green ANSI slots are defined."""
         green_colors = [
             "green",
-            "dark green",
-            "sea green",
-            "spring green",
+            "bright green",
         ]
         for color in green_colors:
             assert color in BANNER_COLORS
 
     def test_purple_colors_defined(self):
-        """Test that purple colors are defined."""
+        """Test that magenta (purple-ish) ANSI slots are defined."""
         purple_colors = [
-            "purple",
-            "dark magenta",
-            "medium purple",
-            "dark violet",
+            "magenta",
+            "bright magenta",
         ]
         for color in purple_colors:
             assert color in BANNER_COLORS
+
+    def test_neutral_color_defined(self):
+        """Test that a neutral grey slot is defined."""
+        assert "grey" in BANNER_COLORS
+
+    def test_palette_uses_ansi_names_only(self):
+        """All palette values must be ANSI names (no truecolor hex, no 256-color names)."""
+        allowed_ansi = {
+            "black", "red", "green", "yellow",
+            "blue", "magenta", "cyan", "white",
+            "bright_black", "bright_red", "bright_green", "bright_yellow",
+            "bright_blue", "bright_magenta", "bright_cyan", "bright_white",
+            "default",
+        }
+        for label, value in BANNER_COLORS.items():
+            assert value in allowed_ansi, (
+                f"Banner color '{label}' = '{value}' is not an ANSI 16 name; "
+                f"this re-introduces palette lock-in."
+            )
 
     def test_colors_have_valid_values(self):
         """Test that all colors have non-empty string values."""

--- a/tests/command_line/test_colors_menu_coverage.py
+++ b/tests/command_line/test_colors_menu_coverage.py
@@ -45,9 +45,9 @@ class TestColorConfiguration:
 
     def test_set_current_banner_color(self):
         config = ColorConfiguration()
-        config.set_current_banner_color("red3")
+        config.set_current_banner_color("red")
         key = config.get_current_banner_key()
-        assert config.current_colors[key] == "red3"
+        assert config.current_colors[key] == "red"
 
     def test_next_banner(self):
         config = ColorConfiguration()

--- a/tests/command_line/test_diff_menu.py
+++ b/tests/command_line/test_diff_menu.py
@@ -194,24 +194,43 @@ class TestColorDictionaries:
     def test_addition_colors_structure(self):
         """Test structure and content of addition colors."""
         assert isinstance(ADDITION_COLORS, dict)
-        assert len(ADDITION_COLORS) > 10  # Should have many color options
+        # ANSI 16-slot vocabulary: small, deliberate palette. Previously
+        # asserted >10 when 256-color jewel-tones provided ~24 options.
+        assert len(ADDITION_COLORS) >= 3
 
+        _ALLOWED_ANSI = {
+            "black", "red", "green", "yellow",
+            "blue", "magenta", "cyan", "white",
+            "bright_black", "bright_red", "bright_green", "bright_yellow",
+            "bright_blue", "bright_magenta", "bright_cyan", "bright_white",
+            "default",
+        }
         for name, color in ADDITION_COLORS.items():
             assert isinstance(name, str)
             assert isinstance(color, str)
-            assert color.startswith("#")  # Should all be hex colors
-            assert len(color) == 7  # #RRGGBB format
+            assert color in _ALLOWED_ANSI, (
+                f"Addition color '{name}' = '{color}' is not an ANSI 16 name; "
+                f"this re-introduces palette lock-in."
+            )
 
     def test_deletion_colors_structure(self):
         """Test structure and content of deletion colors."""
         assert isinstance(DELETION_COLORS, dict)
-        assert len(DELETION_COLORS) > 10  # Should have many color options
+        assert len(DELETION_COLORS) >= 3
 
+        _ALLOWED_ANSI = {
+            "black", "red", "green", "yellow",
+            "blue", "magenta", "cyan", "white",
+            "bright_black", "bright_red", "bright_green", "bright_yellow",
+            "bright_blue", "bright_magenta", "bright_cyan", "bright_white",
+            "default",
+        }
         for name, color in DELETION_COLORS.items():
             assert isinstance(name, str)
             assert isinstance(color, str)
-            assert color.startswith("#")  # Should all be hex colors
-            assert len(color) == 7  # #RRGGBB format
+            assert color in _ALLOWED_ANSI, (
+                f"Deletion color '{name}' = '{color}' is not an ANSI 16 name."
+            )
 
     def test_color_names_are_readable(self):
         """Test that color names are human-readable."""
@@ -486,11 +505,11 @@ class TestColorMenuHandler:
     @patch("code_puppy.command_line.diff_menu._split_panel_selector")
     async def test_additions_color_menu(self, mock_selector):
         """Test additions color menu handling."""
-        mock_selector.return_value = "dark green"
+        mock_selector.return_value = "green"
 
         config = DiffConfiguration()
         # Use an actual color from ADDITION_COLORS so the marker will appear
-        config.current_add_color = ADDITION_COLORS["dark green"]  # "#0b3e0b"
+        config.current_add_color = ADDITION_COLORS["green"]
 
         await _handle_color_menu(config, "additions")
 
@@ -499,9 +518,11 @@ class TestColorMenuHandler:
         call_args = mock_selector.call_args
         assert "addition" in call_args[0][0].lower()  # Title should mention addition
 
-        # Should have more than 10 color choices
+        # ANSI palette is intentionally small; smoke-check there's a sensible
+        # number of choices (was ">10" when the palette was 256-color jewel
+        # tones; current ANSI vocabulary offers ~6 addition slots).
         choices = call_args[0][1]  # choices parameter
-        assert len(choices) > 10
+        assert len(choices) >= 3
 
         # Should include current color marker
         assert any("← current" in choice for choice in choices)
@@ -510,7 +531,7 @@ class TestColorMenuHandler:
     @patch("code_puppy.command_line.diff_menu._split_panel_selector")
     async def test_deletions_color_menu(self, mock_selector):
         """Test deletions color menu handling."""
-        mock_selector.return_value = "dark red"
+        mock_selector.return_value = "red"
 
         config = DiffConfiguration()
         config.current_del_color = "#oldred"
@@ -855,8 +876,8 @@ class TestIntegrationScenarios:
         )
 
         config = DiffConfiguration()
-        config.current_add_color = "#0b3e0b"  # "dark green" hex value
-        config.current_del_color = "#4a0f0f"  # "dark red" hex value
+        config.current_add_color = "green"
+        config.current_del_color = "red"
 
         # Generate preview for different languages
         for i in range(min(5, len(SUPPORTED_LANGUAGES))):

--- a/tests/command_line/test_diff_menu.py
+++ b/tests/command_line/test_diff_menu.py
@@ -199,10 +199,22 @@ class TestColorDictionaries:
         assert len(ADDITION_COLORS) >= 3
 
         _ALLOWED_ANSI = {
-            "black", "red", "green", "yellow",
-            "blue", "magenta", "cyan", "white",
-            "bright_black", "bright_red", "bright_green", "bright_yellow",
-            "bright_blue", "bright_magenta", "bright_cyan", "bright_white",
+            "black",
+            "red",
+            "green",
+            "yellow",
+            "blue",
+            "magenta",
+            "cyan",
+            "white",
+            "bright_black",
+            "bright_red",
+            "bright_green",
+            "bright_yellow",
+            "bright_blue",
+            "bright_magenta",
+            "bright_cyan",
+            "bright_white",
             "default",
         }
         for name, color in ADDITION_COLORS.items():
@@ -219,10 +231,22 @@ class TestColorDictionaries:
         assert len(DELETION_COLORS) >= 3
 
         _ALLOWED_ANSI = {
-            "black", "red", "green", "yellow",
-            "blue", "magenta", "cyan", "white",
-            "bright_black", "bright_red", "bright_green", "bright_yellow",
-            "bright_blue", "bright_magenta", "bright_cyan", "bright_white",
+            "black",
+            "red",
+            "green",
+            "yellow",
+            "blue",
+            "magenta",
+            "cyan",
+            "white",
+            "bright_black",
+            "bright_red",
+            "bright_green",
+            "bright_yellow",
+            "bright_blue",
+            "bright_magenta",
+            "bright_cyan",
+            "bright_white",
             "default",
         }
         for name, color in DELETION_COLORS.items():

--- a/tests/command_line/test_diff_menu_coverage.py
+++ b/tests/command_line/test_diff_menu_coverage.py
@@ -449,7 +449,7 @@ class TestUpdatePreviewCallback:
 
         async def capture_selector(title, choices, on_change, get_preview, config=None):
             captured_callback[0] = on_change
-            return "dark green"  # Return a valid selection
+            return "green"  # Return a valid selection
 
         config = DiffConfiguration()
 
@@ -463,12 +463,12 @@ class TestUpdatePreviewCallback:
         assert captured_callback[0] is not None
 
         # Call the callback with a color choice
-        captured_callback[0]("dark green")
-        assert config.current_add_color == ADDITION_COLORS["dark green"]
+        captured_callback[0]("green")
+        assert config.current_add_color == ADDITION_COLORS["green"]
 
         # Test with " ← current" marker
-        captured_callback[0]("darker green ← current")
-        assert config.current_add_color == ADDITION_COLORS["darker green"]
+        captured_callback[0]("bright green ← current")
+        assert config.current_add_color == ADDITION_COLORS["bright green"]
 
     @pytest.mark.asyncio
     async def test_update_preview_sets_deletion_color(self):
@@ -477,7 +477,7 @@ class TestUpdatePreviewCallback:
 
         async def capture_selector(title, choices, on_change, get_preview, config=None):
             captured_callback[0] = on_change
-            return "dark red"
+            return "red"
 
         config = DiffConfiguration()
 
@@ -490,8 +490,8 @@ class TestUpdatePreviewCallback:
         assert captured_callback[0] is not None
 
         # Call the callback with a deletion color
-        captured_callback[0]("dark red")
-        assert config.current_del_color == DELETION_COLORS["dark red"]
+        captured_callback[0]("red")
+        assert config.current_del_color == DELETION_COLORS["red"]
 
     @pytest.mark.asyncio
     async def test_update_preview_with_unknown_color(self):
@@ -1011,7 +1011,7 @@ class TestColorMenuChoicesConstruction:
 
         config = DiffConfiguration()
         # Set current color to a known value from ADDITION_COLORS
-        config.current_add_color = ADDITION_COLORS["dark green"]
+        config.current_add_color = ADDITION_COLORS["green"]
 
         with patch(
             "code_puppy.command_line.diff_menu._split_panel_selector",
@@ -1023,7 +1023,7 @@ class TestColorMenuChoicesConstruction:
         # Should have a choice marked as current
         current_choices = [c for c in captured_choices[0] if "← current" in c]
         assert len(current_choices) == 1
-        assert "dark green" in current_choices[0]
+        assert "green" in current_choices[0]
 
     @pytest.mark.asyncio
     async def test_deletion_menu_includes_current_marker(self):
@@ -1036,7 +1036,7 @@ class TestColorMenuChoicesConstruction:
 
         config = DiffConfiguration()
         # Set current color to a known value from DELETION_COLORS
-        config.current_del_color = DELETION_COLORS["dark red"]
+        config.current_del_color = DELETION_COLORS["red"]
 
         with patch(
             "code_puppy.command_line.diff_menu._split_panel_selector",
@@ -1048,4 +1048,4 @@ class TestColorMenuChoicesConstruction:
         # Should have a choice marked as current
         current_choices = [c for c in captured_choices[0] if "← current" in c]
         assert len(current_choices) == 1
-        assert "dark red" in current_choices[0]
+        assert "red" in current_choices[0]

--- a/tests/messaging/test_terminal_theme.py
+++ b/tests/messaging/test_terminal_theme.py
@@ -1,0 +1,119 @@
+"""Tests for code_puppy.messaging.terminal_theme."""
+
+from __future__ import annotations
+
+import pytest
+
+from code_puppy.messaging.terminal_theme import (
+    detect_terminal_bg,
+    resolve_code_theme,
+)
+
+
+# ---------------------------------------------------------------------------
+# detect_terminal_bg
+# ---------------------------------------------------------------------------
+
+
+class TestDetectTerminalBg:
+    def test_default_is_dark_with_no_signal(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("COLORFGBG", raising=False)
+        monkeypatch.delenv("CODE_PUPPY_TERMINAL_BG", raising=False)
+        assert detect_terminal_bg() == "dark"
+
+    def test_default_arg_is_honored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("COLORFGBG", raising=False)
+        monkeypatch.delenv("CODE_PUPPY_TERMINAL_BG", raising=False)
+        assert detect_terminal_bg(default="light") == "light"
+
+    @pytest.mark.parametrize("value", ["light", "LIGHT", "  light  "])
+    def test_env_override_light(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+        monkeypatch.setenv("CODE_PUPPY_TERMINAL_BG", value)
+        # Even if COLORFGBG disagrees, the override wins.
+        monkeypatch.setenv("COLORFGBG", "15;0")
+        assert detect_terminal_bg() == "light"
+
+    @pytest.mark.parametrize("value", ["dark", "DARK"])
+    def test_env_override_dark(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+        monkeypatch.setenv("CODE_PUPPY_TERMINAL_BG", value)
+        monkeypatch.setenv("COLORFGBG", "0;15")  # would normally mean light
+        assert detect_terminal_bg() == "dark"
+
+    def test_env_override_bogus_falls_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CODE_PUPPY_TERMINAL_BG", "neon-magenta")
+        monkeypatch.setenv("COLORFGBG", "15;0")
+        # Bogus override is ignored, COLORFGBG kicks in.
+        assert detect_terminal_bg() == "dark"
+
+    @pytest.mark.parametrize("bg_idx", ["0", "1", "2", "3", "4", "5", "6", "8"])
+    def test_colorfgbg_dark_indices(
+        self, monkeypatch: pytest.MonkeyPatch, bg_idx: str
+    ) -> None:
+        monkeypatch.delenv("CODE_PUPPY_TERMINAL_BG", raising=False)
+        monkeypatch.setenv("COLORFGBG", f"15;{bg_idx}")
+        assert detect_terminal_bg() == "dark"
+
+    @pytest.mark.parametrize("bg_idx", ["7", "9", "10", "11", "12", "13", "14", "15"])
+    def test_colorfgbg_light_indices(
+        self, monkeypatch: pytest.MonkeyPatch, bg_idx: str
+    ) -> None:
+        monkeypatch.delenv("CODE_PUPPY_TERMINAL_BG", raising=False)
+        monkeypatch.setenv("COLORFGBG", f"0;{bg_idx}")
+        assert detect_terminal_bg() == "light"
+
+    def test_colorfgbg_three_segments(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Some terminals emit "fg;default;bg" — take the last segment.
+        monkeypatch.delenv("CODE_PUPPY_TERMINAL_BG", raising=False)
+        monkeypatch.setenv("COLORFGBG", "0;default;15")
+        assert detect_terminal_bg() == "light"
+
+    def test_colorfgbg_empty_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CODE_PUPPY_TERMINAL_BG", raising=False)
+        monkeypatch.setenv("COLORFGBG", "")
+        assert detect_terminal_bg(default="light") == "light"
+
+    def test_colorfgbg_garbage_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CODE_PUPPY_TERMINAL_BG", raising=False)
+        monkeypatch.setenv("COLORFGBG", "this-is-not-an-fgbg")
+        # Last token "this-is-not-an-fgbg" isn't in dark set → classified as light.
+        # We're documenting current behavior; weird inputs lean light, which
+        # is the safer choice if a user explicitly set something weird.
+        assert detect_terminal_bg() == "light"
+
+
+# ---------------------------------------------------------------------------
+# resolve_code_theme
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCodeTheme:
+    def test_none_resolves_via_detection_dark(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("COLORFGBG", raising=False)
+        monkeypatch.delenv("CODE_PUPPY_TERMINAL_BG", raising=False)
+        assert resolve_code_theme(None) == "ansi_dark"
+
+    def test_system_resolves_via_detection_light(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CODE_PUPPY_TERMINAL_BG", "light")
+        assert resolve_code_theme("system") == "ansi_light"
+
+    def test_system_case_insensitive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CODE_PUPPY_TERMINAL_BG", "dark")
+        assert resolve_code_theme("SYSTEM") == "ansi_dark"
+
+    @pytest.mark.parametrize("name", ["monokai", "github-dark", "solarized-light"])
+    def test_explicit_override_passthrough(self, name: str) -> None:
+        # Explicit values bypass detection entirely.
+        assert resolve_code_theme(name) == name
+
+    def test_whitespace_is_stripped(self) -> None:
+        assert resolve_code_theme("  monokai  ") == "monokai"
+
+    def test_empty_string_falls_back_to_detection(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CODE_PUPPY_TERMINAL_BG", "light")
+        assert resolve_code_theme("") == "ansi_light"

--- a/tests/messaging/test_terminal_theme.py
+++ b/tests/messaging/test_terminal_theme.py
@@ -16,7 +16,9 @@ from code_puppy.messaging.terminal_theme import (
 
 
 class TestDetectTerminalBg:
-    def test_default_is_dark_with_no_signal(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_default_is_dark_with_no_signal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.delenv("COLORFGBG", raising=False)
         monkeypatch.delenv("CODE_PUPPY_TERMINAL_BG", raising=False)
         assert detect_terminal_bg() == "dark"
@@ -27,19 +29,25 @@ class TestDetectTerminalBg:
         assert detect_terminal_bg(default="light") == "light"
 
     @pytest.mark.parametrize("value", ["light", "LIGHT", "  light  "])
-    def test_env_override_light(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    def test_env_override_light(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
         monkeypatch.setenv("CODE_PUPPY_TERMINAL_BG", value)
         # Even if COLORFGBG disagrees, the override wins.
         monkeypatch.setenv("COLORFGBG", "15;0")
         assert detect_terminal_bg() == "light"
 
     @pytest.mark.parametrize("value", ["dark", "DARK"])
-    def test_env_override_dark(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    def test_env_override_dark(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
         monkeypatch.setenv("CODE_PUPPY_TERMINAL_BG", value)
         monkeypatch.setenv("COLORFGBG", "0;15")  # would normally mean light
         assert detect_terminal_bg() == "dark"
 
-    def test_env_override_bogus_falls_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_env_override_bogus_falls_through(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setenv("CODE_PUPPY_TERMINAL_BG", "neon-magenta")
         monkeypatch.setenv("COLORFGBG", "15;0")
         # Bogus override is ignored, COLORFGBG kicks in.
@@ -72,7 +80,9 @@ class TestDetectTerminalBg:
         monkeypatch.setenv("COLORFGBG", "")
         assert detect_terminal_bg(default="light") == "light"
 
-    def test_colorfgbg_garbage_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_colorfgbg_garbage_falls_back(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.delenv("CODE_PUPPY_TERMINAL_BG", raising=False)
         monkeypatch.setenv("COLORFGBG", "this-is-not-an-fgbg")
         # Last token "this-is-not-an-fgbg" isn't in dark set → classified as light.
@@ -117,3 +127,117 @@ class TestResolveCodeTheme:
     ) -> None:
         monkeypatch.setenv("CODE_PUPPY_TERMINAL_BG", "light")
         assert resolve_code_theme("") == "ansi_light"
+
+
+# ---------------------------------------------------------------------------
+# install_accessible_markdown_styles
+# ---------------------------------------------------------------------------
+
+
+class TestInstallAccessibleMarkdownStyles:
+    """Patches Rich's hardcoded markdown.code / markdown.kbd defaults.
+
+    These tests mutate `rich.themes.DEFAULT.styles`, which is process-global.
+    Each test snapshots and restores the affected keys to keep things hermetic.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_styles(self):
+        from rich import themes
+
+        snapshot = {
+            "markdown.code": themes.DEFAULT.styles.get("markdown.code"),
+            "markdown.kbd": themes.DEFAULT.styles.get("markdown.kbd"),
+        }
+        yield
+        for key, value in snapshot.items():
+            if value is None:
+                themes.DEFAULT.styles.pop(key, None)
+            else:
+                themes.DEFAULT.styles[key] = value
+
+    def test_patches_markdown_code_to_bold_reverse(self) -> None:
+        from rich import themes
+        from rich.style import Style
+
+        from code_puppy.messaging.terminal_theme import (
+            install_accessible_markdown_styles,
+        )
+
+        install_accessible_markdown_styles()
+        patched = themes.DEFAULT.styles["markdown.code"]
+        assert patched == Style(bold=True, reverse=True)
+
+    def test_patches_markdown_kbd_to_bold_reverse(self) -> None:
+        from rich import themes
+        from rich.style import Style
+
+        from code_puppy.messaging.terminal_theme import (
+            install_accessible_markdown_styles,
+        )
+
+        install_accessible_markdown_styles()
+        patched = themes.DEFAULT.styles["markdown.kbd"]
+        assert patched == Style(bold=True, reverse=True)
+
+    def test_patched_style_uses_no_color_slot(self) -> None:
+        """No specific ANSI color = nothing for a theme to mismatch."""
+        from rich import themes
+
+        from code_puppy.messaging.terminal_theme import (
+            install_accessible_markdown_styles,
+        )
+
+        install_accessible_markdown_styles()
+        patched = themes.DEFAULT.styles["markdown.code"]
+        assert patched.color is None
+        assert patched.bgcolor is None
+
+    def test_patched_style_is_bold_for_redundancy(self) -> None:
+        """Bold provides a non-color signal (WCAG 1.4.1)."""
+        from rich import themes
+
+        from code_puppy.messaging.terminal_theme import (
+            install_accessible_markdown_styles,
+        )
+
+        install_accessible_markdown_styles()
+        assert themes.DEFAULT.styles["markdown.code"].bold is True
+
+    def test_patched_style_uses_reverse(self) -> None:
+        """Reverse guarantees fg/bg contrast in any user palette."""
+        from rich import themes
+
+        from code_puppy.messaging.terminal_theme import (
+            install_accessible_markdown_styles,
+        )
+
+        install_accessible_markdown_styles()
+        assert themes.DEFAULT.styles["markdown.code"].reverse is True
+
+    def test_idempotent(self) -> None:
+        """Calling twice yields the same final state."""
+        from rich import themes
+
+        from code_puppy.messaging.terminal_theme import (
+            install_accessible_markdown_styles,
+        )
+
+        install_accessible_markdown_styles()
+        first = themes.DEFAULT.styles["markdown.code"]
+        install_accessible_markdown_styles()
+        second = themes.DEFAULT.styles["markdown.code"]
+        assert first == second
+
+    def test_new_console_inherits_patched_style(self) -> None:
+        """End-to-end: a fresh Console sees the patched style at render time."""
+        from rich.console import Console
+        from rich.style import Style
+
+        from code_puppy.messaging.terminal_theme import (
+            install_accessible_markdown_styles,
+        )
+
+        install_accessible_markdown_styles()
+        console = Console()
+        assert console.get_style("markdown.code") == Style(bold=True, reverse=True)

--- a/tests/test_config_full_coverage.py
+++ b/tests/test_config_full_coverage.py
@@ -786,23 +786,23 @@ class TestPuppyToken:
 # ---------------------------------------------------------------------------
 class TestDiffColors:
     def test_default_addition_color(self):
+        # Default is now the ANSI name 'green' (was hex-coerced via
+        # _coerce_to_hex previously). Terminal palette decides actual pixels.
         cp_config.reset_value("highlight_addition_color")
-        assert cp_config.get_diff_addition_color() == "#0b1f0b"
+        assert cp_config.get_diff_addition_color() == "green"
 
     def test_set_addition_color(self):
-        # Rich color names are normalized to '#RRGGBB' hex on write so
-        # downstream renderers don't have to re-parse them.
+        # ANSI names are stored as-is (no more hex normalization).
         cp_config.set_diff_addition_color("green")
-        assert cp_config.get_diff_addition_color() == "#008000"
+        assert cp_config.get_diff_addition_color() == "green"
 
     def test_default_deletion_color(self):
         cp_config.reset_value("highlight_deletion_color")
-        assert cp_config.get_diff_deletion_color() == "#390e1a"
+        assert cp_config.get_diff_deletion_color() == "red"
 
     def test_set_deletion_color(self):
-        # Rich color names are normalized to '#RRGGBB' hex on write.
         cp_config.set_diff_deletion_color("red")
-        assert cp_config.get_diff_deletion_color() == "#800000"
+        assert cp_config.get_diff_deletion_color() == "red"
 
     def test_set_diff_highlight_style_noop(self):
         # Should not raise
@@ -814,9 +814,11 @@ class TestDiffColors:
 # ---------------------------------------------------------------------------
 class TestBannerColors:
     def test_get_default(self):
+        # 'thinking' banner default is now the ANSI name 'blue' (was
+        # 'deep_sky_blue4' in the 256-color era).
         cp_config.reset_value("banner_color_thinking")
         color = cp_config.get_banner_color("thinking")
-        assert color == "deep_sky_blue4"
+        assert color == "blue"
 
     def test_get_unknown_banner(self):
         assert cp_config.get_banner_color("nonexistent_banner") == "blue"

--- a/tests/test_shell_passthrough.py
+++ b/tests/test_shell_passthrough.py
@@ -106,10 +106,10 @@ class TestFormatBanner:
         """Banner should use the color from get_banner_color."""
         with patch(
             "code_puppy.command_line.shell_passthrough.get_banner_color",
-            return_value="medium_sea_green",
+            return_value="green",
         ):
             banner = _format_banner()
-            assert "medium_sea_green" in banner
+            assert "green" in banner
             assert "SHELL PASSTHROUGH" in banner
 
     def test_banner_name_constant(self):

--- a/tests/tools/test_common_comprehensive.py
+++ b/tests/tools/test_common_comprehensive.py
@@ -16,7 +16,6 @@ from unittest.mock import patch
 from code_puppy.tools.common import (
     DIR_IGNORE_PATTERNS,
     FILE_IGNORE_PATTERNS,
-    brighten_hex,
     format_diff_with_colors,
     generate_group_id,
     should_ignore_dir_path,
@@ -312,77 +311,6 @@ class TestDiffFormatting:
         assert result is not None
 
 
-class TestBrightenHex:
-    """Test hex color brightening function."""
-
-    def test_brighten_hex_basic(self):
-        """Test basic hex color brightening."""
-        result = brighten_hex("#000000", 0.2)
-        assert isinstance(result, str)
-        assert result.startswith("#")
-        assert len(result) == 7  # #RRGGBB format
-
-    def test_brighten_hex_white_unchanged(self):
-        """Test that white color is not brightened beyond limits."""
-        result = brighten_hex("#FFFFFF", 0.5)
-        assert isinstance(result, str)
-        assert result.startswith("#")
-
-    def test_brighten_hex_gray_becomes_lighter(self):
-        """Test that gray becomes lighter when brightened."""
-        original = "#808080"
-        result = brighten_hex(original, 0.3)
-        # Result should be a valid hex color
-        assert isinstance(result, str)
-        assert result.startswith("#")
-        assert len(result) == 7
-
-    def test_brighten_hex_zero_factor(self):
-        """Test brightening with zero factor (no change)."""
-        color = "#FF0000"
-        result = brighten_hex(color, 0.0)
-        # Should not change
-        assert isinstance(result, str)
-        assert result.startswith("#")
-
-    def test_brighten_hex_negative_factor(self):
-        """Test brightening with negative factor (darken)."""
-        color = "#FF0000"
-        result = brighten_hex(color, -0.2)
-        # Should return a valid hex color even with negative
-        assert isinstance(result, str)
-        assert result.startswith("#")
-
-    def test_brighten_hex_large_factor(self):
-        """Test brightening with large factor (cap at white)."""
-        color = "#808080"
-        result = brighten_hex(color, 10.0)
-        # Should cap at white
-        assert isinstance(result, str)
-        assert result.startswith("#")
-
-    def test_brighten_hex_various_colors(self):
-        """Test brightening various colors."""
-        colors = ["#FF0000", "#00FF00", "#0000FF", "#FFFF00", "#FF00FF"]
-        for color in colors:
-            result = brighten_hex(color, 0.2)
-            assert isinstance(result, str)
-            assert result.startswith("#")
-            assert len(result) == 7
-
-    def test_brighten_hex_invalid_input_handling(self):
-        """Test that function handles invalid input gracefully."""
-        # The function might raise or handle differently
-        # Test what it actually does
-        try:
-            result = brighten_hex("invalid", 0.2)
-            # If it doesn't raise, it returned something
-            assert result is not None
-        except (ValueError, IndexError, TypeError):
-            # If it raises, that's also acceptable for invalid input
-            pass
-
-
 class TestIconesUniquePerMessageType:
     """Test console output uniqueness and consistency."""
 
@@ -394,7 +322,6 @@ class TestIconesUniquePerMessageType:
         assert should_ignore_dir_path is not None
         assert generate_group_id is not None
         assert format_diff_with_colors is not None
-        assert brighten_hex is not None
 
     def test_constants_have_values(self):
         """Test that module constants are defined."""
@@ -426,18 +353,6 @@ class TestEdgeCases:
         """Test path filtering with special characters."""
         result = should_ignore_path("file-with-dashes_and_underscores.txt")
         assert isinstance(result, bool)
-
-    def test_brighten_hex_with_lowercase(self):
-        """Test hex color with lowercase letters."""
-        result = brighten_hex("#abcdef", 0.2)
-        assert isinstance(result, str)
-        assert result.startswith("#")
-
-    def test_brighten_hex_with_uppercase(self):
-        """Test hex color with uppercase letters."""
-        result = brighten_hex("#ABCDEF", 0.2)
-        assert isinstance(result, str)
-        assert result.startswith("#")
 
     def test_group_id_with_empty_tool_name(self):
         """Test group ID generation with empty tool name."""

--- a/tests/tools/test_common_coverage.py
+++ b/tests/tools/test_common_coverage.py
@@ -5,7 +5,7 @@ Target functions:
 - should_suppress_browser()
 - should_ignore_dir_path()
 - Syntax highlighting functions (_get_lexer_for_extension, _get_token_color, _highlight_code_line)
-- Diff utilities (brighten_hex, _extract_file_extension_from_diff, _format_diff_with_syntax_highlighting)
+- Diff utilities (_extract_file_extension_from_diff, _format_diff_with_syntax_highlighting)
 """
 
 import importlib.util
@@ -27,7 +27,6 @@ should_suppress_browser = common_module.should_suppress_browser
 should_ignore_dir_path = common_module.should_ignore_dir_path
 DIR_IGNORE_PATTERNS = common_module.DIR_IGNORE_PATTERNS
 FILE_IGNORE_PATTERNS = common_module.FILE_IGNORE_PATTERNS
-brighten_hex = common_module.brighten_hex
 _extract_file_extension_from_diff = common_module._extract_file_extension_from_diff
 _get_lexer_for_extension = common_module._get_lexer_for_extension
 _get_token_color = common_module._get_token_color
@@ -202,70 +201,6 @@ class TestShouldIgnoreDirPath:
 
 
 # =============================================================================
-# TESTS FOR brighten_hex()
-# =============================================================================
-
-
-class TestBrightenHex:
-    """Test the brighten_hex() function."""
-
-    def test_no_change_with_factor_zero(self):
-        """Test that factor=0 returns original color."""
-        result = brighten_hex("#808080", 0.0)
-        assert result == "#808080"
-
-    def test_brightens_color_with_positive_factor(self):
-        """Test that positive factor brightens the color."""
-        result = brighten_hex("#808080", 0.5)
-        # 0x80 = 128, 128 * 1.5 = 192 = 0xc0
-        assert result == "#c0c0c0"
-
-    def test_darkens_color_with_negative_factor(self):
-        """Test that negative factor darkens the color."""
-        result = brighten_hex("#808080", -0.5)
-        # 0x80 = 128, 128 * 0.5 = 64 = 0x40
-        assert result == "#404040"
-
-    def test_clamps_to_max_255(self):
-        """Test that values are clamped to max 255."""
-        result = brighten_hex("#ffffff", 1.0)
-        # 255 * 2 = 510, clamped to 255
-        assert result == "#ffffff"
-
-    def test_clamps_to_min_zero(self):
-        """Test that values are clamped to min 0."""
-        result = brighten_hex("#808080", -2.0)
-        # 128 * -1 would be negative, clamped to 0
-        assert result == "#000000"
-
-    def test_handles_without_hash_prefix(self):
-        """Test that colors without # prefix work."""
-        result = brighten_hex("808080", 0.0)
-        assert result == "#808080"
-
-    def test_handles_pure_black(self):
-        """Test brightening pure black."""
-        result = brighten_hex("#000000", 1.0)
-        # 0 * 2 = 0, stays black
-        assert result == "#000000"
-
-    def test_handles_pure_red(self):
-        """Test brightening pure red."""
-        result = brighten_hex("#ff0000", 0.0)
-        assert result == "#ff0000"
-
-    def test_raises_on_invalid_hex(self):
-        """Test that invalid hex raises ValueError."""
-        with pytest.raises(ValueError):
-            brighten_hex("#fff", 0.5)  # Too short
-
-    def test_raises_on_invalid_format(self):
-        """Test that invalid format raises ValueError."""
-        with pytest.raises(ValueError):
-            brighten_hex("notahex", 0.5)
-
-
-# =============================================================================
 # TESTS FOR _extract_file_extension_from_diff()
 # =============================================================================
 
@@ -416,11 +351,11 @@ class TestGetTokenColor:
 
     @pytest.mark.skipif(not PYGMENTS_AVAILABLE, reason="Pygments not available")
     def test_returns_default_for_unknown_token(self):
-        """Test returns default color for unknown token type."""
+        """Test returns terminal-default color for unknown token type."""
         from pygments.token import Token
 
         color = _get_token_color(Token.Generic)
-        assert color == "#cccccc"  # Default color
+        assert color == "default"  # Terminal-default foreground
 
 
 class TestHighlightCodeLine:

--- a/tests/tools/test_common_extended.py
+++ b/tests/tools/test_common_extended.py
@@ -8,7 +8,6 @@ from code_puppy.tools.common import (
     FILE_IGNORE_PATTERNS,
     IGNORE_PATTERNS,
     _find_best_window,
-    brighten_hex,
     generate_group_id,
     should_ignore_dir_path,
     should_ignore_path,
@@ -179,40 +178,6 @@ class TestCommonExtended:
             assert isinstance(result, bool)
 
     # ==================== Helper Utilities Tests ====================
-
-    def test_brighten_hex(self):
-        """Test hex color brightening function."""
-        # Test basic color brightening - actually it doesn't change with factor 0.5
-        # The function might have different behavior than expected
-        result = brighten_hex("#ff0000", 0.5)
-        assert result.startswith("#")
-        assert len(result) == 7
-
-        # Test no change (factor = 0)
-        result = brighten_hex("#ff0000", 0)
-        assert result.startswith("#")
-        assert len(result) == 7
-
-        # Test edge cases
-        result = brighten_hex("#ffffff", 1.0)  # Should cap at 255
-        assert result.startswith("#")
-        assert len(result) == 7
-
-        # Test lowercase handling
-        result = brighten_hex("FF0000", 0.5)
-        assert result.startswith("#")
-        assert len(result) == 7
-
-        # Test invalid input - brighten_hex has mixed error handling
-        result = brighten_hex("ff0000", 0.5)  # Missing # - handles gracefully
-        assert isinstance(result, str)
-
-        # Some invalid inputs do raise errors
-        with pytest.raises(ValueError):
-            brighten_hex("#ff00", 0.5)  # Too short
-
-        with pytest.raises(ValueError):
-            brighten_hex("#ff0000gg", 0.5)  # Invalid hex
 
     def test_generate_group_id(self):
         """Test group ID generation."""

--- a/tests/tools/test_common_full_coverage.py
+++ b/tests/tools/test_common_full_coverage.py
@@ -246,9 +246,9 @@ class TestGetTokenColor:
     def test_returns_default_for_unknown(self):
         from code_puppy.tools.common import _get_token_color
 
-        # Some random token type
+        # Some random token type — falls back to the terminal default.
         color = _get_token_color("SomeUnknownTokenType")
-        assert color == "#cccccc"
+        assert color == "default"
 
     def test_no_pygments(self):
         import code_puppy.tools.common as mod
@@ -257,7 +257,7 @@ class TestGetTokenColor:
         try:
             mod.PYGMENTS_AVAILABLE = False
             color = mod._get_token_color("anything")
-            assert color == "#cccccc"
+            assert color == "default"
         finally:
             mod.PYGMENTS_AVAILABLE = orig
 
@@ -340,54 +340,49 @@ class TestExtractFileExtensionFromDiff:
 
 
 # ---------------------------------------------------------------------------
-# brighten_hex
+# _brighten_ansi
 # ---------------------------------------------------------------------------
 
 
-class TestBrightenHex:
-    def test_no_change(self):
-        from code_puppy.tools.common import brighten_hex
+class TestBrightenAnsi:
+    @pytest.mark.parametrize(
+        "base,expected",
+        [
+            ("black", "bright_black"),
+            ("red", "bright_red"),
+            ("green", "bright_green"),
+            ("yellow", "bright_yellow"),
+            ("blue", "bright_blue"),
+            ("magenta", "bright_magenta"),
+            ("cyan", "bright_cyan"),
+            ("white", "bright_white"),
+            ("GREEN", "bright_green"),  # case-insensitive
+            ("  red  ", "bright_red"),  # whitespace tolerated
+        ],
+    )
+    def test_base_ansi_maps_to_bright(self, base, expected):
+        from code_puppy.tools.common import _brighten_ansi
 
-        result = brighten_hex("#808080", 0.0)
-        assert result == "#808080"
+        assert _brighten_ansi(base) == expected
 
-    def test_brighten(self):
-        from code_puppy.tools.common import brighten_hex
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "bright_red",  # already bright
+            "#ff8800",  # hex passthrough
+            "default",  # terminal default
+            "deep_sky_blue4",  # exotic Rich name
+        ],
+    )
+    def test_non_base_passthrough(self, value):
+        from code_puppy.tools.common import _brighten_ansi
 
-        result = brighten_hex("#808080", 0.5)
-        # Should be brighter
-        assert result.startswith("#")
-        assert len(result) == 7
+        assert _brighten_ansi(value) == value
 
-    def test_darken(self):
-        from code_puppy.tools.common import brighten_hex
+    def test_empty_string_passthrough(self):
+        from code_puppy.tools.common import _brighten_ansi
 
-        result = brighten_hex("#ffffff", -0.5)
-        assert result.startswith("#")
-
-    def test_clamp_max(self):
-        from code_puppy.tools.common import brighten_hex
-
-        result = brighten_hex("#ffffff", 1.0)
-        assert result == "#ffffff"  # clamped to 255
-
-    def test_clamp_min(self):
-        from code_puppy.tools.common import brighten_hex
-
-        result = brighten_hex("#000000", -1.0)
-        assert result == "#000000"
-
-    def test_invalid_hex(self):
-        from code_puppy.tools.common import brighten_hex
-
-        with pytest.raises(ValueError):
-            brighten_hex("#ff", 0.5)
-
-    def test_with_hash(self):
-        from code_puppy.tools.common import brighten_hex
-
-        result = brighten_hex("#102030", 0.18)
-        assert result.startswith("#")
+        assert _brighten_ansi("") == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_common_missing.py
+++ b/tests/tools/test_common_missing.py
@@ -124,20 +124,6 @@ class TestExtractFileExtension:
         assert ext == ".txt"  # fallback
 
 
-class TestBrightenHex:
-    def test_brighten(self):
-        from code_puppy.tools.common import brighten_hex
-
-        result = brighten_hex("#004400", 1.5)
-        assert result.startswith("#")
-
-    def test_invalid(self):
-        from code_puppy.tools.common import brighten_hex
-
-        with pytest.raises(ValueError):
-            brighten_hex("invalid", 1.5)
-
-
 class TestFormatDiffWithSyntaxHighlighting:
     def test_basic_diff(self):
         from code_puppy.tools.common import _format_diff_with_syntax_highlighting


### PR DESCRIPTION
# Terminal-native theming: respect the user's color scheme

## TL;DR

Code Puppy currently bakes a lot of theming choices into source code via 256-color names and truecolor hex values. This makes it look great in dark Monokai-ish terminals and **awful** in light terminals (Catppuccin Latte, Solarized Light, Modus Operandi) — code blocks render as bright-white-on-white, inline code becomes invisible, banners are vivid against pale backgrounds.

This PR rewrites the theming subsystem so the **user's terminal palette controls the actual pixels**. Net effect: 100% backward-compatible in dark terminals, dramatically improved in light terminals, and accessibility-friendly (WCAG-aware, CVD-aware) by default.

## Motivation

Light-terminal user opens Code Puppy:
- 🤮 Code fences: bright white on white background (Monokai's `#f8f8f2` literally)
- 🤮 Inline `code`: green on dark grey (Rich's hardcoded `cyan on black`)
- 🤮 Banners: 256-color jewel tones designed for dark backgrounds, garish on light
- 🤮 Diff lines: hand-rolled hex tinting that ignores the terminal's diff palette

These aren't styling preferences — they're contrast bugs that hurt readability.

## Approach

Three principles drive every change in this PR:

1. **ANSI over hex.** ANSI base names (`blue`, `magenta`, `cyan`, ...) ask the terminal "use whatever you call blue"; truecolor hex says "ignore the user's theme, use exactly this pixel". Defaults should never do the latter.
2. **Detect, don't dictate.** Probe `COLORFGBG` for background brightness; switch Pygments style (`ansi_dark` ↔ `ansi_light`) accordingly. User override available via `CODE_PUPPY_TERMINAL_BG`.
3. **Color is decoration, not signal.** WCAG 1.4.1: never rely on color alone. Diff lines get `+`/`-` glyphs; inline code gets `bold reverse` so it's distinguishable even in monochrome.

## Commits

| # | Commit | What |
|---|--------|------|
| 1 | `feat(theming): add terminal-bg detection + ANSI code-theme resolver` | New `messaging/terminal_theme.py`: `detect_terminal_bg()`, `resolve_code_theme()`, `current_code_theme()`. 35 tests. |
| 2 | `feat(theming): thread code_theme= into Markdown/Syntax callsites` | 8 callsites in `rich_renderer.py`, `renderers.py`, `mcp/logs_command.py`, `uc_menu.py`. Kills hardcoded `monokai`. |
| 3 | `refactor(theming): kill hex coercion + brighten_hex; diff defaults to ANSI` | Demolishes `_coerce_to_hex` and `brighten_hex` (~80 dead tests gone). Diff defaults flip to ANSI `green`/`red`. `TOKEN_COLORS` becomes ANSI. Net **-241 LOC**. |
| 4 | `feat(theming): accessible markdown.code + CVD-safer TOKEN_COLORS` | Patches Rich's `DEFAULT.styles[markdown.code]` to `Style(bold=True, reverse=True)` (terminal-native, color-blind-safe). Rebuilds `TOKEN_COLORS` on blue/yellow CVD-safe axis instead of triple-magenta collision. |
| 5 | `refactor(theming): banner palettes -> ANSI 16-slot vocabulary` | `DEFAULT_BANNER_COLORS` (19 entries) and `colors_menu.BANNER_COLORS` picker palette (~40 → 13 entries) → ANSI. New test guard `test_palette_uses_ansi_names_only` prevents future regression. |
| 6 | `refactor(theming): diff_menu palette -> ANSI 16-slot vocabulary` | `ADDITION_COLORS` and `DELETION_COLORS` (~30 hex entries → 12 ANSI entries). Same regression-guard pattern. |
| 7 | `style(theming): ruff format pass on PR-touched files only` | Pure cosmetic format pass scoped to PR files. |
| 8 | `fix(theming): repair unreachable return in get_banner_color` | Self-caught regression from commit 5: a fuzzy text-replacement misfire over-indented the fallback by 4 spaces, nesting it inside an `if val:` block. |
| 9 | `test(theming): update TestDiffColors/TestBannerColors for ANSI defaults` | Updates `test_config_full_coverage.py` fixtures to assert ANSI names instead of hex (`#0b1f0b` → `green`, etc.) since `_coerce_to_hex` is gone. |

## Accessibility notes

- **CVD (color vision deficiency):** ~8% of men, ~0.5% of women. Red/green is the worst pair; blue/yellow is the safest. `TOKEN_COLORS` now favors blue/yellow. Diff defaults stay red/green because the `+`/`-` glyphs carry the semantic load (WCAG-compliant redundancy).
- **WCAG 1.4.1 (Use of Color):** Color cannot be the sole way to convey information. Every color-coded affordance in this PR has a non-color signal: `bold` for inline code, `bold reverse` for `<kbd>`, glyphs for diffs, banner text labels.
- **WCAG 1.4.3 (Contrast):** `bold reverse` for inline code uses the terminal's own fg/bg pair, which is guaranteed to meet contrast by definition (it's literally the user's chosen pair).

## Verification

- **9980 tests passing** (full suite, minus 1 pre-existing unrelated failure on `main`: `test_run_pending_credentials_success`)
- Manual verification under Catppuccin Latte (light) and a dark theme via `scripts/visual_theme_demo.py` (renders Markdown three ways: auto-detected, forced `ansi_dark`, forced `ansi_light`)

## What I didn't change (and why)

- **No new dependency on a color-detection library** (e.g., `colorama`, `term-image`). `COLORFGBG` is a 30-year-old xterm convention supported by every modern terminal worth using; the escape hatch handles exotic cases.
- **No "themes" feature.** Tempting, but YAGNI. The terminal IS the theme system. Building a parallel one would just reintroduce the lock-in this PR removes.
- **No refactor of the hand-rolled diff highlighter** to use `rich.syntax.Syntax`. That's a worthy follow-up (would kill another ~150 LOC of duplication) but out of scope here.

## Trying it out

```bash
# auto-detect (uses COLORFGBG)
code-puppy

# force dark
CODE_PUPPY_TERMINAL_BG=dark code-puppy

# force light
CODE_PUPPY_TERMINAL_BG=light code-puppy

# legacy opt-in to monokai
code_theme=monokai code-puppy
```

## Visual demo script

`scripts/visual_theme_demo.py` renders the same Markdown three ways (auto/dark/light) so you can eyeball the behavior in your own terminal.

---

🐶 Authored alongside [tizzy](https://puppy.walmart.com), a Code Puppy persona. Bug in commit 5 (unreachable return) caught and fixed by tizzy during cross-repo cherry-pick verification — yes, the puppy reviews its own work.
