### PR TITLE
Fix /woof slash command to forward prompt to the agent

### DIFF
--- a/code_puppy/plugins/agent_skills/config.py
+++ b/code_puppy/plugins/agent_skills/config.py
@@ -151,9 +151,7 @@ def set_frontmatter_in_system_prompt(enabled: bool) -> None:
         enabled: True to inject frontmatter, False to skip it.
     """
     set_value("frontmatter_in_system_prompt", "true" if enabled else "false")
-    logger.info(
-        f"Frontmatter in system prompt {'enabled' if enabled else 'disabled'}"
-    )
+    logger.info(f"Frontmatter in system prompt {'enabled' if enabled else 'disabled'}")
 
 
 def get_disabled_skills() -> Set[str]:

--- a/code_puppy/plugins/example_custom_command/README.md
+++ b/code_puppy/plugins/example_custom_command/README.md
@@ -39,37 +39,43 @@ code_puppy/plugins/example_custom_command/
 from code_puppy.callbacks import register_callback
 from code_puppy.messaging import emit_info
 
+# Optional dependency on the sibling ``customizable_commands`` plugin.
+# Returning a ``MarkdownCommandResult`` tells the dispatcher to forward
+# the wrapped content to the agent as a user prompt.
+try:
+    from code_puppy.plugins.customizable_commands.register_callbacks import (
+        MarkdownCommandResult,
+    )
+except ImportError:
+    MarkdownCommandResult = None
+
 # 1. Define help entries for your commands
 def _custom_help():
     return [
-        ("woof", "Emit a playful woof message (no model)"),
+        ("woof", "Ask the agent for a dog fact (or any prompt you tack on)"),
         ("echo", "Echo back your text (display only)"),
     ]
 
 # 2. Define command handler
 def _handle_custom_command(command: str, name: str):
-    """Handle custom commands.
-    
-    Args:
-        command: Full command string (e.g., "/woof something")
-        name: Command name without slash (e.g., "woof")
-        
-    Returns:
-        - None: Command not handled by this plugin
-        - True: Command handled successfully  
-        - str: Text to process as user input to the model
-    """
+    """Handle custom commands."""
     if name == "woof":
-        emit_info("🐶 Woof!")
-        return True  # Handled, don't invoke model
-        
+        parts = command.split(maxsplit=1)
+        prompt = parts[1] if len(parts) == 2 else "Tell me a dog fact"
+        emit_info(f"🐶 Woof! sending prompt: {prompt}")
+        # Forward to the agent when possible; otherwise degrade gracefully
+        # to display-only so the user still sees the echoed prompt.
+        if MarkdownCommandResult is not None:
+            return MarkdownCommandResult(prompt)
+        return prompt
+
     if name == "echo":
-        # Extract text after command name
+        # Display-only: dispatcher echoes the returned string and stops.
         parts = command.split(maxsplit=1)
         if len(parts) == 2:
-            return parts[1]  # Return as prompt to model
-        return ""  # Empty prompt
-        
+            return parts[1]
+        return ""
+
     return None  # Not our command
 
 # 3. Register callbacks
@@ -101,14 +107,15 @@ register_callback("custom_command", _handle_custom_command)
 **Description**: Display-only command that shows your text.
 
 **Behavior**:
-- Shows the text you provide
-- Returns it as input to the model
+- Shows the text you provide via `emit_info`
+- Does **not** send anything to the model — the dispatcher treats a bare
+  `str` return as display-only and short-circuits the REPL
 
 **Examples**:
 ```bash
 /echo Hello world
 # → Displays: "example plugin echo -> Hello world"
-# → Sends to model: "Hello world"
+# → No model round-trip
 ```
 
 ## Creating Your Own Plugin
@@ -167,8 +174,8 @@ Your `_handle_custom_command` function can return:
 |-------------|----------|
 | `None` | Command not recognized, try next plugin |
 | `True` | Command handled successfully, no model invocation |
-| `str` | String processed as user input to the model |
-| `MarkdownCommandResult(content)` | Special case for markdown commands |
+| `str` | Display-only message — dispatcher emits it and stops (agent NOT invoked) |
+| `MarkdownCommandResult(content)` | Forwards `content` to the agent as a user prompt |
 
 ## Best Practices
 
@@ -186,7 +193,7 @@ Your `_handle_custom_command` function can return:
 - **Don't use `@register_command`**: That's for built-in commands only
 - **Don't modify global state**: Use Code Puppy's config system
 - **Don't make blocking calls**: Keep commands fast and responsive
-- **Don't invoke the model directly**: Return strings instead
+- **Don't invoke the model directly**: return a `MarkdownCommandResult` and let the dispatcher forward it
 - **Don't duplicate built-in commands**: Check existing commands first
 
 ## Command Execution Order

--- a/code_puppy/plugins/example_custom_command/register_callbacks.py
+++ b/code_puppy/plugins/example_custom_command/register_callbacks.py
@@ -1,10 +1,23 @@
 from code_puppy.callbacks import register_callback
 from code_puppy.messaging import emit_info
 
+# Optional dependency on the sibling ``customizable_commands`` plugin.
+# Returning a ``MarkdownCommandResult`` from a custom command tells the
+# dispatcher to forward the wrapped content to the agent as a prompt
+# (see ``code_puppy.command_line.command_handler.handle_command``).
+# If the sibling plugin is ever absent we fall back to display-only
+# behavior rather than fail the whole plugin load.
+try:
+    from code_puppy.plugins.customizable_commands.register_callbacks import (
+        MarkdownCommandResult,
+    )
+except ImportError:  # pragma: no cover - defensive fallback
+    MarkdownCommandResult = None
+
 
 def _custom_help():
     return [
-        ("woof", "Emit a playful woof message (no model)"),
+        ("woof", "Ask the agent for a dog fact (or any prompt you tack on)"),
         ("echo", "Echo back your text (display only)"),
     ]
 
@@ -12,30 +25,35 @@ def _custom_help():
 def _handle_custom_command(command: str, name: str):
     """Handle a demo custom command.
 
