### PR TITLE
fix(agents): stop baking runtime metadata into cloned agents

### DIFF
--- a/code_puppy/agents/agent_code_puppy.py
+++ b/code_puppy/agents/agent_code_puppy.py
@@ -2,7 +2,6 @@
 
 from code_puppy.config import get_owner_name, get_puppy_name
 
-from .. import callbacks
 from .base_agent import BaseAgent
 
 
@@ -89,8 +88,9 @@ Important rules:
 {r["loop_rule"]}
 - Continue autonomously unless user input is definitively required
 """
-
-        prompt_additions = callbacks.on_load_prompt()
-        if len(prompt_additions):
-            result += "\n".join(prompt_additions)
+        # NOTE: runtime ``load_prompt`` fragments (plugin-injected notes such
+        # as environment context, file-permission rules, memory recall, ...)
+        # are intentionally NOT appended here — they're injected fresh at
+        # runtime by ``BaseAgent.get_full_system_prompt`` so they never get
+        # baked into a cloned/persisted agent definition.
         return result

--- a/code_puppy/agents/agent_manager.py
+++ b/code_puppy/agents/agent_manager.py
@@ -658,7 +658,12 @@ def clone_agent(agent_name: str) -> Optional[str]:
                     agent_instance.display_name, clone_index
                 ),
                 "description": agent_instance.description,
-                "system_prompt": agent_instance.get_full_system_prompt(),
+                # Persist the AUTHORED prompt only. ``get_full_system_prompt``
+                # would bake in runtime ``load_prompt`` fragments (live
+                # timestamp/CWD, kennel memory, ...) and the instance identity
+                # ID — all of which must be (re)injected fresh at runtime, not
+                # frozen into a static clone definition.
+                "system_prompt": agent_instance.get_system_prompt(),
                 "tools": _filter_available_tools(agent_instance.get_available_tools()),
             }
 

--- a/code_puppy/agents/agent_planning.py
+++ b/code_puppy/agents/agent_planning.py
@@ -2,7 +2,6 @@
 
 from code_puppy.config import get_puppy_name
 
-from .. import callbacks
 from .base_agent import BaseAgent
 
 
@@ -157,8 +156,7 @@ Remember: You're the strategic planner, not the implementer. Your job is to crea
 
 IMPORTANT: Only when the user gives clear approval to proceed (such as "execute plan", "go ahead", "let's do it", "start", "begin", "proceed", "sounds good", or any equivalent phrase indicating they want to move forward), coordinate with the appropriate agents to implement your roadmap step by step, otherwise don't start invoking other tools such read file or other agents.
 """
-
-        prompt_additions = callbacks.on_load_prompt()
-        if len(prompt_additions):
-            result += "\n".join(prompt_additions)
+        # Runtime ``load_prompt`` fragments are injected by
+        # ``BaseAgent.get_full_system_prompt`` — see CodePuppyAgent for the
+        # rationale (keeps runtime metadata out of persisted definitions).
         return result

--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -128,7 +128,24 @@ class BaseAgent(ABC):
         )
 
     def get_full_system_prompt(self) -> str:
-        return self.get_system_prompt() + self.get_identity_prompt()
+        """Assemble the runtime system prompt.
+
+        Layered as: authored prompt (``get_system_prompt``) + per-turn
+        ``load_prompt`` plugin fragments + this instance's identity.
+
+        The ``load_prompt`` fragments (live timestamp/CWD, file-permission
+        rules, kennel memory, ...) and the identity ID are *runtime* concerns.
+        They live here — not in ``get_system_prompt`` — so they're recomputed
+        fresh every run and never get persisted into static agent definitions
+        (e.g. when an agent is cloned to JSON). See ``clone_agent``.
+        """
+        from code_puppy import callbacks
+
+        prompt = self.get_system_prompt()
+        prompt_additions = callbacks.on_load_prompt()
+        if prompt_additions:
+            prompt += "\n" + "\n".join(prompt_additions)
+        return prompt + self.get_identity_prompt()
 
     # ---- Message history (plain dict-level access) ------------------------
     def get_message_history(self) -> List[Any]:

--- a/code_puppy/tools/agent_tools.py
+++ b/code_puppy/tools/agent_tools.py
@@ -412,13 +412,11 @@ def register_invoke_agent(agent):
             if puppy_rules:
                 instructions += f"\n\n{puppy_rules}"
 
-            # Apply prompt additions (like file permission handling) to temporary agents
-            from code_puppy import callbacks
+            # NOTE: ``load_prompt`` fragments (file-permission handling, kennel
+            # memory, ...) are already baked into ``get_full_system_prompt``
+            # via BaseAgent, so we must NOT append them again here — doing so
+            # double-injected them for class-based agents.
             from code_puppy.model_utils import prepare_prompt_for_model
