### PR TITLE
Fix: Deduplicate skills and add explicit schema constraints to ask_user_question

### DIFF
--- a/code_puppy/plugins/agent_skills/discovery.py
+++ b/code_puppy/plugins/agent_skills/discovery.py
@@ -235,6 +235,15 @@ def discover_skills(directories: Optional[List[Path]] = None) -> List[SkillInfo]
             if not skill_dir.is_dir() or skill_dir.name.startswith("."):
                 continue
 
+            # First-discovered skill wins - skip duplicates from later directories
+            if skill_dir.name in seen_skill_names:
+                logger.debug(
+                    "Skipping duplicate skill '%s' at %s (already discovered)",
+                    skill_dir.name,
+                    skill_dir,
+                )
+                continue
+
             has_skill_md = is_valid_skill_directory(skill_dir)
             skill_info = SkillInfo(
                 name=skill_dir.name,

--- a/code_puppy/tools/ask_user_question/constants.py
+++ b/code_puppy/tools/ask_user_question/constants.py
@@ -6,7 +6,9 @@ from typing import Final
 MAX_QUESTIONS_PER_CALL: Final[int] = 10  # Reasonable limit for a single TUI interaction
 MIN_OPTIONS_PER_QUESTION: Final[int] = 2
 MAX_OPTIONS_PER_QUESTION: Final[int] = 6
-MAX_HEADER_LENGTH: Final[int] = 60
+MAX_HEADER_LENGTH: Final[int] = (
+    25  # Must fit in left panel (MAX_LEFT_PANEL_WIDTH - padding)
+)
 MAX_LABEL_LENGTH: Final[int] = 50
 MAX_DESCRIPTION_LENGTH: Final[int] = 200
 MAX_QUESTION_LENGTH: Final[int] = 500

--- a/code_puppy/tools/ask_user_question/registration.py
+++ b/code_puppy/tools/ask_user_question/registration.py
@@ -3,16 +3,88 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any, Dict, List
 
-from pydantic import BeforeValidator, Field
+from pydantic import BeforeValidator, Field, WithJsonSchema
 from pydantic_ai import RunContext
 
+from .constants import (
+    MAX_DESCRIPTION_LENGTH,
+    MAX_HEADER_LENGTH,
+    MAX_LABEL_LENGTH,
+    MAX_OPTIONS_PER_QUESTION,
+    MAX_QUESTION_LENGTH,
+    MAX_QUESTIONS_PER_CALL,
+    MIN_OPTIONS_PER_QUESTION,
+)
 from .handler import ask_user_question as _ask_user_question_impl
 from .models import AskUserQuestionOutput
 
 if TYPE_CHECKING:
     from pydantic_ai import Agent
+
+
+# Inline JSON schemas to avoid $defs/$ref that many LLM providers misinterpret.
+# This matches the approach used by replace_in_file for complex nested types.
+# Include maxLength constraints so LLMs know the limits upfront.
+_OPTION_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "label": {
+            "type": "string",
+            "maxLength": MAX_LABEL_LENGTH,
+            "description": f"Short option name (1-5 words, max {MAX_LABEL_LENGTH} chars)",
+        },
+        "description": {
+            "type": "string",
+            "maxLength": MAX_DESCRIPTION_LENGTH,
+            "description": f"Optional explanation (max {MAX_DESCRIPTION_LENGTH} chars)",
+        },
+    },
+    "required": ["label"],
+}
+
+_QUESTION_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "question": {
+            "type": "string",
+            "maxLength": MAX_QUESTION_LENGTH,
+            "description": f"The full question text (max {MAX_QUESTION_LENGTH} chars)",
+        },
+        "header": {
+            "type": "string",
+            "maxLength": MAX_HEADER_LENGTH,
+            "description": f"Short label for compact display (max {MAX_HEADER_LENGTH} chars, no spaces)",
+        },
+        "multi_select": {
+            "type": "boolean",
+            "description": "If true, user can select multiple options (default: false)",
+        },
+        "options": {
+            "type": "array",
+            "items": _OPTION_SCHEMA,
+            "minItems": MIN_OPTIONS_PER_QUESTION,
+            "maxItems": MAX_OPTIONS_PER_QUESTION,
+            "description": f"Array of {MIN_OPTIONS_PER_QUESTION}-{MAX_OPTIONS_PER_QUESTION} selectable options",
+        },
+    },
+    "required": ["question", "header", "options"],
+}
+
+_QUESTIONS_ARRAY_SCHEMA: Dict[str, Any] = {
+    "type": "array",
+    "items": _QUESTION_SCHEMA,
+    "minItems": 1,
+    "maxItems": MAX_QUESTIONS_PER_CALL,
+    "description": (
+        f"Array of 1-{MAX_QUESTIONS_PER_CALL} question objects. Each question needs: "
+        f"'question' (max {MAX_QUESTION_LENGTH} chars), "
+        f"'header' (max {MAX_HEADER_LENGTH} chars, no spaces), "
+        f"'options' (array of {MIN_OPTIONS_PER_QUESTION}-{MAX_OPTIONS_PER_QUESTION} options with 'label'). "
+        "Optional: 'multi_select' (boolean)."
+    ),
+}
 
 
 def _coerce_questions_json_string(v: Any) -> Any:
