### PR TITLE
feat: add /theme plugin — interactive picker with 4-layer theming

### DIFF
--- a/code_puppy/plugins/theme/README.md
+++ b/code_puppy/plugins/theme/README.md
@@ -1,0 +1,76 @@
+# theme — `/theme` for Code Puppy
+
+A friendlier `/theme` command with an **interactive picker**, **live preview**,
+and **four layers of theming** — banner headers, body text, inline markup,
+AND the whole terminal window background/foreground/ANSI palette via OSC
+escape sequences (mure-style).
+
+## What you get
+
+```
+/theme
+```
+Launches a split-panel TUI with 10 themes (4 originals, 4 mure ports, surprise, reset).
+
+## What gets themed
+
+| Level | Surface | Themed? |
+|-------|---------|---------|
+| 0 | Banner headers (`[ THINKING ]`, etc.) | ✅ |
+| 1 | Body text (`emit_info`/`warning`/`success`/`error`/`debug` + diffs) | ✅ |
+| 2 | Inline Rich markup (`[bold cyan]`, `[dim cyan]`, `[magenta]`...) | ✅ |
+| 3 | **Entire terminal window** (bg/fg/16-color ANSI palette via OSC 10/11/4) | ✅ |
+
+**Semantic colors are preserved** at Level 2 (red errors stay angry, yellow warnings warn). Level 3 OSC remap is broader — it changes how *your terminal itself* interprets every ANSI color, so e.g. an `ls` ran after `/theme tokyo-night` will also look Tokyo Night. Pure terminal-level magic.
+
+Themes persist to your Code Puppy config and survive restarts. The OSC palette auto-resets on Code Puppy exit (via `atexit`) so you never get a stuck-pink terminal.
+
+## Bundled themes
+
+| # | Theme | Vibe |
+|---|-------|------|
+| 1 | 🌊 Ocean | cool blues, cyans & teals |
+| 2 | 🌲 Forest | earthy greens & olives |
+| 3 | 🌅 Sunset | warm reds, oranges & gold |
+| 4 | 🪩 Vaporwave | neon pinks & purples |
+| 5 | 🐱 Catppuccin Mocha | soothing pastel dark (mure default) |
+| 6 | ☕ Catppuccin Latte | soothing pastel light |
+| 7 | 🌃 Tokyo Night | neon-on-navy night |
+| 8 | 🍂 Gruvbox Dark | retro warm earth |
+| 9 | 🎲 Surprise Me | a fresh random remix every time |
+| 10 | 🔄 Restore Defaults | back to Code Puppy + terminal factory |
+
+## Power-user shortcuts
+
+```
+/theme 5            apply theme #5 (Catppuccin Mocha)
+/theme mocha        apply by alias (also: latte, tokyo, gruvbox)
+/theme tokyo-night  apply by canonical name
+/theme surprise     re-roll a random palette
+/theme default      restore Code Puppy + terminal factory colors
+/theme reset        alias of /theme default
+/theme show         dump current banner + content style mappings
+```
+
+## Architecture (Zen-compliant, one job per file)
+
+| File | Responsibility |
+|------|----------------|
+| `themes.py` | Theme catalog + banner/content/remap/palette construction |
+| `bundled_palettes.py` | Hex palette data (Catppuccin, Tokyo Night, Gruvbox, +4 originals) |
+| `content_styles.py` | Mutates `RichConsoleRenderer` style maps (Level 1) |
+| `rich_themes.py` | Monkey-patches `Console.get_style()` for inline remap (Level 2) |
+| `osc_palette.py` | OSC escape sequences for terminal-wide bg/fg/ANSI palette (Level 3) |
+| `picker.py` | prompt_toolkit split-panel TUI with live preview |
+| `register_callbacks.py` | `/theme` command handler, glue only |
+| `__init__.py` | Re-applies persisted (L1 + L2 + L3) on plugin load |
+
+## How each level works (the spicy bits)
+
+**Level 1** — mutates `code_puppy.messaging.rich_renderer.DEFAULT_STYLES` and walks live `RichConsoleRenderer._styles` via `gc.get_objects()`.
+
+**Level 2** — Rich's stock `Theme` only intercepts named styles, not base colors inside `[bold cyan]`. So we monkey-patch `Console.get_style()` on every live `Console`: every resolved `Style` flows throughd if `.color`/`.bgcolor` matches our remap, we swap. Tracked in a `WeakKeyDictionary` for clean swap-without-leak.
+
+**Level 3** — fires xterm OSC sequences (`\\033]10;#fg\\007`, `\\033]11;#bg\\007`, `\\033]4;N;#hex\\007`) which modern terminals honor terminal-wide. Auto-resets on exit via `atexit`. Persists across restarts via JSON in `puppy.cfg`. Supported in iTerm2, Terminal.app, Alacritty, kitty, ode, GNOME Terminal, Windows Terminal. Unsupported terminals silently ignore.
+
+Plays nice with `/colors` — same color pool, same config keys for banners.

--- a/code_puppy/plugins/theme/__init__.py
+++ b/code_puppy/plugins/theme/__init__.py
@@ -1,0 +1,16 @@
+"""Theme picker plugin for Code Puppy - banner + content + inline + terminal theming."""
+
+# Re-apply any persisted overrides as soon as the plugin loads so the user's
+# saved theme survives Code Puppy restarts. Banner colors live in puppy.cfg
+# (read lazily by the renderer), but content styles, Rich color remaps, and
+# OSC terminal palettes live in mutable state that resets each process.
+from . import content_styles as _cs
+from . import osc_palette as _osc
+from . import rich_themes as _rt
+
+for _mod in (_cs, _rt, _osc):
+    try:
+        _mod.reapply_from_config()
+    except Exception:
+        # Never let theme persistence break Code Puppy startup.
+        pass

--- a/code_puppy/plugins/theme/bundled_palettes.py
+++ b/code_puppy/plugins/theme/bundled_palettes.py
@@ -1,0 +1,273 @@
+"""Bundled terminal palettes for OSC-level theming.
+
+Each palette ships:
+    bg   = #rrggbb default background
+    fg   = #rrggbb default foreground
+    ansi = list of 16 #rrggbb hex strings (ANSI slots 0-15)
+
+The Catppuccin / Tokyo Night / Gruvbox palettes are the canonical
+upstream specs (same ones mure ships). The four original theme
+palettes (ocean/forest/sunset/vaporwave) are coherent extensions
+of their existing Rich color schemes.
+"""
+
+from __future__ import annotations
+
+# --- Mure-port bundled palettes ---------------------------------------------
+
+CATPPUCCIN_MOCHA = {
+    "bg": "#1e1e2e",
+    "fg": "#cdd6f4",
+    "ansi": [
+        "#45475a",
+        "#f38ba8",
+        "#a6e3a1",
+        "#f9e2af",
+        "#89b4fa",
+        "#f5c2e7",
+        "#94e2d5",
+        "#bac2de",
+        "#585b70",
+        "#f38ba8",
+        "#a6e3a1",
+        "#f9e2af",
+        "#89b4fa",
+        "#f5c2e7",
+        "#94e2d5",
+        "#a6adc8",
+    ],
+}
+
+CATPPUCCIN_LATTE = {
+    "bg": "#eff1f5",
+    "fg": "#4c4f69",
+    "ansi": [
+        "#5c5f77",
+        "#d20f39",
+        "#40a02b",
+        "#df8e1d",
+        "#1e66f5",
+        "#ea76cb",
+        "#179299",
+        "#acb0be",
+        "#6c6f85",
+        "#d20f39",
+        "#40a02b",
+        "#df8e1d",
+        "#1e66f5",
+        "#ea76cb",
+        "#179299",
+        "#bcc0cc",
+    ],
+}
+
+TOKYO_NIGHT = {
+    "bg": "#1a1b26",
+    "fg": "#c0caf5",
+    "ansi": [
+        "#15161e",
+        "#f7768e",
+        "#9ece6a",
+        "#e0af68",
+        "#7aa2f7",
+        "#bb9af7",
+        "#7dcfff",
+        "#a9b1d6",
+        "#414868",
+        "#f7768e",
+        "#9ece6a",
+        "#e0af68",
+        "#7aa2f7",
+        "#bb9af7",
+        "#7dcfff",
+        "#c0caf5",
+    ],
+}
+
+GRUVBOX_DARK = {
+    "bg": "#282828",
+    "fg": "#ebdbb2",
+    "ansi": [
+        "#282828",
+        "#cc241d",
+        "#98971a",
+        "#d79921",
+        "#458588",
+        "#b16286",
+        "#689d6a",
+        "#a89984",
+        "#928374",
+        "#fb4934",
+        "#b8bb26",
+        "#fabd2f",
+        "#83a598",
+        "#d3869b",
+        "#8ec07c",
+        "#ebdbb2",
+    ],
+}
+
+# --- Light-mode bundled palettes -------------------------------------------
+
+SOLARIZED_LIGHT = {
+    "bg": "#fdf6e3",
+    "fg": "#657b83",
+    "ansi": [
+        "#073642",
+        "#dc322f",
+        "#859900",
+        "#b58900",
+        "#268bd2",
+        "#d33682",
+        "#2aa198",
+        "#eee8d5",
+        "#fdf6e3",
+        "#cb4b16",
+        "#93a1a1",
+        "#839496",
+        "#657b83",
+        "#6c71c4",
+        "#586e75",
+        "#002b36",
+    ],
+}
+
+GITHUB_LIGHT = {
+    "bg": "#ffffff",
+    "fg": "#24292e",
+    "ansi": [
+        "#24292e",
+        "#d73a49",
+        "#28a745",
+        "#dbab09",
+        "#0366d6",
+        "#6f42c1",
+        "#1b7c83",
+        "#6a737d",
+        "#586069",
+        "#cb2431",
+        "#22863a",
+        "#b08800",
+        "#005cc5",
+        "#5a32a3",
+        "#3192aa",
+        "#d1d5da",
+    ],
+}
+
+ROSE_PINE_DAWN = {
+    "bg": "#faf4ed",
+    "fg": "#575279",
+    "ansi": [
+        "#f2e9e1",
+        "#b4637a",
+        "#56949f",
+        "#ea9d34",
+        "#286983",
+        "#907aa9",
+        "#d7827e",
+        "#575279",
+        "#9893a5",
+        "#b4637a",
+        "#56949f",
+        "#ea9d34",
+        "#286983",
+        "#907aa9",
+        "#d7827e",
+        "#cecacd",
+    ],
+}
+
+# --- Coherent palettes for the original 4 themes ---------------------------
+
+OCEAN = {
+    "bg": "#0a1929",
+    "fg": "#d6eaf8",
+    "ansi": [
+        "#0a1929",
+        "#e74c3c",
+        "#48c9b0",
+        "#f4d03f",
+        "#3498db",
+        "#1abc9c",
+        "#5dade2",
+        "#aed6f1",
+        "#34495e",
+        "#ec7063",
+        "#1abc9c",
+        "#f7dc6f",
+        "#5499c7",
+        "#48c9b0",
+        "#85c1e9",
+        "#ebf5fb",
+    ],
+}
+
+FOREST = {
+    "bg": "#1a2310",
+    "fg": "#e3eecc",
+    "ansi": [
+        "#1a2310",
+        "#c0392b",
+        "#27ae60",
+        "#d4ac0d",
+        "#7d6608",
+        "#16a085",
+        "#1e8449",
+        "#aed581",
+        "#52682d",
+        "#cd6155",
+        "#52be80",
+        "#f4d03f",
+        "#7d6608",
+        "#48c9b0",
+        "#7dcea0",
+        "#eaf2cf",
+    ],
+}
+
+SUNSET = {
+    "bg": "#2d1b0e",
+    "fg": "#ffe4cc",
+    "ansi": [
+        "#2d1b0e",
+        "#e74c3c",
+        "#d35400",
+        "#f39c12",
+        "#7d3c98",
+        "#c0392b",
+        "#e67e22",
+        "#fad7a0",
+        "#5d4037",
+        "#ec7063",
+        "#e67e22",
+        "#f9e79f",
+        "#a93226",
+        "#d35400",
+        "#f5b041",
+        "#fdebd0",
+    ],
+}
+
+VAPORWAVE = {
+    "bg": "#16002a",
+    "fg": "#ffe0ff",
+    "ansi": [
+        "#16002a",
+        "#ff6ec7",
+        "#48c9b0",
+        "#f7dc6f",
+        "#bb6bd9",
+        "#ec407a",
+        "#7fdbff",
+        "#e8daef",
+        "#5b2c6f",
+        "#ff79c6",
+        "#80deea",
+        "#fff59d",
+        "#d7bde2",
+        "#f06292",
+        "#80deea",
+        "#fce4ec",
+    ],
+}

