### PR TITLE
feat: cap each AGENTS.md at 10,000 chars with truncation notice

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -27,7 +27,9 @@ from code_puppy.callbacks import (
     on_wrap_pydantic_agent,
 )
 from code_puppy.config import (
+    AGENTS_MD_MAX_CHARS_DEFAULT,
     CONFIG_DIR,
+    get_agents_md_max_chars,
     get_global_model_name,
     get_value,
 )
@@ -38,13 +40,13 @@ from code_puppy.model_factory import ModelFactory, make_model_settings
 _AGENT_RULE_FILES = ("AGENTS.md", "AGENT.md", "agents.md", "agent.md")
 _CODE_PUPPY_DIR = ".code_puppy"
 
-# Hard cap on the characters from a single AGENTS.md file that get injected
-# into the system prompt. Users with kitchen-sink AGENTS.md files were
-# bloating context and degrading model attention; this keeps overhead
-# bounded without taking a CLI flag. Per-file (not post-join) so a fat
-# global doesn't silently nuke the project file a developer is actively
-# editing. Bump if you really must — but consider trimming AGENTS.md first.
-AGENTS_MD_MAX_CHARS = 10_000
+# Re-export the default so callers that imported AGENTS_MD_MAX_CHARS from
+# here keep working. The *effective* cap on any given load is whatever
+# ``get_agents_md_max_chars()`` returns (user override via
+# ``/set agents_md_max_chars=<int>``); this constant is just the fallback
+# documented in the warning notice and used by tests that don't care about
+# the override path.
+AGENTS_MD_MAX_CHARS = AGENTS_MD_MAX_CHARS_DEFAULT
 
 
 def _friendly_path(candidate: Path) -> str:
@@ -59,29 +61,32 @@ def _friendly_path(candidate: Path) -> str:
         return str(candidate)
 
 
-def _truncate_agents_md(content: str, source: str) -> str:
-    """Cap one AGENTS.md file at ``AGENTS_MD_MAX_CHARS`` with a labelled notice.
+def _truncate_agents_md(content: str, source: str, max_chars: int) -> str:
+    """Cap one AGENTS.md file at ``max_chars`` with a labelled notice.
 
     Returns ``content`` unchanged when it's within the cap. When it overflows,