-    Policy: custom commands must NOT invoke the model. They should emit
-    messages or return True to indicate handling. Returning a string is
-    treated as a display-only message by the command handler.
+    Custom commands registered via the ``custom_command`` callback may return:
+
+    - ``None``                  -- not our command, let other plugins try.
+    - ``True``                  -- fully handled, no further action.
+    - ``str``                   -- display-only message; the dispatcher emits
+                                   it and stops (the agent is NOT invoked).
+    - ``MarkdownCommandResult`` -- the wrapped ``.content`` is forwarded to
+                                   the agent as a user prompt.
 
     Supports:
-    - /woof          → emits a fun message and returns True
-    - /echo <text>   → emits the text (display-only)
+    - /woof [text]   -> sends a prompt to the agent (defaults to a dog fact)
+    - /echo <text>   -> displays the text (no agent round-trip)
     """
     if not name:
         return None
 
     if name == "woof":
-        # If extra text is provided, pass it as a prompt; otherwise, send a fun default
         parts = command.split(maxsplit=1)
-        if len(parts) == 2:
-            text = parts[1]
-            emit_info(f"🐶 Woof! sending prompt: {text}")
-            return text
-        emit_info("🐶 Woof! sending prompt: Tell me a dog fact")
-        return "Tell me a dog fact"
+        prompt = parts[1] if len(parts) == 2 else "Tell me a dog fact"
+        emit_info(f"🐶 Woof! sending prompt: {prompt}")
+        # Forward to the agent when possible; otherwise degrade gracefully
+        # to display-only so the user at least sees the echoed prompt.
+        if MarkdownCommandResult is not None:
+            return MarkdownCommandResult(prompt)
+        return prompt
 
     if name == "echo":
-        # Return the rest of the command (after the name) to be treated as input
-        # Example: "/echo Hello" → returns "Hello"
+        # Display-only: return the text after the command name and let the
+        # dispatcher's ``str`` branch emit it.
         rest = command.split(maxsplit=1)
         if len(rest) == 2:
             text = rest[1]

--- a/tests/plugins/test_plugin_coverage.py
+++ b/tests/plugins/test_plugin_coverage.py
@@ -42,12 +42,35 @@ class TestExampleCustomCommand:
         assert self._get_handler()("unknown", "unknown") is None
 
     def test_woof_no_args(self):
+        from code_puppy.plugins.customizable_commands.register_callbacks import (
+            MarkdownCommandResult,
+        )
+
         result = self._get_handler()("woof", "woof")
-        assert result == "Tell me a dog fact"
+        assert isinstance(result, MarkdownCommandResult)
+        assert result.content == "Tell me a dog fact"
 
     def test_woof_with_text(self):
+        from code_puppy.plugins.customizable_commands.register_callbacks import (
+            MarkdownCommandResult,
+        )
+
         result = self._get_handler()("woof hello world", "woof")
-        assert result == "hello world"
+        assert isinstance(result, MarkdownCommandResult)
+        assert result.content == "hello world"
+
+    def test_woof_falls_back_to_string_when_markdown_result_unavailable(
+        self, monkeypatch
+    ):
+        """If the sibling ``customizable_commands`` plugin is absent, ``/woof``
+        should degrade gracefully to a bare-string (display-only) return
+        rather than break the plugin.
+        """
+        from code_puppy.plugins.example_custom_command import register_callbacks
+
+        monkeypatch.setattr(register_callbacks, "MarkdownCommandResult", None)
+        result = register_callbacks._handle_custom_command("woof", "woof")
+        assert result == "Tell me a dog fact"
 
     def test_echo_no_args(self):
         result = self._get_handler()("echo", "echo")


### PR DESCRIPTION
The example_custom_command plugin's /woof handler returned a bare str, which the dispatcher treats as a display-only message: it emits the returned text via emit_info and returns True, short-circuiting the REPL before the agent is invoked. The user saw the intended prompt echoed twice and never got a model response.

Return a MarkdownCommandResult from /woof instead, which the dispatcher recognises as 'forward this content to the agent as a user prompt'. The import follows the canonical try/except pattern used by agent_skills, falling back to bare-string (display-only) behaviour if the sibling customizable_commands plugin is ever absent.

/echo is intentionally left alone (it's advertised as display-only). The dispatcher contract is untouched, so other plugins that legitimately return str for display-only output keep working.

Also rewrites the misleading plugin docstring and README sections that documented the old (and broken) behaviour, and updates the existing woof tests plus adds a fallback-path test.