--- a/code_puppy/plugins/theme/content_styles.py
+++ b/code_puppy/plugins/theme/content_styles.py
@@ -1,0 +1,146 @@
+"""Content-text style theming (level 1).
+
+The banner plugin already paints the banner headers. This module paints the
+body text underneath by mutating the `RichConsoleRenderer`'s style maps.
+
+Two upstream knobs:
+    code_puppy.messaging.rich_renderer.DEFAULT_STYLES  (MessageLevel -> style)
+    code_puppy.messaging.rich_renderer.DIFF_STYLES     ({add,remove,context} -> style)
+
+These dicts are **copied** by `RichConsoleRenderer.__init__`. Mutating them
+after construction won't affect already-running renderers, so we also reach
+into live renderer instances (via gc) and update their `_styles` dict in place.
+
+Pure logic + a small amount of surgical monkey patching. Config-persisted so
+preferences survive restarts.
+
+Zen: namespaces are one honking great idea; we keep everything in one place.
+"""
+
+from __future__ import annotations
+
+import gc
+from typing import Callable
+
+from code_puppy.config import get_value, set_config_value
+from code_puppy.messaging import rich_renderer
+from code_puppy.messaging.messages import MessageLevel
+
+# --- The 8 themable content keys -------------------------------------------
+# We expose a flat string-keyed namespace so config persistence is trivial.
+CONTENT_KEYS: tuple[str, ...] = (
+    "info",
+    "warning",
+    "success",
+    "error",
+    "debug",
+    "diff_add",
+    "diff_remove",
+    "diff_context",
+)
+
+_LEVEL_KEYS: dict[str, MessageLevel] = {
+    "info": MessageLevel.INFO,
+    "warning": MessageLevel.WARNING,
+    "success": MessageLevel.SUCCESS,
+    "error": MessageLevel.ERROR,
+    "debug": MessageLevel.DEBUG,
+}
+_DIFF_KEYS: dict[str, str] = {
+    "diff_add": "add",
+    "diff_remove": "remove",
+    "diff_context": "context",
+}
+
+# Snapshot taken at import time (before any mutation). This becomes our
+# "factory default" for restore.
+DEFAULT_CONTENT_STYLES: dict[str, str] = {
+    **{k: rich_renderer.DEFAULT_STYLES[lvl] for k, lvl in _LEVEL_KEYS.items()},
+    **{k: rich_renderer.DIFF_STYLES[v] for k, v in _DIFF_KEYS.items()},
+}
+
+_CONFIG_PREFIX = "content_style_"
+
+
+# --- Persistence helpers ----------------------------------------------------
+def _config_key(name: str) -> str:
+    return f"{_CONFIG_PREFIX}{name}"
+
+
+def get_content_style(name: str) -> str:
+    """Return current style for `name`, falling back to the factory default."""
+    if name not in DEFAULT_CONTENT_STYLES:
+        raise KeyError(f"Unknown content style: {name!r}")
+    return get_value(_config_key(name)) or DEFAULT_CONTENT_STYLES[name]
+
+
+def get_all_content_styles() -> dict[str, str]:
+    """Return the current effective mapping for every content key."""
+    return {name: get_content_style(name) for name in CONTENT_KEYS}
+
+
+def _persist(mapping: dict[str, str]) -> None:
+    for name, style in mapping.items():
+        set_config_value(_config_key(name), style)
+
+
+# --- Mutation -------------------------------------------------------------
+def _push_to_renderers(mapping: dict[str, str]) -> None:
+    """Push a {content_key: style} mapping into module dicts AND live renderers.
+
+    Live renderers copy `DEFAULT_STYLES` at __init__, so mutating the module
+    dict isn't enough — we walk live instances and patch them too.
+    """
+    # 1. Module-level dicts (in case fresh renderers spawn later)
+    for k, lvl in _LEVEL_KEYS.items():
+        rich_renderer.DEFAULT_STYLES[lvl] = mapping[k]
+    for k, diff_key in _DIFF_KEYS.items():
+        rich_renderer.DIFF_STYLES[diff_key] = mapping[k]
+
+    # 2. Live renderer instances (the ones actually painting your terminal)
+    try:
+        for obj in gc.get_objects():
+            if isinstance(obj, rich_renderer.RichConsoleRenderer):
+                styles = getattr(obj, "_styles", None)
+                if isinstance(styles, dict):
+                    for k, lvl in _LEVEL_KEYS.items():
+                        styles[lvl] = mapping[k]
+    except Exception:
+        # gc walks can be flaky in odd interpreters; never let that nuke UX
+        pass
+
+
+def apply_content_styles(
+    mapping: dict[str, str],
+    persist: bool = True,
+    setter: Callable[[dict[str, str]], None] | None = None,
+) -> None:
+    """Apply a content style mapping live + (optionally) persist it.
+
+    Args:
+        mapping: dict with every key in CONTENT_KEYS.
+        persist: if True, write to config so it survives restarts.
+        setter: injectable for tests; defaults to the real persister.
+    """
+    missing = set(CONTENT_KEYS) - mapping.keys()
+    if missing:
+        raise ValueError(f"Content style mapping missing keys: {sorted(missing)}")
+
+    _push_to_renderers(mapping)
+    if persist:
+        (setter or _persist)(mapping)
+
+
+def restore_defaults(persist: bool = True) -> dict[str, str]:
+    """Restore factory-default content styles. Returns the mapping applied."""
+    apply_content_styles(DEFAULT_CONTENT_STYLES, persist=persist)
+    return dict(DEFAULT_CONTENT_STYLES)
+
+
+def reapply_from_config() -> None:
+    """On plugin load, push any persisted overrides into the live renderer.
+
+    Safe to call multiple times; no-op if config has no overrides
+    (since get_content_style falls back to defaults).
+    """
+    _push_to_renderers(get_all_content_styles())

--- a/code_puppy/plugins/theme/osc_palette.py
+++ b/code_puppy/plugins/theme/osc_palette.py
@@ -1,0 +1,178 @@
+"""Terminal-level palette swap via OSC escape sequences.
+
+This module reaches *past* Code Puppy and recolors the whole terminal window
+(bg, fg, ANSI palette slots) using widely-supported xterm OSC sequences:
+
+    OSC 10 ; spec BEL    -> set default foreground
+    OSC 11 ; spec BEL    -> set default background
+    OSC  4 ; N ; spec BEL -> set ANSI palette slot N (0..15)
+    OSC 110 BEL          -> reset foreground
+    OSC 111 BEL          -> reset background
+    OSC 104 BEL          -> reset whole palette
+
+Supported by iTerm2, Terminal.app, Alacritty, kitty, VS Code, GNOME
+Terminal, Windows Terminal. Unsupported terminals silently ignore them.
+
+We always register an atexit handler so the terminal is restored when
+Code Puppy quits, even if the user forgets to /theme default first.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import sys
+from typing import Optional, Sequence
+
+from code_puppy.config import get_value, set_config_value
+
+BEL = "\007"
+ESC = "\033"
+
+_CONFIG_KEY = "osc_palette_json"
+_atexit_registered = False
+
+
+# --- Low-level emit ---------------------------------------------------------
+def _emit(seq: str) -> None:
+    """Write an escape sequence to stdout, ignoring failures (closed tty etc.)."""
+    try:
+        sys.stdout.write(seq)
+        sys.stdout.flush()
+    except Exception:
+        pass
+
+
+def _osc(code: str, *args: str) -> str:
+    """Build an OSC escape: ESC ] code ; args... BEL"""
+    payload = ";".join((code,) + args)
+    return f"{ESC}]{payload}{BEL}"
+
+
+# --- Public escape builders -------------------------------------------------
+def set_bg(color: str) -> None:
+    _emit(_osc("11", color))
+
+
+def set_fg(color: str) -> None:
+    _emit(_osc("10", color))
+
+
+def set_ansi_slot(slot: int, color: str) -> None:
+    if not 0 <= slot <= 15:
+        return
+    _emit(_osc("4", str(slot), color))
+
+
+def reset_bg() -> None:
+    _emit(_osc("111"))
+
+
+def reset_fg() -> None:
+    _emit(_osc("110"))
+
+
+def reset_ansi() -> None:
+    _emit(_osc("104"))
+
+
+# --- High-level API ---------------------------------------------------------
+def apply_palette(
+    palette: dict, persist: bool = True, register_reset: bool = True
+) -> None:
+    """Apply a palette dict to the live terminal.
+
+    Palette shape:
+        {
+            "bg":   "#rrggbb",                 # optional
+            "fg":   "#rrggbb",                 # optional
+            "ansi": ["#rrggbb", ...]           # optional, 0..16 entries
+        }
+
+    `persist=True` writes the palette to config so the next Code Puppy
+    session can replay it. `register_reset=True` ensures we always
+    restore the terminal at process exit.
+    """
+    if not isinstance(palette, dict):
+        return
+
+    bg = palette.get("bg")
+    fg = palette.get("fg")
+    ansi: Sequence[str] = palette.get("ansi") or []
+
+    if bg:
+        set_bg(bg)
+    if fg:
+        set_fg(fg)
+    for i, color in enumerate(ansi[:16]):
+        if color:
+            set_ansi_slot(i, color)
+
+    if persist:
+        try:
+            set_config_value(_CONFIG_KEY, json.dumps(palette))
+        except Exception:
+            pass
+
+    if register_reset:
+        _ensure_atexit_registered()
+
+
+def reset_palette(persist: bool = True) -> None:
+    """Restore the terminal's original bg/fg/ANSI palette."""
+    reset_ansi()
+    reset_bg()
+    reset_fg()
+    if persist:
+        try:
+            set_config_value(_CONFIG_KEY, "")
+        except Exception:
+            pass
+
+
+def get_saved_palette() -> Optional[dict]:
+    """Read the persisted palette (or None if nothing saved)."""
+    raw = get_value(_CONFIG_KEY)
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            return data
+    except Exception:
+        pass
+    return None
+
+
+def reapply_from_config() -> None:
+    """On plugin load, re-fire any persisted palette into the terminal."""
+    palette = get_saved_palette()
+    if palette:
+        apply_palette(palette, persist=False)
+
+
+# --- Cleanup ----------------------------------------------------------------
+def _at_exit_reset() -> None:
+    """Best-effort terminal restore on Python exit.
+
+    We DON'T touch persisted config here — if the user wants the palette
+    next session, they get it; this just makes sure the live terminal
+    doesn't stay stuck in a weird color after Code Puppy dies.
+    """
+    try:
+        reset_ansi()
+        reset_bg()
+        reset_fg()
+    except Exception:
+        pass
+
+
+def _ensure_atexit_registered() -> None:
+    global _atexit_registered
+    if _atexit_registered:
+        return
+    try:
+        atexit.register(_at_exit_reset)
+        _atexit_registered = True
+    except Exception:
+        pass