-
-            prompt_additions = callbacks.on_load_prompt()
-            if len(prompt_additions):
-                instructions += "\n" + "\n".join(prompt_additions)
 
             # Handle claude-code models: swap instructions, and prepend system prompt only on first message
             prepared = prepare_prompt_for_model(

--- a/tests/agents/test_agents_remaining_coverage.py
+++ b/tests/agents/test_agents_remaining_coverage.py
@@ -75,10 +75,27 @@ def test_code_puppy_prompt_allows_callback_additions():
     from code_puppy.agents.agent_code_puppy import CodePuppyAgent
 
     agent = CodePuppyAgent()
-    with patch("code_puppy.agents.agent_code_puppy.callbacks") as mock_cb:
-        mock_cb.on_load_prompt.return_value = ["extra"]
-        prompt = agent.get_system_prompt()
+    # ``load_prompt`` fragments now live in get_full_system_prompt (BaseAgent),
+    # not in the authored get_system_prompt.
+    with patch("code_puppy.callbacks.on_load_prompt", return_value=["extra"]):
+        prompt = agent.get_full_system_prompt()
         assert "extra" in prompt
+
+
+def test_code_puppy_authored_prompt_excludes_runtime_additions():
+    """Authored prompt must NOT contain load_prompt fragments or the identity.
+
+    Regression for the clone bug: cloning persists get_system_prompt(), so
+    runtime-only metadata (kennel memory, live timestamps) and the per-instance
+    identity ID must stay out of it.
+    """
+    from code_puppy.agents.agent_code_puppy import CodePuppyAgent
+
+    agent = CodePuppyAgent()
+    with patch("code_puppy.callbacks.on_load_prompt", return_value=["SECRET-RUNTIME"]):
+        authored = agent.get_system_prompt()
+    assert "SECRET-RUNTIME" not in authored
+    assert agent.get_identity() not in authored
 
 
 # ---------------------------------------------------------------------------
@@ -435,6 +452,49 @@ def test_clone_agent_failure():
         result = clone_agent("totally-nonexistent-agent-xyz")
         # Should return None for nonexistent agent
         assert result is None
+
+
+def test_clone_class_agent_does_not_bake_runtime_metadata(tmp_path):
+    """Cloning a class-based agent must persist only the authored prompt.
+
+    Regression: previously the clone stored ``get_full_system_prompt()`` which
+    baked in runtime ``load_prompt`` fragments (kennel memory, live
+    timestamps/CWD) and the per-instance identity ID into the static JSON.
+    """
+    import code_puppy.agents.agent_manager as am
+    from code_puppy.agents.agent_code_puppy import CodePuppyAgent
+
+    captured = {}
+
+    def fake_atomic_write(path, content):
+        captured["path"] = path
+        captured["content"] = content
+
+    with (
+        patch.object(am, "_discover_agents"),
+        patch.dict(am._AGENT_REGISTRY, {"code-puppy": CodePuppyAgent}, clear=True),
+        patch(
+            "code_puppy.config.get_user_agents_directory",
+            return_value=str(tmp_path),
+        ),
+        patch("code_puppy.config.get_agent_pinned_model", return_value=None),
+        patch(
+            "code_puppy.callbacks.on_load_prompt",
+            return_value=["KENNEL-SECRET-BLOCK"],
+        ),
+        patch.object(am, "atomic_write_text", side_effect=fake_atomic_write),
+        patch.object(am, "emit_success"),
+        patch.object(am, "emit_warning"),
+        patch.object(am, "_filter_available_tools", side_effect=lambda t: t),
+    ):
+        clone_name = am.clone_agent("code-puppy")
+
+    assert clone_name == "code-puppy-clone-1"
+    config = json.loads(captured["content"])
+    # Runtime-only metadata must not be frozen into the clone definition.
+    assert "KENNEL-SECRET-BLOCK" not in config["system_prompt"]
+    # No baked identity ID block.
+    assert "Your ID is" not in config["system_prompt"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Cloning a class-based agent persisted get_full_system_prompt(), which froze runtime-only load_prompt fragments (live timestamp/CWD, memory recall, file-permission notes) and the per-instance identity ID into the static JSON definition. Reloaded clones then carried stale metadata and a second, conflicting identity.

Move load_prompt injection into BaseAgent.get_full_system_prompt so it is applied fresh at runtime for every agent (including JSON clones), keep get_system_prompt authored-only, and clone the authored prompt. Also drop the now-duplicate load_prompt append in the subagent path, which was double-injecting fragments for class-based agents.

Adds regression tests for authored-prompt purity and clone output.