### PR TITLE
feat: Add per-invocation sub-agent model overrides

### DIFF
--- a/code_puppy/agents/agent_code_puppy.py
+++ b/code_puppy/agents/agent_code_puppy.py
@@ -86,7 +86,6 @@ Important rules:
 - Read existing files before modifying them
 - Prefer replace_in_file over create_file. Keep diffs small (100-300 lines).
 {r["loop_rule"]}
-- When invoking sub-agents, you may pass model_name to use a specific configured model for that invocation only. Use it only when the user/project instructions specify model preferences or when escalating a failed/complex subtask; do not change the global model just to run a sub-agent.
 - Continue autonomously unless user input is definitively required
 """
         # NOTE: runtime ``load_prompt`` fragments (plugin-injected notes such

--- a/code_puppy/agents/agent_code_puppy.py
+++ b/code_puppy/agents/agent_code_puppy.py
@@ -86,6 +86,7 @@ Important rules:
 - Read existing files before modifying them
 - Prefer replace_in_file over create_file. Keep diffs small (100-300 lines).
 {r["loop_rule"]}
+- When invoking sub-agents, you may pass model_name to use a specific configured model for that invocation only. Use it only when the user/project instructions specify model preferences or when escalating a failed/complex subtask; do not change the global model just to run a sub-agent.
 - Continue autonomously unless user input is definitively required
 """
         # NOTE: runtime ``load_prompt`` fragments (plugin-injected notes such

--- a/code_puppy/agents/agent_creator_agent.py
+++ b/code_puppy/agents/agent_creator_agent.py
@@ -256,19 +256,23 @@ DONT USE THE TERMINAL TOOL TO RUN THE CODE WE WROTE UNLESS THE USER ASKS YOU TO.
 #### `list_agents()`
 Use this to list all available sub-agents that can be invoked
 
-#### `invoke_agent(agent_name: str, user_prompt: str, session_id: str | None = None)`
+#### `invoke_agent(agent_name: str, prompt: str, session_id: str | None = None, model_name: str | None = None)`
 Use this to invoke another agent with a specific prompt. This allows agents to delegate tasks to specialized sub-agents.
 
 Arguments:
 - agent_name (required): Name of the agent to invoke
-- user_prompt (required): The prompt to send to the invoked agent
+- prompt (required): The prompt to send to the invoked agent
 - session_id (optional): Kebab-case session identifier for conversation memory
   - Format: lowercase, numbers, hyphens only (e.g., "implement-oauth", "review-auth")
   - For NEW sessions: provide a base name - a SHA1 hash suffix is automatically appended for uniqueness
   - To CONTINUE a session: use the session_id from the previous invocation's response
   - If None (default): Auto-generates a unique session like "agent-name-session-a3f2b1"
+- model_name (optional): Configured model name to use for this invocation only
+  - Overrides the invoked agent's default/pinned model for this run
+  - Does not change global model settings or future invocations
+  - Use only when the user/project instructions specify model preferences or an escalation is warranted
 
-Returns: `{{response, agent_name, session_id, error}}`
+Returns: `{{response, agent_name, session_id, model_name, error}}`
 - **session_id in the response is the FULL ID** - use this to continue the conversation!
 
 Example usage:
@@ -276,14 +280,14 @@ Example usage:
 # Common case: one-off invocation (no memory needed)
 result = invoke_agent(
     agent_name="python-tutor", 
-    user_prompt="Explain how to use list comprehensions"
+    prompt="Explain how to use list comprehensions"
 )
 # result.session_id contains the auto-generated full ID
 
 # Multi-turn conversation: start with a base session_id
 result1 = invoke_agent(
     agent_name="code-reviewer", 
-    user_prompt="Review this authentication code",
+    prompt="Review this authentication code",
     session_id="auth-code-review"  # Hash suffix auto-appended
 )
 # result1.session_id is now "auth-code-review-a3f2b1" (or similar)
