### PR TITLE
feat(statusline): customizable status line plugin

### DIFF
--- a/code_puppy/plugins/statusline/__init__.py
+++ b/code_puppy/plugins/statusline/__init__.py
@@ -1,0 +1,14 @@
+"""Status line plugin — a customizable bottom status line for Code Puppy.
+
+Mirrors Claude Code's ``statusLine`` feature: you configure a shell command;
+Code Puppy feeds it JSON session data on stdin; whatever the command prints to
+stdout becomes your status line (ANSI colors supported).
+
+Configure with the ``/statusline`` command or directly via ``/set``:
+
+    /set statusline_enabled=true
+    /set statusline_command=~/.code_puppy/statusline.sh
+
+The command runs throttled in a background thread, so it never blocks the
+prompt. Run ``/statusline json`` to see every field your script receives.
+"""

--- a/code_puppy/plugins/statusline/config.py
+++ b/code_puppy/plugins/statusline/config.py
@@ -1,0 +1,68 @@
+"""Configuration for the statusline plugin (persisted in puppy.cfg)."""
+
+from __future__ import annotations
+
+import logging
+
+from code_puppy.config import get_value, set_value
+
+logger = logging.getLogger(__name__)
+
+KEY_ENABLED = "statusline_enabled"
+KEY_COMMAND = "statusline_command"
+KEY_TIMEOUT = "statusline_timeout_ms"
+KEY_REFRESH = "statusline_refresh_ms"
+KEY_MODE = "statusline_mode"
+
+DEFAULT_TIMEOUT_MS = 1000
+DEFAULT_REFRESH_MS = 1000
+DEFAULT_MODE = "replace"
+_VALID_MODES = ("replace", "above")
+
+
+def _get_int(key: str, default: int) -> int:
+    raw = get_value(key)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(str(raw).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def is_enabled() -> bool:
+    raw = get_value(KEY_ENABLED)
+    if raw is None or raw == "":
+        return False
+    return str(raw).strip().lower() in ("1", "true", "yes", "on")
+
+
+def set_enabled(value: bool) -> None:
+    set_value(KEY_ENABLED, "true" if value else "false")
+
+
+def get_command() -> str:
+    return (get_value(KEY_COMMAND) or "").strip()
+
+
+def set_command(command: str) -> None:
+    set_value(KEY_COMMAND, command or "")
+
+
+def get_timeout_ms() -> int:
+    return max(100, _get_int(KEY_TIMEOUT, DEFAULT_TIMEOUT_MS))
+
+
+def get_refresh_ms() -> int:
+    return max(200, _get_int(KEY_REFRESH, DEFAULT_REFRESH_MS))
+
+
+def get_mode() -> str:
+    raw = (get_value(KEY_MODE) or "").strip().lower()
+    return raw if raw in _VALID_MODES else DEFAULT_MODE
+
+
+def set_mode(mode: str) -> None:
+    mode = (mode or "").strip().lower()
+    if mode in _VALID_MODES:
+        set_value(KEY_MODE, mode)

--- a/code_puppy/plugins/statusline/payload.py
+++ b/code_puppy/plugins/statusline/payload.py
@@ -1,0 +1,119 @@
+"""Build the JSON session payload fed to the status line command on stdin.
+
+Schema mirrors Claude Code's ``statusLine`` stdin contract where the data
+exists in Code Puppy, so scripts written for one are easy to port. Every field
+is best-effort: a failure in one source must never break the payload.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _safe(fn, default=None):
+    try:
+        return fn()
+    except Exception:
+        return default
+
+
+def _model_block() -> Dict[str, Any]:
+    from code_puppy.command_line.model_picker_completion import get_active_model
+
+    model_id = _safe(get_active_model) or "(default)"
+    return {"id": model_id, "display_name": model_id}
+
+
+def _agent_block() -> Optional[Dict[str, Any]]:
+    from code_puppy.agents.agent_manager import get_current_agent
+
+    agent = _safe(get_current_agent)
+    if not agent:
+        return None
+    name = getattr(agent, "display_name", None) or getattr(agent, "name", None)
+    return {"name": name} if name else None
+
+
+def _git_branch(cwd: str) -> Optional[str]:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=0.5,
+        )
+        if out.returncode == 0:
+            branch = out.stdout.strip()
+            return branch or None
+    except Exception:
+        return None
+    return None
+
+
+def _context_block() -> Dict[str, Any]:
+    block: Dict[str, Any] = {}
+    try:
+        from code_puppy.plugins.context_indicator.usage import get_current_usage
+
+        usage = get_current_usage()
+        if usage is not None:
+            block["total_input_tokens"] = int(getattr(usage, "used_tokens", 0))
+            block["context_window_size"] = int(getattr(usage, "capacity", 0))
+            block["used_percentage"] = round(float(usage.percent), 1)
+            block["remaining_percentage"] = round(100.0 - float(usage.percent), 1)
+            block["indicator"] = usage.indicator
+    except Exception:
+        pass
+    return block
+
+
+def _tokens_per_second() -> float:
+    try:
+        from code_puppy.status_display import StatusDisplay
+
+        return round(float(StatusDisplay.get_current_rate()), 1)
+    except Exception:
+        return 0.0
+
+
+def build_payload() -> Dict[str, Any]:
+    """Assemble the full session payload (all fields best-effort)."""
+    from code_puppy.config import get_puppy_name
+
+    cwd = _safe(os.getcwd, "") or ""
+    payload: Dict[str, Any] = {
+        "cwd": cwd,
+        "puppy_name": _safe(get_puppy_name) or "code-puppy",
+        "model": _model_block(),
+        "workspace": {"current_dir": cwd},
+        "context_window": _context_block(),
+        "tokens_per_second": _tokens_per_second(),
+    }
+
+    agent = _agent_block()
+    if agent:
+        payload["agent"] = agent
+
+    branch = _git_branch(cwd)
+    if branch:
+        payload["workspace"]["git_branch"] = branch
+
+    try:
+        from importlib.metadata import version
+
+        payload["version"] = version("code-puppy")
+    except Exception:
+        pass
+
+    return payload
+
+
+def build_payload_json() -> str:
+    return json.dumps(build_payload(), indent=2)

--- a/code_puppy/plugins/statusline/prompt_patch.py
+++ b/code_puppy/plugins/statusline/prompt_patch.py
@@ -1,0 +1,64 @@
+"""Monkey-patch ``get_prompt_with_active_model`` to render the status line.
+
+Same proven seam the ``context_indicator`` plugin uses. The status command's
+stdout may contain ANSI color codes, so we convert it to prompt_toolkit
+``FormattedText`` via ``ANSI``.
+
+Two modes (config ``statusline_mode``):
+
+* ``replace`` (default): the custom status line **replaces** Code Puppy's
+  default prompt content (puppy/agent/model/cwd), keeping only the trailing
+  arrow. No duplicated info, no extra stacked line.
+* ``above``: the custom status line is shown on its own line *above* the
+  unchanged default prompt.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from .config import get_mode
+from .runner import get_status_text
+
+logger = logging.getLogger(__name__)
+
+_PATCH_ATTR = "_statusline_original_prompt_fn"
+_DEFAULT_ARROW = ">>> "
+
+
+def _render(formatted_text, base: str):
+    from prompt_toolkit.formatted_text import ANSI, FormattedText, to_formatted_text
+
+    text = get_status_text()
+    if not text:
+        return formatted_text
+
+    try:
+        status_fragments = list(to_formatted_text(ANSI(text)))
+    except Exception:
+        logger.debug("statusline: failed to parse status text", exc_info=True)
+        return formatted_text
+
+    if get_mode() == "above":
+        # Status line on its own line, default prompt unchanged below it.
+        return FormattedText(status_fragments + [("", "\n")] + list(formatted_text))
+
+    # replace mode: status line + trailing arrow only.
+    arrow = base if base else _DEFAULT_ARROW
+    return FormattedText(status_fragments + [("class:arrow", " " + arrow)])
+
+
+def install_prompt_patch() -> None:
+    """Wrap ``get_prompt_with_active_model`` exactly once."""
+    from code_puppy.command_line import prompt_toolkit_completion as ptc
+
+    if getattr(ptc, _PATCH_ATTR, None) is not None:
+        return  # already patched
+
+    original = ptc.get_prompt_with_active_model
+    setattr(ptc, _PATCH_ATTR, original)
+
+    def patched(base: str = ">>> "):
+        return _render(original(base), base)
+
+    ptc.get_prompt_with_active_model = patched

--- a/code_puppy/plugins/statusline/register_callbacks.py
+++ b/code_puppy/plugins/statusline/register_callbacks.py
@@ -1,0 +1,43 @@
+"""Wire up the statusline plugin."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Optional, Tuple
+
+from code_puppy.callbacks import register_callback
+
+from .prompt_patch import install_prompt_patch
+from .statusline_command import handle_statusline_command, statusline_command_help
+
+logger = logging.getLogger(__name__)
+
+
+def _on_startup() -> None:
+    try:
+        install_prompt_patch()
+    except Exception:
+        logger.debug("statusline: failed to install prompt patch", exc_info=True)
+
+
+def _custom_command_help() -> List[Tuple[str, str]]:
+    return statusline_command_help()
+
+
+def _handle_custom_command(command: str, name: str) -> Optional[Any]:
+    try:
+        return handle_statusline_command(command, name)
+    except Exception:
+        logger.debug("statusline: command handler failed", exc_info=True)
+        return None
+
+
+register_callback("startup", _on_startup)
+register_callback("custom_command_help", _custom_command_help)
+register_callback("custom_command", _handle_custom_command)
+
+# Install immediately too, in case startup already fired before this plugin
+# loaded (plugin load order is not guaranteed relative to the startup hook).
+_on_startup()
+
+logger.debug("statusline plugin registered")

--- a/code_puppy/plugins/statusline/runner.py
+++ b/code_puppy/plugins/statusline/runner.py
@@ -1,0 +1,120 @@
+"""Run the status line command (JSON on stdin -> stdout) without blocking.
+
+The prompt is re-rendered frequently; running a shell command synchronously
+each time would make the prompt janky. So we cache the last stdout and refresh
+it in a background thread no more often than ``statusline_refresh_ms``. The
+prompt always reads the cached value instantly.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import threading
+import time
+
+from .config import get_command, get_refresh_ms, get_timeout_ms, is_enabled
+from .payload import build_payload_json
+
+logger = logging.getLogger(__name__)
+
+_lock = threading.Lock()
+_cached_output: str = ""
+_last_run_monotonic: float = 0.0
+_running: bool = False
+
+
+def _run_command_blocking(command: str) -> str:
+    payload = build_payload_json()
+    try:
+        proc = subprocess.run(
+            command,
+            shell=True,
+            input=payload,
+            capture_output=True,
+            text=True,
+            timeout=get_timeout_ms() / 1000.0,
+        )
+    except subprocess.TimeoutExpired:
+        return ""
+    except Exception:
+        logger.debug("statusline command failed", exc_info=True)
+        return ""
+    out = (proc.stdout or "").strip("\n")
+    # Status line is a single line: collapse any extra newlines.
+    return out.replace("\n", " ").strip()
+
+
+def _refresh_async(command: str) -> None:
+    global _cached_output, _running, _last_run_monotonic
+    try:
+        result = _run_command_blocking(command)
+        with _lock:
+            _cached_output = result
+            _last_run_monotonic = time.monotonic()
+    finally:
+        with _lock:
+            _running = False
+
+
+def get_status_text() -> str:
+    """Return the status line, refreshing in the background when stale.
+
+    First call (cold cache) runs **synchronously** once so the very first
+    prompt — including the one shown at startup — has a status line. After that
+    it never blocks: it returns the cached value and schedules a background
+    refresh when the value goes stale.
+    """
+    global _running, _last_run_monotonic, _cached_output
+    if not is_enabled():
+        return ""
+    command = get_command()
+    if not command:
+        return ""
+
+    now = time.monotonic()
+    with _lock:
+        cached = _cached_output
+        cold = _last_run_monotonic == 0.0
+        if cold:
+            # Reserve the slot so we don't also spawn an async refresh below.
+            _last_run_monotonic = now
+
+    if cold:
+        # One-time synchronous warm-up so the FIRST prompt (startup) has a
+        # status line. Bounded by the command timeout.
+        result = _run_command_blocking(command)
+        with _lock:
+            _cached_output = result
+            _last_run_monotonic = time.monotonic()
+        return result
+
+    with _lock:
+        due = (now - _last_run_monotonic) * 1000.0 >= get_refresh_ms()
+        should_start = due and not _running
+        if should_start:
+            _running = True
+            # Reserve the slot immediately so concurrent prompt renders don't
+            # spawn a thundering herd of refreshes.
+            _last_run_monotonic = now
+
+    if should_start:
+        threading.Thread(target=_refresh_async, args=(command,), daemon=True).start()
+
+    return cached
+
+
+def run_once_sync() -> str:
+    """Run the command synchronously once (for /statusline show preview)."""
+    command = get_command()
+    if not command:
+        return ""
+    return _run_command_blocking(command)
+
+
+def reset_cache() -> None:
+    global _cached_output, _last_run_monotonic, _running
+    with _lock:
+        _cached_output = ""
+        _last_run_monotonic = 0.0
+        _running = False

--- a/code_puppy/plugins/statusline/statusline_command.py
+++ b/code_puppy/plugins/statusline/statusline_command.py
@@ -1,0 +1,155 @@
+"""`/statusline` command — scaffold, enable, inspect the status line.
+
+Mirrors Claude Code's ``/statusline``. Rather than calling the model, this
+scaffolds a ready-to-edit starter script (Claude Code generates one via the
+agent; we hand you a working template you can tweak immediately).
+
+Subcommands:
+    /statusline                 Show current status + quick help
+    /statusline init            Write a starter ~/.code_puppy/statusline.sh,
+                                point config at it, and enable
+    /statusline on | off        Enable / disable rendering
+    /statusline show            Run the command once and preview its output
+    /statusline json            Print the JSON payload your script receives
+"""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+from typing import Any, List, Optional, Tuple
+
+from code_puppy.messaging import emit_info, emit_success, emit_warning
+
+from . import config, payload, runner
+
+_COMMAND_NAME = "statusline"
+
+_STARTER_SCRIPT = """\
+#!/usr/bin/env bash
+# Code Puppy status line. Receives session JSON on stdin; prints one line.
+# In the default "replace" mode this line REPLACES the default prompt content
+# (so include a name/emoji if you want one). Edit freely.
+# Requires `jq` for the parsing below (or parse however you like).
+input=$(cat)
+
+puppy=$(printf '%s' "$input" | jq -r '.puppy_name // "code-puppy"')
+model=$(printf '%s' "$input" | jq -r '.model.display_name // "model"')
+dir=$(printf '%s' "$input" | jq -r '.workspace.current_dir // .cwd // ""')
+branch=$(printf '%s' "$input" | jq -r '.workspace.git_branch // empty')
+ind=$(printf '%s' "$input" | jq -r '.context_window.indicator // ""')
+pct=$(printf '%s' "$input" | jq -r '.context_window.used_percentage // 0')
+tps=$(printf '%s' "$input" | jq -r '.tokens_per_second // 0')
+
+line="\\033[1m🐶 $puppy\\033[0m"
+[ -n "$ind" ] && line="$line $ind"
+line="$line \\033[36m[$model]\\033[0m \\033[2m$(basename "$dir")\\033[0m"
+[ -n "$branch" ] && line="$line \\033[35m($branch)\\033[0m"
+line="$line \\033[33m${pct}%ctx\\033[0m"
+# Show t/s only while generating.
+awk "BEGIN{exit !($tps>0)}" && line="$line \\033[32m${tps} t/s\\033[0m"
+
+printf '%b' "$line"
+"""
+
+
+def statusline_command_help() -> List[Tuple[str, str]]:
+    return [
+        (_COMMAND_NAME, "Customize the bottom status line (init/on/off/show/json)"),
+    ]
+
+
+def _default_script_path() -> Path:
+    return Path.home() / ".code_puppy" / "statusline.sh"
+
+
+def _status_text() -> str:
+    enabled = "ON" if config.is_enabled() else "OFF"
+    cmd = config.get_command() or "(none)"
+    return (
+        f"Status line: {enabled}   mode: {config.get_mode()}\n"
+        f"  command: {cmd}\n"
+        f"  refresh: {config.get_refresh_ms()}ms   timeout: {config.get_timeout_ms()}ms\n"
+        "  Subcommands: init | on | off | mode <replace|above> | show | json"
+    )
+
+
+def _do_init() -> None:
+    path = _default_script_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_STARTER_SCRIPT, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    config.set_command(str(path))
+    config.set_enabled(True)
+    runner.reset_cache()
+    emit_success(f"Wrote starter status line script: {path}")
+    emit_info("Enabled. Edit that file to customize. Preview with /statusline show.")
+    if not _has_jq():
+        emit_warning(
+            "Note: the starter script uses `jq` (not found on PATH). Install jq "
+            "or rewrite the script to parse JSON another way."
+        )
+
+
+def _has_jq() -> bool:
+    from shutil import which
+
+    return which("jq") is not None
+
+
+def handle_statusline_command(command: str, name: str) -> Optional[Any]:
+    if name != _COMMAND_NAME:
+        return None
+
+    tokens = command.split()
+    sub = tokens[1].strip().lower() if len(tokens) > 1 else "status"
+
+    if sub in ("status", ""):
+        emit_info(_status_text())
+        return True
+    if sub == "init":
+        _do_init()
+        return True
+    if sub == "on":
+        if not config.get_command():
+            emit_warning(
+                "No command set. Run /statusline init first, or set "
+                "statusline_command via /set."
+            )
+            return True
+        config.set_enabled(True)
+        runner.reset_cache()
+        emit_success("Status line enabled.")
+        return True
+    if sub == "off":
+        config.set_enabled(False)
+        emit_warning("Status line disabled.")
+        return True
+    if sub == "mode":
+        mode = tokens[2].strip().lower() if len(tokens) > 2 else ""
+        if mode not in ("replace", "above"):
+            emit_warning("Usage: /statusline mode <replace|above>")
+            emit_info(
+                "  replace = your line REPLACES the default prompt (no duplicate)\n"
+                "  above   = your line sits on its own line above the default prompt"
+            )
+            return True
+        config.set_mode(mode)
+        emit_success(f"Status line mode set to '{mode}'.")
+        return True
+    if sub == "show":
+        if not config.get_command():
+            emit_warning("No command set. Run /statusline init first.")
+            return True
+        out = runner.run_once_sync()
+        emit_info("Status line preview (raw output):")
+        emit_info(out or "(empty)")
+        return True
+    if sub == "json":
+        emit_info("JSON payload your status command receives on stdin:")
+        emit_info(payload.build_payload_json())
+        return True
+
+    emit_warning(f"Unknown /statusline subcommand: {sub}")
+    emit_info("Use: init | on | off | show | json")
+    return True

--- a/tests/agents/test_run_stats.py
+++ b/tests/agents/test_run_stats.py
@@ -5,7 +5,6 @@ hooks that drive it (agent_run_start / stream_event / agent_run_end).
 """
 
 import time
-from unittest.mock import MagicMock
 
 import pytest
 


### PR DESCRIPTION
## Summary

Adds a **customizable status line** plugin and a `/statusline` command to configure it. Implemented entirely as a plugin via the callback hooks described in `AGENTS.md` — **no core files are modified**.

## What's included

`code_puppy/plugins/statusline/`:

- **`register_callbacks.py`** — registers `startup` (install the prompt patch), `custom_command`, and `custom_command_help`. Hooks fail gracefully.
- **`prompt_patch.py`** — installs the status-line renderer onto the prompt.
- **`statusline_command.py`** — the `/statusline` command to view/configure the line.
- **`config.py` / `payload.py` / `runner.py`** — configuration, payload assembly, and the renderer.

## Design

- Plugin-only, per the contributing guide ("nearly all new functionality should be a plugin"). No edits to `command_line/` or other core modules.
- The prompt patch is installed on the `startup` hook **and** at import time, to cover the case where the plugin loads after `startup` has already fired (plugin load order vs. the startup hook is not guaranteed).
- Every hook is wrapped to fail gracefully and never crash the app.

## Testing

- `ruff check` / `ruff format` clean.
- Manually verified `/statusline` renders and the patch installs on startup.

## Risk

Low. Opt-in plugin; no core changes; degrades to a no-op on any error.
