### PR TITLE
fix(mcp): warn once when a server is registered but unbound to current agent

### DIFF
--- a/code_puppy/mcp_/manager.py
+++ b/code_puppy/mcp_/manager.py
@@ -15,6 +15,8 @@ from typing import Any, Dict, List, Optional, Union
 
 from pydantic_ai.mcp import MCPServerSSE, MCPServerStdio, MCPServerStreamableHTTP
 
+from code_puppy.messaging import emit_warning
+
 from .async_lifecycle import get_lifecycle_manager
 from .managed_server import ManagedMCPServer, ServerConfig, ServerState
 from .registry import ServerRegistry
@@ -22,6 +24,42 @@ from .status_tracker import ServerStatusTracker
 
 # Configure logging
 logger = logging.getLogger(__name__)
+
+# Module-level dedupe set: ``(server_name, agent_name)`` pairs we've already
+# warned about for the "registered but not bound to this agent" orphan state.
+# Lives for the lifetime of the process — a fresh process resets it, which
+# matches "warn at most once per session per (server, agent) pair". Cleared
+# in tests via :func:`_reset_unbound_warning_cache`.
+_WARNED_UNBOUND: set = set()
+
+
+def _warn_unbound_server(server_name: str, agent_name: str) -> None:
+    """Warn once that a registered MCP server isn't bound to the current agent.
+
+    Companion to ``code_puppy.agents._builder._warn_missing_server``: that one
+    fires when an agent's binding points at a server that isn't installed;
+    this one fires when a server *is* installed (registered via
+    ``mcp_servers.json``) but no binding ties it to the agent currently
+    being built. Without this warning the server is silently skipped on
+    every agent build, which is the exact footgun users hit when they
+    hand-edit ``mcp_servers.json`` and expect ``enabled: true`` to mean
+    "live on next launch".
+    """
+    key = (server_name, agent_name)
+    if key in _WARNED_UNBOUND:
+        return
+    _WARNED_UNBOUND.add(key)
+    emit_warning(
+        f"MCP server '{server_name}' is registered in mcp_servers.json but "
+        f"not bound to agent '{agent_name}'. Run `/mcp start {server_name}` "
+        f"(which will auto-bind it) or `/agents` \u2192 B to manage bindings "
+        f"manually."
+    )
+
+
+def _reset_unbound_warning_cache() -> None:
+    """Clear the warn-once cache. Test hook only."""
+    _WARNED_UNBOUND.clear()
 
 
 @dataclass
@@ -272,6 +310,14 @@ class MCPManager:
                         managed_server.config.name,
                         agent_name,
                     )
+                    # Only warn for servers the user could actually use —
+                    # disabled / quarantined servers are skipped for other
+                    # reasons and the binding warning would be misleading.
+                    if (
+                        managed_server.is_enabled()
+                        and not managed_server.is_quarantined()
+                    ):
+                        _warn_unbound_server(managed_server.config.name, agent_name)
                     continue
                 # Only include enabled, non-quarantined servers
                 if managed_server.is_enabled() and not managed_server.is_quarantined():

--- a/tests/mcp/test_agent_bindings.py
+++ b/tests/mcp/test_agent_bindings.py
@@ -162,6 +162,104 @@ class TestManagerFilter:
         assert len(servers) == 2
 
 
