### PR TITLE
Add /rewind command for conversation turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,19 @@ Would keep the system message plus the 19 most recent messages, removing older o
 
 This is useful for managing context length when you have a long conversation history but only need the most recent interactions.
 
+### Rewind Conversation Turns
+```bash
+/rewind [turns]
+```
+Removes the most recent completed conversation turn(s) from the active model history. Unlike `/truncate`, rewind removes whole user-started turns, including assistant responses, tool calls, tool results, attachments, and other stored message parts that would be sent to the model again.
+
+```bash
+/rewind
+/rewind 2
+```
+
+Use this when a recent prompt or response poisons the context, exceeds the model window, or needs to be forgotten before the next request. The system prompt is always preserved.
+
 ## Available Agents
 
 ### Code-Puppy 🐶 (Default)

--- a/code_puppy/plugins/rewind/__init__.py
+++ b/code_puppy/plugins/rewind/__init__.py
@@ -1,0 +1,1 @@
+"""Rewind command plugin."""

--- a/code_puppy/plugins/rewind/history.py
+++ b/code_puppy/plugins/rewind/history.py
@@ -1,0 +1,71 @@
+"""Helpers for rewinding complete conversation turns."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+
+@dataclass(frozen=True, slots=True)
+class RewindResult:
+    """Result of removing complete turns from message history."""
+
+    history: list[Any]
+    requested_turns: int
+    rewound_turns: int
+    removed_messages: int
+
+
+def rewind_history(history: Sequence[Any], turns: int) -> RewindResult:
+    """Remove the last ``turns`` user-started conversation turns.
+
+    Pydantic AI stores a conversation as a flat list of model messages. A user
+    turn starts at a ``ModelRequest`` containing at least one ``UserPromptPart``;
+    every following message belongs to that turn until the next user prompt.
+    Removing from the turn boundary through the tail removes tool calls, tool
+    returns, text responses, attachment parts, and any other components that
+    would otherwise be sent back to the model.
+    """
+    if turns < 1:
+        raise ValueError("turns must be a positive integer")
+
+    original = list(history)
+    if not original:
+        return RewindResult(original, turns, 0, 0)
+
+    boundary = len(original)
+    rewound = 0
+    for index in range(len(original) - 1, -1, -1):
+        if _is_user_turn_start(original[index]):
+            boundary = index
+            rewound += 1
+            if rewound == turns:
+                break
+
+    if rewound == 0:
+        return RewindResult(original, turns, 0, 0)
+
+    new_history = original[:boundary]
+    return RewindResult(
+        history=new_history,
+        requested_turns=turns,
+        rewound_turns=rewound,
+        removed_messages=len(original) - len(new_history),
+    )
+
+
+def _is_user_turn_start(message: Any) -> bool:
+    """Return True when a message starts a user conversation turn."""
+    try:
+        from pydantic_ai.messages import ModelRequest, UserPromptPart
+    except Exception:  # pragma: no cover - import guard for exotic installs
+        return False
+
+    if not isinstance(message, ModelRequest):
+        return False
+
+    parts = getattr(message, "parts", None) or []
+    return any(isinstance(part, UserPromptPart) for part in parts)
+
+
+__all__ = ["RewindResult", "rewind_history"]

--- a/code_puppy/plugins/rewind/register_callbacks.py
+++ b/code_puppy/plugins/rewind/register_callbacks.py
@@ -1,0 +1,114 @@
+"""Plugin that adds /rewind for removing complete conversation turns."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from code_puppy.callbacks import register_callback
+from code_puppy.plugins.rewind.history import rewind_history
+
+
+def emit_error(message: Any) -> None:
+    from code_puppy.messaging import emit_error as _emit_error
+
+    _emit_error(message)
+
+
+def emit_success(message: Any) -> None:
+    from code_puppy.messaging import emit_success as _emit_success
+
+    _emit_success(message)
+
+
+def emit_warning(message: Any) -> None:
+    from code_puppy.messaging import emit_warning as _emit_warning
+
+    _emit_warning(message)
+
+
+def _custom_help() -> list[tuple[str, str]]:
+    return [
+        (
+            "rewind [turns]",
+            "Remove the most recent completed conversation turn(s) from history",
+        )
+    ]
+
+
+def _parse_rewind_count(command: str) -> int | None:
+    tokens = command.split()
+    if len(tokens) == 1:
+        return 1
+
+    if len(tokens) > 2:
+        emit_error("/rewind: usage: /rewind [turns]")
+        return None
+
+    try:
+        count = int(tokens[1])
+    except ValueError:
+        emit_error(
+            f"/rewind: '{tokens[1]}' is not a valid integer – usage: /rewind [turns]"
+        )
+        return None
+
+    if count < 1:
+        emit_error("/rewind: turns must be a positive integer")
+        return None
+
+    return count
+
+
+def _handle_rewind_command(command: str) -> bool:
+    from code_puppy.agents.agent_manager import get_current_agent
+
+    count = _parse_rewind_count(command)
+    if count is None:
+        return True
+
+    try:
+        agent = get_current_agent()
+    except Exception as exc:
+        emit_error(f"/rewind: could not get current agent – {exc}")
+        return True
+
+    history = list(agent.get_message_history())
+    result = rewind_history(history, count)
+
+    if result.rewound_turns == 0:
+        emit_warning("/rewind: no completed conversation turns to remove")
+        return True
+
+    try:
+        agent.set_message_history(result.history)
+    except Exception as exc:
+        emit_error(f"/rewind: failed to update message history – {exc}")
+        return True
+
+    turn_word = "turn" if result.rewound_turns == 1 else "turns"
+    message_word = "message" if result.removed_messages == 1 else "messages"
+    summary = f"⏪ Rewound {result.rewound_turns} {turn_word}"
+    if result.rewound_turns < result.requested_turns:
+        summary += f" (requested {result.requested_turns}; only {result.rewound_turns} available)"
+    summary += f". Removed {result.removed_messages} history {message_word}."
+    emit_success(summary)
+    return True
+
+
+def _handle_custom_command(command: str, name: str) -> bool | None:
+    if name != "rewind":
+        return None
+
+    return _handle_rewind_command(command)
+
+
+register_callback("custom_command_help", _custom_help)
+register_callback("custom_command", _handle_custom_command)
+
+
+__all__ = [
+    "_custom_help",
+    "_handle_custom_command",
+    "_handle_rewind_command",
+    "_parse_rewind_count",
+]