@@ -291,17 +295,32 @@ result1 = invoke_agent(
 # Continue the SAME conversation using session_id from the response
 result2 = invoke_agent(
     agent_name="code-reviewer",
-    user_prompt="Can you also check the authorization logic?",
+    prompt="Can you also check the authorization logic?",
     session_id=result1.session_id  # Use session_id from previous response!
 )
 
 # Independent task (different base name = different session)
 result3 = invoke_agent(
     agent_name="code-reviewer",
-    user_prompt="Review the payment processing code",
+    prompt="Review the payment processing code",
     session_id="payment-review"  # Gets its own unique hash suffix
 )
 # result3.session_id is different from result1.session_id
+
+# Per-call model override: use only real configured model names
+quick_review = invoke_agent(
+    agent_name="code-reviewer",
+    prompt="Cheap first pass: look for obvious issues only.",
+    model_name="<configured-fast-model-name>"
+)
+
+if quick_review.error or "uncertain" in (quick_review.response or "").lower():
+    deep_review = invoke_agent(
+        agent_name="code-reviewer",
+        prompt="Continue from the previous review and reason more deeply.",
+        session_id=quick_review.session_id,
+        model_name="<configured-strong-reasoning-model-name>"
+    )
 ```
 
 Best-practice guidelines for `invoke_agent`:
@@ -309,6 +328,7 @@ Best-practice guidelines for `invoke_agent`:
 • Clearly specify what you want the invoked agent to do
 • Be specific in your prompts to get better results
 • Avoid circular dependencies (don't invoke yourself!)
+• `model_name` is a temporary runtime override; omit it unless the task/user instructions justify a specific configured model
 • **Session management:**
   - Default behavior (session_id=None): Each invocation is independent with no memory
   - For NEW sessions: provide a human-readable base name like "review-oauth" - hash suffix is auto-appended

--- a/code_puppy/agents/agent_creator_agent.py
+++ b/code_puppy/agents/agent_creator_agent.py
@@ -256,8 +256,8 @@ DONT USE THE TERMINAL TOOL TO RUN THE CODE WE WROTE UNLESS THE USER ASKS YOU TO.
 #### `list_agents()`
 Use this to list all available sub-agents that can be invoked
 
-#### `invoke_agent(agent_name: str, prompt: str, session_id: str | None = None, model_name: str | None = None)`
-Use this to invoke another agent with a specific prompt. This allows agents to delegate tasks to specialized sub-agents.
+#### `invoke_agent(agent_name: str, prompt: str, session_id: str | None = None)`
+Use this to invoke another agent with a specific prompt using that agent's configured model. This allows agents to delegate tasks to specialized sub-agents.
 
 Arguments:
 - agent_name (required): Name of the agent to invoke
@@ -267,10 +267,15 @@ Arguments:
   - For NEW sessions: provide a base name - a SHA1 hash suffix is automatically appended for uniqueness
   - To CONTINUE a session: use the session_id from the previous invocation's response
   - If None (default): Auto-generates a unique session like "agent-name-session-a3f2b1"
-- model_name (optional): Configured model name to use for this invocation only
-  - Overrides the invoked agent's default/pinned model for this run
-  - Does not change global model settings or future invocations
-  - Use only when the user/project instructions specify model preferences or an escalation is warranted
+
+#### Model override tools for power-user agents
+Normal agents should use `invoke_agent` only. Add `list_available_models` and `invoke_agent_with_model` only for agents that intentionally route work across models, such as judge, planner, or orchestrator agents.
+
+#### `list_available_models()`
+Discover valid configured model aliases for explicit model overrides. It returns safe metadata only.
+
+#### `invoke_agent_with_model(agent_name: str, prompt: str, model_name: str, session_id: str | None = None)`
+Invoke a sub-agent with an explicit one-call model override. `model_name` is required and should be an alias returned by `list_available_models`. Prefer `invoke_agent` for normal delegation.
 
 Returns: `{{response, agent_name, session_id, model_name, error}}`
 - **session_id in the response is the FULL ID** - use this to continue the conversation!
@@ -307,20 +312,8 @@ result3 = invoke_agent(
 )
 # result3.session_id is different from result1.session_id
 
-# Per-call model override: use only real configured model names
-quick_review = invoke_agent(
-    agent_name="code-reviewer",
-    prompt="Cheap first pass: look for obvious issues only.",
-    model_name="<configured-fast-model-name>"
-)
-
-if quick_review.error or "uncertain" in (quick_review.response or "").lower():
-    deep_review = invoke_agent(
-        agent_name="code-reviewer",
-        prompt="Continue from the previous review and reason more deeply.",
-        session_id=quick_review.session_id,
-        model_name="<configured-strong-reasoning-model-name>"
-    )
+# Power-user agents only: first discover real configured model aliases,
+# then pass one returned alias to invoke_agent_with_model(..., model_name=...).
 ```
 
 Best-practice guidelines for `invoke_agent`:
@@ -328,7 +321,7 @@ Best-practice guidelines for `invoke_agent`:
 • Clearly specify what you want the invoked agent to do
 • Be specific in your prompts to get better results
 • Avoid circular dependencies (don't invoke yourself!)
-• `model_name` is a temporary runtime override; omit it unless the task/user instructions justify a specific configured model
+• Use `invoke_agent` for normal delegation; only agents intentionally granted `list_available_models` and `invoke_agent_with_model` can perform per-call model overrides
 • **Session management:**
   - Default behavior (session_id=None): Each invocation is independent with no memory
   - For NEW sessions: provide a human-readable base name like "review-oauth" - hash suffix is auto-appended
@@ -364,6 +357,8 @@ Available templates for tools:
 - `agent_run_shell_command`: Standard shell command execution
 - `list_agents`: Standard agent listing operations
 - `invoke_agent`: Standard agent invocation operations
+- `invoke_agent_with_model`: Explicit model-override agent invocation for power-user orchestrators
+- `list_available_models`: Safe model alias discovery for model-override workflows
 
 Each agent you create should only include templates for tools it actually uses. The `replace_in_file` tool template
 should always include its detailed usage instructions when selected.

--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -15,7 +15,8 @@ from __future__ import annotations
 
 import uuid
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Set
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, Optional, Set
 
 import pydantic_ai.models
 
@@ -71,6 +72,7 @@ class BaseAgent(ABC):
         self._compacted_message_hashes: Set[int] = set()
         self._code_generation_agent: Any = None
         self._last_model_name: Optional[str] = None
+        self._runtime_model_name_override: Optional[str] = None
         self._puppy_rules: Optional[str] = None
         self._mcp_servers: List[Any] = []
         self.cur_model: Optional[pydantic_ai.models.Model] = None
@@ -112,7 +114,35 @@ class BaseAgent(ABC):
     def get_user_prompt(self) -> Optional[str]:
         return None
 
+    def get_runtime_model_name_override(self) -> Optional[str]:
+        """Return a temporary per-run model override, if one is active."""
+        return self._runtime_model_name_override
+
+    def set_runtime_model_name_override(self, model_name: Optional[str]) -> None:
+        """Set a temporary per-run model override.
+
+        This is intentionally not persisted. It lets orchestration code run an
+        agent on a specific model for one invocation without mutating global,
+        pinned, or JSON agent model configuration.
+        """
+        self._runtime_model_name_override = model_name
+
+    @contextmanager
+    def temporary_model_name_override(
+        self, model_name: Optional[str]
+    ) -> Iterator[None]:
+        """Temporarily apply a per-run model override within a scoped block."""
+        previous_model_name = self.get_runtime_model_name_override()
+        try:
+            self.set_runtime_model_name_override(model_name)
+            yield
+        finally:
+            self.set_runtime_model_name_override(previous_model_name)
+
     def get_model_name(self) -> Optional[str]:
+        override = self.get_runtime_model_name_override()
+        if override:
+            return override
         pinned = get_agent_pinned_model(self.name)
         return pinned if pinned else get_global_model_name()
 

--- a/code_puppy/agents/json_agent.py
+++ b/code_puppy/agents/json_agent.py
@@ -199,11 +199,15 @@ class JSONAgent(BaseAgent):
         self._validate_config()
 
     def get_model_name(self) -> Optional[str]:
-        """Get pinned model name from JSON config, if specified.
+        """Get the effective model name for this JSON agent.
 
-        Returns:
-            Model name to use for this agent, or None to use global default.
+        A runtime override is deliberately checked first so orchestrators can
+        choose a model for one invocation without editing the JSON file.
         """
+        override = self.get_runtime_model_name_override()
+        if override:
+            return override
+
         result = self._config.get("model")
         if result is None:
             result = super().get_model_name()

--- a/code_puppy/messaging/messages.py
+++ b/code_puppy/messaging/messages.py
@@ -278,6 +278,10 @@ class SubAgentInvocationMessage(BaseMessage):
     message_count: int = Field(
         default=0, description="Number of messages in history (for continuation)"
     )
+    model_name: Optional[str] = Field(
+        default=None,
+        description="Optional per-invocation model override requested for this sub-agent run",
+    )
 
 
 class SubAgentResponseMessage(BaseMessage):

--- a/code_puppy/messaging/rich_renderer.py
+++ b/code_puppy/messaging/rich_renderer.py
@@ -818,8 +818,13 @@ class RichConsoleRenderer:
             f"[dim]({session_type})[/dim]"
         )
 
-        # Session ID
+        # Invocation details
         self._console.print(f"[dim]Session:[/dim] [bold]{msg.session_id}[/bold]")
+        if msg.model_name:
+            safe_model_name = escape_rich_markup(msg.model_name)
+            self._console.print(
+                f"[dim]Requested model override:[/dim] [bold magenta]{safe_model_name}[/bold magenta]"
+            )
 
         # Prompt (truncated if too long, rendered as markdown)
         prompt_display = (

--- a/code_puppy/tools/__init__.py
+++ b/code_puppy/tools/__init__.py
@@ -1,6 +1,10 @@
 from code_puppy.callbacks import on_register_agent_tools, on_register_tools
 from code_puppy.messaging import emit_warning
-from code_puppy.tools.agent_tools import register_invoke_agent, register_list_agents
+from code_puppy.tools.agent_tools import register_list_agents
+from code_puppy.tools.subagent_invocation import (
+    register_invoke_agent,
+    register_invoke_agent_with_model,
+)
 from code_puppy.tools.ask_user_question import register_ask_user_question
 
 # Browser automation tools
@@ -77,6 +81,7 @@ from code_puppy.tools.file_operations import (
     register_read_file,
 )
 from code_puppy.tools.image_tools import register_load_image
+from code_puppy.tools.model_tools import register_list_available_models
 from code_puppy.tools.skills_tools import (
     register_activate_skill,
     register_list_or_search_skills,
@@ -88,6 +93,8 @@ TOOL_REGISTRY = {
     # Agent Tools
     "list_agents": register_list_agents,
     "invoke_agent": register_invoke_agent,
+    "invoke_agent_with_model": register_invoke_agent_with_model,
+    "list_available_models": register_list_available_models,
     # File Operations
     "list_files": register_list_files,
     "read_file": register_read_file,

--- a/code_puppy/tools/agent_tools.py
+++ b/code_puppy/tools/agent_tools.py
@@ -1,46 +1,28 @@
 # agent_tools.py
-import asyncio
 import hashlib
 import json
 import pickle
 import re
-import traceback
-from contextlib import AsyncExitStack
 from datetime import datetime
-from functools import partial
 from pathlib import Path
-from typing import List, Set
+from typing import List
 
 from pydantic import BaseModel
 
-# Import Agent from pydantic_ai to create temporary agents for invocation
-from pydantic_ai import Agent, RunContext, UsageLimits
+from pydantic_ai import RunContext
 from pydantic_ai.messages import ModelMessage
 
-from code_puppy.callbacks import (
-    on_agent_run_cancel,
-    on_agent_run_context,
-    on_wrap_pydantic_agent,
-)
 from code_puppy.config import (
     DATA_DIR,
-    get_message_limit,
 )
 from code_puppy.messaging import (
-    SubAgentInvocationMessage,
-    SubAgentResponseMessage,
     emit_error,
     emit_info,
-    emit_success,
     get_message_bus,
     get_session_context,
     set_session_context,
 )
 from code_puppy.tools.common import atomic_write_text, generate_group_id
-from code_puppy.tools.subagent_context import subagent_context
-
-# Set to track active subagent invocation tasks
-_active_subagent_tasks: Set[asyncio.Task] = set()
 
 
 def _generate_session_hash_suffix() -> str:
@@ -224,6 +206,7 @@ class AgentInvokeOutput(BaseModel):
     response: str | None
     agent_name: str
     session_id: str | None = None
+    model_name: str | None = None
     error: str | None = None
 
 
@@ -283,323 +266,30 @@ def register_list_agents(agent):
     return list_agents
 
 
-def register_invoke_agent(agent):
-    """Register the invoke_agent tool with the provided agent.
+# Backward-compatible exports for callers that import invocation tools from
+# code_puppy.tools.agent_tools. The implementation lives in the focused
+# subagent_invocation module so this file stays below the puppy bloat line.
+from code_puppy.tools.subagent_invocation import (  # noqa: E402
+    _active_subagent_tasks,
+    register_invoke_agent,
+    register_invoke_agent_with_model,
+)
 
-    Args:
-        agent: The agent to register the tool with
-    """
-
-    @agent.tool
-    async def invoke_agent(
-        context: RunContext, agent_name: str, prompt: str, session_id: str | None = None
-    ) -> AgentInvokeOutput:
-        """Invoke a specific sub-agent with a given prompt.
-
-        Returns:
-            AgentInvokeOutput: Contains response, agent_name, session_id, and error fields.
-        """
-        from code_puppy.agents.agent_manager import load_agent
-
-        # Validate user-provided session_id if given
-        if session_id is not None:
-            try:
-                _validate_session_id(session_id)
-            except ValueError as e:
-                # Return error immediately if session_id is invalid
-                group_id = generate_group_id("invoke_agent", agent_name)
-                emit_error(str(e), message_group=group_id)
-                return AgentInvokeOutput(
-                    response=None, agent_name=agent_name, error=str(e)
-                )
-
-        # Generate a group ID for this tool execution
-        group_id = generate_group_id("invoke_agent", agent_name)
-
-        # Check if this is an existing session or a new one
-        # For user-provided session_id, check if it exists
-        # For None, we'll generate a new one below
-        if session_id is not None:
-            message_history = _load_session_history(session_id)
-            is_new_session = len(message_history) == 0
-        else:
-            message_history = []
-            is_new_session = True
-
-        # Generate or finalize session_id
-        if session_id is None:
-            # Auto-generate a session ID with hash suffix for uniqueness
-            # Example: "qa-expert-session-a3f2b1"
-            # Sanitize agent_name to kebab-case so capitalised names like
-            # "LPZ-Main-Coder" don't produce invalid session IDs.
-            hash_suffix = _generate_session_hash_suffix()
-            safe_agent_name = _sanitize_for_session_id(agent_name) or "agent"
-            session_id = f"{safe_agent_name}-session-{hash_suffix}"
-        elif is_new_session:
-            # User provided a base name for a NEW session - append hash suffix
-            # Example: "review-auth" -> "review-auth-a3f2b1"
-            # Sanitize the user-provided base to be forgiving of casing/
-            # underscores while still producing a valid kebab-case ID.
-            hash_suffix = _generate_session_hash_suffix()
-            safe_base = _sanitize_for_session_id(session_id) or "session"
-            session_id = f"{safe_base}-{hash_suffix}"
-        # else: continuing existing session, use session_id as-is
-
-        # Lazy imports to avoid circular dependency
-        from code_puppy.agents.subagent_stream_handler import subagent_stream_handler
-
-        # Emit structured invocation message via MessageBus
-        bus = get_message_bus()
-        bus.emit(
-            SubAgentInvocationMessage(
-                agent_name=agent_name,
-                session_id=session_id,
-                prompt=prompt,
-                is_new_session=is_new_session,
-                message_count=len(message_history),
-            )
-        )
-
-        # Save current session context and set the new one for this sub-agent
-        previous_session_id = get_session_context()
-        set_session_context(session_id)
-
-        # Set browser session for browser tools (qa-kitten, etc.)
-        # This allows parallel agent invocations to each have their own browser
-        from code_puppy.tools.browser.browser_manager import (
-            set_browser_session,
-        )
-
-        browser_session_token = set_browser_session(f"browser-{session_id}")
-
-        # Bound up-front so the ``except`` block can always reach for it even
-        # if load_agent() itself fails before assignment.
-        agent_config = None
-
-        try:
-            # Lazy import to break circular dependency with messaging module
-            from code_puppy.model_factory import ModelFactory, make_model_settings
-
-            # Load the specified agent config
-            agent_config = load_agent(agent_name)
-
-            # Seed the wrapper's message history with the loaded session so that
-            # ``make_history_processor(agent_config)`` — wired into the temp
-            # agent's ``history_processors`` — mutates ``agent_config._message_history``
-            # in place as the run progresses. That means on a mid-run crash we
-            # can read partial progress straight off the wrapper below.
-            agent_config.set_message_history(list(message_history))
-
-            # Get the current model for creating a temporary agent
-            model_name = agent_config.get_model_name()
-            models_config = ModelFactory.load_config()
-
-            # Only proceed if we have a valid model configuration
-            if model_name not in models_config:
-                raise ValueError(f"Model '{model_name}' not found in configuration")
-
-            model = ModelFactory.get_model(model_name, models_config)
-
-            # Create a temporary agent instance to avoid interfering with current agent state
-            instructions = agent_config.get_full_system_prompt()
-
-            # Add AGENTS.md content to subagents.
-            # ``load_puppy_rules`` lives on the builder module since the
-            # base_agent split in 79dfc3c8; it's not a method on the agent.
-            from code_puppy.agents._builder import load_puppy_rules
-
-            puppy_rules = load_puppy_rules()
-            if puppy_rules:
-                instructions += f"\n\n{puppy_rules}"
-
-            # NOTE: ``load_prompt`` fragments (file-permission handling, kennel
-            # memory, ...) are already baked into ``get_full_system_prompt``
-            # via BaseAgent, so we must NOT append them again here — doing so
-            # double-injected them for class-based agents.
-            from code_puppy.model_utils import prepare_prompt_for_model
-
-            # Handle claude-code models: swap instructions, and prepend system prompt only on first message
-            prepared = prepare_prompt_for_model(
-                model_name,
-                instructions,
-                prompt,
-                prepend_system_to_user=is_new_session,  # Only prepend on first message
-            )
-            instructions = prepared.instructions
-            prompt = prepared.user_prompt
-
-            model_settings = make_model_settings(model_name)
-
-            # Get MCP servers bound to this sub-agent and warm up any with
-            # ``auto_start=True``. We MUST use the async autostart variant
-            # here (NOT ``start_server_sync``/``load_mcp_servers``) because
-            # ``temp_agent.run(...)`` below is wrapped in
-            # ``asyncio.create_task``, so pydantic-ai opens the MCP toolset's
-            # anyio cancel scopes inside *that* task. The fire-and-forget
-            # sync variant returns before the lifecycle task has entered
-            # the MCP singleton's context, which races pydantic-ai's entry
-            # and produces ``Attempted to exit a cancel scope that isn't
-            # the current task's current cancel scope`` on unwind.
-            # ``autostart_bound_servers_async`` awaits readiness, so by the
-            # time we hand the toolsets to pydantic-ai the lifecycle task
-            # already owns each cancel scope and pydantic-ai's re-entry
-            # hits the ``_running_count > 0`` no-op fast-path.
-            from code_puppy.agents._builder import autostart_bound_servers_async
-            from code_puppy.config import get_value
-            from code_puppy.mcp_ import get_mcp_manager
-
-            mcp_servers = []
-            mcp_disabled = get_value("disable_mcp_servers")
-            if not (
-                mcp_disabled and str(mcp_disabled).lower() in ("1", "true", "yes", "on")
-            ):
-                manager = get_mcp_manager()
-                bound_agent_name = getattr(agent_config, "name", None)
-                if bound_agent_name:
-                    await autostart_bound_servers_async(manager, bound_agent_name)
-                mcp_servers = manager.get_servers_for_agent(agent_name=bound_agent_name)
-
-            from code_puppy.agents._compaction import make_history_processor
-
-            # Build the pydantic-ai agent. MCP servers are always included in
-            # the constructor; plugins (e.g. DBOS) may swap them out at run
-            # time via the ``agent_run_context`` hook if their wrapper can't
-            # handle them directly.
-            temp_agent = Agent(
-                model=model,
-                instructions=instructions,
-                output_type=str,
-                retries=3,
-                toolsets=mcp_servers,
-                history_processors=[make_history_processor(agent_config)],
-                model_settings=model_settings,
-            )
-
-            # Register the tools that the agent needs
-            from code_puppy.tools import register_tools_for_agent
-
-            agent_tools = agent_config.get_available_tools()
-            register_tools_for_agent(temp_agent, agent_tools, model_name=model_name)
-
-            # Allow plugins to wrap the agent (e.g. DBOS durable-exec wrapper).
-            temp_agent = on_wrap_pydantic_agent(
-                agent_config,
-                temp_agent,
-                event_stream_handler=None,
-                message_group=group_id,
-                kind="subagent",
-            )
-
-            # Always use subagent_stream_handler to silence output and update console manager
-            # This ensures all sub-agent output goes through the aggregated dashboard
-            stream_handler = partial(subagent_stream_handler, session_id=session_id)
-
-            # Wrap the agent run in subagent context for tracking
-            with subagent_context(agent_name):
-                run_ctxs = on_agent_run_context(
-                    agent_config, temp_agent, group_id, mcp_servers
-                )
-                async with AsyncExitStack() as stack:
-                    for cm in run_ctxs:
-                        await stack.enter_async_context(cm)
-                    task = asyncio.create_task(
-                        temp_agent.run(
-                            prompt,
-                            message_history=message_history,
-                            usage_limits=UsageLimits(request_limit=get_message_limit()),
-                            event_stream_handler=stream_handler,
-                        )
-                    )
-                    _active_subagent_tasks.add(task)
-
-                    try:
-                        result = await task
-                    finally:
-                        _active_subagent_tasks.discard(task)
-                        if task.cancelled():
-                            await on_agent_run_cancel(group_id)
-
-            # Extract the response from the result
-            response = result.output
-
-            # Update the session history with the new messages from this interaction
-            # The result contains all_messages which includes the full conversation
-            updated_history = result.all_messages()
-
-            # Save to filesystem (include initial prompt only for new sessions)
-            _save_session_history(
-                session_id=session_id,
-                message_history=updated_history,
-                agent_name=agent_name,
-                initial_prompt=prompt if is_new_session else None,
-            )
-
-            # Emit structured response message via MessageBus
-            bus.emit(
-                SubAgentResponseMessage(
-                    agent_name=agent_name,
-                    session_id=session_id,
-                    response=response,
-                    message_count=len(updated_history),
-                )
-            )
-
-            # Emit clean completion summary
-            emit_success(
-                f"✓ {agent_name} completed successfully", message_group=group_id
-            )
-
-            return AgentInvokeOutput(
-                response=response, agent_name=agent_name, session_id=session_id
-            )
-
-        except Exception as e:
-            # Emit clean failure summary
-            emit_error(f"✗ {agent_name} failed: {str(e)}", message_group=group_id)
-
-            # Full traceback for debugging
-            error_msg = f"Error invoking agent '{agent_name}': {traceback.format_exc()}"
-            emit_error(error_msg, message_group=group_id)
-
-            # Save whatever progress the agent made before crashing. The history
-            # processor keeps ``agent_config._message_history`` in sync with each
-            # completed turn, so this captures every committed turn up to the
-            # failure point. Best-effort: a save failure must not mask the
-            # original error, so we swallow anything the save itself raises.
-            try:
-                partial_history = (
-                    agent_config.get_message_history() if agent_config else []
-                )
-                if partial_history and len(partial_history) > len(message_history):
-                    _save_session_history(
-                        session_id=session_id,
-                        message_history=partial_history,
-                        agent_name=agent_name,
-                        initial_prompt=prompt if is_new_session else None,
-                    )
-                    emit_info(
-                        f"💾 Saved partial session '{session_id}' "
-                        f"({len(partial_history)} message(s)) before error",
-                        message_group=group_id,
-                    )
-            except Exception:
-                pass
-
-            return AgentInvokeOutput(
-                response=None,
-                agent_name=agent_name,
-                session_id=session_id,
-                error=error_msg,
-            )
-
-        finally:
-            # Restore the previous session context
-            set_session_context(previous_session_id)
-            # Reset browser session context
-            from code_puppy.tools.browser.browser_manager import (
-                _browser_session_var,
-            )
-
-            _browser_session_var.reset(browser_session_token)
-
-    return invoke_agent
+__all__ = [
+    "AgentInfo",
+    "AgentInvokeOutput",
+    "ListAgentsOutput",
+    "_active_subagent_tasks",
+    "_generate_session_hash_suffix",
+    "_get_subagent_sessions_dir",
+    "_load_session_history",
+    "get_message_bus",
+    "get_session_context",
+    "_sanitize_for_session_id",
+    "_save_session_history",
+    "_validate_session_id",
+    "register_invoke_agent",
+    "register_invoke_agent_with_model",
+    "register_list_agents",
+    "set_session_context",
+]

--- a/code_puppy/tools/model_tools.py
+++ b/code_puppy/tools/model_tools.py
@@ -1,0 +1,105 @@
+"""Model discovery tools with safe, explicit metadata projection.
+
+Future model-routing work can extend this projection with explicit public
+metadata such as standardized capability tags (for example: ``thinking``,
+``vision``, ``tool-use``, ``long-context``) and higher-level profiles (for
+example: ``cheap-and-fast`` or ``strong-architect``). Keep that metadata
+allowlisted here instead of exposing raw model config.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+from pydantic_ai import RunContext
+
+from code_puppy.messaging import emit_error, emit_info
+from code_puppy.tools.common import generate_group_id
+
+
+class AvailableModelInfo(BaseModel):
+    """Safe model metadata exposed to agents for model selection."""
+
+    name: str
+    type: str | None = None
+    provider: str | None = None
+    context_length: int | None = None
+    description: str | None = None
+    supported_settings: list[str] = Field(default_factory=list)
+
+
+class ListAvailableModelsOutput(BaseModel):
+    """Output for the list_available_models tool."""
+
+    models: list[AvailableModelInfo]
+    error: str | None = None
+
+
+def _safe_str(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _safe_int(value: Any) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _safe_str_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def project_available_model(name: str, config: Any) -> AvailableModelInfo:
+    """Project one raw model config into a safe allowlisted summary.
+
+    Important: this intentionally copies only known-safe fields. Do not expose
+    raw model config here; model configs may contain endpoints, headers,
+    API-key env var names, literal secrets from user/plugin config, or other
+    implementation details that do not belong in LLM context.
+    """
+    if not isinstance(config, dict):
+        return AvailableModelInfo(name=name)
+
+    return AvailableModelInfo(
+        name=name,
+        type=_safe_str(config.get("type")),
+        provider=_safe_str(config.get("provider")),
+        context_length=_safe_int(config.get("context_length")),
+        description=_safe_str(config.get("description")),
+        supported_settings=_safe_str_list(config.get("supported_settings")),
+    )
+
+
+def register_list_available_models(agent):
+    """Register the list_available_models tool with the provided agent."""
+
+    @agent.tool
+    def list_available_models(context: RunContext) -> ListAvailableModelsOutput:
+        """List configured model aliases usable for explicit model overrides.
+
+        Returns safe metadata only. Endpoint, auth, API key, environment
+        variable, header, and arbitrary provider/plugin configuration are
+        intentionally omitted.
+        """
+        group_id = generate_group_id("list_available_models")
+
+        try:
+            from code_puppy.model_factory import ModelFactory
+
+            models_config = ModelFactory.load_config()
+            models = [
+                project_available_model(name, cfg)
+                for name, cfg in sorted(models_config.items())
+            ]
+            emit_info(
+                f"Found {len(models)} configured model(s).",
+                message_group=group_id,
+            )
+            return ListAvailableModelsOutput(models=models)
+        except Exception as exc:
+            error_msg = f"Error listing available models: {str(exc)}"
+            emit_error(error_msg, message_group=group_id)
+            return ListAvailableModelsOutput(models=[], error=error_msg)
+
+    return list_available_models

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -1,0 +1,466 @@
+"""Sub-agent invocation tools."""
+
+import asyncio
+import inspect
+import traceback
+from contextlib import AsyncExitStack
+from functools import partial
+from typing import Set
+
+from pydantic_ai import Agent, RunContext, UsageLimits
+
+from code_puppy.callbacks import (
+    on_agent_run_cancel,
+    on_agent_run_context,
+    on_wrap_pydantic_agent,
+)
+from code_puppy.config import get_message_limit
+from code_puppy.messaging import (
+    SubAgentInvocationMessage,
+    SubAgentResponseMessage,
+    emit_error,
+    emit_info,
+    emit_success,
+    get_message_bus,
+    get_session_context,
+    set_session_context,
+)
+from code_puppy.tools.agent_tools import (
+    AgentInvokeOutput,
+    _generate_session_hash_suffix,
+    _load_session_history,
+    _sanitize_for_session_id,
+    _save_session_history,
+    _validate_session_id,
+)
+from code_puppy.tools.common import generate_group_id
+from code_puppy.tools.subagent_context import subagent_context
+
+# Set to track active subagent invocation tasks
+_active_subagent_tasks: Set[asyncio.Task] = set()
+
+
+async def _invoke_agent_impl(
+    context: RunContext,
+    agent_name: str,
+    prompt: str,
+    session_id: str | None = None,
+    model_name: str | None = None,
+) -> AgentInvokeOutput:
+    """Invoke a sub-agent, optionally with an explicit temporary model override."""
+    from code_puppy.agents.agent_manager import load_agent
+
+    # Validate user-provided session_id if given
+    if session_id is not None:
+        try:
+            _validate_session_id(session_id)
+        except ValueError as e:
+            # Return error immediately if session_id is invalid
+            group_id = generate_group_id("invoke_agent", agent_name)
+            emit_error(str(e), message_group=group_id)
+            return AgentInvokeOutput(
+                response=None,
+                agent_name=agent_name,
+                model_name=model_name,
+                error=str(e),
+            )
+
+    # Generate a group ID for this tool execution
+    group_id = generate_group_id("invoke_agent", agent_name)
+
+    # Check if this is an existing session or a new one
+    # For user-provided session_id, check if it exists
+    # For None, we'll generate a new one below
+    if session_id is not None:
+        message_history = _load_session_history(session_id)
+        is_new_session = len(message_history) == 0
+    else:
+        message_history = []
+        is_new_session = True
+
+    # Generate or finalize session_id
+    if session_id is None:
+        # Auto-generate a session ID with hash suffix for uniqueness
+        # Example: "qa-expert-session-a3f2b1"
+        # Sanitize agent_name to kebab-case so capitalised names like
+        # "LPZ-Main-Coder" don't produce invalid session IDs.
+        hash_suffix = _generate_session_hash_suffix()
+        safe_agent_name = _sanitize_for_session_id(agent_name) or "agent"
+        session_id = f"{safe_agent_name}-session-{hash_suffix}"
+    elif is_new_session:
+        # User provided a base name for a NEW session - append hash suffix
+        # Example: "review-auth" -> "review-auth-a3f2b1"
+        # Sanitize the user-provided base to be forgiving of casing/
+        # underscores while still producing a valid kebab-case ID.
+        hash_suffix = _generate_session_hash_suffix()
+        safe_base = _sanitize_for_session_id(session_id) or "session"
+        session_id = f"{safe_base}-{hash_suffix}"
+    # else: continuing existing session, use session_id as-is
+
+    # Lazy imports to avoid circular dependency
+    from code_puppy.agents.subagent_stream_handler import subagent_stream_handler
+
+    # Emit structured invocation message via MessageBus
+    bus = get_message_bus()
+    bus.emit(
+        SubAgentInvocationMessage(
+            agent_name=agent_name,
+            session_id=session_id,
+            prompt=prompt,
+            is_new_session=is_new_session,
+            message_count=len(message_history),
+            model_name=model_name,
+        )
+    )
+
+    # Save current session context and set the new one for this sub-agent
+    previous_session_id = get_session_context()
+    set_session_context(session_id)
+
+    # Set browser session for browser tools (qa-kitten, etc.)
+    # This allows parallel agent invocations to each have their own browser
+    from code_puppy.tools.browser.browser_manager import (
+        set_browser_session,
+    )
+
+    browser_session_token = set_browser_session(f"browser-{session_id}")
+
+    # Bound up-front so the ``except`` block can always reach for it even
+    # if load_agent() itself fails before assignment.
+    agent_config = None
+    effective_model_name = model_name
+
+    try:
+        # Lazy import to break circular dependency with messaging module
+        from code_puppy.model_factory import ModelFactory, make_model_settings
+
+        # Load the specified agent config
+        agent_config = load_agent(agent_name)
+
+        with agent_config.temporary_model_name_override(model_name):
+            # Seed the wrapper's message history with the loaded session so that
+            # ``make_history_processor(agent_config)`` — wired into the temp
+            # agent's ``history_processors`` — mutates ``agent_config._message_history``
+            # in place as the run progresses. That means on a mid-run crash we
+            # can read partial progress straight off the wrapper below.
+            agent_config.set_message_history(list(message_history))
+
+            # Resolve the effective model through the agent so precedence lives
+            # in one place: runtime override -> pinned model -> global default.
+            effective_model_name = agent_config.get_model_name()
+            models_config = ModelFactory.load_config()
+
+            if not effective_model_name:
+                raise ValueError("No model configured for sub-agent invocation")
+
+            # Only proceed if we have a valid model configuration
+            if effective_model_name not in models_config:
+                raise ValueError(
+                    f"Model '{effective_model_name}' not found in configuration"
+                )
+
+            model = ModelFactory.get_model(effective_model_name, models_config)
+            if model is None:
+                raise ValueError(
+                    f"Model '{effective_model_name}' is configured but could not be "
+                    "initialized. Check credentials, provider availability, and usage "
+                    "limits for that model."
+                )
+
+            # Create a temporary agent instance to avoid interfering with current agent state
+            instructions = agent_config.get_full_system_prompt()
+
+            # Add AGENTS.md content to subagents.
+            # ``load_puppy_rules`` lives on the builder module since the
+            # base_agent split in 79dfc3c8; it's not a method on the agent.
+            from code_puppy.agents._builder import load_puppy_rules
+
+            puppy_rules = load_puppy_rules()
+            if puppy_rules:
+                instructions += f"\n\n{puppy_rules}"
+
+            # NOTE: ``load_prompt`` fragments (file-permission handling, kennel
+            # memory, ...) are already baked into ``get_full_system_prompt``
+            # via BaseAgent, so we must NOT append them again here — doing so
+            # double-injected them for class-based agents.
+            from code_puppy.model_utils import prepare_prompt_for_model
+
+            # Handle claude-code models: swap instructions, and prepend system prompt only on first message
+            prepared = prepare_prompt_for_model(
+                effective_model_name,
+                instructions,
+                prompt,
+                prepend_system_to_user=is_new_session,  # Only prepend on first message
+            )
+            instructions = prepared.instructions
+            prompt = prepared.user_prompt
+
+            model_settings = make_model_settings(effective_model_name)
+
+            # Get MCP servers bound to this sub-agent and warm up any with
+            # ``auto_start=True``. We MUST use the async autostart variant
+            # here (NOT ``start_server_sync``/``load_mcp_servers``) because
+            # ``temp_agent.run(...)`` below is wrapped in
+            # ``asyncio.create_task``, so pydantic-ai opens the MCP toolset's
+            # anyio cancel scopes inside *that* task. The fire-and-forget
+            # sync variant returns before the lifecycle task has entered
+            # the MCP singleton's context, which races pydantic-ai's entry
+            # and produces ``Attempted to exit a cancel scope that isn't
+            # the current task's current cancel scope`` on unwind.
+            # ``autostart_bound_servers_async`` awaits readiness, so by the
+            # time we hand the toolsets to pydantic-ai the lifecycle task
+            # already owns each cancel scope and pydantic-ai's re-entry
+            # hits the ``_running_count > 0`` no-op fast-path.
+            from code_puppy.agents._builder import autostart_bound_servers_async
+            from code_puppy.config import get_value
+            from code_puppy.mcp_ import get_mcp_manager
+
+            mcp_servers = []
+            mcp_disabled = get_value("disable_mcp_servers")
+            if not (
+                mcp_disabled and str(mcp_disabled).lower() in ("1", "true", "yes", "on")
+            ):
+                manager = get_mcp_manager()
+                bound_agent_name = getattr(agent_config, "name", None)
+                if bound_agent_name:
+                    await autostart_bound_servers_async(manager, bound_agent_name)
+                mcp_servers = manager.get_servers_for_agent(agent_name=bound_agent_name)
+
+            from code_puppy.agents._compaction import make_history_processor
+
+            # Build the pydantic-ai agent. MCP servers are always included in
+            # the constructor; plugins (e.g. DBOS) may swap them out at run
+            # time via the ``agent_run_context`` hook if their wrapper can't
+            # handle them directly.
+            temp_agent = Agent(
+                model=model,
+                instructions=instructions,
+                output_type=str,
+                retries=3,
+                toolsets=mcp_servers,
+                history_processors=[make_history_processor(agent_config)],
+                model_settings=model_settings,
+            )
+
+            # Register the tools that the agent needs
+            from code_puppy.tools import register_tools_for_agent
+
+            agent_tools = agent_config.get_available_tools()
+            register_tools_for_agent(
+                temp_agent, agent_tools, model_name=effective_model_name
+            )
+
+            # Allow plugins to wrap the agent (e.g. DBOS durable-exec wrapper).
+            temp_agent = on_wrap_pydantic_agent(
+                agent_config,
+                temp_agent,
+                event_stream_handler=None,
+                message_group=group_id,
+                kind="subagent",
+            )
+
+            # Always use subagent_stream_handler to silence output and update console manager
+            # This ensures all sub-agent output goes through the aggregated dashboard
+            stream_handler = partial(subagent_stream_handler, session_id=session_id)
+
+            # Wrap the agent run in subagent context for tracking
+            with subagent_context(agent_name):
+                run_ctxs = on_agent_run_context(
+                    agent_config, temp_agent, group_id, mcp_servers
+                )
+                async with AsyncExitStack() as stack:
+                    for cm in run_ctxs:
+                        await stack.enter_async_context(cm)
+                    task = asyncio.create_task(
+                        temp_agent.run(
+                            prompt,
+                            message_history=message_history,
+                            usage_limits=UsageLimits(request_limit=get_message_limit()),
+                            event_stream_handler=stream_handler,
+                        )
+                    )
+                    _active_subagent_tasks.add(task)
+
+                    try:
+                        result = await task
+                    finally:
+                        _active_subagent_tasks.discard(task)
+                        if task.cancelled():
+                            await on_agent_run_cancel(group_id)
+
+            # Extract the response from the result
+            response = result.output
+
+            # Update the session history with the new messages from this interaction
+            # The result contains all_messages which includes the full conversation
+            updated_history = result.all_messages()
+
+            # Save to filesystem (include initial prompt only for new sessions)
+            _save_session_history(
+                session_id=session_id,
+                message_history=updated_history,
+                agent_name=agent_name,
+                initial_prompt=prompt if is_new_session else None,
+            )
+
+            # Emit structured response message via MessageBus
+            bus.emit(
+                SubAgentResponseMessage(
+                    agent_name=agent_name,
+                    session_id=session_id,
+                    response=response,
+                    message_count=len(updated_history),
+                )
+            )
+
+            # Emit clean completion summary
+            emit_success(
+                f"✓ {agent_name} completed successfully", message_group=group_id
+            )
+
+            return AgentInvokeOutput(
+                response=response,
+                agent_name=agent_name,
+                session_id=session_id,
+                model_name=effective_model_name,
+            )
+
+    except Exception as e:
+        # Emit clean failure summary
+        emit_error(f"✗ {agent_name} failed: {str(e)}", message_group=group_id)
+
+        # Full traceback for debugging
+        error_msg = f"Error invoking agent '{agent_name}': {traceback.format_exc()}"
+        emit_error(error_msg, message_group=group_id)
+
+        # Save whatever progress the agent made before crashing. The history
+        # processor keeps ``agent_config._message_history`` in sync with each
+        # completed turn, so this captures every committed turn up to the
+        # failure point. Best-effort: a save failure must not mask the
+        # original error, so we swallow anything the save itself raises.
+        try:
+            partial_history = agent_config.get_message_history() if agent_config else []
+            if partial_history and len(partial_history) > len(message_history):
+                _save_session_history(
+                    session_id=session_id,
+                    message_history=partial_history,
+                    agent_name=agent_name,
+                    initial_prompt=prompt if is_new_session else None,
+                )
+                emit_info(
+                    f"💾 Saved partial session '{session_id}' "
+                    f"({len(partial_history)} message(s)) before error",
+                    message_group=group_id,
+                )
+        except Exception:
+            pass
+
+        return AgentInvokeOutput(
+            response=None,
+            agent_name=agent_name,
+            session_id=session_id,
+            model_name=effective_model_name,
+            error=error_msg,
+        )
+
+    finally:
+        # Restore the previous session context
+        set_session_context(previous_session_id)
+        # Reset browser session context
+        from code_puppy.tools.browser.browser_manager import (
+            _browser_session_var,
+        )
+
+        _browser_session_var.reset(browser_session_token)
+
+
+def register_invoke_agent(agent):
+    """Register the default invoke_agent tool with no model override affordance."""
+
+    async def invoke_agent(
+        context: RunContext,
+        agent_name: str,
+        prompt: str,
+        session_id: str | None = None,
+        **_ignored_kwargs,
+    ) -> AgentInvokeOutput:
+        """Invoke a specific sub-agent using its configured model.
+
+        Args:
+            agent_name: Name of the sub-agent to invoke.
+            prompt: Task prompt for the sub-agent.
+            session_id: Optional kebab-case session id for continuing memory.
+
+        Returns:
+            AgentInvokeOutput: Contains response, agent_name, session_id,
+            effective model_name, and error fields.
+        """
+        return await _invoke_agent_impl(
+            context=context,
+            agent_name=agent_name,
+            prompt=prompt,
+            session_id=session_id,
+            model_name=None,
+        )
+
+    # Keep the pydantic-ai tool schema intentionally free of **kwargs/model_name
+    # while preserving Python-call compatibility with older tests/callers that
+    # passed extra keywords directly. The explicit model override affordance is
+    # register_invoke_agent_with_model; don't smuggle it back into invoke_agent.
+    invoke_agent.__signature__ = inspect.Signature(
+        parameter
+        for parameter in inspect.signature(invoke_agent).parameters.values()
+        if parameter.kind is not inspect.Parameter.VAR_KEYWORD
+    )
+
+    return agent.tool(invoke_agent)
+
+
+def register_invoke_agent_with_model(agent):
+    """Register the explicit model-override sub-agent invocation tool."""
+
+    @agent.tool
+    async def invoke_agent_with_model(
+        context: RunContext,
+        agent_name: str,
+        prompt: str,
+        model_name: str,
+        session_id: str | None = None,
+    ) -> AgentInvokeOutput:
+        """Invoke a sub-agent with an explicit one-call model override.
+
+        Use this only when a model override is intentionally required. For
+        normal delegation, use invoke_agent so the sub-agent's configured model
+        is respected.
+
+        Args:
+            agent_name: Name of the sub-agent to invoke.
+            prompt: Task prompt for the sub-agent.
+            model_name: Configured model alias to use for this invocation only.
+            session_id: Optional kebab-case session id for continuing memory.
+
+        Returns:
+            AgentInvokeOutput: Contains response, agent_name, session_id,
+            effective model_name, and error fields.
+        """
+        normalized_model_name = model_name.strip()
+        if not normalized_model_name:
+            group_id = generate_group_id("invoke_agent", agent_name)
+            error_msg = "model_name cannot be empty"
+            emit_error(error_msg, message_group=group_id)
+            return AgentInvokeOutput(
+                response=None,
+                agent_name=agent_name,
+                session_id=session_id,
+                model_name=model_name,
+                error=error_msg,
+            )
+        return await _invoke_agent_impl(
+            context=context,
+            agent_name=agent_name,
+            prompt=prompt,
+            session_id=session_id,
+            model_name=normalized_model_name,
+        )
+
+    return invoke_agent_with_model

--- a/tests/agents/test_agent_creator_agent.py
+++ b/tests/agents/test_agent_creator_agent.py
@@ -176,6 +176,14 @@ class TestAgentCreatorAgent:
         assert "## ALL AVAILABLE MODELS:" in prompt
         assert "You are the Agent Creator! 🏗️" in prompt
 
+    def test_prompt_describes_model_override_tools_as_power_user_scoped(self):
+        agent = AgentCreatorAgent()
+        prompt = agent.get_system_prompt()
+
+        assert "Normal agents should use `invoke_agent` only" in prompt
+        assert "power-user agents" in prompt
+        assert "`model_name` is required" in prompt
+
     def test_get_available_tools_with_uc_enabled(self):
         """Test that get_available_tools includes UC when enabled."""
         with patch(

--- a/tests/messaging/test_rich_renderer.py
+++ b/tests/messaging/test_rich_renderer.py
@@ -437,10 +437,13 @@ def test_render_subagent_invocation_continuing(mock_sub, renderer, console):
         prompt="short",
         is_new_session=False,
         message_count=5,
+        model_name="chatgpt-gpt-5.2",
     )
     renderer._render_subagent_invocation(msg)
     out = output(console)
     assert "Continuing" in out
+    assert "Requested model override:" in out
+    assert "chatgpt-gpt-5.2" in out
 
 
 def test_render_subagent_response(renderer, console):

--- a/tests/test_agent_pinned_models.py
+++ b/tests/test_agent_pinned_models.py
@@ -83,6 +83,31 @@ class TestAgentPinnedModels:
         # Clean up
         clear_agent_pinned_model(agent_name)
 
+    def test_runtime_model_override_wins_over_pinned_model(self):
+        """Temporary runtime overrides should beat pinned/default models."""
+        agent = CodePuppyAgent()
+        agent_name = agent.name
+
+        set_agent_pinned_model(agent_name, "pinned-model")
+        try:
+            agent.set_runtime_model_name_override("override-model")
+            assert agent.get_model_name() == "override-model"
+
+            agent.set_runtime_model_name_override(None)
+            assert agent.get_model_name() == "pinned-model"
+        finally:
+            clear_agent_pinned_model(agent_name)
+
+    def test_temporary_model_name_override_restores_previous_value(self):
+        """Scoped overrides should restore the previous runtime override."""
+        agent = CodePuppyAgent()
+        agent.set_runtime_model_name_override("outer-model")
+
+        with agent.temporary_model_name_override("inner-model"):
+            assert agent.get_model_name() == "inner-model"
+
+        assert agent.get_model_name() == "outer-model"
+
     def test_different_agents_different_models(self):
         """Test that different agents can have different pinned models."""
         agent1_name = "agent-one"

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1,5 +1,6 @@
 """Tests for agent tools functionality."""
 
+import inspect
 import json
 import tempfile
 from pathlib import Path
@@ -15,6 +16,7 @@ from code_puppy.tools.agent_tools import (
     _save_session_history,
     _validate_session_id,
     register_invoke_agent,
+    register_invoke_agent_with_model,
     register_list_agents,
 )
 
@@ -37,6 +39,44 @@ class TestAgentTools:
 
         # Register the tool - this should not raise an exception
         register_invoke_agent(mock_agent)
+
+    def test_invoke_agent_with_model_tool(self):
+        """Test that invoke_agent_with_model tool registers correctly."""
+        mock_agent = MagicMock()
+
+        register_invoke_agent_with_model(mock_agent)
+
+    def test_invoke_agent_schema_omits_model_name(self):
+        """Default invoke_agent should not advertise model override."""
+        registered_func = None
+        mock_agent = MagicMock()
+
+        def capture_tool(func):
+            nonlocal registered_func
+            registered_func = func
+            return func
+
+        mock_agent.tool = capture_tool
+        register_invoke_agent(mock_agent)
+
+        signature = inspect.signature(registered_func)
+        assert "model_name" not in signature.parameters
+
+    def test_invoke_agent_with_model_requires_model_name(self):
+        """Explicit override tool should require model_name."""
+        registered_func = None
+        mock_agent = MagicMock()
+
+        def capture_tool(func):
+            nonlocal registered_func
+            registered_func = func
+            return func
+
+        mock_agent.tool = capture_tool
+        register_invoke_agent_with_model(mock_agent)
+
+        parameter = inspect.signature(registered_func).parameters["model_name"]
+        assert parameter.default is inspect.Signature.empty
 
     def test_invoke_agent_includes_prompt_additions(self):
         """Test that invoke_agent includes prompt additions like file permission handling."""

--- a/tests/test_agent_tools_coverage.py
+++ b/tests/test_agent_tools_coverage.py
@@ -11,8 +11,9 @@ DBOS workflow-id tests were removed when DBOS moved to a plugin; see
 """
 
 import tempfile
+from contextlib import ExitStack, contextmanager
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -156,6 +157,7 @@ class TestPydanticModels:
             assert output.response == "This is the agent's response"
             assert output.agent_name == "test-agent"
             assert output.session_id == "session-abc123"
+            assert output.model_name is None
             assert output.error is None
 
         def test_create_error_response(self):
@@ -176,6 +178,7 @@ class TestPydanticModels:
                 agent_name="agent",
             )
             assert output.session_id is None
+            assert output.model_name is None
             assert output.error is None
 
         def test_serialization(self):
@@ -184,11 +187,13 @@ class TestPydanticModels:
                 response="Hello!",
                 agent_name="greeter",
                 session_id="session-123",
+                model_name="test-model",
             )
             data = output.model_dump()
             assert data["response"] == "Hello!"
             assert data["agent_name"] == "greeter"
             assert data["session_id"] == "session-123"
+            assert data["model_name"] == "test-model"
 
 
 class TestRegisterListAgentsExecution:
@@ -433,6 +438,213 @@ class TestRegisterInvokeAgentExecution:
             assert result.error is not None
             assert "nonexistent-model" in result.error
             assert mock_emit_error.called
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_uses_model_override_for_runtime(self):
+        """A supplied model_name should drive all model-specific run setup."""
+        invoke_agent = self._get_registered_invoke_agent()
+        mock_context = MagicMock()
+
+        mock_agent_config = MagicMock()
+
+        @contextmanager
+        def temporary_override(model_name):
+            yield
+
+        mock_agent_config.temporary_model_name_override.side_effect = temporary_override
+        mock_agent_config.get_model_name.return_value = "override-model"
+        mock_agent_config.get_full_system_prompt.return_value = "Test instructions"
+        mock_agent_config.get_available_tools.return_value = ["list_files"]
+
+        mock_result = MagicMock()
+        mock_result.output = "subagent response"
+        mock_result.all_messages.return_value = ["updated-history"]
+
+        mock_temp_agent = MagicMock()
+        mock_temp_agent.run = AsyncMock(return_value=mock_result)
+
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.agent_tools.generate_group_id",
+                    return_value="test-group",
+                )
+            )
+            mock_bus = stack.enter_context(
+                patch("code_puppy.tools.agent_tools.get_message_bus")
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.agent_tools.get_session_context",
+                    return_value="parent",
+                )
+            )
+            stack.enter_context(
+                patch("code_puppy.tools.agent_tools.set_session_context")
+            )
+            stack.enter_context(patch("code_puppy.tools.agent_tools.emit_info"))
+            stack.enter_context(patch("code_puppy.tools.agent_tools.emit_success"))
+            stack.enter_context(
+                patch("code_puppy.tools.agent_tools._save_session_history")
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.agents.agent_manager.load_agent",
+                    return_value=mock_agent_config,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.model_factory.ModelFactory.load_config",
+                    return_value={"default-model": {}, "override-model": {}},
+                )
+            )
+            mock_get_model = stack.enter_context(
+                patch("code_puppy.model_factory.ModelFactory.get_model")
+            )
+            mock_settings = stack.enter_context(
+                patch("code_puppy.model_factory.make_model_settings")
+            )
+            stack.enter_context(
+                patch("code_puppy.agents._builder.load_puppy_rules", return_value=None)
+            )
+            stack.enter_context(
+                patch("code_puppy.callbacks.on_load_prompt", return_value=[])
+            )
+            mock_prepare = stack.enter_context(
+                patch("code_puppy.model_utils.prepare_prompt_for_model")
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.agents._builder.autostart_bound_servers_async",
+                    new=AsyncMock(),
+                )
+            )
+            stack.enter_context(
+                patch("code_puppy.config.get_value", return_value="true")
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.agents._compaction.make_history_processor",
+                    return_value=lambda messages: messages,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.agent_tools.Agent", return_value=mock_temp_agent
+                )
+            )
+            mock_register_tools = stack.enter_context(
+                patch("code_puppy.tools.register_tools_for_agent")
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.agent_tools.on_wrap_pydantic_agent",
+                    side_effect=lambda _cfg, agent, **_kwargs: agent,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.agent_tools.on_agent_run_context", return_value=[]
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.agent_tools._load_session_history",
+                    return_value=[],
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.agent_tools._generate_session_hash_suffix",
+                    return_value="abc123",
+                )
+            )
+
+            mock_bus.return_value.emit = MagicMock()
+            mock_prepare.return_value = MagicMock(
+                instructions="prepared instructions", user_prompt="prepared prompt"
+            )
+
+            result = await invoke_agent(
+                mock_context,
+                agent_name="test-agent",
+                prompt="Hello",
+                model_name="override-model",
+            )
+
+        assert result.response == "subagent response"
+        assert result.model_name == "override-model"
+        mock_agent_config.temporary_model_name_override.assert_called_once_with(
+            "override-model"
+        )
+        mock_get_model.assert_called_once_with(
+            "override-model", {"default-model": {}, "override-model": {}}
+        )
+        mock_prepare.assert_called_once()
+        assert mock_prepare.call_args.args[0] == "override-model"
+        mock_settings.assert_called_once_with("override-model")
+        assert mock_register_tools.call_args.kwargs["model_name"] == "override-model"
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_invalid_override_returns_error(self):
+        """Invalid explicit model overrides should fail, not silently fallback."""
+        invoke_agent = self._get_registered_invoke_agent()
+        mock_context = MagicMock()
+
+        mock_agent_config = MagicMock()
+
+        @contextmanager
+        def temporary_override(model_name):
+            yield
+
+        mock_agent_config.temporary_model_name_override.side_effect = temporary_override
+        mock_agent_config.get_model_name.return_value = "missing-model"
+
+        with (
+            patch(
+                "code_puppy.tools.agent_tools.generate_group_id",
+                return_value="test-group",
+            ),
+            patch("code_puppy.tools.agent_tools.get_message_bus") as mock_bus,
+            patch(
+                "code_puppy.tools.agent_tools.get_session_context",
+                return_value="parent",
+            ),
+            patch("code_puppy.tools.agent_tools.set_session_context"),
+            patch("code_puppy.tools.agent_tools.emit_error"),
+            patch(
+                "code_puppy.agents.agent_manager.load_agent",
+                return_value=mock_agent_config,
+            ),
+            patch(
+                "code_puppy.model_factory.ModelFactory.load_config",
+                return_value={"default-model": {}},
+            ),
+            patch(
+                "code_puppy.tools.agent_tools._load_session_history", return_value=[]
+            ),
+            patch(
+                "code_puppy.tools.agent_tools._generate_session_hash_suffix",
+                return_value="abc123",
+            ),
+        ):
+            mock_bus.return_value.emit = MagicMock()
+
+            result = await invoke_agent(
+                mock_context,
+                agent_name="test-agent",
+                prompt="Hello",
+                model_name="missing-model",
+            )
+
+        assert result.response is None
+        assert result.model_name == "missing-model"
+        assert result.error is not None
+        assert "missing-model" in result.error
+        mock_agent_config.temporary_model_name_override.assert_called_once_with(
+            "missing-model"
+        )
 
     @pytest.mark.asyncio
     async def test_invoke_agent_session_context_restored_on_error(self):

--- a/tests/test_agent_tools_coverage.py
+++ b/tests/test_agent_tools_coverage.py
@@ -23,6 +23,7 @@ from code_puppy.tools.agent_tools import (
     ListAgentsOutput,
     _get_subagent_sessions_dir,
     register_invoke_agent,
+    register_invoke_agent_with_model,
     register_list_agents,
 )
 
@@ -347,6 +348,13 @@ class TestRegisterInvokeAgentExecution:
 
     def _get_registered_invoke_agent(self):
         """Helper to capture the registered invoke_agent function."""
+        return self._capture_registered_tool(register_invoke_agent)
+
+    def _get_registered_invoke_agent_with_model(self):
+        """Helper to capture the registered invoke_agent_with_model function."""
+        return self._capture_registered_tool(register_invoke_agent_with_model)
+
+    def _capture_registered_tool(self, register_func):
         mock_agent = MagicMock()
         registered_func = None
 
@@ -356,7 +364,7 @@ class TestRegisterInvokeAgentExecution:
             return func
 
         mock_agent.tool = capture_tool
-        register_invoke_agent(mock_agent)
+        register_func(mock_agent)
         return registered_func
 
     @pytest.mark.asyncio
@@ -366,9 +374,9 @@ class TestRegisterInvokeAgentExecution:
         mock_context = MagicMock()
 
         with (
-            patch("code_puppy.tools.agent_tools.emit_error") as mock_emit_error,
+            patch("code_puppy.tools.subagent_invocation.emit_error") as mock_emit_error,
             patch(
-                "code_puppy.tools.agent_tools.generate_group_id",
+                "code_puppy.tools.subagent_invocation.generate_group_id",
                 return_value="test-group",
             ),
         ):
@@ -398,16 +406,16 @@ class TestRegisterInvokeAgentExecution:
 
         with (
             patch(
-                "code_puppy.tools.agent_tools.generate_group_id",
+                "code_puppy.tools.subagent_invocation.generate_group_id",
                 return_value="test-group",
             ),
-            patch("code_puppy.tools.agent_tools.get_message_bus") as mock_bus,
+            patch("code_puppy.tools.subagent_invocation.get_message_bus") as mock_bus,
             patch(
-                "code_puppy.tools.agent_tools.get_session_context",
+                "code_puppy.tools.subagent_invocation.get_session_context",
                 return_value="parent",
             ),
-            patch("code_puppy.tools.agent_tools.set_session_context"),
-            patch("code_puppy.tools.agent_tools.emit_error") as mock_emit_error,
+            patch("code_puppy.tools.subagent_invocation.set_session_context"),
+            patch("code_puppy.tools.subagent_invocation.emit_error") as mock_emit_error,
             patch(
                 "code_puppy.agents.agent_manager.load_agent",
                 return_value=mock_agent_config,
@@ -417,11 +425,11 @@ class TestRegisterInvokeAgentExecution:
                 return_value={},  # No models configured
             ),
             patch(
-                "code_puppy.tools.agent_tools._load_session_history",
+                "code_puppy.tools.subagent_invocation._load_session_history",
                 return_value=[],
             ),
             patch(
-                "code_puppy.tools.agent_tools._generate_session_hash_suffix",
+                "code_puppy.tools.subagent_invocation._generate_session_hash_suffix",
                 return_value="abc123",
             ),
         ):
@@ -440,9 +448,9 @@ class TestRegisterInvokeAgentExecution:
             assert mock_emit_error.called
 
     @pytest.mark.asyncio
-    async def test_invoke_agent_uses_model_override_for_runtime(self):
+    async def test_invoke_agent_with_model_uses_override_for_runtime(self):
         """A supplied model_name should drive all model-specific run setup."""
-        invoke_agent = self._get_registered_invoke_agent()
+        invoke_agent = self._get_registered_invoke_agent_with_model()
         mock_context = MagicMock()
 
         mock_agent_config = MagicMock()
@@ -466,26 +474,28 @@ class TestRegisterInvokeAgentExecution:
         with ExitStack() as stack:
             stack.enter_context(
                 patch(
-                    "code_puppy.tools.agent_tools.generate_group_id",
+                    "code_puppy.tools.subagent_invocation.generate_group_id",
                     return_value="test-group",
                 )
             )
             mock_bus = stack.enter_context(
-                patch("code_puppy.tools.agent_tools.get_message_bus")
+                patch("code_puppy.tools.subagent_invocation.get_message_bus")
             )
             stack.enter_context(
                 patch(
-                    "code_puppy.tools.agent_tools.get_session_context",
+                    "code_puppy.tools.subagent_invocation.get_session_context",
                     return_value="parent",
                 )
             )
             stack.enter_context(
-                patch("code_puppy.tools.agent_tools.set_session_context")
+                patch("code_puppy.tools.subagent_invocation.set_session_context")
             )
-            stack.enter_context(patch("code_puppy.tools.agent_tools.emit_info"))
-            stack.enter_context(patch("code_puppy.tools.agent_tools.emit_success"))
+            stack.enter_context(patch("code_puppy.tools.subagent_invocation.emit_info"))
             stack.enter_context(
-                patch("code_puppy.tools.agent_tools._save_session_history")
+                patch("code_puppy.tools.subagent_invocation.emit_success")
+            )
+            stack.enter_context(
+                patch("code_puppy.tools.subagent_invocation._save_session_history")
             )
             stack.enter_context(
                 patch(
@@ -531,7 +541,8 @@ class TestRegisterInvokeAgentExecution:
             )
             stack.enter_context(
                 patch(
-                    "code_puppy.tools.agent_tools.Agent", return_value=mock_temp_agent
+                    "code_puppy.tools.subagent_invocation.Agent",
+                    return_value=mock_temp_agent,
                 )
             )
             mock_register_tools = stack.enter_context(
@@ -539,24 +550,25 @@ class TestRegisterInvokeAgentExecution:
             )
             stack.enter_context(
                 patch(
-                    "code_puppy.tools.agent_tools.on_wrap_pydantic_agent",
+                    "code_puppy.tools.subagent_invocation.on_wrap_pydantic_agent",
                     side_effect=lambda _cfg, agent, **_kwargs: agent,
                 )
             )
             stack.enter_context(
                 patch(
-                    "code_puppy.tools.agent_tools.on_agent_run_context", return_value=[]
-                )
-            )
-            stack.enter_context(
-                patch(
-                    "code_puppy.tools.agent_tools._load_session_history",
+                    "code_puppy.tools.subagent_invocation.on_agent_run_context",
                     return_value=[],
                 )
             )
             stack.enter_context(
                 patch(
-                    "code_puppy.tools.agent_tools._generate_session_hash_suffix",
+                    "code_puppy.tools.subagent_invocation._load_session_history",
+                    return_value=[],
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.subagent_invocation._generate_session_hash_suffix",
                     return_value="abc123",
                 )
             )
@@ -587,9 +599,9 @@ class TestRegisterInvokeAgentExecution:
         assert mock_register_tools.call_args.kwargs["model_name"] == "override-model"
 
     @pytest.mark.asyncio
-    async def test_invoke_agent_invalid_override_returns_error(self):
+    async def test_invoke_agent_with_model_invalid_override_returns_error(self):
         """Invalid explicit model overrides should fail, not silently fallback."""
-        invoke_agent = self._get_registered_invoke_agent()
+        invoke_agent = self._get_registered_invoke_agent_with_model()
         mock_context = MagicMock()
 
         mock_agent_config = MagicMock()
@@ -603,16 +615,16 @@ class TestRegisterInvokeAgentExecution:
 
         with (
             patch(
-                "code_puppy.tools.agent_tools.generate_group_id",
+                "code_puppy.tools.subagent_invocation.generate_group_id",
                 return_value="test-group",
             ),
-            patch("code_puppy.tools.agent_tools.get_message_bus") as mock_bus,
+            patch("code_puppy.tools.subagent_invocation.get_message_bus") as mock_bus,
             patch(
-                "code_puppy.tools.agent_tools.get_session_context",
+                "code_puppy.tools.subagent_invocation.get_session_context",
                 return_value="parent",
             ),
-            patch("code_puppy.tools.agent_tools.set_session_context"),
-            patch("code_puppy.tools.agent_tools.emit_error"),
+            patch("code_puppy.tools.subagent_invocation.set_session_context"),
+            patch("code_puppy.tools.subagent_invocation.emit_error"),
             patch(
                 "code_puppy.agents.agent_manager.load_agent",
                 return_value=mock_agent_config,
@@ -622,10 +634,11 @@ class TestRegisterInvokeAgentExecution:
                 return_value={"default-model": {}},
             ),
             patch(
-                "code_puppy.tools.agent_tools._load_session_history", return_value=[]
+                "code_puppy.tools.subagent_invocation._load_session_history",
+                return_value=[],
             ),
             patch(
-                "code_puppy.tools.agent_tools._generate_session_hash_suffix",
+                "code_puppy.tools.subagent_invocation._generate_session_hash_suffix",
                 return_value="abc123",
             ),
         ):
@@ -660,19 +673,19 @@ class TestRegisterInvokeAgentExecution:
 
         with (
             patch(
-                "code_puppy.tools.agent_tools.generate_group_id",
+                "code_puppy.tools.subagent_invocation.generate_group_id",
                 return_value="test-group",
             ),
-            patch("code_puppy.tools.agent_tools.get_message_bus") as mock_bus,
+            patch("code_puppy.tools.subagent_invocation.get_message_bus") as mock_bus,
             patch(
-                "code_puppy.tools.agent_tools.get_session_context",
+                "code_puppy.tools.subagent_invocation.get_session_context",
                 return_value="original-parent",
             ),
             patch(
-                "code_puppy.tools.agent_tools.set_session_context",
+                "code_puppy.tools.subagent_invocation.set_session_context",
                 side_effect=lambda x: set_context_calls.append(x),
             ),
-            patch("code_puppy.tools.agent_tools.emit_error"),
+            patch("code_puppy.tools.subagent_invocation.emit_error"),
             patch(
                 "code_puppy.agents.agent_manager.load_agent",
                 return_value=mock_agent_config,
@@ -682,11 +695,11 @@ class TestRegisterInvokeAgentExecution:
                 side_effect=RuntimeError("Config load failed"),
             ),
             patch(
-                "code_puppy.tools.agent_tools._load_session_history",
+                "code_puppy.tools.subagent_invocation._load_session_history",
                 return_value=[],
             ),
             patch(
-                "code_puppy.tools.agent_tools._generate_session_hash_suffix",
+                "code_puppy.tools.subagent_invocation._generate_session_hash_suffix",
                 return_value="abc123",
             ),
         ):
@@ -744,17 +757,17 @@ class TestInvokeAgentPartialSessionSaveOnCrash:
 
         with (
             patch(
-                "code_puppy.tools.agent_tools.generate_group_id",
+                "code_puppy.tools.subagent_invocation.generate_group_id",
                 return_value="test-group",
             ),
-            patch("code_puppy.tools.agent_tools.get_message_bus") as mock_bus,
+            patch("code_puppy.tools.subagent_invocation.get_message_bus") as mock_bus,
             patch(
-                "code_puppy.tools.agent_tools.get_session_context",
+                "code_puppy.tools.subagent_invocation.get_session_context",
                 return_value="parent",
             ),
-            patch("code_puppy.tools.agent_tools.set_session_context"),
-            patch("code_puppy.tools.agent_tools.emit_error"),
-            patch("code_puppy.tools.agent_tools.emit_info"),
+            patch("code_puppy.tools.subagent_invocation.set_session_context"),
+            patch("code_puppy.tools.subagent_invocation.emit_error"),
+            patch("code_puppy.tools.subagent_invocation.emit_info"),
             patch(
                 "code_puppy.agents.agent_manager.load_agent",
                 return_value=mock_agent_config,
@@ -765,14 +778,16 @@ class TestInvokeAgentPartialSessionSaveOnCrash:
                 side_effect=RuntimeError("boom"),
             ),
             patch(
-                "code_puppy.tools.agent_tools._load_session_history",
+                "code_puppy.tools.subagent_invocation._load_session_history",
                 return_value=["msg_from_loaded_session"],
             ),
             patch(
-                "code_puppy.tools.agent_tools._generate_session_hash_suffix",
+                "code_puppy.tools.subagent_invocation._generate_session_hash_suffix",
                 return_value="abc123",
             ),
-            patch("code_puppy.tools.agent_tools._save_session_history") as mock_save,
+            patch(
+                "code_puppy.tools.subagent_invocation._save_session_history"
+            ) as mock_save,
         ):
             mock_bus.return_value.emit = MagicMock()
 
@@ -802,17 +817,17 @@ class TestInvokeAgentPartialSessionSaveOnCrash:
 
         with (
             patch(
-                "code_puppy.tools.agent_tools.generate_group_id",
+                "code_puppy.tools.subagent_invocation.generate_group_id",
                 return_value="test-group",
             ),
-            patch("code_puppy.tools.agent_tools.get_message_bus") as mock_bus,
+            patch("code_puppy.tools.subagent_invocation.get_message_bus") as mock_bus,
             patch(
-                "code_puppy.tools.agent_tools.get_session_context",
+                "code_puppy.tools.subagent_invocation.get_session_context",
                 return_value="parent",
             ),
-            patch("code_puppy.tools.agent_tools.set_session_context"),
-            patch("code_puppy.tools.agent_tools.emit_error"),
-            patch("code_puppy.tools.agent_tools.emit_info"),
+            patch("code_puppy.tools.subagent_invocation.set_session_context"),
+            patch("code_puppy.tools.subagent_invocation.emit_error"),
+            patch("code_puppy.tools.subagent_invocation.emit_info"),
             patch(
                 "code_puppy.agents.agent_manager.load_agent",
                 return_value=mock_agent_config,
@@ -822,14 +837,16 @@ class TestInvokeAgentPartialSessionSaveOnCrash:
                 side_effect=RuntimeError("boom"),
             ),
             patch(
-                "code_puppy.tools.agent_tools._load_session_history",
+                "code_puppy.tools.subagent_invocation._load_session_history",
                 return_value=loaded,
             ),
             patch(
-                "code_puppy.tools.agent_tools._generate_session_hash_suffix",
+                "code_puppy.tools.subagent_invocation._generate_session_hash_suffix",
                 return_value="abc123",
             ),
-            patch("code_puppy.tools.agent_tools._save_session_history") as mock_save,
+            patch(
+                "code_puppy.tools.subagent_invocation._save_session_history"
+            ) as mock_save,
         ):
             mock_bus.return_value.emit = MagicMock()
 
@@ -851,17 +868,17 @@ class TestInvokeAgentPartialSessionSaveOnCrash:
 
         with (
             patch(
-                "code_puppy.tools.agent_tools.generate_group_id",
+                "code_puppy.tools.subagent_invocation.generate_group_id",
                 return_value="test-group",
             ),
-            patch("code_puppy.tools.agent_tools.get_message_bus") as mock_bus,
+            patch("code_puppy.tools.subagent_invocation.get_message_bus") as mock_bus,
             patch(
-                "code_puppy.tools.agent_tools.get_session_context",
+                "code_puppy.tools.subagent_invocation.get_session_context",
                 return_value="parent",
             ),
-            patch("code_puppy.tools.agent_tools.set_session_context"),
-            patch("code_puppy.tools.agent_tools.emit_error"),
-            patch("code_puppy.tools.agent_tools.emit_info"),
+            patch("code_puppy.tools.subagent_invocation.set_session_context"),
+            patch("code_puppy.tools.subagent_invocation.emit_error"),
+            patch("code_puppy.tools.subagent_invocation.emit_info"),
             patch(
                 "code_puppy.agents.agent_manager.load_agent",
                 return_value=mock_agent_config,
@@ -871,15 +888,15 @@ class TestInvokeAgentPartialSessionSaveOnCrash:
                 side_effect=RuntimeError("original boom"),
             ),
             patch(
-                "code_puppy.tools.agent_tools._load_session_history",
+                "code_puppy.tools.subagent_invocation._load_session_history",
                 return_value=["a"],
             ),
             patch(
-                "code_puppy.tools.agent_tools._generate_session_hash_suffix",
+                "code_puppy.tools.subagent_invocation._generate_session_hash_suffix",
                 return_value="abc123",
             ),
             patch(
-                "code_puppy.tools.agent_tools._save_session_history",
+                "code_puppy.tools.subagent_invocation._save_session_history",
                 side_effect=OSError("disk full"),
             ),
         ):
@@ -903,29 +920,31 @@ class TestInvokeAgentPartialSessionSaveOnCrash:
 
         with (
             patch(
-                "code_puppy.tools.agent_tools.generate_group_id",
+                "code_puppy.tools.subagent_invocation.generate_group_id",
                 return_value="test-group",
             ),
-            patch("code_puppy.tools.agent_tools.get_message_bus") as mock_bus,
+            patch("code_puppy.tools.subagent_invocation.get_message_bus") as mock_bus,
             patch(
-                "code_puppy.tools.agent_tools.get_session_context",
+                "code_puppy.tools.subagent_invocation.get_session_context",
                 return_value="parent",
             ),
-            patch("code_puppy.tools.agent_tools.set_session_context"),
-            patch("code_puppy.tools.agent_tools.emit_error"),
+            patch("code_puppy.tools.subagent_invocation.set_session_context"),
+            patch("code_puppy.tools.subagent_invocation.emit_error"),
             patch(
                 "code_puppy.agents.agent_manager.load_agent",
                 side_effect=RuntimeError("agent gone"),
             ),
             patch(
-                "code_puppy.tools.agent_tools._load_session_history",
+                "code_puppy.tools.subagent_invocation._load_session_history",
                 return_value=[],
             ),
             patch(
-                "code_puppy.tools.agent_tools._generate_session_hash_suffix",
+                "code_puppy.tools.subagent_invocation._generate_session_hash_suffix",
                 return_value="abc123",
             ),
-            patch("code_puppy.tools.agent_tools._save_session_history") as mock_save,
+            patch(
+                "code_puppy.tools.subagent_invocation._save_session_history"
+            ) as mock_save,
         ):
             mock_bus.return_value.emit = MagicMock()
 
@@ -983,9 +1002,9 @@ class TestSessionIdValidationInInvokeAgent:
         mock_context = MagicMock()
 
         with (
-            patch("code_puppy.tools.agent_tools.emit_error"),
+            patch("code_puppy.tools.subagent_invocation.emit_error"),
             patch(
-                "code_puppy.tools.agent_tools.generate_group_id",
+                "code_puppy.tools.subagent_invocation.generate_group_id",
                 return_value="test-group",
             ),
         ):
@@ -1006,9 +1025,9 @@ class TestSessionIdValidationInInvokeAgent:
         mock_context = MagicMock()
 
         with (
-            patch("code_puppy.tools.agent_tools.emit_error"),
+            patch("code_puppy.tools.subagent_invocation.emit_error"),
             patch(
-                "code_puppy.tools.agent_tools.generate_group_id",
+                "code_puppy.tools.subagent_invocation.generate_group_id",
                 return_value="test-group",
             ),
         ):
@@ -1029,9 +1048,9 @@ class TestSessionIdValidationInInvokeAgent:
         mock_context = MagicMock()
 
         with (
-            patch("code_puppy.tools.agent_tools.emit_error"),
+            patch("code_puppy.tools.subagent_invocation.emit_error"),
             patch(
-                "code_puppy.tools.agent_tools.generate_group_id",
+                "code_puppy.tools.subagent_invocation.generate_group_id",
                 return_value="test-group",
             ),
         ):
@@ -1052,9 +1071,9 @@ class TestSessionIdValidationInInvokeAgent:
         mock_context = MagicMock()
 
         with (
-            patch("code_puppy.tools.agent_tools.emit_error"),
+            patch("code_puppy.tools.subagent_invocation.emit_error"),
             patch(
-                "code_puppy.tools.agent_tools.generate_group_id",
+                "code_puppy.tools.subagent_invocation.generate_group_id",
                 return_value="test-group",
             ),
         ):

--- a/tests/test_coverage_agents_gaps.py
+++ b/tests/test_coverage_agents_gaps.py
@@ -63,6 +63,19 @@ class TestCodePuppyAgentTools:
         assert "delete_snippet" in tools
         assert "invoke_agent" in tools
 
+    def test_default_code_puppy_does_not_get_model_override_tools(self):
+        from code_puppy.agents.agent_code_puppy import CodePuppyAgent
+
+        agent = CodePuppyAgent()
+        tools = agent.get_available_tools()
+        prompt = agent.get_system_prompt()
+
+        assert "invoke_agent" in tools
+        assert "invoke_agent_with_model" not in tools
+        assert "list_available_models" not in tools
+        assert "model_name" not in prompt
+        assert "invoke_agent_with_model" not in prompt
+
 
 # =============================================================================
 # summarization_agent.py gaps

--- a/tests/test_json_agents.py
+++ b/tests/test_json_agents.py
@@ -107,6 +107,30 @@ class TestJSONAgent:
         expected_tools = ["list_files", "read_file", "edit_file"]
         assert tools == expected_tools
 
+    def test_json_agent_runtime_model_override_wins_over_configured_model(
+        self, sample_json_config
+    ):
+        """A per-run override should beat the JSON agent's configured model."""
+        sample_json_config["model"] = "json-model"
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix="-agent.json", delete=False
+        ) as f:
+            json.dump(sample_json_config, f)
+            temp_path = f.name
+
+        try:
+            agent = JSONAgent(temp_path)
+            assert agent.get_model_name() == "json-model"
+
+            agent.set_runtime_model_name_override("override-model")
+            assert agent.get_model_name() == "override-model"
+
+            agent.set_runtime_model_name_override(None)
+            assert agent.get_model_name() == "json-model"
+        finally:
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+
     def test_json_agent_inheritance(self, temp_json_file):
         """Test that JSONAgent properly inherits from BaseAgent."""
         agent = JSONAgent(temp_json_file)

--- a/tests/test_tools_registration.py
+++ b/tests/test_tools_registration.py
@@ -26,6 +26,8 @@ class TestToolRegistration:
             "agent_run_shell_command",
             "list_agents",
             "invoke_agent",
+            "invoke_agent_with_model",
+            "list_available_models",
         ]
 
         assert isinstance(TOOL_REGISTRY, dict)

--- a/tests/tools/test_agent_tools.py
+++ b/tests/tools/test_agent_tools.py
@@ -1,5 +1,6 @@
 """Tests for code_puppy/tools/agent_tools.py - 100% coverage."""
 
+import contextlib
 import json
 import pickle
 from unittest.mock import MagicMock, patch
@@ -297,3 +298,64 @@ class TestRegisterInvokeAgent:
         ):
             result = await captured["fn"](ctx, agent_name="nonexistent", prompt="hi")
         assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_configured_model_that_cannot_initialize_fails_clearly(self):