@@ -34,24 +106,31 @@ def _coerce_questions_json_string(v: Any) -> Any:
     return v
 
 
+# Type alias with explicit JSON schema override so LLMs see the full structure.
+# The BeforeValidator handles JSON-string coercion before validation.
+# The WithJsonSchema tells pydantic to emit our inline schema instead of inferring.
+QuestionsListWithSchema = Annotated[
+    List[Dict[str, Any]],
+    BeforeValidator(_coerce_questions_json_string),
+    WithJsonSchema(_QUESTIONS_ARRAY_SCHEMA),
+    Field(
+        description=(
+            f"Array of 1-{MAX_QUESTIONS_PER_CALL} question objects. Each question needs: "
+            f"'question' (max {MAX_QUESTION_LENGTH} chars), "
+            f"'header' (max {MAX_HEADER_LENGTH} chars), "
+            f"'options' ({MIN_OPTIONS_PER_QUESTION}-{MAX_OPTIONS_PER_QUESTION} options with 'label')."
+        )
+    ),
+]
+
+
 def register_ask_user_question(agent: Agent) -> None:
     """Register the ask_user_question tool with the given agent."""
 
     @agent.tool
     def ask_user_question(
         context: RunContext,  # noqa: ARG001 - Required by framework
-        questions: Annotated[
-            list[dict[str, Any]],
-            BeforeValidator(_coerce_questions_json_string),
-            Field(
-                description=(
-                    "Array of question objects. Each question should include: "
-                    "'question' (string), 'header' (short string), optional "
-                    "'multi_select' (boolean), and 'options' (array of option "
-                    "objects with 'label' and optional 'description')."
-                )
-            ),
-        ],
+        questions: QuestionsListWithSchema,
     ) -> AskUserQuestionOutput:
         """Ask the user multiple related questions in an interactive TUI."""
         # Keep the external tool schema simple for provider compatibility.

--- a/tests/plugins/test_agent_skills.py
+++ b/tests/plugins/test_agent_skills.py
@@ -288,6 +288,48 @@ class TestSkillDiscovery:
         assert "name: plugin-skill" in content
         assert "description: From plugin" in content
 
+    def test_discover_skills_deduplicates_across_directories(self, tmp_path, caplog):
+        """Test that same skill name in multiple directories only keeps first discovered.
+
+        When the same skill name exists in multiple skill directories (e.g.,
+        ~/.code_puppy/skills/foo and ~/.claude/skills/foo), only the first one
+        discovered should be kept. This prevents /help from showing duplicate entries.
+        """
+        # Create first skill directory (higher priority - discovered first)
+        first_dir = tmp_path / "primary-skills"
+        first_dir.mkdir()
+        first_skill = first_dir / "duplicate-skill"
+        first_skill.mkdir()
+        (first_skill / "SKILL.md").write_text(
+            "---\nname: duplicate-skill\ndescription: First version\n---\n"
+        )
+
+        # Create second skill directory (lower priority - discovered second)
+        second_dir = tmp_path / "secondary-skills"
+        second_dir.mkdir()
+        second_skill = second_dir / "duplicate-skill"
+        second_skill.mkdir()
+        (second_skill / "SKILL.md").write_text(
+            "---\nname: duplicate-skill\ndescription: Second version\n---\n"
+        )
+
+        # Discover skills from both directories in order
+        with caplog.at_level(logging.DEBUG):
+            skills = discover_skills(directories=[first_dir, second_dir])
+
+        # Should only have one skill, not two
+        duplicate_skills = [s for s in skills if s.name == "duplicate-skill"]
+        assert len(duplicate_skills) == 1, (
+            "Expected exactly one 'duplicate-skill', got "
+            f"{len(duplicate_skills)}: {[s.path for s in duplicate_skills]}"
+        )
+
+        # First-discovered wins - should be from the first directory
+        assert duplicate_skills[0].path == first_skill
+
+        # Verify debug log about skipping duplicate
+        assert "Skipping duplicate skill 'duplicate-skill'" in caplog.text
+
     def test_filesystem_skill_wins_over_plugin_collision(self, tmp_path, monkeypatch):
         from code_puppy.plugins.agent_skills import discovery as discovery_module
 