--- a/code_puppy/plugins/theme/picker.py
+++ b/code_puppy/plugins/theme/picker.py
@@ -1,0 +1,319 @@
+"""Interactive theme picker TUI.
+
+Reuses prompt_toolkit's full-screen pattern (cribbed from
+``code_puppy.command_line.colors_menu``) but pared down to the curated
+theme choices, with a live preview that shows banners AND content text
+in the theme's body styles.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import random
+import sys
+from typing import Optional
+
+from prompt_toolkit import Application
+from prompt_toolkit.formatted_text import ANSI, FormattedText
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.layout import Layout, VSplit, Window
+from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.widgets import Frame
+from rich.console import Console
+
+from code_puppy.command_line.colors_menu import (
+    BANNER_DISPLAY_INFO,
+    BANNER_SAMPLE_CONTENT,
+)
+
+from .themes import (
+    MENU,
+    color_remap_for,
+    colors_for,
+    content_styles_for,
+    terminal_palette_for,
+)
+
+# A few representative banners to show in the preview pane (keeps it readable).
+PREVIEW_BANNERS = [
+    "thinking",
+    "agent_response",
+    "shell_command",
+    "read_file",
+    "edit_file",
+    "grep",
+    "invoke_agent",
+    "subagent_response",
+]
+
+# Sample lines to demonstrate body content styling.
+CONTENT_SAMPLES = [
+    ("info", "i  Heads up, this is an info message."),
+    ("success", "v Success - task finished cleanly."),
+    ("warning", "! Warning - proceeding with caution."),
+    ("error", "x Error - something went wrong."),
+    ("debug", ". debug trace (only shown if you ask)"),
+]
+
+# Inline-markup samples to demonstrate the Level 2 color remap.
+# These mirror the kind of hardcoded tags scattered through the renderer.
+INLINE_MARKUP_SAMPLES = [
+    "[bold cyan]bold cyan headline[/bold cyan]",
+    "[dim cyan]dim cyan detail[/dim cyan]",
+    "[bold blue]bold blue label[/bold blue]",
+    "[magenta]magenta accent[/magenta]",
+]
+
+
+def _render_preview(theme_name: str, surprise_seed: int) -> ANSI:
+    """Render a full-color preview of the theme using Rich -> ANSI.
+
+    ``surprise_seed`` makes the "Surprise Me" preview stable while highlighted
+    (otherwise it would re-roll on every redraw - dizzying).
+    """
+    buffer = io.StringIO()
+    console = Console(
+        file=buffer,
+        force_terminal=True,
+        width=70,
+        legacy_windows=False,
+        color_system="truecolor",
+        no_color=False,
+        force_interactive=True,
+    )
+
+    rng = random.Random(surprise_seed) if theme_name == "surprise" else None
+    banner_mapping = colors_for(theme_name, rng=rng)
+    content_mapping = content_styles_for(theme_name, rng=rng)
+    color_remap = color_remap_for(theme_name, rng=rng)
+    theme = dict(MENU)[theme_name]
+
+    # Apply the Level 2 remap to *this preview console only* so users see
+    # exactly what the inline markup will look like.
+    from . import rich_themes as rt
+
+    if color_remap:
+        rt._install_patch(console, color_remap)
+
+    console.print("[bold]" + "=" * 60 + "[/bold]")
+    console.print(
+        f"[bold cyan] {theme['icon']} {theme['label']}[/bold cyan]  "
+        f"[dim]- {theme['blurb']}[/dim]"
+    )
+    console.print("[bold]" + "=" * 60 + "[/bold]")
+    console.print()
+
+    # Banner samples
+    for banner in PREVIEW_BANNERS:
+        if banner not in banner_mapping:
+            continue
+        display, icon = BANNER_DISPLAY_INFO[banner]
+        color = banner_mapping[banner]
+        icon_str = f" {icon}" if icon else ""
+        console.print(
+            f"[bold white on {color}] {display} [/bold white on {color}]{icon_str}"
+        )
+        sample = BANNER_SAMPLE_CONTENT.get(banner, "")
+        first_line = sample.split("\n", 1)[0]
+        if first_line:
+            console.print(f"    [dim]{first_line}[/dim]")
+        console.print()
+
+    # Content text samples (the new bit - Level 1 theming)
+    console.print("[bold]" + "-" * 60 + "[/bold]")
+    console.print("[bold dim]content text styles:[/bold dim]")
+    for key, text in CONTENT_SAMPLES:
+        style = content_mapping[key]
+        console.print(f"  [{style}]{text}[/]")
+
+    # Inline markup samples (Level 2 - remapped colors)
+    console.print("[bold dim]inline markup remap:[/bold dim]")
+    for sample in INLINE_MARKUP_SAMPLES:
+        console.print("  " + sample)
+    console.print("[bold]" + "=" * 60 + "[/bold]")
+
+    if theme_name == "surprise":
+        console.print(
+            "[dim italic]Every apply re-rolls a fresh random palette.[/dim italic]"
+        )
+    elif theme_name == "default":
+        console.print(
+            "[dim italic]Resets banners + content to Code Puppy defaults.[/dim italic]"
+        )
+
+    # Terminal-palette note (Level 3 - OSC sequences recolor the whole window)
+    tp = terminal_palette_for(theme_name)
+    if tp:
+        bg = tp.get("bg", "?")
+        fg = tp.get("fg", "?")
+        ansi = tp.get("ansi") or []
+        ansi_note = f" + {len(ansi)}-color ANSI palette" if ansi else ""
+
+        # Big swatch block: shows the actual bg/fg combo so the user can
+        # judge readability BEFORE applying. The OSC isn't fired live
+        # (would flicker the whole terminal on every arrow keypress).
+        console.print("[bold dim]terminal palette preview:[/bold dim]")
+        sample_bg = bg if bg.startswith("#") else "#000000"
+        sample_fg = fg if fg.startswith("#") else "#ffffff"
+        # Two rows of the bg/fg combo with real text on top for readability check.
+        console.print(
+            f"  [{sample_fg} on {sample_bg}]"
+            f"  the quick brown puppy jumps over a sleepy log   [/]"
+        )
+        console.print(
+            f"  [{sample_fg} on {sample_bg}]"
+            f"  bg={bg}  fg={fg}{' ' * max(0, 18 - len(bg) - len(fg))}  [/]"
+        )
+
+        # ANSI palette: 16 swatches in 2 rows of 8 so users see the rainbow.
+        if ansi:
+            console.print("[bold dim]ANSI palette (slots 0-15):[/bold dim]")
+            for row_start in (0, 8):
+                line = "  "
+                for slot in range(row_start, min(row_start + 8, len(ansi))):
+                    swatch_color = (
+                        ansi[slot] if ansi[slot].startswith("#") else "#888888"
+                    )
+                    line += f"[on {swatch_color}]      [/]"
+                console.print(line)
+
+        console.print(
+            f"[bold yellow]\u26a1[/bold yellow] [dim]Enter applies these to the whole terminal"
+            f"{ansi_note}.[/dim]"
+        )
+    elif theme_name == "default":
+        console.print(
+            "[bold yellow]\u26a1[/bold yellow] [dim]Resets terminal bg/fg/ANSI palette too.[/dim]"
+        )
+    return ANSI(buffer.getvalue())
+
+
+def _format_menu(selected_index: int) -> FormattedText:
+    """Build the left-hand menu text with a highlighted selection."""
+    lines: list[tuple[str, str]] = [
+        ("bold cyan", "Pick a Theme"),
+        ("", "\n\n"),
+    ]
+    for i, (name, theme) in enumerate(MENU):
+        prefix = "> " if i == selected_index else "  "
+        style = "fg:ansigreen bold" if i == selected_index else ""
+        line = f"{prefix}{i + 1}. {theme['icon']} {theme['label']}"
+        lines.append((style, line))
+        lines.append(("", "\n"))
+        lines.append(("fg:ansigray", f"     {theme['blurb']}"))
+        lines.append(("", "\n\n"))
+
+    lines.append(("", "\n"))
+    lines.append(
+        (
+            "fg:ansicyan",
+            "Up/Down Navigate  |  Enter Apply  |  Esc / Ctrl-C Cancel",
+        )
+    )
+    return FormattedText(lines)
+
+
+async def interactive_theme_picker() -> Optional[str]:
+    """Show the full-screen theme picker.
+
+    Returns:
+        The selected theme key (e.g. ``"ocean"``) or ``None`` if cancelled.
+    """
+    from code_puppy.tools.command_runner import set_awaiting_user_input
+
+    selected = [0]
+    result: list[Optional[str]] = [None]
+    # Stable seed for "Surprise Me" preview per highlight; bumps on each focus.
+    surprise_seed = [random.randint(0, 1_000_000)]
+
+    set_awaiting_user_input(True)
+    sys.stdout.write("\033[?1049h\033[2J\033[H")
+    sys.stdout.flush()
+    await asyncio.sleep(0.05)
+
+    kb = KeyBindings()
+
+    def _refresh_surprise_seed_if_focused() -> None:
+        name, _ = MENU[selected[0]]
+        if name == "surprise":
+            surprise_seed[0] = random.randint(0, 1_000_000)
+
+    @kb.add("up")
+    @kb.add("c-p")
+    def _(event):
+        selected[0] = (selected[0] - 1) % len(MENU)
+        _refresh_surprise_seed_if_focused()
+        event.app.invalidate()
+
+    @kb.add("down")
+    @kb.add("c-n")
+    def _(event):
+        selected[0] = (selected[0] + 1) % len(MENU)
+        _refresh_surprise_seed_if_focused()
+        event.app.invalidate()
+
+    @kb.add("enter")
+    def _(event):
+        result[0] = MENU[selected[0]][0]
+        event.app.exit()
+
+    @kb.add("escape")
+    @kb.add("c-c")
+    def _(event):
+        result[0] = None
+        event.app.exit()
+
+    def _current_preview_style() -> str:
+        """Dynamic prompt_toolkit style for the preview pane.
+
+        Paints the WHOLE right pane background with the selected theme's bg,
+        and picks a readable fg, so the user instantly sees the new color.
+        Updates every render via prompt_toolkit's dynamic-style support.
+        """
+        name, _ = MENU[selected[0]]
+        try:
+            tp = terminal_palette_for(name)
+        except Exception:
+            tp = None
+        if not tp:
+            return ""
+        bg = tp.get("bg")
+        fg = tp.get("fg", "")
+        parts = []
+        if bg:
+            parts.append(f"bg:{bg}")
+        if fg:
+            parts.append(f"fg:{fg}")
+        return " ".join(parts)
+
+    left = Window(
+        content=FormattedTextControl(lambda: _format_menu(selected[0])),
+        width=40,
+    )
+    right = Window(
+        content=FormattedTextControl(
+            lambda: _render_preview(MENU[selected[0]][0], surprise_seed[0])
+        ),
+        style=_current_preview_style,
+    )
+
+    layout = Layout(
+        VSplit([Frame(left, title="Themes"), Frame(right, title="Live Preview")])
+    )
+    app = Application(
+        layout=layout,
+        key_bindings=kb,
+        full_screen=False,
+        mouse_support=False,
+        color_depth="DEPTH_24_BIT",
+    )
+
+    try:
+        await app.run_async()
+    finally:
+        set_awaiting_user_input(False)
+        sys.stdout.write("\033[?1049l")
+        sys.stdout.flush()
+
+    return result[0]

--- a/code_puppy/plugins/theme/register_callbacks.py
+++ b/code_puppy/plugins/theme/register_callbacks.py
@@ -1,0 +1,161 @@
+"""/theme — pick a curated banner+content color theme, interactively or by name.
+
+UX:
+  /theme               → interactive split-panel picker with live preview
+  /theme <N>           → apply theme number N (1-6)
+  /theme <name>        → apply by name (ocean, forest, sunset, vaporwave,
+                         surprise, default)
+  /theme reset         → restore Code Puppy defaults (alias of /theme default)
+  /theme show          → show current banner → color mapping
+
+The 5th option (🎲 Surprise Me) re-rolls a random palette every time.
+The 6th option (🔄 Restore Defaults) puts everything back to factory.
+
+Plays nice with /colors — same color pool, same config keys.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+
+from code_puppy.callbacks import register_callback
+from code_puppy.command_line.colors_menu import BANNER_DISPLAY_INFO
+from code_puppy.config import (
+    get_all_banner_colors,
+    reset_all_banner_colors,
+)
+from code_puppy.messaging import emit_error, emit_info, emit_warning
+
+from . import content_styles as cs
+from . import osc_palette as osc
+from . import rich_themes as rt
+from .picker import interactive_theme_picker
+from .themes import (
+    MENU_BY_NAME,
+    apply,
+    color_remap_for,
+    colors_for,
+    content_styles_for,
+    resolve_theme_arg,
+    terminal_palette_for,
+)
+
+_INTERACTIVE_TIMEOUT_SECONDS = 300  # 5 min — generous; user is browsing
+
+
+def _custom_help():
+    return [
+        ("theme", "Pick a curated banner+content color theme (interactive: /theme)"),
+    ]
+
+
+# --- Rendering helpers ------------------------------------------------------
+# Note: emit_info escapes Rich markup for safety, so these helpers emit
+# plain text only. Pretty visual previews live in the picker (which uses
+# Rich directly).
+def _format_banner_mapping(mapping: dict[str, str]) -> str:
+    lines = []
+    for banner, color in mapping.items():
+        display, icon = BANNER_DISPLAY_INFO.get(banner, (banner, ""))
+        prefix = f"{icon} " if icon else "  "
+        lines.append(f"  {prefix}{display:<24} -> {color}")
+    return "\n".join(lines)
+
+
+def _format_content_mapping(mapping: dict[str, str]) -> str:
+    lines = []
+    for key, style in mapping.items():
+        lines.append(f"  {key:<14} -> {style}")
+    return "\n".join(lines)
+
+
+def _announce_applied(theme_name: str) -> None:
+    """Quietly confirm the theme is applied. Mappings available via /theme show."""
+    theme = MENU_BY_NAME[theme_name]
+    emit_info(
+        f"{theme['icon']} {theme['label']} theme applied. "
+        f"(/theme show to inspect, /theme default to undo)"
+    )
+
+
+# --- Interactive flow -------------------------------------------------------
+def _run_interactive_picker() -> str | None:
+    """Run the async TUI from a sync command handler."""
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        future = executor.submit(lambda: asyncio.run(interactive_theme_picker()))
+        return future.result(timeout=_INTERACTIVE_TIMEOUT_SECONDS)
+
+
+def _apply_theme(theme_name: str) -> None:
+    """Apply banner colors + content styles + inline remap + terminal palette.
+
+    `default` is special: resets banner config, content styles, Rich color
+    remap, AND the terminal-level OSC palette.
+    """
+    if theme_name == "default":
+        reset_all_banner_colors()
+        cs.restore_defaults()
+        rt.restore()
+        osc.reset_palette()
+    else:
+        banner_mapping = colors_for(theme_name)
+        content_mapping = content_styles_for(theme_name)
+        remap = color_remap_for(theme_name)
+        terminal_palette = terminal_palette_for(theme_name)
+        apply(banner_mapping)
+        cs.apply_content_styles(content_mapping)
+        rt.apply_remap(remap)
+        if terminal_palette:
+            osc.apply_palette(terminal_palette)
+
+    _announce_applied(theme_name)
+
+
+# --- Command handler --------------------------------------------------------
+def _handle_theme(command: str, name: str):
+    if name != "theme":
+        return None
+
+    parts = command.split()
+    sub = parts[1].lower() if len(parts) > 1 else ""
+
+    if sub == "":
+        try:
+            chosen = _run_interactive_picker()
+        except Exception as e:  # pragma: no cover — defensive UX
+            emit_error(f"Theme picker failed: {e}")
+            return True
+        if chosen is None:
+            emit_info("🎨 Theme unchanged.")
+            return True
+        _apply_theme(chosen)
+        return True
+
+    if sub == "show":
+        emit_info(
+            "🎨 Current theme:\n"
+            "Banners:\n"
+            + _format_banner_mapping(get_all_banner_colors())
+            + "\nContent text:\n"
+            + _format_content_mapping(cs.get_all_content_styles())
+        )
+        return True
+
+    theme_name = resolve_theme_arg(sub)
+    if theme_name is None:
+        valid = ", ".join(
+            k for k in MENU_BY_NAME if k not in ("random", "reset", "defaults")
+        )
+        emit_warning(
+            f"Unknown theme '{sub}'. Try /theme for the picker, "
+            f"or pick one of: {valid}."
+        )
+        return True
+
+    _apply_theme(theme_name)
+    return True
+
+
+register_callback("custom_command_help", _custom_help)
+register_callback("custom_command", _handle_theme)

