### PR TITLE
Fix UnicodeEncodeError crash on Windows first run (legacy console code page)

### DIFF
--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -1105,8 +1105,24 @@ async def execute_single_prompt(prompt: str, message_renderer) -> None:
         emit_error(f"Error executing prompt: {str(e)}")
 
 
+def _force_utf8_stdio():
+    """Ensure stdout/stderr can encode non-ASCII output (e.g. emoji prompts).
+
+    On Windows the console often defaults to a legacy code page (e.g. cp1252),
+    so writing UTF-8 characters such as the "🐾" onboarding banner raises
+    UnicodeEncodeError and crashes the very first run. Reconfigure the streams
+    to UTF-8 where the runtime supports it; no-op otherwise.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
+
+
 def main_entry():
     """Entry point for the installed CLI tool."""
+    _force_utf8_stdio()
     try:
         asyncio.run(main())
     except KeyboardInterrupt:


### PR DESCRIPTION
## Problem

On Windows the console frequently uses a legacy code page (e.g. cp1252). The
first-run onboarding in `ensure_config_exists()` writes a UTF-8 emoji banner:

```python
sys.stdout.write("🐾 Let's get your Puppy ready!\n")
```

Under cp1252 this raises `UnicodeEncodeError` and crashes the very first run,
before the user can configure anything:

```
  File "...\code_puppy\config.py", line 225, in ensure_config_exists
    sys.stdout.write("🐾 Let's get your Puppy ready!\n")
  File "...\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f43e' in position 0: character maps to <undefined>
```

The same class of failure affects other emoji output paths (e.g. the auto-saved
session messages).

**Repro:** fresh install on Windows (PowerShell/cmd at the default code page),
run `code-puppy` / `python -m code_puppy` with no existing
`~/.code_puppy/puppy.cfg`. (Current workaround is setting `PYTHONUTF8=1`.)

## Fix

Reconfigure `stdout`/`stderr` to UTF-8 (`errors="replace"`) once at
`main_entry()`. This fixes every non-ASCII output path rather than escaping
individual strings, and is wrapped in `try/except` so it is a no-op where
`reconfigure` is unsupported.

```python
def _force_utf8_stdio():
    for stream in (sys.stdout, sys.stderr):
        try:
            stream.reconfigure(encoding="utf-8", errors="replace")
        except Exception:
            pass
```

## Notes

- Single-file change in `cli_runner.py`; no behavior change on platforms that
  already use UTF-8.
- Makes Code Puppy work out of the box on a default Windows console.