+class TestUnboundOrphanWarning:
+    """Hand-edited mcp_servers.json should produce a visible orphan warning.
+
+    Covers CPUP-6ym: a server registered via mcp_servers.json but with no
+    binding for the current agent used to be silently dropped on every
+    agent build with a logger.debug call no one would see. We now emit a
+    visible warning once per ``(server, agent)`` pair per process.
+    """
+
+    def _fresh_manager(self):
+        from code_puppy.mcp_ import manager as mgr_mod
+        from code_puppy.mcp_.manager import MCPManager
+
+        with (
+            patch.object(MCPManager, "sync_from_config"),
+            patch.object(MCPManager, "_initialize_servers"),
+        ):
+            manager = MCPManager()
+        mgr_mod._reset_unbound_warning_cache()
+        return manager, mgr_mod
+
+    def test_unbound_orphan_emits_warning(self, tmp_bindings):
+        manager, mgr_mod = self._fresh_manager()
+        manager._managed_servers = {"a": _fake_managed("nu")}
+
+        with patch.object(mgr_mod, "emit_warning") as mock_warn:
+            servers = manager.get_servers_for_agent(agent_name="python")
+
+        assert servers == []
+        assert mock_warn.call_count == 1
+        msg = mock_warn.call_args.args[0]
+        assert "'nu'" in msg
+        assert "'python'" in msg
+        assert "/mcp start nu" in msg
+
+    def test_warning_deduped_per_pair_per_process(self, tmp_bindings):
+        manager, mgr_mod = self._fresh_manager()
+        manager._managed_servers = {"a": _fake_managed("nu")}
+
+        with patch.object(mgr_mod, "emit_warning") as mock_warn:
+            for _ in range(5):
+                manager.get_servers_for_agent(agent_name="python")
+
+        assert mock_warn.call_count == 1
+
+    def test_distinct_pairs_each_warn_once(self, tmp_bindings):
+        manager, mgr_mod = self._fresh_manager()
+        manager._managed_servers = {
+            "a": _fake_managed("nu"),
+            "b": _fake_managed("mu"),
+        }
+
+        with patch.object(mgr_mod, "emit_warning") as mock_warn:
+            manager.get_servers_for_agent(agent_name="python")
+            manager.get_servers_for_agent(agent_name="python")
+            manager.get_servers_for_agent(agent_name="rust")
+
+        # 2 server-names x first python build (2) + first rust build (2) = 4.
+        # Second python build is fully deduped.
+        assert mock_warn.call_count == 4
+        seen_pairs = {
+            (call.args[0].split("'")[1], call.args[0].split("'")[3])
+            for call in mock_warn.call_args_list
+        }
+        assert seen_pairs == {
+            ("nu", "python"),
+            ("mu", "python"),
+            ("nu", "rust"),
+            ("mu", "rust"),
+        }
+
+    def test_disabled_or_quarantined_does_not_warn(self, tmp_bindings):
+        manager, mgr_mod = self._fresh_manager()
+
+        disabled = _fake_managed("disabled-srv")
+        disabled.is_enabled.return_value = False
+        quarantined = _fake_managed("quar-srv")
+        quarantined.is_quarantined.return_value = True
+        manager._managed_servers = {"d": disabled, "q": quarantined}
+
+        with patch.object(mgr_mod, "emit_warning") as mock_warn:
+            manager.get_servers_for_agent(agent_name="python")
+
+        mock_warn.assert_not_called()
+
+    def test_bound_server_does_not_warn(self, tmp_bindings):
+        manager, mgr_mod = self._fresh_manager()
+        manager._managed_servers = {"a": _fake_managed("nu")}
+
+        ab.set_binding("python", "nu")
+
+        with patch.object(mgr_mod, "emit_warning") as mock_warn:
+            servers = manager.get_servers_for_agent(agent_name="python")
+
+        assert len(servers) == 1
+        mock_warn.assert_not_called()
+
+
 def _fake_managed(name: str):
     """Tiny mock for ManagedMCPServer satisfying get_servers_for_agent."""
     from unittest.mock import MagicMock


### PR DESCRIPTION
## What

Adds a one-shot warning when `MCPManager.get_servers_for_agent()` skips a
registered MCP server because no binding ties it to the current agent.
Fires at most once per `(server_name, agent_name)` pair per process, and
only for servers the user could actually use (enabled + non-quarantined).

Fixes CPUP-6ym.

## Why (and how this relates to #359)

This is the **belt-and-suspenders companion to #359** (CPUP-ne1, auto-bind
on `/mcp start`). The two PRs cover the same footgun from opposite
directions:

| Path                                          | Covered by                  |
| --------------------------------------------- | --------------------------- |
| User runs `/mcp start <name>`                 | **#359** — auto-binds       |
| User hand-edits `mcp_servers.json` + restarts | **this PR** — warns         |

Even after #359 lands, the hand-edit path still silently drops the server
on every agent build with only a `logger.debug` call no one will see.
That's the exact "I enabled it, where are my tools?" support thread we
want to short-circuit.

The two are independent — this PR doesn't depend on #359 merging first,
and the warning text (`Run /mcp start <name> (which will auto-bind it)`)
is forward-compatible with either ordering.

## Implementation

Mirrors the existing `_warn_missing_server` pattern in
`code_puppy/agents/_builder.py`:

- Module-level `_WARNED_UNBOUND: set[tuple[str, str]]` dedupe set
- `_warn_unbound_server(server_name, agent_name)` helper using
  `emit_warning` (same channel as the sibling warning, so users see it
  in the same place)
- `_reset_unbound_warning_cache()` test hook
- Wired into the existing "not in bound_names" skip branch in
  `get_servers_for_agent`, gated on `is_enabled() and not is_quarantined()`
  so disabled/quarantined servers don't trigger a misleading binding
  warning

## Tests

5 new tests in `tests/mcp/test_agent_bindings.py::TestUnboundOrphanWarning`:

- orphan server emits a warning with server name, agent name, and the
  `/mcp start <name>` hint
- repeated `get_servers_for_agent` calls dedupe to one warning
- distinct `(server, agent)` pairs each warn exactly once
- disabled / quarantined servers stay silent (binding isn't the issue)
- properly-bound servers stay silent (no false positive)

Full `tests/mcp tests/agents` suite: **1423 passed, 6 skipped, 0 failed**.

## Out of scope (intentionally)

The issue mentioned an *optional* matching warning in `sync_from_config`
for "the moment of registration, before any agent is built." I skipped
it: at sync time there's no current agent, so the wording would have to
be the awkward "bound to NO agent" flavor, and the
`get_servers_for_agent` warning already catches the exact moment the
user actually hits the orphan state. Trivial follow-up if a reviewer
wants it.