--- a/tests/test_rewind_plugin.py
+++ b/tests/test_rewind_plugin.py
@@ -1,0 +1,202 @@
+from unittest.mock import MagicMock, patch
+
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    SystemPromptPart,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+
+from code_puppy.plugins.rewind.history import rewind_history
+from code_puppy.plugins.rewind.register_callbacks import (
+    _handle_custom_command,
+    _parse_rewind_count,
+)
+
+
+def request(text: str) -> ModelRequest:
+    return ModelRequest(parts=[UserPromptPart(content=text)])
+
+
+def response(text: str) -> ModelResponse:
+    return ModelResponse(parts=[TextPart(content=text)])
+
+
+def system(text: str = "system") -> ModelRequest:
+    return ModelRequest(parts=[SystemPromptPart(content=text)])
+
+
+def flatten_history_text(history) -> str:
+    chunks = []
+    for message in history:
+        for part in getattr(message, "parts", []) or []:
+            chunks.append(str(getattr(part, "content", "")))
+            chunks.append(str(getattr(part, "args", "")))
+    return "\n".join(chunks)
+
+
+def test_baseline_history_keeps_prior_user_fact_without_rewind():
+    history = [
+        system(),
+        request("what's 5+5"),
+        response("10"),
+        request("my name is john"),
+        response("Nice to meet you, John."),
+        request("what is my name"),
+    ]
+
+    assert "my name is john" in flatten_history_text(history)
+    assert "John" in flatten_history_text(history)
+
+
+def test_rewind_one_turn_removes_fact_before_next_question():
+    history = [
+        system(),
+        request("what's 5+5"),
+        response("10"),
+        request("my name is john"),
+        response("Nice to meet you, John."),
+    ]
+
+    result = rewind_history(history, 1)
+    next_request_history = [*result.history, request("what is my name?")]
+
+    assert result.rewound_turns == 1
+    assert "my name is john" not in flatten_history_text(next_request_history)
+    assert "Nice to meet you, John." not in flatten_history_text(next_request_history)
+    assert "what is my name?" in flatten_history_text(next_request_history)
+
+
+def test_rewind_removes_full_tool_component_turn_from_next_model_request():
+    history = [
+        system(),
+        request("safe earlier fact"),
+        response("kept"),
+        request("latest turn with secret attachment: john"),
+        ModelResponse(
+            parts=[
+                TextPart(content="I'll inspect that."),
+                ToolCallPart(
+                    tool_name="read_file",
+                    args={"file_path": "john-secret.txt"},
+                    tool_call_id="call-1",
+                ),
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="read_file",
+                    content="oversized context window poison john",
+                    tool_call_id="call-1",
+                )
+            ]
+        ),
+        response("Tool result says john."),
+    ]
+
+    result = rewind_history(history, 1)
+    next_request_history = [*result.history, request("continue")]
+    text = flatten_history_text(next_request_history)
+
+    assert result.removed_messages == 4
+    assert "safe earlier fact" in text
+    assert "latest turn with secret attachment" not in text
+    assert "john-secret.txt" not in text
+    assert "oversized context window poison john" not in text
+    assert "Tool result says john" not in text
+
+
+def test_rewind_recovers_from_oversized_latest_turn():
+    poison = "TOO_BIG " * 20_000
+    history = [system(), request("small ok"), response("ok"), request(poison)]
+
+    result = rewind_history(history, 1)
+    next_request_history = [*result.history, request("now answer normally")]
+
+    assert poison not in flatten_history_text(next_request_history)
+    assert "small ok" in flatten_history_text(next_request_history)
+
+
+def test_rewind_two_turns_and_never_removes_system_message():
+    history = [
+        system("do not remove me"),
+        request("turn one"),
+        response("one"),
+        request("turn two"),
+        response("two"),
+    ]
+
+    result = rewind_history(history, 2)
+
+    assert result.rewound_turns == 2
+    assert result.history == [history[0]]
+    assert "do not remove me" in flatten_history_text(result.history)
+
+
+def test_rewind_more_turns_than_exist_removes_safely_available_turns():
+    history = [system(), request("only turn"), response("only response")]
+
+    result = rewind_history(history, 99)
+
+    assert result.rewound_turns == 1
+    assert result.requested_turns == 99
+    assert result.history == [history[0]]
+
+
+def test_rewind_with_no_completed_turns_does_not_crash():
+    result = rewind_history([system()], 1)
+
+    assert result.rewound_turns == 0
+    assert len(result.history) == 1
+
+
+def test_parse_rewind_defaults_to_one():
+    assert _parse_rewind_count("/rewind") == 1
+
+
+def test_parse_rewind_rejects_invalid_counts_without_mutation_path():
+    with patch("code_puppy.messaging.emit_error") as emit_error:
+        assert _parse_rewind_count("/rewind 0") is None
+        assert _parse_rewind_count("/rewind -1") is None
+        assert _parse_rewind_count("/rewind abc") is None
+
+    assert emit_error.call_count == 3
+
+
+def test_rewind_command_updates_active_agent_history():
+    agent = MagicMock()
+    history = [system(), request("name is john"), response("hi john")]
+    agent.get_message_history.return_value = history
+
+    with (
+        patch(
+            "code_puppy.agents.agent_manager.get_current_agent",
+            return_value=agent,
+        ),
+        patch("code_puppy.messaging.emit_success") as emit_success,
+    ):
+        handled = _handle_custom_command("/rewind 1", "rewind")
+
+    assert handled is True
+    agent.set_message_history.assert_called_once_with([history[0]])
+    emit_success.assert_called_once()
+
+
+def test_rewind_command_invalid_count_does_not_mutate_history():
+    agent = MagicMock()
+
+    with (
+        patch(
+            "code_puppy.agents.agent_manager.get_current_agent",
+            return_value=agent,
+        ),
+        patch("code_puppy.messaging.emit_error"),
+    ):
+        handled = _handle_custom_command("/rewind nope", "rewind")
+
+    assert handled is True
+    agent.set_message_history.assert_not_called()