-    keeps exactly the first ``AGENTS_MD_MAX_CHARS`` characters of the original
-    and appends a delimited warning addressed to the agent (so the agent can
+    keeps exactly the first ``max_chars`` characters of the original and
+    appends a delimited warning addressed to the agent (so the agent can
     surface it to the user on the next turn). ``source`` is a human-readable
     label for the file — used in the warning so the agent can tell the user
-    which specific file to trim when multiple files overflow.
+    which specific file to trim when multiple files overflow. ``max_chars``
+    is resolved once per load by the caller (see ``get_agents_md_max_chars``)
+    so a session-wide ``/set`` override is honoured.
     """
     original_len = len(content)
-    if original_len <= AGENTS_MD_MAX_CHARS:
+    if original_len <= max_chars:
         return content
-    dropped = original_len - AGENTS_MD_MAX_CHARS
+    dropped = original_len - max_chars
     notice = (
         f"\n\n--- AGENTS.md truncated ---\n"
         f"The {source} content was truncated: original was "
         f"{original_len:,} chars, {dropped:,} chars dropped. Please tell "
-        f"the user to trim {source} below {AGENTS_MD_MAX_CHARS:,} "
-        f"characters so the full rules can take effect.\n"
+        f"the user to trim {source} below {max_chars:,} "
+        f"characters so the full rules can take effect (or raise the cap "
+        f"via `/set agents_md_max_chars=<int>`).\n"
         f"--- end truncation notice ---"
     )
-    return content[:AGENTS_MD_MAX_CHARS] + notice
+    return content[:max_chars] + notice
 
 
 def load_puppy_rules() -> Optional[str]:
@@ -96,10 +101,14 @@ def load_puppy_rules() -> Optional[str]:
     2. ``./AGENTS.md`` (alternate location)
 
     Each file is independently truncated via :func:`_truncate_agents_md` so
-    the combined system-prompt overhead stays bounded.
+    the combined system-prompt overhead stays bounded. The per-file cap is
+    resolved once per call via :func:`get_agents_md_max_chars` so a user
+    can raise (or lower) it with ``/set agents_md_max_chars=<int>``.
 
     Returns ``None`` if neither exists.
     """
+    max_chars = get_agents_md_max_chars()
+
     global_rules: Optional[str] = None
     for name in _AGENT_RULE_FILES:
         candidate = Path(CONFIG_DIR) / name
@@ -107,6 +116,7 @@ def load_puppy_rules() -> Optional[str]:
             global_rules = _truncate_agents_md(
                 candidate.read_text(encoding="utf-8-sig"),
                 source=f"global {_friendly_path(candidate)}",
+                max_chars=max_chars,
             )
             break
 
@@ -121,6 +131,7 @@ def load_puppy_rules() -> Optional[str]:
                 project_rules = _truncate_agents_md(
                     candidate.read_text(encoding="utf-8-sig"),
                     source=f"project {candidate}",
+                    max_chars=max_chars,
                 )
                 break
 
@@ -132,6 +143,7 @@ def load_puppy_rules() -> Optional[str]:
                 project_rules = _truncate_agents_md(
                     candidate.read_text(encoding="utf-8-sig"),
                     source=f"project {candidate}",
+                    max_chars=max_chars,
                 )
                 break
 

--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -38,6 +38,51 @@ from code_puppy.model_factory import ModelFactory, make_model_settings
 _AGENT_RULE_FILES = ("AGENTS.md", "AGENT.md", "agents.md", "agent.md")
 _CODE_PUPPY_DIR = ".code_puppy"
 
+# Hard cap on the characters from a single AGENTS.md file that get injected
+# into the system prompt. Users with kitchen-sink AGENTS.md files were
+# bloating context and degrading model attention; this keeps overhead
+# bounded without taking a CLI flag. Per-file (not post-join) so a fat
+# global doesn't silently nuke the project file a developer is actively
+# editing. Bump if you really must — but consider trimming AGENTS.md first.
+AGENTS_MD_MAX_CHARS = 10_000
+
+
+def _friendly_path(candidate: Path) -> str:
+    """Render ``candidate`` as ``~/relative`` when it's under ``$HOME``.
+
+    Keeps the absolute home path out of the system prompt (and out of any
+    Slack paste of the agent's "please trim AGENTS.md" reply).
+    """
+    try:
+        return f"~/{candidate.relative_to(Path.home())}"
+    except ValueError:
+        return str(candidate)
+
+
+def _truncate_agents_md(content: str, source: str) -> str:
+    """Cap one AGENTS.md file at ``AGENTS_MD_MAX_CHARS`` with a labelled notice.
+
+    Returns ``content`` unchanged when it's within the cap. When it overflows,
+    keeps exactly the first ``AGENTS_MD_MAX_CHARS`` characters of the original
+    and appends a delimited warning addressed to the agent (so the agent can
+    surface it to the user on the next turn). ``source`` is a human-readable
+    label for the file — used in the warning so the agent can tell the user
+    which specific file to trim when multiple files overflow.
+    """
+    original_len = len(content)
+    if original_len <= AGENTS_MD_MAX_CHARS:
+        return content
+    dropped = original_len - AGENTS_MD_MAX_CHARS
+    notice = (
+        f"\n\n--- AGENTS.md truncated ---\n"
+        f"The {source} content was truncated: original was "
+        f"{original_len:,} chars, {dropped:,} chars dropped. Please tell "
+        f"the user to trim {source} below {AGENTS_MD_MAX_CHARS:,} "
+        f"characters so the full rules can take effect.\n"
+        f"--- end truncation notice ---"
+    )
+    return content[:AGENTS_MD_MAX_CHARS] + notice
+
 
 def load_puppy_rules() -> Optional[str]:
     """Load AGENT(S).md from global config dir and/or the current project dir.
@@ -50,13 +95,19 @@ def load_puppy_rules() -> Optional[str]:
     1. ``.code_puppy/AGENTS.md`` (preferred — keeps root clean)
     2. ``./AGENTS.md`` (alternate location)
 
+    Each file is independently truncated via :func:`_truncate_agents_md` so
+    the combined system-prompt overhead stays bounded.
+
     Returns ``None`` if neither exists.
     """
     global_rules: Optional[str] = None
     for name in _AGENT_RULE_FILES:
         candidate = Path(CONFIG_DIR) / name
         if candidate.exists():
-            global_rules = candidate.read_text(encoding="utf-8-sig")
+            global_rules = _truncate_agents_md(
+                candidate.read_text(encoding="utf-8-sig"),
+                source=f"global {_friendly_path(candidate)}",
+            )
             break
 
     project_rules: Optional[str] = None
@@ -67,7 +118,10 @@ def load_puppy_rules() -> Optional[str]:
         for name in _AGENT_RULE_FILES:
             candidate = code_puppy_dir / name
             if candidate.exists():
-                project_rules = candidate.read_text(encoding="utf-8-sig")
+                project_rules = _truncate_agents_md(
+                    candidate.read_text(encoding="utf-8-sig"),
+                    source=f"project {candidate}",
+                )
                 break
 
     # Priority 2: Fallback to project root
@@ -75,7 +129,10 @@ def load_puppy_rules() -> Optional[str]:
         for name in _AGENT_RULE_FILES:
             candidate = Path(name)
             if candidate.exists():
-                project_rules = candidate.read_text(encoding="utf-8-sig")
+                project_rules = _truncate_agents_md(
+                    candidate.read_text(encoding="utf-8-sig"),
+                    source=f"project {candidate}",
+                )
                 break
 
     rules = [r for r in (global_rules, project_rules) if r]

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -1303,11 +1303,12 @@ def get_resume_message_count() -> int:
 
 
 # Default cap (in characters) for any single AGENTS.md file injected into
-# the system prompt. Bound from above by AGENTS_MD_MAX_CHARS_CEILING so a
-# typo'd ``/set agents_md_max_chars=10000000`` can't accidentally re-bloat
-# every session. Tuned in get_agents_md_max_chars() below.
+# the system prompt. Users can override this via
+# ``/set agents_md_max_chars=<int>`` — any positive integer is honoured so
+# models with very large context windows (1M+ tokens) can opt into bigger
+# AGENTS.md files when it makes sense. The default of 10,000 just keeps
+# the unbounded out-of-the-box behaviour from regressing.
 AGENTS_MD_MAX_CHARS_DEFAULT = 10_000
-AGENTS_MD_MAX_CHARS_CEILING = 200_000
 
 
 def get_agents_md_max_chars() -> int:
@@ -1316,10 +1317,9 @@ def get_agents_md_max_chars() -> int:
     Read from the ``agents_md_max_chars`` config key (settable via
     ``/set agents_md_max_chars=<int>``). Defaults to
     ``AGENTS_MD_MAX_CHARS_DEFAULT`` (10,000) when unset, and falls back to
-    the default on garbage values (non-numeric, negative, zero). Clamped
-    to ``[1, AGENTS_MD_MAX_CHARS_CEILING]`` so a typo can't blow up the
-    system-prompt budget. The ceiling is generous on purpose — it's a
-    sanity bound, not a recommended max.
+    the default on values that can't be a sensible cap (non-numeric,
+    negative, zero). No upper clamp — if a user with a 1M-token model
+    wants ``/set agents_md_max_chars=500000``, that's their call.
     """
     val = get_value("agents_md_max_chars")
     try:
@@ -1328,7 +1328,7 @@ def get_agents_md_max_chars() -> int:
         return AGENTS_MD_MAX_CHARS_DEFAULT
     if configured <= 0:
         return AGENTS_MD_MAX_CHARS_DEFAULT
-    return min(configured, AGENTS_MD_MAX_CHARS_CEILING)
+    return configured
 
 
 def get_compaction_threshold():

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -351,6 +351,8 @@ def get_config_keys():
         default_keys.append(f"banner_color_{banner_name}")
     # Add resume message count configuration
     default_keys.append("resume_message_count")
+    # Per-file AGENTS.md character cap (see get_agents_md_max_chars()).
+    default_keys.append("agents_md_max_chars")
     # Add /goal iteration cap (owned by the wiggum plugin, surfaced here so
     # /set autocompletes it). See plugins/wiggum/register_callbacks.py.
     default_keys.append("goal_max_iterations")
@@ -1298,6 +1300,35 @@ def get_resume_message_count() -> int:
         return max(0, min(configured_value, 100))
     except (ValueError, TypeError):
         return 50
+
+
+# Default cap (in characters) for any single AGENTS.md file injected into
+# the system prompt. Bound from above by AGENTS_MD_MAX_CHARS_CEILING so a
+# typo'd ``/set agents_md_max_chars=10000000`` can't accidentally re-bloat
+# every session. Tuned in get_agents_md_max_chars() below.
+AGENTS_MD_MAX_CHARS_DEFAULT = 10_000
+AGENTS_MD_MAX_CHARS_CEILING = 200_000
+
+
+def get_agents_md_max_chars() -> int:
+    """Return the per-file AGENTS.md character cap, honouring user override.
+
+    Read from the ``agents_md_max_chars`` config key (settable via
+    ``/set agents_md_max_chars=<int>``). Defaults to
+    ``AGENTS_MD_MAX_CHARS_DEFAULT`` (10,000) when unset, and falls back to
+    the default on garbage values (non-numeric, negative, zero). Clamped
+    to ``[1, AGENTS_MD_MAX_CHARS_CEILING]`` so a typo can't blow up the
+    system-prompt budget. The ceiling is generous on purpose — it's a
+    sanity bound, not a recommended max.
+    """
+    val = get_value("agents_md_max_chars")
+    try:
+        configured = int(val) if val else AGENTS_MD_MAX_CHARS_DEFAULT
+    except (ValueError, TypeError):
+        return AGENTS_MD_MAX_CHARS_DEFAULT
+    if configured <= 0:
+        return AGENTS_MD_MAX_CHARS_DEFAULT
+    return min(configured, AGENTS_MD_MAX_CHARS_CEILING)
 
 
 def get_compaction_threshold():

--- a/tests/agents/test_builder_load_puppy_rules.py
+++ b/tests/agents/test_builder_load_puppy_rules.py
@@ -223,7 +223,10 @@ class TestTruncation:
         )
 
         content = "x" * (AGENTS_MD_MAX_CHARS - 1)
-        assert _truncate_agents_md(content, source="test") == content
+        assert (
+            _truncate_agents_md(content, source="test", max_chars=AGENTS_MD_MAX_CHARS)
+            == content
+        )
 
     def test_helper_at_limit_returns_verbatim(self):
         from code_puppy.agents._builder import (
@@ -232,7 +235,9 @@ class TestTruncation:
         )
 
         content = "x" * AGENTS_MD_MAX_CHARS
-        result = _truncate_agents_md(content, source="test")
+        result = _truncate_agents_md(
+            content, source="test", max_chars=AGENTS_MD_MAX_CHARS
+        )
         assert result == content
         assert "truncated" not in result
 
@@ -244,7 +249,9 @@ class TestTruncation:
 
         original_len = AGENTS_MD_MAX_CHARS + 5_000
         content = "y" * original_len
-        result = _truncate_agents_md(content, source="global ~/x/AGENTS.md")
+        result = _truncate_agents_md(
+            content, source="global ~/x/AGENTS.md", max_chars=AGENTS_MD_MAX_CHARS
+        )
 
         # First N chars verbatim from the original.
         assert result[:AGENTS_MD_MAX_CHARS] == content[:AGENTS_MD_MAX_CHARS]
@@ -256,6 +263,19 @@ class TestTruncation:
         # Counts present (thousands-separated, since that's what the notice uses).
         assert f"{original_len:,}" in result
         assert f"{original_len - AGENTS_MD_MAX_CHARS:,}" in result
+        # Hints the user at the config knob.
+        assert "agents_md_max_chars" in result
+
+    def test_helper_respects_caller_max_chars(self):
+        """Cap is whatever the caller passes — not a hardcoded global."""
+        from code_puppy.agents._builder import _truncate_agents_md
+
+        content = "z" * 5_000
+        # Caller-provided cap below the default — should truncate.
+        result = _truncate_agents_md(content, source="test", max_chars=1_000)
+        assert result[:1_000] == content[:1_000]
+        assert "--- AGENTS.md truncated ---" in result
+        assert "4,000 chars dropped" in result
 
     # --- end-to-end through load_puppy_rules ------------------------------
 
@@ -410,3 +430,102 @@ class TestTruncation:
 
         outside_home = tmp_path / "elsewhere" / "AGENTS.md"
         assert _friendly_path(outside_home) == str(outside_home)
+
+    # --- /set agents_md_max_chars override ----------------------------------
+
+    def test_override_raises_cap_and_keeps_file_intact(
+        self, temp_project, mock_config_dir
+    ):
+        """`/set agents_md_max_chars=20000` lets a 15k file load verbatim."""
+        from code_puppy.agents._builder import load_puppy_rules
+
+        (temp_project / "AGENTS.md").write_text("r" * 15_000)
+
+        with (
+            patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)),
+            patch(
+                "code_puppy.agents._builder.get_agents_md_max_chars",
+                return_value=20_000,
+            ),
+        ):
+            result = load_puppy_rules()
+
+        assert result == "r" * 15_000
+        assert "truncated" not in result
+
+    def test_override_lowers_cap_and_truncates_under_default(
+        self, temp_project, mock_config_dir
+    ):
+        """`/set agents_md_max_chars=2000` truncates an 8k file the default would have allowed."""
+        from code_puppy.agents._builder import load_puppy_rules
+
+        (temp_project / "AGENTS.md").write_text("s" * 8_000)
+
+        with (
+            patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)),
+            patch(
+                "code_puppy.agents._builder.get_agents_md_max_chars",
+                return_value=2_000,
+            ),
+        ):
+            result = load_puppy_rules()
+
+        assert result is not None
+        assert result[:2_000] == "s" * 2_000
+        assert "--- AGENTS.md truncated ---" in result
+        assert "6,000 chars dropped" in result
+        # The new cap is reflected in the user-facing notice.
+        assert "2,000" in result
+
+
+class TestGetAgentsMdMaxChars:
+    """Tests for the config getter that backs ``/set agents_md_max_chars``."""
+
+    def test_unset_returns_default(self):
+        from code_puppy.config import (
+            AGENTS_MD_MAX_CHARS_DEFAULT,
+            get_agents_md_max_chars,
+        )
+
+        with patch("code_puppy.config.get_value", return_value=None):
+            assert get_agents_md_max_chars() == AGENTS_MD_MAX_CHARS_DEFAULT
+
+    def test_valid_int_string_is_honoured(self):
+        from code_puppy.config import get_agents_md_max_chars
+
+        with patch("code_puppy.config.get_value", return_value="25000"):
+            assert get_agents_md_max_chars() == 25_000
+
+    def test_garbage_falls_back_to_default(self):
+        from code_puppy.config import (
+            AGENTS_MD_MAX_CHARS_DEFAULT,
+            get_agents_md_max_chars,
+        )
+
+        with patch("code_puppy.config.get_value", return_value="banana"):
+            assert get_agents_md_max_chars() == AGENTS_MD_MAX_CHARS_DEFAULT
+
+    def test_zero_or_negative_falls_back_to_default(self):
+        from code_puppy.config import (
+            AGENTS_MD_MAX_CHARS_DEFAULT,
+            get_agents_md_max_chars,
+        )
+
+        for bogus in ("0", "-1", "-9999"):
+            with patch("code_puppy.config.get_value", return_value=bogus):
+                assert get_agents_md_max_chars() == AGENTS_MD_MAX_CHARS_DEFAULT
+
+    def test_above_ceiling_is_clamped(self):
+        from code_puppy.config import (
+            AGENTS_MD_MAX_CHARS_CEILING,
+            get_agents_md_max_chars,
+        )
+
+        with patch("code_puppy.config.get_value", return_value="99999999"):
+            assert get_agents_md_max_chars() == AGENTS_MD_MAX_CHARS_CEILING
+
+    def test_key_is_in_config_keys_for_set_autocomplete(self):
+        """The key must appear in get_config_keys() so /set tab-completes it."""
+        from code_puppy.config import get_config_keys
+
+        assert "agents_md_max_chars" in get_config_keys()

--- a/tests/agents/test_builder_load_puppy_rules.py
+++ b/tests/agents/test_builder_load_puppy_rules.py
@@ -192,3 +192,225 @@ class TestLoadPuppyRulesCodePuppyDir:
             result = load_puppy_rules()
 
         assert result == "# Global only"
+
+
+class TestTruncation:
+    """Tests for the AGENTS.md character-cap behaviour.
+
+    Each AGENTS.md file (global and project) is independently capped at
+    ``AGENTS_MD_MAX_CHARS``. Overflowing files keep the first N chars
+    verbatim and have a labelled warning notice appended; under-limit
+    files are returned untouched.
+    """
+
+    @pytest.fixture
+    def temp_project(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        return tmp_path
+
+    @pytest.fixture
+    def mock_config_dir(self, tmp_path):
+        config_dir = tmp_path / "global_config"
+        config_dir.mkdir()
+        return config_dir
+
+    # --- direct unit tests on the pure helper -----------------------------
+
+    def test_helper_under_limit_returns_verbatim(self):
+        from code_puppy.agents._builder import (
+            AGENTS_MD_MAX_CHARS,
+            _truncate_agents_md,
+        )
+
+        content = "x" * (AGENTS_MD_MAX_CHARS - 1)
+        assert _truncate_agents_md(content, source="test") == content
+
+    def test_helper_at_limit_returns_verbatim(self):
+        from code_puppy.agents._builder import (
+            AGENTS_MD_MAX_CHARS,
+            _truncate_agents_md,
+        )
+
+        content = "x" * AGENTS_MD_MAX_CHARS
+        result = _truncate_agents_md(content, source="test")
+        assert result == content
+        assert "truncated" not in result
+
+    def test_helper_over_limit_truncates_with_warning(self):
+        from code_puppy.agents._builder import (
+            AGENTS_MD_MAX_CHARS,
+            _truncate_agents_md,
+        )
+
+        original_len = AGENTS_MD_MAX_CHARS + 5_000
+        content = "y" * original_len
+        result = _truncate_agents_md(content, source="global ~/x/AGENTS.md")
+
+        # First N chars verbatim from the original.
+        assert result[:AGENTS_MD_MAX_CHARS] == content[:AGENTS_MD_MAX_CHARS]
+        # Notice present and addressed to the agent.
+        assert "--- AGENTS.md truncated ---" in result
+        assert "--- end truncation notice ---" in result
+        # Source label propagated so the agent can name the offending file.
+        assert "global ~/x/AGENTS.md" in result
+        # Counts present (thousands-separated, since that's what the notice uses).
+        assert f"{original_len:,}" in result
+        assert f"{original_len - AGENTS_MD_MAX_CHARS:,}" in result
+
+    # --- end-to-end through load_puppy_rules ------------------------------
+
+    def test_under_limit_unchanged(self, temp_project, mock_config_dir):
+        from code_puppy.agents._builder import load_puppy_rules
+
+        (temp_project / "AGENTS.md").write_text("a" * 5_000)
+
+        with patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)):
+            result = load_puppy_rules()
+
+        assert result == "a" * 5_000
+        assert "truncated" not in result
+
+    def test_exactly_at_limit_unchanged(self, temp_project, mock_config_dir):
+        from code_puppy.agents._builder import (
+            AGENTS_MD_MAX_CHARS,
+            load_puppy_rules,
+        )
+
+        (temp_project / "AGENTS.md").write_text("a" * AGENTS_MD_MAX_CHARS)
+
+        with patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)):
+            result = load_puppy_rules()
+
+        assert result == "a" * AGENTS_MD_MAX_CHARS
+        assert "truncated" not in result
+
+    def test_over_limit_truncated_with_warning(self, temp_project, mock_config_dir):
+        from code_puppy.agents._builder import (
+            AGENTS_MD_MAX_CHARS,
+            load_puppy_rules,
+        )
+
+        original_len = 15_000
+        content = "b" * original_len
+        (temp_project / "AGENTS.md").write_text(content)
+
+        with patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)):
+            result = load_puppy_rules()
+
+        assert result is not None
+        # First N chars are verbatim from the original.
+        assert result[:AGENTS_MD_MAX_CHARS] == content[:AGENTS_MD_MAX_CHARS]
+        # Notice block follows.
+        assert "--- AGENTS.md truncated ---" in result
+        # Numbers reported correctly.
+        assert f"{original_len:,}" in result
+        assert f"{original_len - AGENTS_MD_MAX_CHARS:,}" in result
+        # Source label includes the file path so the agent can name it.
+        assert "AGENTS.md" in result
+        assert "project" in result
+
+    def test_truncation_per_file_global_only(
+        self, temp_project, mock_config_dir
+    ):
+        from code_puppy.agents._builder import (
+            AGENTS_MD_MAX_CHARS,
+            load_puppy_rules,
+        )
+
+        # Fat global, small project. Per-file truncation must keep the
+        # project file fully intact.
+        (mock_config_dir / "AGENTS.md").write_text("g" * 15_000)
+        (temp_project / "AGENTS.md").write_text("# Project rules (short)")
+
+        with patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)):
+            result = load_puppy_rules()
+
+        assert result is not None
+        # Project file landed untouched.
+        assert "# Project rules (short)" in result
+        # Global file got truncated with a labelled notice.
+        assert "--- AGENTS.md truncated ---" in result
+        assert "global" in result
+        # The 15k of 'g' was capped at AGENTS_MD_MAX_CHARS: a contiguous
+        # block of exactly N g's survives, but a block of N+1 does not.
+        assert "g" * AGENTS_MD_MAX_CHARS in result
+        assert "g" * (AGENTS_MD_MAX_CHARS + 1) not in result
+
+    def test_truncation_per_file_project_only(
+        self, temp_project, mock_config_dir
+    ):
+        from code_puppy.agents._builder import (
+            AGENTS_MD_MAX_CHARS,
+            load_puppy_rules,
+        )
+
+        # Small global, fat project. Global must land untouched.
+        (mock_config_dir / "AGENTS.md").write_text("# Global rules (short)")
+        (temp_project / "AGENTS.md").write_text("p" * 15_000)
+
+        with patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)):
+            result = load_puppy_rules()
+
+        assert result is not None
+        assert "# Global rules (short)" in result
+        assert "--- AGENTS.md truncated ---" in result
+        assert "project" in result
+        assert "p" * AGENTS_MD_MAX_CHARS in result
+        assert "p" * (AGENTS_MD_MAX_CHARS + 1) not in result
+
+    def test_warning_identifies_source_when_both_truncated(
+        self, temp_project, mock_config_dir
+    ):
+        """When both files overflow, the agent must be able to tell them apart."""
+        from code_puppy.agents._builder import load_puppy_rules
+
+        (mock_config_dir / "AGENTS.md").write_text("g" * 15_000)
+        (temp_project / "AGENTS.md").write_text("p" * 15_000)
+
+        with patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)):
+            result = load_puppy_rules()
+
+        assert result is not None
+        # Two distinct truncation notices.
+        assert result.count("--- AGENTS.md truncated ---") == 2
+        # Both source classes are named so the agent can disambiguate.
+        assert "global" in result
+        assert "project" in result
+
+    def test_truncation_via_preferred_code_puppy_dir(
+        self, temp_project, mock_config_dir
+    ):
+        """Closes branch-coverage parity: truncation also fires from .code_puppy/."""
+        from code_puppy.agents._builder import (
+            AGENTS_MD_MAX_CHARS,
+            load_puppy_rules,
+        )
+
+        code_puppy_dir = temp_project / ".code_puppy"
+        code_puppy_dir.mkdir()
+        (code_puppy_dir / "AGENTS.md").write_text("q" * 15_000)
+
+        with patch("code_puppy.agents._builder.CONFIG_DIR", str(mock_config_dir)):
+            result = load_puppy_rules()
+
+        assert result is not None
+        assert "--- AGENTS.md truncated ---" in result
+        assert ".code_puppy" in result  # source label names the preferred path
+        assert "q" * AGENTS_MD_MAX_CHARS in result
+        assert "q" * (AGENTS_MD_MAX_CHARS + 1) not in result
+
+    def test_friendly_path_collapses_home(self, tmp_path, monkeypatch):
+        """Paths under $HOME render as ~/...; paths outside fall back to absolute."""
+        from pathlib import Path
+
+        from code_puppy.agents._builder import _friendly_path
+
+        fake_home = tmp_path / "home" / "user"
+        fake_home.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+        under_home = fake_home / ".code_puppy" / "AGENTS.md"
+        assert _friendly_path(under_home) == "~/.code_puppy/AGENTS.md"
+
+        outside_home = tmp_path / "elsewhere" / "AGENTS.md"
+        assert _friendly_path(outside_home) == str(outside_home)

--- a/tests/agents/test_builder_load_puppy_rules.py
+++ b/tests/agents/test_builder_load_puppy_rules.py
@@ -515,14 +515,15 @@ class TestGetAgentsMdMaxChars:
             with patch("code_puppy.config.get_value", return_value=bogus):
                 assert get_agents_md_max_chars() == AGENTS_MD_MAX_CHARS_DEFAULT
 
-    def test_above_ceiling_is_clamped(self):
-        from code_puppy.config import (
-            AGENTS_MD_MAX_CHARS_CEILING,
-            get_agents_md_max_chars,
-        )
+    def test_very_large_values_pass_through_uncapped(self):
+        """No upper clamp: 1M-context models can opt into huge AGENTS.md files."""
+        from code_puppy.config import get_agents_md_max_chars
+
+        with patch("code_puppy.config.get_value", return_value="500000"):
+            assert get_agents_md_max_chars() == 500_000
 
         with patch("code_puppy.config.get_value", return_value="99999999"):
-            assert get_agents_md_max_chars() == AGENTS_MD_MAX_CHARS_CEILING
+            assert get_agents_md_max_chars() == 99_999_999
 
     def test_key_is_in_config_keys_for_set_autocomplete(self):
         """The key must appear in get_config_keys() so /set tab-completes it."""

--- a/tests/agents/test_builder_load_puppy_rules.py
+++ b/tests/agents/test_builder_load_puppy_rules.py
@@ -309,9 +309,7 @@ class TestTruncation:
         assert "AGENTS.md" in result
         assert "project" in result
 
-    def test_truncation_per_file_global_only(
-        self, temp_project, mock_config_dir
-    ):
+    def test_truncation_per_file_global_only(self, temp_project, mock_config_dir):
         from code_puppy.agents._builder import (
             AGENTS_MD_MAX_CHARS,
             load_puppy_rules,
@@ -336,9 +334,7 @@ class TestTruncation:
         assert "g" * AGENTS_MD_MAX_CHARS in result
         assert "g" * (AGENTS_MD_MAX_CHARS + 1) not in result
 
-    def test_truncation_per_file_project_only(
-        self, temp_project, mock_config_dir
-    ):
+    def test_truncation_per_file_project_only(self, temp_project, mock_config_dir):
         from code_puppy.agents._builder import (
             AGENTS_MD_MAX_CHARS,
             load_puppy_rules,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -285,6 +285,7 @@ class TestGetConfigKeys:
         mock_parser_instance.read.assert_called_once_with(mock_cfg_file)
         assert keys == sorted(
             [
+                "agents_md_max_chars",
                 "allow_recursion",
                 "auto_save_session",
                 "banner_color_agent_reasoning",
@@ -351,6 +352,7 @@ class TestGetConfigKeys:
         keys = cp_config.get_config_keys()
         assert keys == sorted(
             [
+                "agents_md_max_chars",
                 "allow_recursion",
                 "auto_save_session",
                 "banner_color_agent_reasoning",


### PR DESCRIPTION
## Summary

Cap each `AGENTS.md` the CLI loads at a configurable character budget before
injecting it into the system prompt. **Defaults to 10,000 chars**, settable
via `/set agents_md_max_chars=<int>`. Over-cap files keep the first N chars
verbatim and get a labelled warning notice appended that names the source
file, the original character count, how many characters were dropped, and
hints at the `/set` knob so users can self-discover the override. The
notice is addressed at the agent so it surfaces the issue back to the user
on the next turn.

## Usage

From the TUI, set the per-file character cap with:

```
/set agents_md_max_chars=<int>
```

Where `<int>` is the maximum number of characters allowed per `AGENTS.md`
file. Tab-completion is wired up for the key. Examples:

| Command | Effect |
|---|---|
| *(not set)* | 10,000-char default applies |
| `/set agents_md_max_chars=20000` | Raise the cap to 20,000 chars |
| `/set agents_md_max_chars=500000` | Raise to 500,000 chars (for 1M-token-context models) |
| `/set agents_md_max_chars=2000` | Lower the cap to 2,000 chars |
| `/set agents_md_max_chars=0` (or any garbage) | Falls back to the 10,000 default |

The key name is `agents_md_max_chars`. The setting persists in
`~/.code_puppy/puppy.cfg` and applies to every subsequent `AGENTS.md`
load (global and project).

## Why

Users have started writing very large `AGENTS.md` files (kitchen-sink style)
that bloat the system prompt, increase token cost on every turn, and degrade
model attention to the rest of the prompt. A per-file cap keeps overhead
bounded without anyone having to think about it, and the configurable knob
lets users with large-context models (1M+ tokens) opt into bigger files
when it genuinely makes sense.

## What changed

### `code_puppy/config.py`

- New constant `AGENTS_MD_MAX_CHARS_DEFAULT = 10_000`.
- New getter `get_agents_md_max_chars()` reads the `agents_md_max_chars`
  config key (settable via `/set agents_md_max_chars=<int>`). Falls back
  to the default on values that can't be a sensible cap — non-numeric,
  zero, or negative. **No upper clamp:** any positive integer is honoured
  verbatim so 1M-context-window users aren't artificially limited.
- New key registered in `get_config_keys()` so `/set` tab-completes it.

### `code_puppy/agents/_builder.py`

- Module re-exports `AGENTS_MD_MAX_CHARS = AGENTS_MD_MAX_CHARS_DEFAULT`
  for back-compat with anything that imported the original constant.
- Pure helper `_truncate_agents_md(content, source, max_chars)` —
  takes the cap as a parameter so it stays library-agnostic and easily
  testable. Under the cap returns `content` unchanged; over the cap
  returns `content[:max_chars]` plus a delimited warning that includes
  the source label, original length, dropped count, and the
  `/set agents_md_max_chars=<int>` hint.
- Tiny helper `_friendly_path(candidate)` renders the global config
  path as `~/...` rather than the absolute home path so `$HOME` doesn't
  leak into the system prompt.
- `load_puppy_rules()` resolves the cap once per call via
  `get_agents_md_max_chars()` and wraps each read (global, project
  `.code_puppy/`, project root fallback) with the truncation helper,
  independently per file. Per-file rather than post-join so a fat global
  `AGENTS.md` doesn't silently drop the smaller project file a developer
  is actively editing.

### Tests

- `tests/agents/test_builder_load_puppy_rules.py` — 31 tests:
  - `TestTruncation` covers the helper directly (under-limit, at-limit,
    over-limit), end-to-end through the loader (under, at, over,
    per-file isolation in both directions, both-files truncated, custom
    cap passed to helper, override raises the cap, override lowers the
    cap), and the `_friendly_path` helper.
  - `TestGetAgentsMdMaxChars` covers the new config getter:
    unset → default, valid integer, garbage → default, zero/negative →
    default, very-large-values-pass-through-uncapped (asserts 500,000
    and 99,999,999 are honoured verbatim — proves the no-ceiling
    contract), and presence in `get_config_keys()`.
- `tests/test_config.py` — two pre-existing `get_config_keys()`
  assertions updated to include the new `agents_md_max_chars` key.

## Behaviour matrix

| Scenario | Outcome |
|---|---|
| `AGENTS.md` ≤ cap | Loaded verbatim. No warning. |
| `AGENTS.md` > cap | First `cap` chars kept verbatim + warning appended. |
| Global oversized, project small | Global truncated, project intact. Single warning. |
| Project oversized, global small | Project truncated, global intact. Single warning. |
| Both oversized | Both truncated, two distinct warnings (each names its own file). |
| `/set agents_md_max_chars=N` (positive int) | Cap becomes `N`. No upper clamp. |
| `/set agents_md_max_chars=banana` (or `0`, `-1`) | Falls back to 10,000 default. |
| Key unset entirely | Cap is 10,000 default. |

## Verification

- 31/31 tests pass in `tests/agents/test_builder_load_puppy_rules.py`.
- 75/75 tests pass across `tests/agents/test_builder_load_puppy_rules.py`
  + `tests/test_config.py`.
- 612 tests collected across `tests/agents/` (full suite green locally).
- Validated end-to-end via headless `code-puppy --prompt ...`:
  - Default cap, 42,399-char `AGENTS.md`: agent quoted the notice
    citing `42,399` original / `32,399` dropped (matches
    `original − cap`), and surfaced the `/set` hint organically.
  - `/set agents_md_max_chars=20000`, 12,650-char `AGENTS.md`: agent
    confirmed "no truncation notice present" — content intact.
  - `/set agents_md_max_chars=2000`, 5,000-char `AGENTS.md`: agent
    extracted from the notice: cap=2,000, original=5,000, dropped=3,000.
  - `/set agents_md_max_chars=250000`, 220,000-char `AGENTS.md`
    (would have been clamped to 200k and truncated under any reasonable
    upper bound): agent confirmed "no truncation notice present" —
    proves the no-ceiling contract end-to-end.

## Design notes / non-goals

- **Configurable via `/set`, no CLI flag, no env var.** The TUI's
  `/set` mechanism is the canonical user-facing knob for runtime
  config; adding a CLI flag or env var would split the surface for no
  added power. Tab-completion is wired up via `get_config_keys()`.
- **No upper clamp on the override.** Earlier iterations had a
  200,000-char ceiling as a typo-guard, but 1M-token-context models
  (Gemini 1.5 Pro, Claude extended context, etc.) make any fixed
  ceiling short-sighted. Garbage / zero / negative still fall back to
  the default, so the footgun-guard for unintentional bad input is
  intact; the only thing removed is the cap on values that are clearly
  intentional and positive.
- **No `emit_warning` to the terminal.** The agent already gets the
  signal in its prompt and will tell the user. A second channel would
  be noise.
- **No exact-length assertions in the tests.** They pin structure
  (prefix-length, marker presence, source label, numeric counts) so the
  warning text can drift without test rewrites.
- **Truncation is at code-point boundary.** `len(str)` counts code
  points, so emoji-heavy files cap at code-point N with no
  partial-character mojibake (Python strings can't have partial code
  points).
- **Truncation notice self-documents the override.** The warning text
  ends with `(or raise the cap via /set agents_md_max_chars=<int>)`
  so the first time a user hits the cap they discover the knob
  organically — no need to read this PR or the docs.

## Downstream impact (free wins, no code changes)

- `plugins/context_indicator/usage.py` consumes `load_puppy_rules()` output,
  so its AGENTS.md token bucket now reflects the truncated size — a small
  accuracy improvement for the `/context` command.
- Sub-agents (`tools/subagent_invocation.py`) inherit the truncated content
  + warning, which is the right behaviour: they can also tell the user to
  trim (or raise the cap).
- Claude-code first-turn path (`_runtime.py`) prepends the same truncated
  content + warning.

