### PR TITLE
Remove line that gives warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,6 @@ omit = ["code_puppy/main.py"]
 
 [tool.uv]
 python-preference = "only-managed"
-exclude-newer = "7 days"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Currently, starting Code Puppy gives a warning from the TOML file because this feature takes an absolute date, not a relative date.  This PR removes the line entirely since I don't think we want a 2026-05-17 type line calcified in the repo.