### PR DESCRIPTION
## Summary

Adds a `/rewind [turns]` plugin command that removes the most recent completed user-started conversation turn(s) from the active agent history.

Unlike `/truncate`, rewind slices history at turn boundaries so it removes the full model-visible context for recent interactions: user prompts, assistant responses, tool calls, tool returns, attachments, and other stored message parts. System prompt messages are preserved.

## Why

Sometimes a recent turn poisons the context, includes sensitive/incorrect information, or pushes the model over its context window. `/rewind` gives users a quick way to remove that recent turn before the next request.

## Changes

- Added `code_puppy.plugins.rewind.history.rewind_history`
  - pure helper for removing whole user-started turns from Pydantic AI message history
  - returns metadata about requested turns, rewound turns, and removed messages
- Added `/rewind [turns]` custom command plugin
  - defaults to one turn
  - validates count
  - updates the active agent message history
  - emits success/warning/error messages
- Added README docs for `/rewind`
- Added tests for:
  - baseline memory behavior
  - rewind removing prior fact before next prompt
  - tool call/tool return cleanup
  - oversized latest-turn recovery
  - multiple-turn rewind
  - too-many-turns safety
  - no-turn safety
  - command validation and mutation behavior

## Testing

```bash
uv run pytest tests/test_rewind_plugin.py
# 11 passed

uv run pytest tests/test_rewind_plugin.py tests/test_command_handler.py -q
# 102 passed
```

Also ran the full suite:

```bash
uv run pytest -q
```

Result:

```text
10363 passed, 86 skipped, 1 xpassed, 3 failed
```

The failing tests appear unrelated to this change:

```text
tests/agents/test_builder_autostart_mcp.py::TestSubagentInvocationUsesAsyncAutostart::test_agent_tools_calls_async_autostart
tests/agents/test_builder_autostart_mcp.py::TestSubagentInvocationUsesAsyncAutostart::test_agent_tools_uses_manager_directly_for_filtering
tests/command_line/test_add_model_menu_coverage.py::TestRun::test_run_pending_credentials_success
```