--- a/tests/tools/test_ask_user_question/test_handler.py
+++ b/tests/tools/test_ask_user_question/test_handler.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from code_puppy.command_line.wiggum_state import start_wiggum, stop_wiggum
+from code_puppy.tools.ask_user_question.constants import MAX_HEADER_LENGTH
 from code_puppy.tools.ask_user_question.handler import (
     ask_user_question,
     is_interactive,
@@ -89,19 +90,21 @@ class TestAskUserQuestionValidation:
         assert result.answers == []
 
     def test_header_too_long(self) -> None:
-        """Header over 60 chars should return validation error."""
+        """Header over MAX_HEADER_LENGTH chars should return validation error."""
         result = ask_user_question(
             [
                 {
                     "question": "Which database?",
-                    "header": "A" * 61,  # exceeds MAX_HEADER_LENGTH=60
+                    "header": "A" * (MAX_HEADER_LENGTH + 1),
                     "options": [{"label": "A"}, {"label": "B"}],
                 }
             ]
         )
         assert result.error is not None
         # The error message includes the constraint info
-        assert "60" in result.error or "header" in result.error.lower()
+        assert (
+            str(MAX_HEADER_LENGTH) in result.error or "header" in result.error.lower()
+        )
 
     def test_too_few_options(self) -> None:
         """Less than 2 options should return validation error."""

--- a/tests/tools/test_ask_user_question/test_models.py
+++ b/tests/tools/test_ask_user_question/test_models.py
@@ -3,6 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
+from code_puppy.tools.ask_user_question.constants import MAX_HEADER_LENGTH
 from code_puppy.tools.ask_user_question.models import (
     AskUserQuestionInput,
     AskUserQuestionOutput,
@@ -91,11 +92,11 @@ class TestQuestion:
         assert q.multi_select is False
 
     def test_header_too_long(self, valid_options: list[QuestionOption]) -> None:
-        """Header over 60 chars should fail."""
+        """Header over MAX_HEADER_LENGTH chars should fail."""
         with pytest.raises(ValidationError):
             Question(
                 question="Which option?",
-                header="A" * 61,  # exceeds MAX_HEADER_LENGTH=60
+                header="A" * (MAX_HEADER_LENGTH + 1),
                 options=valid_options,
             )
 

--- a/tests/tools/test_ask_user_question/test_registration.py
+++ b/tests/tools/test_ask_user_question/test_registration.py
@@ -85,3 +85,62 @@ class TestCoerceQuestionsJsonString:
         result = _coerce_questions_json_string(json.dumps(q))
         assert result == q
         assert len(result) == 1
+
+
+class TestToolSchemaConstraints:
+    """Verify the JSON schema includes all constraints for LLM guidance."""
+
+    def test_schema_includes_all_maxlength_constraints(self):
+        """Schema should include maxLength for all string fields."""
+        from pydantic_ai import Agent
+
+        from code_puppy.tools.ask_user_question.constants import (
+            MAX_DESCRIPTION_LENGTH,
+            MAX_HEADER_LENGTH,
+            MAX_LABEL_LENGTH,
+            MAX_OPTIONS_PER_QUESTION,
+            MAX_QUESTION_LENGTH,
+            MAX_QUESTIONS_PER_CALL,
+            MIN_OPTIONS_PER_QUESTION,
+        )
+        from code_puppy.tools.ask_user_question.registration import (
+            register_ask_user_question,
+        )
+
+        agent = Agent("test")
+        register_ask_user_question(agent)
+
+        # Get the schema from the registered tool
+        toolset = agent._function_toolset
+        tool = toolset.tools["ask_user_question"]
+        schema = tool.function_schema.json_schema
+
+        # Check questions array constraints
+        questions_schema = schema["properties"]["questions"]
+        assert questions_schema["minItems"] == 1
+        assert questions_schema["maxItems"] == MAX_QUESTIONS_PER_CALL
+
+        # Check question object constraints
+        question_schema = questions_schema["items"]
+        assert (
+            question_schema["properties"]["question"]["maxLength"]
+            == MAX_QUESTION_LENGTH
+        )
+        assert question_schema["properties"]["header"]["maxLength"] == MAX_HEADER_LENGTH
+        assert "question" in question_schema["required"]
+        assert "header" in question_schema["required"]
+        assert "options" in question_schema["required"]
+
+        # Check options array constraints
+        options_schema = question_schema["properties"]["options"]
+        assert options_schema["minItems"] == MIN_OPTIONS_PER_QUESTION
+        assert options_schema["maxItems"] == MAX_OPTIONS_PER_QUESTION
+
+        # Check option object constraints
+        option_schema = options_schema["items"]
+        assert option_schema["properties"]["label"]["maxLength"] == MAX_LABEL_LENGTH
+        assert (
+            option_schema["properties"]["description"]["maxLength"]
+            == MAX_DESCRIPTION_LENGTH
+        )
+        assert "label" in option_schema["required"]


### PR DESCRIPTION
## Fix: Deduplicate skills and add explicit schema constraints to ask_user_question

### Summary

Two related fixes to improve LLM tool usage and prevent duplicate UI entries:

1. **Skill deduplication** - When the same skill exists in multiple directories, only the first-discovered one is kept
2. **ask_user_question schema** - LLMs now see explicit field structure and constraints, reducing validation errors

### Problem

**Skills:** When users pulled the same skill to multiple directories (e.g., `~/.code_puppy/skills/foo` and `~/.claude/skills/foo`), `/help` showed duplicate entries.

**ask_user_question:** The JSON schema sent to LLMs was too vague:
```json
{"items": {"additionalProperties": true, "type": "object"}}
```
LLMs had to guess the structure, often causing validation errors and retry loops like "Oops, let me fix that up!"

### Solution

**Skills:**
- Added check in `discover_skills()` to skip already-seen skill names
- First-discovered skill wins (based on directory priority order)
- Consistent with existing plugin-registered skill behavior

**ask_user_question:**
- Added `WithJsonSchema` with explicit inline schema (no `$defs/$ref` that confuse LLMs)
- Added `maxLength` constraints matching actual UI limits:
  | Field | Limit | Reason |
  |-------|-------|--------|
  | header | 25 | Fits left panel (36 - 14 padding = 22 usable) |
  | question | 500 | Reasonable question length |
  | label | 50 | Short option names |
  | description | 200 | Option explanations |
- Added `minItems`/`maxItems` for arrays (questions: 1-10, options: 2-6)

### Schema Before vs After

**Before:**
```json
{"questions": {"items": {"type": "object"}}}
```

**After:**
```json
{
  "questions": {
    "minItems": 1, "maxItems": 10,
    "items": {
      "required": ["question", "header", "options"],
      "properties": {
        "question": {"type": "string", "maxLength": 500},
        "header": {"type": "string", "maxLength": 25},
        "options": {
          "minItems": 2, "maxItems": 6,
          "items": {"properties": {"label": {"maxLength": 50}}}
        }
      }
    }
  }
}
```

### Testing

- Added `test_discover_skills_deduplicates_across_directories` 
- Added `test_schema_includes_all_maxlength_constraints`
- Updated existing tests to use constants instead of hardcoded values
- All 179 tests pass

### Files Changed

| File | Change |
|------|--------|
| `discovery.py` | Skip duplicate skill names |
| `constants.py` | MAX_HEADER_LENGTH: 60 → 25 |
| `registration.py` | WithJsonSchema + all constraints |
| `test_agent_skills.py` | Deduplication test |
| `test_registration.py` | Schema constraints test |
| `test_handler.py` | Use MAX_HEADER_LENGTH constant |
| `test_models.py` | Use MAX_HEADER_LENGTH constant |
