### PR TITLE
fix(claude_code_hooks): emit Stop for main agent, not SubagentStop

### DIFF
--- a/code_puppy/plugins/claude_code_hooks/register_callbacks.py
+++ b/code_puppy/plugins/claude_code_hooks/register_callbacks.py
@@ -16,8 +16,6 @@ _SUBAGENT_NAMES = frozenset(
     {
         "pack_leader",
         "bloodhound",
-        "code-puppy",
-        "code_puppy",
         "retriever",
         "shepherd",
         "terrier",

--- a/tests/plugins/test_claude_code_hooks_subagent_classification.py
+++ b/tests/plugins/test_claude_code_hooks_subagent_classification.py
@@ -1,0 +1,124 @@
+"""Regression tests for CPUP-a4a: main agent must classify as Stop, not SubagentStop.
+
+The ``_SUBAGENT_NAMES`` frozenset in
+``code_puppy/plugins/claude_code_hooks/register_callbacks.py`` previously
+included ``"code-puppy"`` and ``"code_puppy"`` — the main agent's own names.
+As a result, ``on_agent_run_end_hook`` classified every top-level turn-end
+as ``SubagentStop`` instead of ``Stop``, which caused any ``hooks.json``
+integration wired to the ``Stop`` matcher (e.g. cmux desktop notifications,
+cmux iMessage Mode, Reorder on Notification) to silently never fire on the
+main agent's reply.
+
+These tests pin the corrected classification so the bug can't sneak back in.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class TestSubagentNamesSet:
+    """The frozenset must NOT mark the main agent's own names as sub-agents."""
+
+    def test_main_agent_names_excluded(self):
+        from code_puppy.plugins.claude_code_hooks.register_callbacks import (
+            _SUBAGENT_NAMES,
+        )
+
+        assert "code-puppy" not in _SUBAGENT_NAMES
+        assert "code_puppy" not in _SUBAGENT_NAMES
+
+    def test_real_subagents_still_included(self):
+        """Real sub-agent names must keep their SubagentStop classification."""
+        from code_puppy.plugins.claude_code_hooks.register_callbacks import (
+            _SUBAGENT_NAMES,
+        )
+
+        expected = {
+            "pack_leader",
+            "bloodhound",
+            "retriever",
+            "shepherd",
+            "terrier",
+            "watchdog",
+            "subagent",
+            "sub_agent",
+        }
+        # Using >= rather than == so adding new real sub-agents later
+        # doesn't regress this test.
+        assert _SUBAGENT_NAMES >= expected
+
+
+class TestOnAgentRunEndClassification:
+    """End-to-end check that the callback emits the right hook event_type."""
+
+    @pytest.mark.asyncio
+    async def test_main_agent_fires_stop(self):
+        from code_puppy.hook_engine.models import ProcessEventResult
+        from code_puppy.plugins.claude_code_hooks import register_callbacks
+
+        mock_engine = MagicMock()
+        mock_engine.process_event = AsyncMock(
+            return_value=ProcessEventResult(blocked=False, executed_hooks=1, results=[])
+        )
+
+        original = register_callbacks._hook_engine
+        register_callbacks._hook_engine = mock_engine
+        try:
+            await register_callbacks.on_agent_run_end_hook(
+                agent_name="code-puppy",
+                model_name="claude-4-7-opus",
+                session_id="sess-1",
+                success=True,
+            )
+            event_type_arg = mock_engine.process_event.call_args[0][0]
+            event_data_arg = mock_engine.process_event.call_args[0][1]
+            assert event_type_arg == "Stop"
+            assert event_data_arg.event_type == "Stop"
+        finally:
+            register_callbacks._hook_engine = original
+
+    @pytest.mark.asyncio
+    async def test_underscore_main_agent_fires_stop(self):
+        """The underscore spelling ``code_puppy`` must also fire Stop."""
+        from code_puppy.hook_engine.models import ProcessEventResult
+        from code_puppy.plugins.claude_code_hooks import register_callbacks
+
+        mock_engine = MagicMock()
+        mock_engine.process_event = AsyncMock(
+            return_value=ProcessEventResult(blocked=False, executed_hooks=1, results=[])
+        )
+
+        original = register_callbacks._hook_engine
+        register_callbacks._hook_engine = mock_engine
+        try:
+            await register_callbacks.on_agent_run_end_hook(
+                agent_name="code_puppy",
+                model_name="claude-4-7-opus",
+            )
+            event_type_arg = mock_engine.process_event.call_args[0][0]
+            assert event_type_arg == "Stop"
+        finally:
+            register_callbacks._hook_engine = original
+
+    @pytest.mark.asyncio
+    async def test_real_subagent_fires_subagent_stop(self):
+        from code_puppy.hook_engine.models import ProcessEventResult
+        from code_puppy.plugins.claude_code_hooks import register_callbacks
+
+        mock_engine = MagicMock()
+        mock_engine.process_event = AsyncMock(
+            return_value=ProcessEventResult(blocked=False, executed_hooks=1, results=[])
+        )
+
+        original = register_callbacks._hook_engine
+        register_callbacks._hook_engine = mock_engine
+        try:
+            await register_callbacks.on_agent_run_end_hook(
+                agent_name="bloodhound",
+                model_name="claude-4-7-opus",
+            )
+            event_type_arg = mock_engine.process_event.call_args[0][0]
+            assert event_type_arg == "SubagentStop"
+        finally:
+            register_callbacks._hook_engine = original


### PR DESCRIPTION
## What

Drops `"code-puppy"` and `"code_puppy"` from the `_SUBAGENT_NAMES` frozenset in `code_puppy/plugins/claude_code_hooks/register_callbacks.py`. Those are the **main** agent's own names, not sub-agent names.

## Why

`on_agent_run_end_hook` does:

```python
agent_lower = (agent_name or "").lower()
is_subagent = any(name in agent_lower for name in _SUBAGENT_NAMES)
event_type = "SubagentStop" if is_subagent else "Stop"
```

Because the main agent is invoked with `agent_name="code-puppy"` (see `code_puppy/agents/_runtime.py`'s call to `on_agent_run_end(agent_name=agent.name, ...)`), the classifier hits `"code-puppy" in "code-puppy"` → `True` → emits **`SubagentStop`** for every top-level turn-end.

That means any `hooks.json` integration wired to the `Stop` matcher **never fires for the main agent**. In particular, for users running Code Puppy inside cmux, this silently breaks:

- 🔔 Desktop "turn complete" notifications via `cmux-notify.sh stop` (the default cmux integration)
- 💬 cmux iMessage Mode previews of assistant replies in the sidebar
- 🔃 cmux's "Reorder on Notification" surface bubbling

Real sub-agent names in the same set (`pack_leader`, `bloodhound`, `retriever`, `shepherd`, `terrier`, `watchdog`, `subagent`, `sub_agent`) keep their `SubagentStop` classification — those entries are correct.

## How I verified

1. Reproduced the bug end-to-end in a live Code Puppy + cmux session with diagnostic instrumentation on the cmux feed bridge — confirmed `agent=code-puppy event=SubagentStop` was firing for main-agent turn-ends, which (combined with `hooks.json`'s `Stop` matcher) produced exactly zero `Stop` events on the cmux bus.
2. Applied the patch, re-ran, confirmed `agent=code-puppy event=Stop` now fires.
3. Added focused regression tests (next section).

## Tests

New file: `tests/plugins/test_claude_code_hooks_subagent_classification.py` (5 tests, all green locally).

The existing `tests/plugins/test_claude_code_hooks_plugin.py` is marked **`IMMUTABLE TEST FILE — DO NOT MODIFY`** in its header, so the new coverage lives in a sibling module rather than being appended. It pins both:

- The frozenset contents (`code-puppy`/`code_puppy` excluded; real sub-agents still included).
- The end-to-end `event_type` passed to `process_event(...)` for `agent_name in {"code-puppy", "code_puppy", "bloodhound"}`.

Local results:
```
tests/plugins/test_claude_code_hooks_subagent_classification.py ......  5 passed
tests/plugins/test_claude_code_hooks_plugin.py + _merging.py ..........  29 passed (unchanged)
```

## Scope

- 2-line removal from `_SUBAGENT_NAMES`.
- 1 new test module.
- No public API changes, no behavior change for real sub-agents.

## Tracking

CPUP-a4a (local beads).

## Updated for clarity

### "Doesn't this break Code Puppy when it's used as a sub-agent?"

Reasonable concern — here's why it doesn't:

`on_agent_run_end` is only fired from the top-level agent loop
(`code_puppy/agents/_runtime.py`), with `agent_name=agent.name`. The
`claude_code_hooks` classifier therefore only ever sees the active
top-level agent's name within any one Code Puppy process.

• In-process sub-agents via `invoke_agent` (including
  `invoke_agent("code-puppy", …))` run through `temp_agent.run(...)`
  in `code_puppy/tools/agent_tools.py` and never fire `on_agent_run_end`
  at all — the classifier doesn't apply, so the `frozenset` can't
  misroute them.
• Code Puppy spawned as a sub-agent in a separate process has its
  own top-level loop and its own `hooks.json`. Inside that process,
  code-puppy is the main agent, so emitting `Stop` is the correct
  semantics for any hook the user wired to that process.

The names that remain in `_SUBAGENT_NAMES` are exactly the agents that
today run as the top-level `agent.name` while semantically being
sub-agents to a parent — the only situation where the substring match
is doing real work.