+        import contextvars
+
+        from code_puppy.tools.agent_tools import register_invoke_agent
+
+        agent = MagicMock()
+        captured = {}
+        agent.tool = lambda fn: (captured.update({"fn": fn}), fn)[-1]
+        register_invoke_agent(agent)
+
+        fake_agent_config = MagicMock()
+        fake_agent_config.temporary_model_name_override.return_value = (
+            contextlib.nullcontext()
+        )
+        fake_agent_config.get_model_name.return_value = "expired-model"
+        fake_agent_config.get_message_history.return_value = []
+
+        fake_browser_var = contextvars.ContextVar("fake_browser")
+        browser_token = fake_browser_var.set("y")
+
+        ctx = MagicMock()
+        with (
+            patch("code_puppy.tools.agent_tools.generate_group_id", return_value="grp"),
+            patch("code_puppy.tools.agent_tools.emit_error"),
+            patch("code_puppy.tools.agent_tools.emit_info"),
+            patch("code_puppy.tools.agent_tools.get_message_bus"),
+            patch(
+                "code_puppy.tools.agent_tools.get_session_context", return_value=None
+            ),
+            patch("code_puppy.tools.agent_tools.set_session_context"),
+            patch(
+                "code_puppy.tools.browser.browser_manager.set_browser_session",
+                return_value=browser_token,
+            ),
+            patch(
+                "code_puppy.tools.browser.browser_manager._browser_session_var",
+                fake_browser_var,
+            ),
+            patch(
+                "code_puppy.agents.agent_manager.load_agent",
+                return_value=fake_agent_config,
+            ),
+            patch(
+                "code_puppy.model_factory.ModelFactory.load_config",
+                return_value={"expired-model": {"type": "openai", "name": "gpt-nope"}},
+            ),
+            patch("code_puppy.model_factory.ModelFactory.get_model", return_value=None),
+        ):
+            result = await captured["fn"](
+                ctx,
+                agent_name="reviewer",
+                prompt="hi",
+                model_name="expired-model",
+            )
+
+        assert result.response is None
+        assert result.model_name == "expired-model"
+        assert result.error is not None
+        assert "could not be initialized" in result.error