--- a/code_puppy/plugins/theme/rich_themes.py
+++ b/code_puppy/plugins/theme/rich_themes.py
@@ -1,0 +1,202 @@
+"""Level 2 theming: live remap of inline Rich color names.
+
+The renderer is full of hardcoded inline markup like `[bold cyan]`,
+`[dim cyan]`, `[dim white]`, etc. Rich's stock `Theme` class can intercept
+top-level *named styles* (`[my_style]`) but it does NOT remap base color
+names embedded inside complex styles (`[bold cyan]` → still cyan).
+
+So we go one level deeper: monkey-patch `Console.get_style()` on live console
+instances. Every parsed style flows through it; we inspect the resolved
+`Style.color` (and `bgcolor`) and swap it out if it's in our remap dict.
+
+What we DO remap by default: "decorative" colors (cyan, blue, magenta,
+bright_*). What we DON'T touch:
+    - red    (errors must look angry)
+    - yellow (warnings)
+    - green  (success / diff add)
+    - white  (high-contrast text)
+
+That keeps semantic meaning intact across all themes.
+
+Persisted via config so the patch survives Code Puppy restarts.
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+import weakref
+from typing import Callable, Optional
+
+from rich.color import Color
+from rich.console import Console
+from rich.style import Style
+
+from code_puppy.config import get_value, set_config_value
+from code_puppy.messaging import rich_renderer
+
+# --- Remap registry ---------------------------------------------------------
+# Per-console bookkeeping: original get_style + current remap dict.
+# WeakKeyDictionary so we don't keep dead consoles alive.
+_PATCHED: "weakref.WeakKeyDictionary[Console, Callable]" = weakref.WeakKeyDictionary()
+
+_CONFIG_KEY = "rich_color_remap_json"
+
+
+# --- Color-swap mechanics ---------------------------------------------------
+def _safe_parse(name: str) -> Optional[Color]:
+    """Parse a color name, returning None if Rich can't handle it.
+
+    Rich's named-color set is a strict subset of what some palettes use
+    (e.g. ``cyan4`` and ``dark_orchid`` exist as banner backgrounds but
+    aren't parseable as standalone Colors). Never let one bad name take
+    down rendering.
+    """
+    try:
+        return Color.parse(name)
+    except Exception:
+        return None
+
+
+def _swap_color(style: Style, remap: dict[str, str]) -> Style:
+    """Return a new Style with color/bgcolor remapped if names match."""
+    changes = {}
+    if style.color is not None and style.color.name in remap:
+        new = _safe_parse(remap[style.color.name])
+        if new is not None:
+            changes["color"] = new
+    if style.bgcolor is not None and style.bgcolor.name in remap:
+        new = _safe_parse(remap[style.bgcolor.name])
+        if new is not None:
+            changes["bgcolor"] = new
+    if not changes:
+        return style
+    return style + Style(**changes)
+
+
+def _install_patch(console: Console, remap: dict[str, str]) -> None:
+    """Patch a console's get_style to apply the remap. Idempotent."""
+    if not remap:
+        _uninstall_patch(console)
+        return
+
+    if console in _PATCHED:
+        # Already patched — just swap the remap (closure captures it).
+        # Re-install to refresh the captured remap dict.
+        _uninstall_patch(console)
+
+    original = console.get_style
+
+    def patched(name, *, default=None):
+        style = original(name, default=default)
+        return _swap_color(style, remap)
+
+    console.get_style = patched  # type: ignore[method-assign]
+    _PATCHED[console] = original
+
+
+def _uninstall_patch(console: Console) -> None:
+    """Restore a console's original get_style. Safe if not patched."""
+    original = _PATCHED.pop(console, None)
+    if original is not None:
+        try:
+            console.get_style = original  # type: ignore[method-assign]
+        except Exception:
+            pass
+
+
+# --- Live-console discovery -------------------------------------------------
+def _live_consoles() -> list[Console]:
+    """Find every live rich.console.Console instance via gc.
+
+    Cheap heuristic but reliable. We patch them all so subagent renderers
+    and the interactive renderer get themed alongside the bus renderer.
+    """
+    consoles: list[Console] = []
+    try:
+        for obj in gc.get_objects():
+            if isinstance(obj, Console):
+                consoles.append(obj)
+        # Also grab any Console hanging off a live RichConsoleRenderer
+        # (belt-and-suspenders; usually already covered by the above).
+        for obj in gc.get_objects():
+            if isinstance(obj, rich_renderer.RichConsoleRenderer):
+                c = getattr(obj, "_console", None)
+                if isinstance(c, Console) and c not in consoles:
+                    consoles.append(c)
+    except Exception:
+        pass
+    return consoles
+
+
+# --- Public API -------------------------------------------------------------
+def apply_remap(remap: dict[str, str], persist: bool = True) -> int:
+    """Apply a color remap to every live Console. Returns how many got patched.
+
+    Empty remap = restore (un-patch everything).
+    """
+    consoles = _live_consoles()
+    if remap:
+        for c in consoles:
+            _install_patch(c, remap)
+    else:
+        for c in consoles:
+            _uninstall_patch(c)
+
+    if persist:
+        try:
+            set_config_value(_CONFIG_KEY, json.dumps(remap))
+        except Exception:
+            pass
+    return len(consoles)
+
+
+def restore() -> int:
+    """Remove the color remap from every live console."""
+    return apply_remap({}, persist=True)
+
+
+def get_saved_remap() -> dict[str, str]:
+    """Read the persisted remap from config (or {} if none)."""
+    raw = get_value(_CONFIG_KEY)
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            return {str(k): str(v) for k, v in data.items()}
+    except Exception:
+        pass
+    return {}
+
+
+def reapply_from_config() -> None:
+    """Push any persisted remap back into live consoles. Safe to call repeatedly."""
+    remap = get_saved_remap()
+    if remap:
+        apply_remap(remap, persist=False)
+
+
+# --- Reasonable default palette presets -------------------------------------
+# Used by themes.py. Keep semantic colors (red/yellow/green) untouched.
+def make_remap(
+    cyan: Optional[str] = None,
+    blue: Optional[str] = None,
+    magenta: Optional[str] = None,
+    bright_cyan: Optional[str] = None,
+    bright_blue: Optional[str] = None,
+    bright_magenta: Optional[str] = None,
+    white: Optional[str] = None,
+) -> dict[str, str]:
+    """Build a clean remap dict from optional kwargs (None = skip)."""
+    mapping = {
+        "cyan": cyan,
+        "blue": blue,
+        "magenta": magenta,
+        "bright_cyan": bright_cyan,
+        "bright_blue": bright_blue,
+        "bright_magenta": bright_magenta,
+        "white": white,
+    }
+    # Drop entries Rich can't parse so a typo in a theme never crashes the UI.
+    return {k: v for k, v in mapping.items() if v and _safe_parse(v) is not None}

--- a/code_puppy/plugins/theme/themes.py
+++ b/code_puppy/plugins/theme/themes.py
@@ -1,0 +1,602 @@
+"""Theme definitions and application logic.
+
+Pure module: no I/O beyond reading/writing config via code_puppy.config and
+content_styles. Testable in isolation. Zen: simple is better than complex.
+"""
+
+from __future__ import annotations
+
+import random
+from itertools import cycle
+from typing import Callable
+
+from code_puppy.command_line.colors_menu import BANNER_COLORS, BANNER_DISPLAY_INFO
+from code_puppy.config import set_banner_color
+
+from . import bundled_palettes as bp
+from . import content_styles as cs
+from . import rich_themes as rt
+
+# Palette = the Rich color values from /colors (deduped, sorted for determinism)
+PALETTE: list[str] = sorted(set(BANNER_COLORS.values()))
+BANNER_KEYS: list[str] = list(BANNER_DISPLAY_INFO.keys())
+
+
+# A smaller palette suited to *foreground* text (the full PALETTE includes some
+# very dark colors that are unreadable as text on a dark terminal, and a
+# couple of names like ``cyan4`` / ``dark_orchid`` that Rich can't even parse
+# as standalone Colors despite working as background tags).
+def _parseable(name: str) -> bool:
+    from rich.color import Color
+
+    try:
+        Color.parse(name)
+        return True
+    except Exception:
+        return False
+
+
+TEXT_PALETTE: list[str] = sorted(
+    {
+        c
+        for c in PALETTE
+        if _parseable(c)
+        and not any(bad in c for bad in ("black", "navy_blue", "dark_red", "grey0"))
+    }
+)
+
+# --- Curated themes ---------------------------------------------------------
+# Each curated theme is just an ordered list of palette colors; we cycle
+# through them to color every banner. Keep it small + opinionated.
+CURATED_THEMES: dict[str, dict] = {
+    "ocean": {
+        "icon": "🌊",
+        "label": "Ocean",
+        "blurb": "cool blues, cyans & teals",
+        "colors": [
+            "deep_sky_blue4",
+            "cyan4",
+            "dodger_blue3",
+            "dark_turquoise",
+            "steel_blue",
+            "blue",
+            "navy_blue",
+            "dark_cyan",
+            "aquamarine1",
+        ],
+        "content_styles": {
+            "info": "cyan",
+            "warning": "yellow",
+            "success": "bright_cyan",
+            "error": "bold red",
+            "debug": "dim cyan",
+            "diff_add": "bright_cyan",
+            "diff_remove": "red",
+            "diff_context": "dim blue",
+        },
+        "color_remap": rt.make_remap(
+            cyan="deep_sky_blue4",
+            blue="dodger_blue3",
+            magenta="dark_turquoise",
+            bright_cyan="aquamarine1",
+            bright_blue="steel_blue",
+            bright_magenta="dark_cyan",
+        ),
+        "terminal_palette": bp.OCEAN,
+    },
+    "forest": {
+        "icon": "🌲",
+        "label": "Forest",
+        "blurb": "earthy greens & olives",
+        "colors": [
+            "green4",
+            "dark_green",
+            "dark_sea_green4",
+            "spring_green4",
+            "chartreuse4",
+            "dark_olive_green3",
+            "dark_goldenrod",
+        ],
+        "content_styles": {
+            "info": "green",
+            "warning": "dark_goldenrod",
+            "success": "bright_green",
+            "error": "bold red",
+            "debug": "dim green",
+            "diff_add": "bright_green",
+            "diff_remove": "red",
+            "diff_context": "dim green",
+        },
+        "color_remap": rt.make_remap(
+            cyan="spring_green4",
+            blue="green4",
+            magenta="dark_sea_green4",
+            bright_cyan="chartreuse4",
+            bright_blue="dark_green",
+            bright_magenta="dark_olive_green3",
+        ),
+        "terminal_palette": bp.FOREST,
+    },
+    "sunset": {
+        "icon": "🌅",
+        "label": "Sunset",
+        "blurb": "warm reds, oranges & gold",
+        "colors": [
+            "orange_red1",
+            "dark_orange3",
+            "gold3",
+            "red3",
+            "indian_red",
+            "dark_red",
+            "hot_pink3",
+        ],
+        "content_styles": {
+            "info": "gold3",
+            "warning": "dark_orange3",
+            "success": "orange_red1",
+            "error": "bold red",
+            "debug": "dim yellow",
+            "diff_add": "gold3",
+            "diff_remove": "red3",
+            "diff_context": "dim yellow",
+        },
+        "color_remap": rt.make_remap(
+            cyan="gold3",
+            blue="orange_red1",
+            magenta="hot_pink3",
+            bright_cyan="dark_orange3",
+            bright_blue="indian_red",
+            bright_magenta="hot_pink3",
+        ),
+        "terminal_palette": bp.SUNSET,
+    },
+    "vaporwave": {
+        "icon": "🪩",
+        "label": "Vaporwave",
+        "blurb": "neon pinks & purples",
+        "colors": [
+            "hot_pink3",
+            "dark_magenta",
+            "purple",
+            "dark_violet",
+            "medium_purple4",
+            "dark_orchid",
+            "deep_pink4",
+            "pale_violet_red1",
+        ],
+        "content_styles": {
+            "info": "magenta",
+            "warning": "hot_pink3",
+            "success": "bright_magenta",
+            "error": "bold red",
+            "debug": "dim magenta",
+            "diff_add": "bright_magenta",
+            "diff_remove": "red",
+            "diff_context": "dim magenta",
+        },
+        "color_remap": rt.make_remap(
+            cyan="hot_pink3",
+            blue="purple",
+            magenta="dark_magenta",
+            bright_cyan="pale_violet_red1",
+            bright_blue="dark_violet",
+            bright_magenta="medium_orchid",
+        ),
+        "terminal_palette": bp.VAPORWAVE,
+    },
+    # --- Mure-port "palette-first" themes ---------------------------------
+    # These rely primarily on the OSC ANSI palette swap (slot 6 = cyan, etc.)
+    # so Rich's own [cyan]/[blue]/[magenta] tags automatically render in the
+    # new palette. Rich-level color_remap stays empty for these.
+    "catppuccin-mocha": {
+        "icon": "🐱",
+        "label": "Catppuccin Mocha",
+        "blurb": "soothing pastel dark",
+        "colors": [
+            "cyan",
+            "magenta",
+            "blue",
+            "green",
+            "yellow",
+            "red",
+            "bright_cyan",
+            "bright_magenta",
+        ],
+        "content_styles": {
+            "info": "cyan",
+            "warning": "yellow",
+            "success": "green",
+            "error": "bold red",
+            "debug": "dim white",
+            "diff_add": "green",
+            "diff_remove": "red",
+            "diff_context": "dim white",
+        },
+        "color_remap": {},
+        "terminal_palette": bp.CATPPUCCIN_MOCHA,
+    },
+    "catppuccin-latte": {
+        "icon": "☕",
+        "label": "Catppuccin Latte",
+        "blurb": "soothing pastel light",
+        "colors": [
+            "blue",
+            "magenta",
+            "green",
+            "yellow",
+            "cyan",
+            "red",
+            "bright_blue",
+            "bright_magenta",
+        ],
+        "content_styles": {
+            "info": "blue",
+            "warning": "yellow",
+            "success": "green",
+            "error": "bold red",
+            "debug": "dim white",
+            "diff_add": "green",
+            "diff_remove": "red",
+            "diff_context": "dim white",
+        },
+        "color_remap": {},
+        "terminal_palette": bp.CATPPUCCIN_LATTE,
+    },
+    "tokyo-night": {
+        "icon": "🌃",
+        "label": "Tokyo Night",
+        "blurb": "neon-on-navy night",
+        "colors": [
+            "blue",
+            "cyan",
+            "magenta",
+            "green",
+            "yellow",
+            "red",
+            "bright_blue",
+            "bright_cyan",
+        ],
+        "content_styles": {
+            "info": "cyan",
+            "warning": "yellow",
+            "success": "green",
+            "error": "bold red",
+            "debug": "dim white",
+            "diff_add": "green",
+            "diff_remove": "red",
+            "diff_context": "dim white",
+        },
+        "color_remap": {},
+        "terminal_palette": bp.TOKYO_NIGHT,
+    },
+    "gruvbox-dark": {
+        "icon": "🍂",
+        "label": "Gruvbox Dark",
+        "blurb": "retro warm earth",
+        "colors": [
+            "yellow",
+            "red",
+            "green",
+            "cyan",
+            "magenta",
+            "blue",
+            "bright_yellow",
+            "bright_red",
+        ],
+        "content_styles": {
+            "info": "yellow",
+            "warning": "bright_yellow",
+            "success": "green",
+            "error": "bold red",
+            "debug": "dim white",
+            "diff_add": "green",
+            "diff_remove": "red",
+            "diff_context": "dim white",
+        },
+        "color_remap": {},
+        "terminal_palette": bp.GRUVBOX_DARK,
+    },
+    # --- Light-mode themes ------------------------------------------------
+    # For light themes, `debug` uses dim *black* (not white) so dim text stays
+    # visible against a light background.
+    "solarized-light": {
+        "icon": "☀️",
+        "label": "Solarized Light",
+        "blurb": "classic warm beige with calm accents",
+        "colors": [
+            "blue",
+            "magenta",
+            "green",
+            "yellow",
+            "cyan",
+            "red",
+            "bright_blue",
+            "bright_magenta",
+        ],
+        "content_styles": {
+            "info": "blue",
+            "warning": "yellow",
+            "success": "green",
+            "error": "bold red",
+            "debug": "dim black",
+            "diff_add": "green",
+            "diff_remove": "red",
+            "diff_context": "dim black",
+        },
+        "color_remap": {},
+        "terminal_palette": bp.SOLARIZED_LIGHT,
+    },
+    "github-light": {
+        "icon": "📄",
+        "label": "GitHub Light",
+        "blurb": "crisp white, familiar code colors",
+        "colors": [
+            "blue",
+            "magenta",
+            "green",
+            "yellow",
+            "cyan",
+            "red",
+            "bright_blue",
+            "bright_magenta",
+        ],
+        "content_styles": {
+            "info": "blue",
+            "warning": "yellow",
+            "success": "green",
+            "error": "bold red",
+            "debug": "dim black",
+            "diff_add": "green",
+            "diff_remove": "red",
+            "diff_context": "dim black",
+        },
+        "color_remap": {},
+        "terminal_palette": bp.GITHUB_LIGHT,
+    },
+    "rose-pine-dawn": {
+        "icon": "🌸",
+        "label": "Rose Pine Dawn",
+        "blurb": "soft pastel rose light",
+        "colors": [
+            "magenta",
+            "blue",
+            "cyan",
+            "yellow",
+            "green",
+            "red",
+            "bright_magenta",
+            "bright_blue",
+        ],
+        "content_styles": {
+            "info": "blue",
+            "warning": "yellow",
+            "success": "green",
+            "error": "bold red",
+            "debug": "dim black",
+            "diff_add": "green",
+            "diff_remove": "red",
+            "diff_context": "dim black",
+        },
+        "color_remap": {},
+        "terminal_palette": bp.ROSE_PINE_DAWN,
+    },
+}
+
+# The 5th option: surprise me — special case, regenerated each preview/apply.
+SURPRISE = {
+    "icon": "🎲",
+    "label": "Surprise Me",
+    "blurb": "a fresh random remix every time",
+    "colors": None,
+    "content_styles": None,  # generated dynamically
+    "color_remap": None,  # generated dynamically
+    "terminal_palette": None,  # randomized at apply time
+}
+
+# The 6th option: restore Code Puppy defaults (banners + content).
+DEFAULT = {
+    "icon": "🔄",
+    "label": "Restore Defaults",
+    "blurb": "back to Code Puppy factory colors",
+    "colors": None,
+    "content_styles": None,  # handled specially
+    "color_remap": None,  # handled specially (empty)
+    "terminal_palette": None,  # handled specially (OSC reset)
+}
+
+# Ordered menu: 4 originals, 2 dark ports, 2 light themes, surprise, default.
+# (Catppuccin Mocha, Solarized Light, Rose Pine Dawn removed by request -
+# still resolvable by name as aliases for power users.)
+MENU: list[tuple[str, dict]] = [
+    ("ocean", CURATED_THEMES["ocean"]),
+    ("forest", CURATED_THEMES["forest"]),
+    ("sunset", CURATED_THEMES["sunset"]),
+    ("vaporwave", CURATED_THEMES["vaporwave"]),
+    ("catppuccin-latte", CURATED_THEMES["catppuccin-latte"]),
+    ("github-light", CURATED_THEMES["github-light"]),
+    ("surprise", SURPRISE),
+    ("default", DEFAULT),
+]
+MENU_BY_NAME: dict[str, dict] = {name: theme for name, theme in MENU}
+MENU_BY_INDEX: dict[str, str] = {str(i + 1): name for i, (name, _) in enumerate(MENU)}
+
+# Friendly aliases (no spaces, alt names).
+MENU_BY_NAME["random"] = SURPRISE
+MENU_BY_NAME["reset"] = DEFAULT
+MENU_BY_NAME["defaults"] = DEFAULT
+MENU_BY_NAME["mocha"] = CURATED_THEMES["catppuccin-mocha"]
+MENU_BY_NAME["latte"] = CURATED_THEMES["catppuccin-latte"]
+MENU_BY_NAME["tokyo"] = CURATED_THEMES["tokyo-night"]
+MENU_BY_NAME["gruvbox"] = CURATED_THEMES["gruvbox-dark"]
+MENU_BY_NAME["solarized"] = CURATED_THEMES["solarized-light"]
+MENU_BY_NAME["github"] = CURATED_THEMES["github-light"]
+MENU_BY_NAME["rose-pine"] = CURATED_THEMES["rose-pine-dawn"]
+MENU_BY_NAME["dawn"] = CURATED_THEMES["rose-pine-dawn"]
+
+
+def colors_for(theme_name: str, rng: random.Random | None = None) -> dict[str, str]:
+    """Build a {banner: color} mapping for the named theme.
+
+    For curated themes, cycles through the theme palette deterministically.
+    For ``surprise``, samples randomly from the full PALETTE.
+    For ``default``, returns the Code Puppy factory banner colors.
+    """
+    if theme_name not in MENU_BY_NAME:
+        raise KeyError(f"Unknown theme: {theme_name!r}")
+
+    if theme_name == "default":
+        from code_puppy.config import DEFAULT_BANNER_COLORS
+
+        return dict(DEFAULT_BANNER_COLORS)
+
+    if theme_name in ("surprise", "random"):
+        chooser = rng.choice if rng is not None else random.choice
+        return {banner: chooser(PALETTE) for banner in BANNER_KEYS}
+
+    palette = cycle(MENU_BY_NAME[theme_name]["colors"])
+    return {banner: next(palette) for banner in BANNER_KEYS}
+
+
+def content_styles_for(
+    theme_name: str, rng: random.Random | None = None
+) -> dict[str, str]:
+    """Build a {content_key: style} mapping for the named theme.
+
+    For curated themes, returns the hand-picked palette.
+    For ``surprise``, generates a random remix (error stays red — it's a UX
+    contract that errors look angry).
+    For ``default``, returns the factory defaults.
+    """
+    if theme_name not in MENU_BY_NAME:
+        raise KeyError(f"Unknown theme: {theme_name!r}")
+
+    if theme_name == "default":
+        return dict(cs.DEFAULT_CONTENT_STYLES)
+
+    if theme_name in ("surprise", "random"):
+        chooser = rng.choice if rng is not None else random.choice
+        mapping = {key: chooser(TEXT_PALETTE) for key in cs.CONTENT_KEYS}
+        # Errors should always be visually distinct + alarming.
+        mapping["error"] = "bold red"
+        return mapping
+
+    return dict(MENU_BY_NAME[theme_name]["content_styles"])
+
+
+def color_remap_for(
+    theme_name: str, rng: random.Random | None = None
+) -> dict[str, str]:
+    """Build a Rich color remap dict for the named theme (Level 2 theming).
+
+    For curated themes, returns the hand-picked remap.
+    For ``surprise``, picks random replacements (semantic colors untouched).
+    For ``default``, returns an empty dict (= no remap, restore).
+    """
+    if theme_name not in MENU_BY_NAME:
+        raise KeyError(f"Unknown theme: {theme_name!r}")
+
+    if theme_name == "default":
+        return {}
+
+    if theme_name in ("surprise", "random"):
+        chooser = rng.choice if rng is not None else random.choice
+        return rt.make_remap(
+            cyan=chooser(TEXT_PALETTE),
+            blue=chooser(TEXT_PALETTE),
+            magenta=chooser(TEXT_PALETTE),
+            bright_cyan=chooser(TEXT_PALETTE),
+            bright_blue=chooser(TEXT_PALETTE),
+            bright_magenta=chooser(TEXT_PALETTE),
+        )
+
+    return dict(MENU_BY_NAME[theme_name]["color_remap"])
+
+
+def terminal_palette_for(
+    theme_name: str, rng: random.Random | None = None
+) -> dict | None:
+    """Build an OSC terminal palette for the named theme.
+
+    Returns None if the theme has no terminal palette (rare). For
+    ``default``, returns None (caller is expected to call osc_palette.reset).
+    For ``surprise``, generates a random bg/fg pair (no full ANSI swap).
+    """
+    if theme_name not in MENU_BY_NAME:
+        raise KeyError(f"Unknown theme: {theme_name!r}")
+
+    if theme_name == "default":
+        return None
+
+    if theme_name in ("surprise", "random"):
+        chooser = rng.choice if rng is not None else random.choice
+        # Random bg/fg pair with enough contrast to read text.
+        LIGHT_BGS = [
+            "#fdf6e3",
+            "#ffffff",
+            "#faf4ed",
+            "#eff1f5",
+            "#f5f5f5",
+            "#f8f0e3",
+        ]
+        DARK_FGS = [
+            "#657b83",
+            "#24292e",
+            "#575279",
+            "#4c4f69",
+            "#2d2d2d",
+            "#3c3c3c",
+        ]
+        DARK_BGS = [
+            "#0a1929",
+            "#1a2310",
+            "#2d1b0e",
+            "#16002a",
+            "#1e1e2e",
+            "#1a1b26",
+            "#282828",
+            "#0e0e2c",
+        ]
+        LIGHT_FGS = [
+            "#d6eaf8",
+            "#e3eecc",
+            "#ffe4cc",
+            "#ffe0ff",
+            "#cdd6f4",
+            "#c0caf5",
+            "#ebdbb2",
+            "#f5f5f5",
+        ]
+        # 30% chance of a light surprise, 70% dark (most users prefer dark TUI).
+        if (rng or random).random() < 0.3:
+            return {"bg": chooser(LIGHT_BGS), "fg": chooser(DARK_FGS)}
+        return {"bg": chooser(DARK_BGS), "fg": chooser(LIGHT_FGS)}
+
+    return MENU_BY_NAME[theme_name].get("terminal_palette")
+
+
+def apply(
+    mapping: dict[str, str], setter: Callable[[str, str], None] = set_banner_color
+) -> None:
+    """Persist a banner→color mapping via the config layer.
+
+    ``setter`` is injectable for tests.
+    """
+    for banner, color in mapping.items():
+        setter(banner, color)
+
+
+def resolve_theme_arg(arg: str) -> str | None:
+    """Resolve '1'..'6' or a theme name to a canonical theme key.
+
+    Returns None if the argument is not recognized.
+    """
+    if arg in MENU_BY_INDEX:
+        return MENU_BY_INDEX[arg]
+    if arg in MENU_BY_NAME:
+        # Normalize aliases to canonical keys.
+        if arg == "random":
+            return "surprise"
+        if arg in ("reset", "defaults"):
+            return "default"
+        return arg
+    return None

--- a/tests/plugins/test_theme_plugin.py
+++ b/tests/plugins/test_theme_plugin.py
@@ -1,0 +1,449 @@
+"""Tests for the /theme custom-command plugin."""
+
+from __future__ import annotations
+
+import random
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from code_puppy.plugins.theme.themes import (
+    CURATED_THEMES,
+    DEFAULT,
+    MENU,
+    MENU_BY_INDEX,
+    MENU_BY_NAME,
+    SURPRISE,
+    apply,
+    color_remap_for,
+    colors_for,
+    content_styles_for,
+    resolve_theme_arg,
+    terminal_palette_for,
+)
+from code_puppy.plugins.theme.bundled_palettes import (
+    CATPPUCCIN_LATTE,
+    CATPPUCCIN_MOCHA,
+    FOREST,
+    GITHUB_LIGHT,
+    GRUVBOX_DARK,
+    OCEAN,
+    ROSE_PINE_DAWN,
+    SOLARIZED_LIGHT,
+    SUNSET,
+    TOKYO_NIGHT,
+    VAPORWAVE,
+)
+from code_puppy.plugins.theme.rich_themes import make_remap, _swap_color, _safe_parse
+from code_puppy.plugins.theme.content_styles import (
+    CONTENT_KEYS,
+    DEFAULT_CONTENT_STYLES,
+    get_all_content_styles,
+    get_content_style,
+    apply_content_styles,
+    restore_defaults,
+)
+from code_puppy.plugins.theme.osc_palette import (
+    _osc,
+    BEL,
+    ESC,
+    get_saved_palette,
+    apply_palette,
+    reset_palette,
+)
+
+
+# ---------------------------------------------------------------------------
+# themes.py
+# ---------------------------------------------------------------------------
+class TestThemeCatalog:
+    def test_curated_themes_count(self):
+        assert len(CURATED_THEMES) == 11
+
+    def test_menu_has_expected_entries(self):
+        names = [name for name, _ in MENU]
+        assert "ocean" in names
+        assert "forest" in names
+        assert "sunset" in names
+        assert "vaporwave" in names
+        assert "surprise" in names
+        assert "default" in names
+
+    def test_menu_by_index_maps_strings(self):
+        assert MENU_BY_INDEX["1"] == "ocean"
+        assert MENU_BY_INDEX[str(len(MENU))] == "default"
+
+    def test_aliases_resolve(self):
+        assert MENU_BY_NAME["mocha"] is CURATED_THEMES["catppuccin-mocha"]
+        assert MENU_BY_NAME["tokyo"] is CURATED_THEMES["tokyo-night"]
+        assert MENU_BY_NAME["gruvbox"] is CURATED_THEMES["gruvbox-dark"]
+        assert MENU_BY_NAME["random"] is SURPRISE
+        assert MENU_BY_NAME["reset"] is DEFAULT
+
+    def test_every_curated_theme_has_required_keys(self):
+        for name, theme in CURATED_THEMES.items():
+            assert "icon" in theme, f"{name} missing icon"
+            assert "label" in theme, f"{name} missing label"
+            assert "colors" in theme, f"{name} missing colors"
+            assert "content_styles" in theme, f"{name} missing content_styles"
+            assert "color_remap" in theme, f"{name} missing color_remap"
+            assert "terminal_palette" in theme, f"{name} missing terminal_palette"
+
+
+class TestColorsFor:
+    def test_curated_theme_returns_mapping(self):
+        m = colors_for("ocean")
+        assert isinstance(m, dict)
+        assert len(m) > 0
+
+    def test_all_menu_themes_produce_mappings(self):
+        # "reset"/"defaults" are aliases for "default"; colors_for only
+        # handles them via the literal "default" check, so use
+        # resolve_theme_arg first (as the real command handler does).
+        for name in MENU_BY_NAME:
+            resolved = resolve_theme_arg(name) or name
+            m = colors_for(resolved)
+            assert isinstance(m, dict) and len(m) > 0, name
+
+    def test_surprise_with_seed_is_deterministic(self):
+        a = colors_for("surprise", rng=random.Random(42))
+        b = colors_for("surprise", rng=random.Random(42))
+        assert a == b
+
+    def test_surprise_different_seeds_differ(self):
+        a = colors_for("surprise", rng=random.Random(1))
+        b = colors_for("surprise", rng=random.Random(999))
+        assert a != b
+
+    def test_default_returns_factory_colors(self):
+        from code_puppy.config import DEFAULT_BANNER_COLORS
+
+        m = colors_for("default")
+        assert m == dict(DEFAULT_BANNER_COLORS)
+
+    def test_unknown_theme_raises(self):
+        with pytest.raises(KeyError):
+            colors_for("nonexistent")
+
+
+class TestContentStylesFor:
+    def test_ocean_has_all_content_keys(self):
+        s = content_styles_for("ocean")
+        for key in CONTENT_KEYS:
+            assert key in s
+
+    def test_surprise_error_stays_red(self):
+        s = content_styles_for("surprise", rng=random.Random(42))
+        assert s["error"] == "bold red"
+
+    def test_default_matches_factory(self):
+        s = content_styles_for("default")
+        assert s == dict(DEFAULT_CONTENT_STYLES)
+
+    def test_unknown_theme_raises(self):
+        with pytest.raises(KeyError):
+            content_styles_for("nonexistent")
+
+
+class TestColorRemapFor:
+    def test_ocean_has_remap_entries(self):
+        r = color_remap_for("ocean")
+        assert isinstance(r, dict)
+        assert len(r) > 0
+
+    def test_default_returns_empty(self):
+        assert color_remap_for("default") == {}
+
+    def test_palette_first_themes_have_empty_remap(self):
+        for name in ("mocha", "latte", "tokyo", "gruvbox"):
+            assert color_remap_for(name) == {}, name
+
+    def test_unknown_theme_raises(self):
+        with pytest.raises(KeyError):
+            color_remap_for("nonexistent")
+
+
+class TestTerminalPaletteFor:
+    def test_ocean_has_bg_fg_ansi(self):
+        p = terminal_palette_for("ocean")
+        assert p is not None
+        assert "bg" in p and "fg" in p and "ansi" in p
+        assert len(p["ansi"]) == 16
+
+    def test_default_returns_none(self):
+        assert terminal_palette_for("default") is None
+
+    def test_surprise_returns_bg_fg(self):
+        p = terminal_palette_for("surprise", rng=random.Random(42))
+        assert p is not None
+        assert "bg" in p and "fg" in p
+
+    def test_unknown_theme_raises(self):
+        with pytest.raises(KeyError):
+            terminal_palette_for("nonexistent")
+
+
+class TestApply:
+    def test_calls_setter_for_each_banner(self):
+        setter = MagicMock()
+        mapping = {"a": "red", "b": "blue"}
+        apply(mapping, setter=setter)
+        assert setter.call_count == 2
+        setter.assert_any_call("a", "red")
+        setter.assert_any_call("b", "blue")
+
+
+class TestResolveThemeArg:
+    @pytest.mark.parametrize(
+        "arg,expected",
+        [
+            ("1", "ocean"),
+            ("ocean", "ocean"),
+            ("forest", "forest"),
+            ("random", "surprise"),
+            ("reset", "default"),
+            ("defaults", "default"),
+        ],
+    )
+    def test_valid_args(self, arg, expected):
+        assert resolve_theme_arg(arg) == expected
+
+    def test_unknown_returns_none(self):
+        assert resolve_theme_arg("nope") is None
+        assert resolve_theme_arg("") is None
+
+    def test_alias_keys_are_accepted(self):
+        assert resolve_theme_arg("mocha") is not None
+        assert resolve_theme_arg("tokyo") is not None
+        assert resolve_theme_arg("gruvbox") is not None
+
+
+# ---------------------------------------------------------------------------
+# bundled_palettes.py
+# ---------------------------------------------------------------------------
+class TestBundledPalettes:
+    @pytest.mark.parametrize(
+        "palette",
+        [
+            OCEAN,
+            FOREST,
+            SUNSET,
+            VAPORWAVE,
+            CATPPUCCIN_MOCHA,
+            CATPPUCCIN_LATTE,
+            TOKYO_NIGHT,
+            GRUVBOX_DARK,
+            SOLARIZED_LIGHT,
+            GITHUB_LIGHT,
+            ROSE_PINE_DAWN,
+        ],
+    )
+    def test_palette_structure(self, palette):
+        assert "bg" in palette
+        assert "fg" in palette
+        assert "ansi" in palette
+        assert len(palette["ansi"]) == 16
+
+    @pytest.mark.parametrize(
+        "palette",
+        [
+            OCEAN,
+            FOREST,
+            SUNSET,
+            VAPORWAVE,
+            CATPPUCCIN_MOCHA,
+            CATPPUCCIN_LATTE,
+            TOKYO_NIGHT,
+            GRUVBOX_DARK,
+            SOLARIZED_LIGHT,
+            GITHUB_LIGHT,
+            ROSE_PINE_DAWN,
+        ],
+    )
+    def test_palette_hex_format(self, palette):
+        assert palette["bg"].startswith("#")
+        assert palette["fg"].startswith("#")
+        for color in palette["ansi"]:
+            assert color.startswith("#"), f"Bad ANSI color: {color}"
+
+
+# ---------------------------------------------------------------------------
+# rich_themes.py
+# ---------------------------------------------------------------------------
+class TestRichThemes:
+    def test_make_remap_filters_none(self):
+        r = make_remap(cyan="blue", magenta=None, blue="green")
+        assert "cyan" in r and "blue" in r
+        assert "magenta" not in r
+
+    def test_make_remap_filters_unparseable(self):
+        r = make_remap(cyan="totally_not_a_color_xyz")
+        assert r == {}
+
+    def test_safe_parse_valid(self):
+        assert _safe_parse("red") is not None
+        assert _safe_parse("blue") is not None
+
+    def test_safe_parse_invalid_returns_none(self):
+        assert _safe_parse("not_a_real_color_999") is None
+
+    def test_swap_color_noop_when_no_match(self):
+        from rich.style import Style
+
+        style = Style(color="red")
+        result = _swap_color(style, {"blue": "green"})
+        assert result.color.name == "red"
+
+    def test_swap_color_replaces_match(self):
+        from rich.style import Style
+
+        style = Style(color="cyan")
+        result = _swap_color(style, {"cyan": "blue"})
+        assert result.color.name == "blue"
+
+
+# ---------------------------------------------------------------------------
+# content_styles.py
+# ---------------------------------------------------------------------------
+class TestContentStyles:
+    def test_content_keys_count(self):
+        assert len(CONTENT_KEYS) == 8
+
+    def test_default_styles_has_all_keys(self):
+        for key in CONTENT_KEYS:
+            assert key in DEFAULT_CONTENT_STYLES
+
+    def test_get_content_style_returns_default(self):
+        style = get_content_style("error")
+        assert isinstance(style, str)
+        assert len(style) > 0
+
+    def test_get_content_style_unknown_raises(self):
+        with pytest.raises(KeyError):
+            get_content_style("not_a_key")
+
+    def test_get_all_returns_full_mapping(self):
+        styles = get_all_content_styles()
+        assert len(styles) == 8
+        for key in CONTENT_KEYS:
+            assert key in styles
+
+    def test_apply_missing_key_raises(self):
+        with pytest.raises(ValueError, match="missing keys"):
+            apply_content_styles({"info": "cyan"}, persist=False)
+
+    def test_apply_and_restore_roundtrip(self):
+        original = get_all_content_styles()
+        custom = {k: "magenta" for k in CONTENT_KEYS}
+        custom["error"] = "bold red"
+        apply_content_styles(custom, persist=False)
+        restore_defaults(persist=False)
+        restored = get_all_content_styles()
+        assert restored == original
+
+
+# ---------------------------------------------------------------------------
+# osc_palette.py
+# ---------------------------------------------------------------------------
+class TestOscPalette:
+    def test_osc_bg_sequence(self):
+        seq = _osc("11", "#0a1929")
+        assert seq == f"{ESC}]11;#0a1929{BEL}"
+
+    def test_osc_fg_sequence(self):
+        seq = _osc("10", "#ffffff")
+        assert seq == f"{ESC}]10;#ffffff{BEL}"
+
+    def test_osc_ansi_slot_sequence(self):
+        seq = _osc("4", "0", "#ff0000")
+        assert seq == f"{ESC}]4;0;#ff0000{BEL}"
+
+    def test_apply_palette_emits_sequences(self):
+        palette = {"bg": "#000", "fg": "#fff", "ansi": ["#111"] * 16}
+        with patch("code_puppy.plugins.theme.osc_palette._emit") as mock_emit:
+            apply_palette(palette, persist=False, register_reset=False)
+        assert mock_emit.call_count == 18  # 1 bg + 1 fg + 16 ansi
+
+    def test_reset_palette_emits_resets(self):
+        with patch("code_puppy.plugins.theme.osc_palette._emit") as mock_emit:
+            reset_palette(persist=False)
+        assert mock_emit.call_count == 3  # ansi + bg + fg
+
+    def test_get_saved_palette_returns_none_when_empty(self):
+        with patch("code_puppy.plugins.theme.osc_palette.get_value", return_value=None):
+            assert get_saved_palette() is None
+
+    def test_get_saved_palette_returns_dict(self):
+        import json
+
+        data = {"bg": "#000", "fg": "#fff"}
+        with patch(
+            "code_puppy.plugins.theme.osc_palette.get_value",
+            return_value=json.dumps(data),
+        ):
+            result = get_saved_palette()
+        assert result == data
+
+
+# ---------------------------------------------------------------------------
+# register_callbacks.py
+# ---------------------------------------------------------------------------
+class TestRegisterCallbacks:
+    def test_custom_help_returns_theme_entry(self):
+        from code_puppy.plugins.theme.register_callbacks import _custom_help
+
+        entries = dict(_custom_help())
+        assert "theme" in entries
+
+    def test_handle_theme_ignores_other_commands(self):
+        from code_puppy.plugins.theme.register_callbacks import _handle_theme
+
+        assert _handle_theme("/colors", "colors") is None
+
+    def test_handle_theme_show(self):
+        from code_puppy.plugins.theme.register_callbacks import _handle_theme
+
+        with patch(
+            "code_puppy.plugins.theme.register_callbacks.emit_info"
+        ) as mock_info:
+            result = _handle_theme("/theme show", "theme")
+        assert result is True
+        assert mock_info.called
+
+    def test_handle_theme_unknown_warns(self):
+        from code_puppy.plugins.theme.register_callbacks import _handle_theme
+
+        with patch(
+            "code_puppy.plugins.theme.register_callbacks.emit_warning"
+        ) as mock_warn:
+            result = _handle_theme("/theme bogus_theme", "theme")
+        assert result is True
+        assert mock_warn.called
+
+    def test_handle_theme_by_name_applies(self):
+        from code_puppy.plugins.theme.register_callbacks import _handle_theme
+
+        with (
+            patch("code_puppy.plugins.theme.register_callbacks.apply") as mock_apply,
+            patch("code_puppy.plugins.theme.register_callbacks.cs"),
+            patch("code_puppy.plugins.theme.register_callbacks.rt"),
+            patch("code_puppy.plugins.theme.register_callbacks.osc"),
+            patch("code_puppy.plugins.theme.register_callbacks.emit_info"),
+        ):
+            result = _handle_theme("/theme ocean", "theme")
+        assert result is True
+        mock_apply.assert_called_once()
+
+    def test_handle_theme_interactive_cancel(self):
+        from code_puppy.plugins.theme.register_callbacks import _handle_theme
+
+        with (
+            patch(
+                "code_puppy.plugins.theme.register_callbacks._run_interactive_picker",
+                return_value=None,
+            ),
+            patch("code_puppy.plugins.theme.register_callbacks.emit_info") as mock_info,
+        ):
+            result = _handle_theme("/theme", "theme")
+        assert result is True
+        assert "unchanged" in str(mock_info.call_args)


### PR DESCRIPTION
## Summary

- Adds a builtin `/theme` plugin with an interactive split-panel TUI picker and **four levels of color theming**: banner headers, body text styles, inline Rich markup remap, and terminal-wide OSC palette swap
- Ships **11 curated themes** (Ocean, Forest, Sunset, Vaporwave, Catppuccin Mocha/Latte, Tokyo Night, Gruvbox Dark, Solarized Light, GitHub Light, Rose Pine Dawn) plus Surprise Me and Restore Defaults
- Themes persist across restarts; terminal palette auto-resets on exit via `atexit`

## Architecture

| File | Responsibility |
|------|----------------|
| `themes.py` | Theme catalog + banner/content/remap/palette construction |
| `bundled_palettes.py` | Hex palette data (Catppuccin, Tokyo Night, Gruvbox, +4 originals) |
| `content_styles.py` | Mutates `RichConsoleRenderer` style maps (Level 1) |
| `rich_themes.py` | Monkey-patches `Console.get_style()` for inline remap (Level 2) |
| `osc_palette.py` | OSC escape sequences for terminal-wide bg/fg/ANSI palette (Level 3) |
| `picker.py` | prompt_toolkit split-panel TUI with live preview |
| `register_callbacks.py` | `/theme` command handler, glue only |
| `__init__.py` | Re-applies persisted (L1 + L2 + L3) on plugin load |

## Test plan

- [x] All files pass `ruff check` and `ruff format`
- [x] All files under 600-line cap
- [x] Smoke tests pass: theme catalog, `colors_for`, `content_styles_for`, `color_remap_for`, `terminal_palette_for`, `resolve_theme_arg`, bundled palettes (16-slot ANSI), `make_remap`
- [x] Manual: run `code-puppy` and test `/theme` interactive picker
- [x] Manual: test `/theme ocean`, `/theme show`, `/theme reset`

