### PR TITLE
fix: respect exact user-provided puppy_name casing instead of forcing .title()

### DIFF
--- a/code_puppy/messaging/spinner/spinner_base.py
+++ b/code_puppy/messaging/spinner/spinner_base.py
@@ -23,7 +23,7 @@ class SpinnerBase(ABC):
         "( 🐶   ) ",
         "(🐶    ) ",
     ]
-    puppy_name = get_puppy_name().title()
+    puppy_name = get_puppy_name()
 
     # Default message when processing
     THINKING_MESSAGE = f"{puppy_name} is thinking... "


### PR DESCRIPTION
`get_puppy_name()` correctly returns exactly what the user types (via onboarding or `/set puppy_name "Allister McTash III"`).

However, several UI locations were calling `.title()` on the result. This mangles real names:
- "Allister McTash III" → "Allister Mctash Iii"
- "McTash", "III", "de la Cruz", etc. all get incorrectly altered.

This change removes the forced `.title()` calls so the name the user chose is displayed exactly as they entered it.

The core persona system prompts already used the raw name correctly. This is a small, low-risk improvement for user control over their puppy's name.