--- a/tests/tools/test_model_tools.py
+++ b/tests/tools/test_model_tools.py
@@ -1,0 +1,110 @@
+"""Tests for safe model discovery tools."""
+
+from unittest.mock import MagicMock, patch
+
+from code_puppy.tools.model_tools import (
+    AvailableModelInfo,
+    ListAvailableModelsOutput,
+    project_available_model,
+    register_list_available_models,
+)
+
+
+def _capture_tool(register_func):
+    agent = MagicMock()
+    registered = None
+
+    def capture(func):
+        nonlocal registered
+        registered = func
+        return func
+
+    agent.tool = capture
+    register_func(agent)
+    return registered
+
+
+def test_project_available_model_uses_strict_safe_allowlist():
+    raw = {
+        "type": "custom_openai",
+        "provider": "internal",
+        "name": "provider-model-id",
+        "description": "Internal model",
+        "context_length": 128000,
+        "supported_settings": ["temperature", "top_p", 123, None],
+        "custom_endpoint": {
+            "url": "https://secret.internal/v1",
+            "headers": {"Authorization": "Bearer $SECRET_TOKEN"},
+            "api_key": "literal-secret",
+        },
+        "api_key": "$DIRECT_SECRET_ENV",
+    }
+
+    projected = project_available_model("internal-alias", raw)
+    dumped = projected.model_dump_json()
+
+    assert projected == AvailableModelInfo(
+        name="internal-alias",
+        type="custom_openai",
+        provider="internal",
+        description="Internal model",
+        context_length=128000,
+        supported_settings=["temperature", "top_p"],
+    )
+    assert "secret.internal" not in dumped
+    assert "SECRET_TOKEN" not in dumped
+    assert "literal-secret" not in dumped
+    assert "DIRECT_SECRET_ENV" not in dumped
+    assert "custom_endpoint" not in dumped
+    assert "api_key" not in dumped
+    assert "headers" not in dumped
+
+
+def test_project_available_model_handles_non_dict_config():
+    assert project_available_model("weird", None) == AvailableModelInfo(name="weird")
+
+
+def test_list_available_models_tool_returns_safe_projection():
+    list_available_models = _capture_tool(register_list_available_models)
+
+    with (
+        patch(
+            "code_puppy.model_factory.ModelFactory.load_config",
+            return_value={
+                "z-model": {
+                    "type": "openai",
+                    "description": "Useful model",
+                    "context_length": 42,
+                },
+                "a-secret-model": {
+                    "type": "custom_openai",
+                    "custom_endpoint": {"api_key": "nope"},
+                },
+            },
+        ),
+        patch("code_puppy.tools.model_tools.emit_info"),
+    ):
+        result = list_available_models(MagicMock())
+
+    assert isinstance(result, ListAvailableModelsOutput)
+    assert result.error is None
+    assert [model.name for model in result.models] == ["a-secret-model", "z-model"]
+    assert "nope" not in result.model_dump_json()
+
+
+def test_list_available_models_tool_returns_error_on_failure():
+    list_available_models = _capture_tool(register_list_available_models)
+
+    with (
+        patch(
+            "code_puppy.model_factory.ModelFactory.load_config",
+            side_effect=RuntimeError("boom"),
+        ),
+        patch("code_puppy.tools.model_tools.emit_error") as emit_error,
+    ):
+        result = list_available_models(MagicMock())
+
+    assert result.models == []
+    assert result.error is not None
+    assert "boom" in result.error
+    assert emit_error.called


### PR DESCRIPTION
## Summary

Adds support for per-invocation model overrides when calling sub-agents.

This lets a caller run a sub-agent with a specific configured model for a single task without changing the agent’s pinned model or global/default model configuration.

## Why

Some sub-agent calls benefit from temporarily using a different model:

- Use a stronger model for one complex planning/review task.
- Use a cheaper/faster model for a simple delegated task.
- Experiment with a model on a sub-agent without repinning that agent permanently.

## Examples

From the CLI, a user can ask Code Puppy to delegate to a sub-agent with its normal configured model:

```text
> Ask the reviewer agent to review this implementation.
```

For a deeper one-off review, the user can request a stronger model just for that sub-agent call:

```text
> Ask the reviewer agent to do a deeper architecture review of this change using gpt-5.
```

For simpler delegated work, the user can request a cheaper/faster model without repinning the sub-agent:

```text
> Ask the planner agent to outline the next steps using gpt-4o-mini.
```

Under the hood, this is passed through the `invoke_agent` tool as an optional `model_name`:

```text
invoke_agent(
  agent_name="reviewer",
  prompt="Do a deeper architecture review of this change",
  model_name="gpt-5"
)
```

## What changed

- Added optional `model_name` support to the `invoke_agent` tool.
- Propagated model override metadata through sub-agent invocation messages.
- Added temporary model override handling so the override applies only to that invocation.
- Preserved model precedence:
  1. per-invocation override
  2. pinned agent model
  3. global/default model
- Updated rendering/tests for the new model override behavior.
