### PR TITLE
feat: project-level plugin discovery via .code_puppy/plugins/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,15 @@
 
 ## How Plugins Work
 
-Create `code_puppy/plugins/my_feature/register_callbacks.py` (builtin) or `~/.code_puppy/plugins/my_feature/register_callbacks.py` (user):
+Plugins are discovered from three tiers, loaded in order:
+
+| Tier | Location | When to use |
+|------|----------|-------------|
+| **Builtin** | `code_puppy/plugins/<name>/register_callbacks.py` | Core functionality shipped with Code Puppy |
+| **User** | `~/.code_puppy/plugins/<name>/register_callbacks.py` | Personal plugins, applied to every project |
+| **Project** | `<CWD>/.code_puppy/plugins/<name>/register_callbacks.py` | Repo-specific plugins, shared with your team via git |
+
+All three tiers use the same pattern — drop a `register_callbacks.py` in a named subdirectory:
 
 ```python
 from code_puppy.callbacks import register_callback
@@ -17,6 +25,26 @@ register_callback("startup", _on_startup)
 ```
 
 That's it. The plugin loader auto-discovers `register_callbacks.py` in subdirs.
+
+### Project Plugins
+
+Project plugins live at `<CWD>/.code_puppy/plugins/<name>/register_callbacks.py`.
+This mirrors the project-level discovery already used by agents (`<CWD>/.code_puppy/agents/`)
+and skills (`<CWD>/.code_puppy/skills/`).
+
+**Key details:**
+
+- **Directory must be created intentionally.** Code Puppy will never auto-create
+  `.code_puppy/plugins/` — your team opts in by creating it.
+- **Load order is builtin → user → project.** Project plugins load last, giving
+  them highest precedence for override-style hooks.
+- **Project wins on name collision.** If a project plugin shares a name with a
+  user plugin, only the project copy loads (the user plugin is skipped). This
+  matches how agents deduplicate — `discover_json_agents()` overwrites user
+  agents with project agents of the same name. A warning is logged when a
+  project plugin shadows a builtin.
+- **Module namespace isolation.** Project plugins use `project_plugins.<name>.register_callbacks`
+  in `sys.modules`, so they never collide with user plugins at the import level.
 
 ## Available Hooks
 
@@ -60,3 +88,4 @@ Full list + rarely-used hooks: see `code_puppy/callbacks.py` source.
 5. **Return `None` from commands you don't own**
 6. **Always run linters - `ruff check --fix`, `ruff format .`
 7. **NEVER ALLOW A CLAUDE CO-AUTHOR COMMIT**
+

--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import traceback
-from typing import Any, Callable, Dict, List, Literal, Optional
+from typing import Any, Callable, Dict, List, Literal, Optional, Set
 
 PhaseType = Literal[
     "startup",
@@ -112,6 +112,49 @@ _callbacks: Dict[PhaseType, List[CallbackFunc]] = {
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Plugin ownership tracking
+# ---------------------------------------------------------------------------
+# Maps each registered callback function to the plugin that registered it.
+# Populated by register_callback() when a loading context is active.
+_callback_owners: Dict[CallbackFunc, str] = {}
+
+# Set by the plugin loader before importing each plugin's register_callbacks.py,
+# cleared immediately after.  register_callback() reads this to record ownership.
+_current_loading_plugin: Optional[str] = None
+
+
+def set_loading_context(plugin_name: str) -> None:
+    """Mark *plugin_name* as the plugin currently being loaded.
+
+    Called by the plugin loader before importing a plugin's
+    ``register_callbacks`` module.  Any callbacks registered while this
+    context is active are associated with *plugin_name*.
+    """
+    global _current_loading_plugin
+    _current_loading_plugin = plugin_name
+
+
+def clear_loading_context() -> None:
+    """Clear the current plugin loading context."""
+    global _current_loading_plugin
+    _current_loading_plugin = None
+
+
+def get_callback_owner(func: CallbackFunc) -> Optional[str]:
+    """Return the plugin name that registered *func*, or ``None``."""
+    return _callback_owners.get(func)
+
+
+def _get_disabled_plugins() -> Set[str]:
+    """Lazy accessor for the disabled-plugins set (avoids circular import)."""
+    try:
+        from code_puppy.plugins.config import get_disabled_plugins
+
+        return get_disabled_plugins()
+    except Exception:
+        return set()
+
 
 def register_callback(phase: PhaseType, func: CallbackFunc) -> None:
     if phase not in _callbacks:
@@ -131,6 +174,11 @@ def register_callback(phase: PhaseType, func: CallbackFunc) -> None:
         return
 
     _callbacks[phase].append(func)
+
+    # Record ownership if we know which plugin is loading.
+    if _current_loading_plugin is not None:
+        _callback_owners[func] = _current_loading_plugin
+
     logger.debug(f"Registered async callback {func.__name__} for phase '{phase}'")
 
 
@@ -159,8 +207,23 @@ def clear_callbacks(phase: Optional[PhaseType] = None) -> None:
             logger.debug(f"Cleared async callbacks for phase '{phase}'")
 
 
-def get_callbacks(phase: PhaseType) -> List[CallbackFunc]:
-    return _callbacks.get(phase, []).copy()
+def get_callbacks(
+    phase: PhaseType, *, include_disabled: bool = False
+) -> List[CallbackFunc]:
+    """Return callbacks for *phase*, filtering out disabled plugins.
+
+    When *include_disabled* is ``True`` the filter is bypassed — useful for
+    introspection (e.g. listing all registered callbacks).
+    """
+    all_cbs = _callbacks.get(phase, []).copy()
+    if include_disabled:
+        return all_cbs
+
+    disabled = _get_disabled_plugins()
+    if not disabled:
+        return all_cbs
+
+    return [cb for cb in all_cbs if _callback_owners.get(cb) not in disabled]
 
 
 def count_callbacks(phase: Optional[PhaseType] = None) -> int:

--- a/code_puppy/plugins/__init__.py
+++ b/code_puppy/plugins/__init__.py
@@ -2,6 +2,7 @@ import importlib
 import importlib.util
 import logging
 import sys
+import types
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -11,6 +12,10 @@ USER_PLUGINS_DIR = Path.home() / ".code_puppy" / "plugins"
 
 # Track if plugins have already been loaded to prevent duplicate registration
 _PLUGINS_LOADED = False
+
+# Stores the loaded plugin names by tier after the first load_plugin_callbacks() call.
+# Populated once, then read by get_loaded_plugins().
+_loaded_plugin_names: dict[str, list[str]] = {"builtin": [], "user": [], "project": []}
 
 
 def _load_builtin_plugins(plugins_dir: Path) -> list[str]:
@@ -54,15 +59,49 @@ def _load_builtin_plugins(plugins_dir: Path) -> list[str]:
     return loaded
 
 
-def _load_user_plugins(user_plugins_dir: Path) -> list[str]:
+def _scan_plugin_names(plugins_dir: Path) -> set[str]:
+    """Return the set of plugin directory names under *plugins_dir*.
+
+    Only performs a cheap filesystem scan — nothing is imported.  Used to
+    pre-detect project plugin names so that ``_load_user_plugins`` can
+    skip names that the project tier will supersede (project wins on
+    collision, matching the agents dedup strategy).
+    """
+    names: set[str] = set()
+    if not plugins_dir.is_dir():
+        return names
+    for item in plugins_dir.iterdir():
+        if (
+            item.is_dir()
+            and not item.name.startswith("_")
+            and not item.name.startswith(".")
+        ):
+            # Only count it if it actually has a loadable entry point
+            if (item / "register_callbacks.py").exists() or (
+                item / "__init__.py"
+            ).exists():
+                names.add(item.name)
+    return names
+
+
+def _load_user_plugins(
+    user_plugins_dir: Path,
+    skip_names: set[str] | None = None,
+) -> list[str]:
     """Load user plugins from ~/.code_puppy/plugins/.
 
     Each plugin should be a directory containing a register_callbacks.py file.
     Plugins are loaded by adding their parent to sys.path and importing them.
 
+    *skip_names*, when provided, is a set of plugin names that will be loaded
+    from a higher-precedence tier (project plugins).  User plugins whose name
+    appears in this set are skipped so that only one copy registers callbacks
+    (matching the agents dedup strategy).
+
     Returns list of successfully loaded plugin names.
     """
     loaded = []
+    skip_names = skip_names or set()
 
     if not user_plugins_dir.exists():
         return loaded
@@ -83,6 +122,14 @@ def _load_user_plugins(user_plugins_dir: Path) -> list[str]:
             and not item.name.startswith(".")
         ):
             plugin_name = item.name
+
+            if plugin_name in skip_names:
+                logger.info(
+                    f"Skipping user plugin '{plugin_name}' — "
+                    f"overridden by project plugin of the same name"
+                )
+                continue
+
             callbacks_file = item / "register_callbacks.py"
 
             if callbacks_file.exists():
@@ -139,14 +186,197 @@ def _load_user_plugins(user_plugins_dir: Path) -> list[str]:
     return loaded
 
 
+_PROJECT_PLUGINS_NS = "project_plugins"
+
+
+def _ensure_project_ns() -> None:
+    """Create the synthetic ``project_plugins`` namespace package.
+
+    Needed once so that ``project_plugins.<name>.register_callbacks`` can
+    resolve relative imports (``from . import state``, etc.).  Without a
+    parent package in ``sys.modules`` Python raises ``ModuleNotFoundError``
+    when it encounters ``from .``.
+    """
+    if _PROJECT_PLUGINS_NS not in sys.modules:
+        ns_pkg = types.ModuleType(_PROJECT_PLUGINS_NS)
+        ns_pkg.__path__ = []  # namespace package
+        ns_pkg.__package__ = _PROJECT_PLUGINS_NS
+        sys.modules[_PROJECT_PLUGINS_NS] = ns_pkg
+
+
+def _ensure_plugin_package(plugin_dir: Path, plugin_name: str) -> bool:
+    """Register a synthetic package for *plugin_name* under the project namespace.
+
+    If the plugin directory contains an ``__init__.py`` it is executed so
+    that any package-level attributes (``__version__``, etc.) are available.
+    Otherwise a bare namespace module is created with ``__path__`` pointing
+    at the plugin directory — enough for the import machinery to locate
+    sibling modules when ``register_callbacks.py`` does relative imports.
+
+    Returns ``True`` if a real ``__init__.py`` was executed, ``False`` if a
+    bare namespace fallback was used (no init, or spec/loader was ``None``).
+    """
+    pkg_name = f"{_PROJECT_PLUGINS_NS}.{plugin_name}"
+    if pkg_name in sys.modules:
+        return True
+
+    init_file = plugin_dir / "__init__.py"
+    if init_file.exists():
+        spec_init = importlib.util.spec_from_file_location(
+            pkg_name,
+            init_file,
+            submodule_search_locations=[str(plugin_dir)],
+        )
+        if spec_init is None or spec_init.loader is None:
+            # Fallback: bare namespace (init exists but can't be loaded)
+            pkg_mod = types.ModuleType(pkg_name)
+            pkg_mod.__path__ = [str(plugin_dir)]
+            pkg_mod.__package__ = pkg_name
+            sys.modules[pkg_name] = pkg_mod
+            return False
+
+        pkg_mod = importlib.util.module_from_spec(spec_init)
+        sys.modules[pkg_name] = pkg_mod
+        spec_init.loader.exec_module(pkg_mod)
+        return True
+    else:
+        pkg_mod = types.ModuleType(pkg_name)
+        pkg_mod.__path__ = [str(plugin_dir)]
+        pkg_mod.__package__ = pkg_name
+        sys.modules[pkg_name] = pkg_mod
+        return False
+
+
+def _load_project_plugins(
+    project_plugins_dir: Path,
+    builtin_names: set[str],
+    user_names: set[str],
+) -> list[str]:
+    """Load project plugins from <CWD>/.code_puppy/plugins/.
+
+    Mirrors _load_user_plugins() but uses a ``project_plugins.`` sys.modules
+    namespace and warns on name collisions with builtin or user plugins.
+
+    Before loading each plugin's ``register_callbacks.py``, a synthetic
+    parent package is registered in ``sys.modules`` so that relative
+    imports (``from . import state``, ``from .utils import …``) resolve
+    correctly.
+
+    Returns list of successfully loaded plugin names.
+    """
+    loaded = []
+
+    if not project_plugins_dir.exists():
+        return loaded
+
+    if not project_plugins_dir.is_dir():
+        logger.warning(
+            f"Project plugins path is not a directory: {project_plugins_dir}"
+        )
+        return loaded
+
+    project_plugins_str = str(project_plugins_dir)
+    if project_plugins_str not in sys.path:
+        sys.path.insert(0, project_plugins_str)
+
+    # Create the top-level namespace package once
+    _ensure_project_ns()
+
+    for item in project_plugins_dir.iterdir():
+        if (
+            item.is_dir()
+            and not item.name.startswith("_")
+            and not item.name.startswith(".")
+        ):
+            plugin_name = item.name
+
+            # Warn if a project plugin shadows a builtin (user collisions
+            # are handled earlier by skipping the user plugin entirely).
+            if plugin_name in builtin_names:
+                logger.warning(
+                    f"Project plugin '{plugin_name}' shadows builtin plugin of the same name"
+                )
+
+            callbacks_file = item / "register_callbacks.py"
+
+            if callbacks_file.exists():
+                try:
+                    # Register parent package so relative imports resolve
+                    _ensure_plugin_package(item, plugin_name)
+
+                    module_name = (
+                        f"{_PROJECT_PLUGINS_NS}.{plugin_name}.register_callbacks"
+                    )
+                    spec = importlib.util.spec_from_file_location(
+                        module_name, callbacks_file
+                    )
+                    if spec is None or spec.loader is None:
+                        logger.warning(
+                            f"Could not create module spec for project plugin: {plugin_name}"
+                        )
+                        continue
+
+                    module = importlib.util.module_from_spec(spec)
+                    sys.modules[module_name] = module
+                    spec.loader.exec_module(module)
+                    loaded.append(plugin_name)
+
+                except ImportError as e:
+                    logger.warning(
+                        f"Failed to import callbacks from project plugin {plugin_name}: {e}"
+                    )
+                except Exception as e:
+                    logger.error(
+                        f"Unexpected error loading project plugin {plugin_name}: {e}",
+                        exc_info=True,
+                    )
+            else:
+                # Fallback to __init__.py (mirrors user plugin behavior)
+                init_file = item / "__init__.py"
+                if init_file.exists():
+                    try:
+                        if _ensure_plugin_package(item, plugin_name):
+                            loaded.append(plugin_name)
+                        else:
+                            logger.warning(
+                                f"Could not load __init__.py for project plugin: {plugin_name}"
+                            )
+
+                    except Exception as e:
+                        logger.error(
+                            f"Unexpected error loading project plugin {plugin_name}: {e}",
+                            exc_info=True,
+                        )
+
+    return loaded
+
+
+def get_project_plugins_directory() -> Path | None:
+    """Get the project-local plugins directory path.
+
+    Looks for a .code_puppy/plugins/ directory in the current working directory.
+    Does NOT create the directory if it doesn't exist — the team must create it
+    intentionally.
+
+    Returns:
+        Path to the project's plugins directory if it exists, or None.
+    """
+    project_plugins_dir = Path.cwd() / ".code_puppy" / "plugins"
+    if project_plugins_dir.is_dir():
+        return project_plugins_dir
+    return None
+
+
 def load_plugin_callbacks() -> dict[str, list[str]]:
     """Dynamically load register_callbacks.py from all plugin sources.
 
     Loads plugins from:
     1. Built-in plugins in the code_puppy/plugins/ directory
     2. User plugins in ~/.code_puppy/plugins/
+    3. Project plugins in <CWD>/.code_puppy/plugins/
 
-    Returns dict with 'builtin' and 'user' keys containing lists of loaded plugin names.
+    Returns dict with 'builtin', 'user', and 'project' keys containing
+    lists of loaded plugin names.
 
     NOTE: This function is idempotent - calling it multiple times will only
     load plugins once. Subsequent calls return empty lists.
@@ -157,19 +387,56 @@ def load_plugin_callbacks() -> dict[str, list[str]]:
     # so re-importing would cause duplicate registrations
     if _PLUGINS_LOADED:
         logger.debug("Plugins already loaded, skipping duplicate load")
-        return {"builtin": [], "user": []}
+        return {"builtin": [], "user": [], "project": []}
 
     plugins_dir = Path(__file__).parent
 
+    # Pre-scan project plugin names so we can skip user plugins that the
+    # project tier will supersede (project wins, matching agents dedup).
+    project_plugins_dir = get_project_plugins_directory()
+    project_plugin_names = (
+        _scan_plugin_names(project_plugins_dir)
+        if project_plugins_dir is not None
+        else set()
+    )
+
+    builtin_loaded = _load_builtin_plugins(plugins_dir)
+    user_loaded = _load_user_plugins(USER_PLUGINS_DIR, skip_names=project_plugin_names)
+
+    # Load project plugins last (highest precedence)
+    project_loaded = []
+    if project_plugins_dir is not None:
+        logger.info(f"Loading project plugins from {project_plugins_dir}")
+        project_loaded = _load_project_plugins(
+            project_plugins_dir,
+            builtin_names=set(builtin_loaded),
+            user_names=set(user_loaded),
+        )
+
     result = {
-        "builtin": _load_builtin_plugins(plugins_dir),
-        "user": _load_user_plugins(USER_PLUGINS_DIR),
+        "builtin": builtin_loaded,
+        "user": user_loaded,
+        "project": project_loaded,
     }
 
     _PLUGINS_LOADED = True
-    logger.debug(f"Loaded plugins: builtin={result['builtin']}, user={result['user']}")
+    _loaded_plugin_names.update(result)
+    logger.debug(
+        f"Loaded plugins: builtin={result['builtin']}, "
+        f"user={result['user']}, project={result['project']}"
+    )
 
     return result
+
+
+def get_loaded_plugins() -> dict[str, list[str]]:
+    """Return the loaded plugin names grouped by tier.
+
+    Returns a dict with 'builtin', 'user', and 'project' keys, each
+    containing a list of plugin names loaded during startup.  Safe to
+    call at any time — returns empty lists before plugins are loaded.
+    """
+    return dict(_loaded_plugin_names)
 
 
 def get_user_plugins_dir() -> Path:

--- a/code_puppy/plugins/__init__.py
+++ b/code_puppy/plugins/__init__.py
@@ -5,6 +5,8 @@ import sys
 import types
 from pathlib import Path
 
+from code_puppy.callbacks import clear_loading_context, set_loading_context
+
 logger = logging.getLogger(__name__)
 
 # User plugins directory
@@ -45,6 +47,7 @@ def _load_builtin_plugins(plugins_dir: Path) -> list[str]:
 
                 try:
                     module_name = f"code_puppy.plugins.{plugin_name}.register_callbacks"
+                    set_loading_context(plugin_name)
                     importlib.import_module(module_name)
                     loaded.append(plugin_name)
                 except ImportError as e:
@@ -55,6 +58,8 @@ def _load_builtin_plugins(plugins_dir: Path) -> list[str]:
                     logger.error(
                         f"Unexpected error loading built-in plugin {plugin_name}: {e}"
                     )
+                finally:
+                    clear_loading_context()
 
     return loaded
 
@@ -148,7 +153,11 @@ def _load_user_plugins(
                     module = importlib.util.module_from_spec(spec)
                     sys.modules[module_name] = module
 
-                    spec.loader.exec_module(module)
+                    set_loading_context(plugin_name)
+                    try:
+                        spec.loader.exec_module(module)
+                    finally:
+                        clear_loading_context()
                     loaded.append(plugin_name)
 
                 except ImportError as e:
@@ -174,7 +183,11 @@ def _load_user_plugins(
 
                         module = importlib.util.module_from_spec(spec)
                         sys.modules[module_name] = module
-                        spec.loader.exec_module(module)
+                        set_loading_context(plugin_name)
+                        try:
+                            spec.loader.exec_module(module)
+                        finally:
+                            clear_loading_context()
                         loaded.append(plugin_name)
 
                     except Exception as e:
@@ -318,7 +331,11 @@ def _load_project_plugins(
 
                     module = importlib.util.module_from_spec(spec)
                     sys.modules[module_name] = module
-                    spec.loader.exec_module(module)
+                    set_loading_context(plugin_name)
+                    try:
+                        spec.loader.exec_module(module)
+                    finally:
+                        clear_loading_context()
                     loaded.append(plugin_name)
 
                 except ImportError as e:
@@ -335,7 +352,12 @@ def _load_project_plugins(
                 init_file = item / "__init__.py"
                 if init_file.exists():
                     try:
-                        if _ensure_plugin_package(item, plugin_name):
+                        set_loading_context(plugin_name)
+                        try:
+                            loaded_ok = _ensure_plugin_package(item, plugin_name)
+                        finally:
+                            clear_loading_context()
+                        if loaded_ok:
                             loaded.append(plugin_name)
                         else:
                             logger.warning(

--- a/code_puppy/plugins/config.py
+++ b/code_puppy/plugins/config.py
@@ -1,0 +1,65 @@
+"""Central config helpers for the plugin system.
+
+Follows the same pattern as ``agent_skills.config`` — a ``disabled_plugins``
+JSON list in ``puppy.cfg`` controls which plugins are suppressed at runtime.
+
+Plugins listed here are still *loaded* (their ``register_callbacks.py`` is
+imported) but their callbacks are **skipped** during dispatch.  This means
+toggling takes effect immediately without a restart.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Set
+
+from code_puppy.config import get_value, set_value
+
+logger = logging.getLogger(__name__)
+
+
+def get_disabled_plugins() -> Set[str]:
+    """Return the set of explicitly disabled plugin names.
+
+    Reads from ``disabled_plugins`` config key (JSON list in puppy.cfg).
+    """
+    config_value = get_value("disabled_plugins")
+    if config_value:
+        try:
+            disabled_list = json.loads(config_value)
+            if isinstance(disabled_list, list):
+                return set(disabled_list)
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse disabled_plugins config: {e}")
+    return set()
+
+
+def is_plugin_disabled(plugin_name: str) -> bool:
+    """Check whether *plugin_name* is currently disabled."""
+    return plugin_name in get_disabled_plugins()
+
+
+def set_plugin_disabled(plugin_name: str, disabled: bool) -> bool:
+    """Disable or re-enable a plugin by name.
+
+    Returns ``True`` if the state changed, ``False`` if it was already in the
+    requested state.
+    """
+    disabled_plugins = get_disabled_plugins()
+
+    if disabled:
+        if plugin_name in disabled_plugins:
+            logger.info(f"Plugin already disabled: {plugin_name}")
+            return False
+        disabled_plugins.add(plugin_name)
+        logger.info(f"Disabled plugin: {plugin_name}")
+    else:
+        if plugin_name not in disabled_plugins:
+            logger.info(f"Plugin already enabled: {plugin_name}")
+            return False
+        disabled_plugins.remove(plugin_name)
+        logger.info(f"Enabled plugin: {plugin_name}")
+
+    set_value("disabled_plugins", json.dumps(sorted(disabled_plugins)))
+    return True

--- a/code_puppy/plugins/example_custom_command/README.md
+++ b/code_puppy/plugins/example_custom_command/README.md
@@ -120,13 +120,43 @@ register_callback("custom_command", _handle_custom_command)
 
 ## Creating Your Own Plugin
 
+Plugins can live at any of the three discovery tiers:
+
+| Tier | Location | Scope |
+|------|----------|-------|
+| **Builtin** | `code_puppy/plugins/<name>/` | Shipped with Code Puppy |
+| **User** | `~/.code_puppy/plugins/<name>/` | Personal, all projects |
+| **Project** | `<CWD>/.code_puppy/plugins/<name>/` | Repo-specific, team-shared |
+
+All tiers use the exact same `register_callbacks.py` pattern.
+
 ### Step 1: Create Plugin Directory
+
+**Builtin plugin** (shipped with Code Puppy):
 
 ```bash
 mkdir -p code_puppy/plugins/my_plugin
 touch code_puppy/plugins/my_plugin/__init__.py
 touch code_puppy/plugins/my_plugin/register_callbacks.py
 ```
+
+**User plugin** (personal, applies to all projects):
+
+```bash
+mkdir -p ~/.code_puppy/plugins/my_plugin
+touch ~/.code_puppy/plugins/my_plugin/register_callbacks.py
+```
+
+**Project plugin** (shared with your team via git):
+
+```bash
+mkdir -p .code_puppy/plugins/my_plugin
+touch .code_puppy/plugins/my_plugin/register_callbacks.py
+```
+
+> **Note:** Code Puppy never auto-creates `.code_puppy/plugins/` — your team
+> opts in by creating the directory. Project plugins load last (after builtin
+> and user), giving them highest precedence for override-style hooks.
 
 ### Step 2: Implement Callbacks
 
@@ -248,6 +278,17 @@ def test_unknown_command():
     result = _handle_custom_command("/unknown", "unknown")
     assert result is None
 ```
+
+## Plugin Discovery Tiers
+
+| Feature | Builtin | User | Project |
+|---------|---------|------|---------|
+| **Location** | `code_puppy/plugins/` | `~/.code_puppy/plugins/` | `<CWD>/.code_puppy/plugins/` |
+| **Load order** | First | Second | Last (highest precedence) |
+| **Auto-created** | N/A (in package) | No | No — team must create intentionally |
+| **Name collisions** | N/A | Warning logged | Warning logged, still loads (shadow) |
+| **Module namespace** | `code_puppy.plugins.<name>` | `<name>.register_callbacks` | `project_plugins.<name>.register_callbacks` |
+| **Shared via git** | Yes (in repo) | No (local only) | Yes (in `.code_puppy/`) |
 
 ## Difference from Built-in Commands
 

--- a/code_puppy/plugins/plugin_list/plugins_menu.py
+++ b/code_puppy/plugins/plugin_list/plugins_menu.py
@@ -1,0 +1,313 @@
+"""Interactive TUI for managing plugins.
+
+Launch with ``/plugins`` to browse and toggle plugins on/off.
+Built with prompt_toolkit, following the same pattern as the skills menu.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from typing import List, Optional, Tuple
+
+from prompt_toolkit.application import Application
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.layout import Dimension, Layout, VSplit, Window
+from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.widgets import Frame
+
+from code_puppy.command_line.pagination import (
+    ensure_visible_page,
+    get_page_bounds,
+    get_total_pages,
+)
+from code_puppy.tools.command_runner import set_awaiting_user_input
+
+PAGE_SIZE = 20
+
+
+class _PluginEntry:
+    """Lightweight struct for a loaded plugin."""
+
+    __slots__ = ("name", "tier")
+
+    def __init__(self, name: str, tier: str) -> None:
+        self.name = name
+        self.tier = tier
+
+
+class PluginsMenu:
+    """Interactive TUI for enabling/disabling plugins."""
+
+    def __init__(self) -> None:
+        self.plugins: List[_PluginEntry] = []
+        self.disabled: set[str] = set()
+
+        self.selected_idx = 0
+        self.current_page = 0
+        self.result: Optional[str] = None
+
+        self.menu_control: Optional[FormattedTextControl] = None
+        self.detail_control: Optional[FormattedTextControl] = None
+
+        self._refresh_data()
+
+    # -- data helpers ------------------------------------------------------
+
+    def _refresh_data(self) -> None:
+        from code_puppy.plugins import get_loaded_plugins
+        from code_puppy.plugins.config import get_disabled_plugins
+
+        loaded = get_loaded_plugins()
+        self.disabled = get_disabled_plugins()
+
+        entries: List[_PluginEntry] = []
+        for tier in ("builtin", "user", "project"):
+            for name in sorted(loaded.get(tier, [])):
+                entries.append(_PluginEntry(name, tier))
+        self.plugins = entries
+
+    def _current(self) -> Optional[_PluginEntry]:
+        if 0 <= self.selected_idx < len(self.plugins):
+            return self.plugins[self.selected_idx]
+        return None
+
+    def _toggle_current(self) -> None:
+        entry = self._current()
+        if not entry:
+            return
+        from code_puppy.plugins.config import set_plugin_disabled
+
+        is_disabled = entry.name in self.disabled
+        set_plugin_disabled(entry.name, not is_disabled)
+        self._refresh_data()
+        self.update_display()
+
+    # -- rendering ---------------------------------------------------------
+
+    def _render_list(self) -> List[Tuple[str, str]]:
+        lines: List[Tuple[str, str]] = []
+
+        lines.append(("bold", " Plugins"))
+        lines.append(("", "\n\n"))
+
+        if not self.plugins:
+            lines.append(("fg:ansiyellow", "  No plugins loaded."))
+            lines.append(("", "\n"))
+            self._render_hints(lines)
+            return lines
+
+        total_pages = get_total_pages(len(self.plugins), PAGE_SIZE)
+        start_idx, end_idx = get_page_bounds(
+            self.current_page, len(self.plugins), PAGE_SIZE
+        )
+
+        for i in range(start_idx, end_idx):
+            entry = self.plugins[i]
+            is_selected = i == self.selected_idx
+            is_disabled = entry.name in self.disabled
+
+            icon = "x" if is_disabled else "+"
+            icon_style = "fg:ansired" if is_disabled else "fg:ansigreen"
+            prefix = " > " if is_selected else "   "
+
+            if is_selected:
+                lines.append(("bold", prefix))
+                lines.append((icon_style + " bold", icon))
+                lines.append(("bold", f" {entry.name}"))
+            else:
+                lines.append(("", prefix))
+                lines.append((icon_style, icon))
+                lines.append(("fg:ansibrightblack", f" {entry.name}"))
+
+            lines.append(("", "\n"))
+
+        lines.append(("", "\n"))
+        lines.append(
+            ("fg:ansibrightblack", f" Page {self.current_page + 1}/{total_pages}")
+        )
+        lines.append(("", "\n"))
+
+        self._render_hints(lines)
+        return lines
+
+    def _render_hints(self, lines: List[Tuple[str, str]]) -> None:
+        lines.append(("", "\n"))
+        lines.append(("fg:ansibrightblack", "  up/down or j/k "))
+        lines.append(("", "Navigate\n"))
+        lines.append(("fg:ansibrightblack", "  left/right     "))
+        lines.append(("", "Page\n"))
+        lines.append(("fg:ansigreen", "  Enter          "))
+        lines.append(("", "Toggle\n"))
+        lines.append(("fg:ansired", "  q / Esc        "))
+        lines.append(("", "Exit"))
+
+    def _render_detail(self) -> List[Tuple[str, str]]:
+        lines: List[Tuple[str, str]] = []
+
+        lines.append(("dim cyan", " PLUGIN DETAILS"))
+        lines.append(("", "\n\n"))
+
+        entry = self._current()
+        if not entry:
+            lines.append(("fg:ansiyellow", "  No plugin selected."))
+            return lines
+
+        is_disabled = entry.name in self.disabled
+
+        # Name
+        lines.append(("bold", f"  {entry.name}"))
+        lines.append(("", "\n\n"))
+
+        # Tier
+        lines.append(("bold", "  Tier: "))
+        lines.append(("", entry.tier))
+        lines.append(("", "\n\n"))
+
+        # Status
+        lines.append(("bold", "  Status: "))
+        if is_disabled:
+            lines.append(("fg:ansired bold", "Disabled"))
+            lines.append(("", "\n"))
+            lines.append(
+                ("fg:ansibrightblack", "  Callbacks are skipped at dispatch time.")
+            )
+        else:
+            lines.append(("fg:ansigreen bold", "Enabled"))
+            lines.append(("", "\n"))
+            lines.append(("fg:ansibrightblack", "  All callbacks are active."))
+        lines.append(("", "\n\n"))
+
+        lines.append(("fg:ansibrightblack", "  Press Enter to toggle."))
+
+        return lines
+
+    # -- display update ----------------------------------------------------
+
+    def update_display(self) -> None:
+        if self.menu_control:
+            self.menu_control.text = self._render_list()
+        if self.detail_control:
+            self.detail_control.text = self._render_detail()
+
+    # -- application -------------------------------------------------------
+
+    def run(self) -> Optional[str]:
+        self.menu_control = FormattedTextControl(text="")
+        self.detail_control = FormattedTextControl(text="")
+
+        menu_window = Window(
+            content=self.menu_control, wrap_lines=True, width=Dimension(weight=40)
+        )
+        detail_window = Window(
+            content=self.detail_control, wrap_lines=True, width=Dimension(weight=60)
+        )
+
+        menu_frame = Frame(menu_window, width=Dimension(weight=40), title="Plugins")
+        detail_frame = Frame(detail_window, width=Dimension(weight=60), title="Details")
+
+        root_container = VSplit([menu_frame, detail_frame])
+
+        kb = KeyBindings()
+
+        @kb.add("up")
+        @kb.add("k")
+        def _(event):
+            if self.selected_idx > 0:
+                self.selected_idx -= 1
+                self.current_page = ensure_visible_page(
+                    self.selected_idx,
+                    self.current_page,
+                    len(self.plugins),
+                    PAGE_SIZE,
+                )
+            self.update_display()
+
+        @kb.add("down")
+        @kb.add("j")
+        def _(event):
+            if self.selected_idx < len(self.plugins) - 1:
+                self.selected_idx += 1
+                self.current_page = ensure_visible_page(
+                    self.selected_idx,
+                    self.current_page,
+                    len(self.plugins),
+                    PAGE_SIZE,
+                )
+            self.update_display()
+
+        @kb.add("left")
+        def _(event):
+            if self.current_page > 0:
+                self.current_page -= 1
+                self.selected_idx = self.current_page * PAGE_SIZE
+                self.update_display()
+
+        @kb.add("right")
+        def _(event):
+            total_pages = get_total_pages(len(self.plugins), PAGE_SIZE)
+            if self.current_page < total_pages - 1:
+                self.current_page += 1
+                self.selected_idx = self.current_page * PAGE_SIZE
+                self.update_display()
+
+        @kb.add("enter")
+        def _(event):
+            self._toggle_current()
+            self.result = "changed"
+
+        @kb.add("q")
+        @kb.add("escape")
+        def _(event):
+            self.result = "quit"
+            event.app.exit()
+
+        @kb.add("c-c")
+        def _(event):
+            self.result = "quit"
+            event.app.exit()
+
+        layout = Layout(root_container)
+        app = Application(
+            layout=layout,
+            key_bindings=kb,
+            full_screen=False,
+            mouse_support=False,
+        )
+
+        set_awaiting_user_input(True)
+
+        sys.stdout.write("\033[?1049h")  # Enter alternate buffer
+        sys.stdout.write("\033[2J\033[H")  # Clear and home
+        sys.stdout.flush()
+        time.sleep(0.05)
+
+        try:
+            self.update_display()
+
+            sys.stdout.write("\033[2J\033[H")
+            sys.stdout.flush()
+
+            app.run(in_thread=True)
+
+        finally:
+            sys.stdout.write("\033[?1049l")  # Exit alternate buffer
+            sys.stdout.flush()
+
+            try:
+                import termios
+
+                termios.tcflush(sys.stdin.fileno(), termios.TCIFLUSH)
+            except Exception:
+                pass
+
+            time.sleep(0.1)
+            set_awaiting_user_input(False)
+
+        return self.result
+
+
+def run_plugins_menu() -> Optional[str]:
+    """Entry point: create and run the plugins TUI, return the result."""
+    menu = PluginsMenu()
+    return menu.run()

--- a/code_puppy/plugins/plugin_list/register_callbacks.py
+++ b/code_puppy/plugins/plugin_list/register_callbacks.py
@@ -1,0 +1,76 @@
+"""``/plugins`` slash command — lists loaded plugins grouped by source tier.
+
+Dogfoods the plugin system by implementing itself as a builtin plugin that
+hooks into ``custom_command`` and ``custom_command_help``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from code_puppy.callbacks import register_callback
+
+logger = logging.getLogger(__name__)
+
+
+def _format_plugin_list(names: list[str]) -> str:
+    """Return a bullet list of plugin names, or a placeholder when empty."""
+    if not names:
+        return "  (none)"
+    return "\n".join(f"  • {name}" for name in sorted(names))
+
+
+def _build_output() -> str:
+    """Build the full /plugins display string."""
+    # Lazy import to avoid circular-import at registration time.
+    from code_puppy.plugins import (
+        get_loaded_plugins,
+        get_project_plugins_directory,
+    )
+
+    loaded = get_loaded_plugins()
+
+    builtin_path = str(Path(__file__).parent.parent) + "/"
+    user_path = "~/.code_puppy/plugins/"
+    project_dir = get_project_plugins_directory()
+    project_path = (
+        str(project_dir) + "/" if project_dir else "<CWD>/.code_puppy/plugins/"
+    )
+
+    lines = [
+        "Loaded Plugins",
+        "",
+        f"Builtin ({builtin_path}):",
+        _format_plugin_list(loaded["builtin"]),
+        "",
+        f"User ({user_path}):",
+        _format_plugin_list(loaded["user"]),
+        "",
+        f"Project ({project_path}):",
+        _format_plugin_list(loaded["project"]),
+    ]
+
+    return "\n".join(lines)
+
+
+# ── custom_command hooks ──────────────────────────────────────────────────
+
+
+def _custom_help() -> list[tuple[str, str]]:
+    return [("plugins", "Show loaded plugins grouped by source tier")]
+
+
+def _handle_custom_command(command: str, name: str) -> Optional[bool]:
+    if name != "plugins":
+        return None  # Not our command — let other plugins try.
+
+    from code_puppy.messaging import emit_info
+
+    emit_info(_build_output())
+    return True  # Fully handled.
+
+
+register_callback("custom_command_help", _custom_help)
+register_callback("custom_command", _handle_custom_command)

--- a/code_puppy/plugins/plugin_list/register_callbacks.py
+++ b/code_puppy/plugins/plugin_list/register_callbacks.py
@@ -1,4 +1,11 @@
-"""``/plugins`` slash command — lists loaded plugins grouped by source tier.
+"""``/plugins`` slash command -- manage plugins interactively or via subcommands.
+
+Usage::
+
+    /plugins                   -- open interactive TUI
+    /plugins list              -- print loaded plugins with status
+    /plugins disable <name>    -- disable a plugin (callbacks are skipped)
+    /plugins enable <name>     -- re-enable a disabled plugin
 
 Dogfoods the plugin system by implementing itself as a builtin plugin that
 hooks into ``custom_command`` and ``custom_command_help``.
@@ -15,22 +22,29 @@ from code_puppy.callbacks import register_callback
 logger = logging.getLogger(__name__)
 
 
-def _format_plugin_list(names: list[str]) -> str:
-    """Return a bullet list of plugin names, or a placeholder when empty."""
+def _format_plugin_list(names: list[str], disabled: set[str]) -> str:
+    """Return a bullet list of plugin names with status indicators."""
     if not names:
         return "  (none)"
-    return "\n".join(f"  • {name}" for name in sorted(names))
+    lines = []
+    for name in sorted(names):
+        if name in disabled:
+            lines.append(f"   {name}  (disabled)")
+        else:
+            lines.append(f"   {name}")
+    return "\n".join(lines)
 
 
 def _build_output() -> str:
-    """Build the full /plugins display string."""
-    # Lazy import to avoid circular-import at registration time.
+    """Build the full /plugins list display string."""
     from code_puppy.plugins import (
         get_loaded_plugins,
         get_project_plugins_directory,
     )
+    from code_puppy.plugins.config import get_disabled_plugins
 
     loaded = get_loaded_plugins()
+    disabled = get_disabled_plugins()
 
     builtin_path = str(Path(__file__).parent.parent) + "/"
     user_path = "~/.code_puppy/plugins/"
@@ -43,33 +57,129 @@ def _build_output() -> str:
         "Loaded Plugins",
         "",
         f"Builtin ({builtin_path}):",
-        _format_plugin_list(loaded["builtin"]),
+        _format_plugin_list(loaded["builtin"], disabled),
         "",
         f"User ({user_path}):",
-        _format_plugin_list(loaded["user"]),
+        _format_plugin_list(loaded["user"], disabled),
         "",
         f"Project ({project_path}):",
-        _format_plugin_list(loaded["project"]),
+        _format_plugin_list(loaded["project"], disabled),
     ]
+
+    if disabled:
+        lines.extend(
+            [
+                "",
+                f"Disabled: {', '.join(sorted(disabled))}",
+                "Use /plugins enable <name> to re-enable.",
+            ]
+        )
 
     return "\n".join(lines)
 
 
-# ── custom_command hooks ──────────────────────────────────────────────────
+def _all_loaded_plugin_names() -> set[str]:
+    """Return the set of all loaded plugin names across all tiers."""
+    from code_puppy.plugins import get_loaded_plugins
+
+    loaded = get_loaded_plugins()
+    names: set[str] = set()
+    for tier_names in loaded.values():
+        names.update(tier_names)
+    return names
+
+
+def _handle_disable(plugin_name: str) -> bool:
+    """Disable a plugin by name."""
+    from code_puppy.messaging import emit_error, emit_info, emit_success
+    from code_puppy.plugins.config import set_plugin_disabled
+
+    all_names = _all_loaded_plugin_names()
+    if plugin_name not in all_names:
+        emit_error(
+            f"Plugin '{plugin_name}' is not loaded. "
+            f"Use /plugins to see available plugins."
+        )
+        return True
+
+    if set_plugin_disabled(plugin_name, disabled=True):
+        emit_success(f"Plugin '{plugin_name}' disabled. Its callbacks will be skipped.")
+        emit_info("This takes effect immediately -- no restart required.")
+    else:
+        emit_info(f"Plugin '{plugin_name}' is already disabled.")
+    return True
+
+
+def _handle_enable(plugin_name: str) -> bool:
+    """Enable a previously disabled plugin."""
+    from code_puppy.messaging import emit_error, emit_info, emit_success
+    from code_puppy.plugins.config import set_plugin_disabled
+
+    all_names = _all_loaded_plugin_names()
+    if plugin_name not in all_names:
+        emit_error(
+            f"Plugin '{plugin_name}' is not loaded. "
+            f"Use /plugins to see available plugins."
+        )
+        return True
+
+    if set_plugin_disabled(plugin_name, disabled=False):
+        emit_success(f"Plugin '{plugin_name}' re-enabled.")
+        emit_info("This takes effect immediately -- no restart required.")
+    else:
+        emit_info(f"Plugin '{plugin_name}' is already enabled.")
+    return True
+
+
+# -- custom_command hooks --------------------------------------------------
 
 
 def _custom_help() -> list[tuple[str, str]]:
-    return [("plugins", "Show loaded plugins grouped by source tier")]
+    return [("plugins", "List, enable, or disable plugins")]
 
 
 def _handle_custom_command(command: str, name: str) -> Optional[bool]:
     if name != "plugins":
-        return None  # Not our command — let other plugins try.
+        return None  # Not our command.
 
-    from code_puppy.messaging import emit_info
+    from code_puppy.messaging import emit_error, emit_info
 
-    emit_info(_build_output())
-    return True  # Fully handled.
+    tokens = command.strip().split()
+
+    # Bare /plugins -> interactive TUI
+    if len(tokens) <= 1:
+        try:
+            from code_puppy.plugins.plugin_list.plugins_menu import run_plugins_menu
+
+            run_plugins_menu()
+        except Exception as exc:
+            logger.warning(f"Plugins TUI failed, falling back to list: {exc}")
+            emit_info(_build_output())
+        return True
+
+    subcommand = tokens[1].lower()
+
+    if subcommand == "list":
+        emit_info(_build_output())
+        return True
+
+    if subcommand == "disable":
+        if len(tokens) < 3:
+            emit_error("Usage: /plugins disable <plugin-name>")
+            return True
+        return _handle_disable(tokens[2])
+
+    if subcommand == "enable":
+        if len(tokens) < 3:
+            emit_error("Usage: /plugins enable <plugin-name>")
+            return True
+        return _handle_enable(tokens[2])
+
+    emit_error(
+        f"Unknown subcommand: '{subcommand}'. "
+        "Usage: /plugins [list | enable <name> | disable <name>]"
+    )
+    return True
 
 
 register_callback("custom_command_help", _custom_help)

--- a/tests/plugins/test_plugin_list.py
+++ b/tests/plugins/test_plugin_list.py
@@ -1,0 +1,141 @@
+"""Tests for the plugin_list plugin (/plugins slash command)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from code_puppy.plugins.plugin_list.register_callbacks import (
+    _build_output,
+    _custom_help,
+    _format_plugin_list,
+    _handle_custom_command,
+)
+
+# Patch targets live on the source module because _build_output() uses
+# lazy imports: ``from code_puppy.plugins import …``.
+_PLUGINS_MOD = "code_puppy.plugins"
+
+
+# ── Unit tests for helpers ────────────────────────────────────────────────
+
+
+class TestFormatPluginList:
+    def test_empty_list(self):
+        assert _format_plugin_list([]) == "  (none)"
+
+    def test_single_plugin(self):
+        result = _format_plugin_list(["shell_safety"])
+        assert "shell_safety" in result
+
+    def test_multiple_sorted(self):
+        result = _format_plugin_list(["zebra", "alpha", "mid"])
+        lines = result.split("\n")
+        assert len(lines) == 3
+        assert "alpha" in lines[0]
+        assert "mid" in lines[1]
+        assert "zebra" in lines[2]
+
+
+class TestBuildOutput:
+    def test_all_tiers_populated(self):
+        loaded = {
+            "builtin": ["shell_safety", "agent_skills"],
+            "user": ["my_tool"],
+            "project": ["repo_guard"],
+        }
+        with (
+            patch(
+                f"{_PLUGINS_MOD}.get_loaded_plugins",
+                return_value=loaded,
+            ),
+            patch(
+                f"{_PLUGINS_MOD}.get_project_plugins_directory",
+                return_value=Path("/tmp/proj/.code_puppy/plugins"),
+            ),
+        ):
+            output = _build_output()
+            assert "Loaded Plugins" in output
+            assert "Builtin (" in output
+            assert "agent_skills" in output
+            assert "shell_safety" in output
+            assert "User (~/.code_puppy/plugins/):" in output
+            assert "my_tool" in output
+            assert "Project (/tmp/proj/.code_puppy/plugins/):" in output
+            assert "repo_guard" in output
+
+    def test_empty_tiers_show_none(self):
+        loaded = {"builtin": ["one"], "user": [], "project": []}
+        with (
+            patch(
+                f"{_PLUGINS_MOD}.get_loaded_plugins",
+                return_value=loaded,
+            ),
+            patch(
+                f"{_PLUGINS_MOD}.get_project_plugins_directory",
+                return_value=None,
+            ),
+        ):
+            output = _build_output()
+            lines = output.split("\n")
+            user_idx = next(
+                i for i, line in enumerate(lines) if line.startswith("User")
+            )
+            project_idx = next(
+                i for i, line in enumerate(lines) if line.startswith("Project")
+            )
+            assert lines[user_idx + 1].strip() == "(none)"
+            assert lines[project_idx + 1].strip() == "(none)"
+
+    def test_project_path_placeholder_when_no_dir(self):
+        loaded = {"builtin": [], "user": [], "project": []}
+        with (
+            patch(
+                f"{_PLUGINS_MOD}.get_loaded_plugins",
+                return_value=loaded,
+            ),
+            patch(
+                f"{_PLUGINS_MOD}.get_project_plugins_directory",
+                return_value=None,
+            ),
+        ):
+            output = _build_output()
+            assert "<CWD>/.code_puppy/plugins/" in output
+
+
+# ── Slash command tests ───────────────────────────────────────────────────
+
+
+class TestHandleCustomCommand:
+    def test_unrelated_command_returns_none(self):
+        assert _handle_custom_command("/foo", "foo") is None
+        assert _handle_custom_command("/help", "help") is None
+
+    def test_plugins_command_returns_true(self):
+        loaded = {"builtin": ["a"], "user": [], "project": []}
+        with (
+            patch(
+                f"{_PLUGINS_MOD}.get_loaded_plugins",
+                return_value=loaded,
+            ),
+            patch(
+                f"{_PLUGINS_MOD}.get_project_plugins_directory",
+                return_value=None,
+            ),
+            patch(
+                "code_puppy.messaging.emit_info",
+            ) as mock_emit,
+        ):
+            result = _handle_custom_command("/plugins", "plugins")
+            assert result is True
+            mock_emit.assert_called_once()
+            assert "Loaded Plugins" in mock_emit.call_args[0][0]
+
+
+class TestCustomHelp:
+    def test_returns_plugins_entry(self):
+        entries = _custom_help()
+        assert len(entries) == 1
+        cmd, desc = entries[0]
+        assert cmd == "plugins"
+        assert "plugin" in desc.lower()

--- a/tests/plugins/test_plugin_list.py
+++ b/tests/plugins/test_plugin_list.py
@@ -15,6 +15,7 @@ from code_puppy.plugins.plugin_list.register_callbacks import (
 # Patch targets live on the source module because _build_output() uses
 # lazy imports: ``from code_puppy.plugins import …``.
 _PLUGINS_MOD = "code_puppy.plugins"
+_PLUGINS_CONFIG_MOD = "code_puppy.plugins.config"
 
 
 # ── Unit tests for helpers ────────────────────────────────────────────────
@@ -22,19 +23,25 @@ _PLUGINS_MOD = "code_puppy.plugins"
 
 class TestFormatPluginList:
     def test_empty_list(self):
-        assert _format_plugin_list([]) == "  (none)"
+        assert _format_plugin_list([], set()) == "  (none)"
 
     def test_single_plugin(self):
-        result = _format_plugin_list(["shell_safety"])
+        result = _format_plugin_list(["shell_safety"], set())
         assert "shell_safety" in result
 
     def test_multiple_sorted(self):
-        result = _format_plugin_list(["zebra", "alpha", "mid"])
+        result = _format_plugin_list(["zebra", "alpha", "mid"], set())
         lines = result.split("\n")
         assert len(lines) == 3
         assert "alpha" in lines[0]
         assert "mid" in lines[1]
         assert "zebra" in lines[2]
+
+    def test_disabled_shown(self):
+        result = _format_plugin_list(["alpha", "beta"], {"beta"})
+        lines = result.split("\n")
+        assert "(disabled)" not in lines[0]  # alpha
+        assert "(disabled)" in lines[1]  # beta
 
 
 class TestBuildOutput:
@@ -52,6 +59,10 @@ class TestBuildOutput:
             patch(
                 f"{_PLUGINS_MOD}.get_project_plugins_directory",
                 return_value=Path("/tmp/proj/.code_puppy/plugins"),
+            ),
+            patch(
+                f"{_PLUGINS_CONFIG_MOD}.get_disabled_plugins",
+                return_value=set(),
             ),
         ):
             output = _build_output()
@@ -74,6 +85,10 @@ class TestBuildOutput:
             patch(
                 f"{_PLUGINS_MOD}.get_project_plugins_directory",
                 return_value=None,
+            ),
+            patch(
+                f"{_PLUGINS_CONFIG_MOD}.get_disabled_plugins",
+                return_value=set(),
             ),
         ):
             output = _build_output()
@@ -98,6 +113,10 @@ class TestBuildOutput:
                 f"{_PLUGINS_MOD}.get_project_plugins_directory",
                 return_value=None,
             ),
+            patch(
+                f"{_PLUGINS_CONFIG_MOD}.get_disabled_plugins",
+                return_value=set(),
+            ),
         ):
             output = _build_output()
             assert "<CWD>/.code_puppy/plugins/" in output
@@ -111,7 +130,15 @@ class TestHandleCustomCommand:
         assert _handle_custom_command("/foo", "foo") is None
         assert _handle_custom_command("/help", "help") is None
 
-    def test_plugins_command_returns_true(self):
+    def test_bare_plugins_launches_tui(self):
+        with patch(
+            "code_puppy.plugins.plugin_list.plugins_menu.run_plugins_menu",
+        ) as mock_menu:
+            result = _handle_custom_command("/plugins", "plugins")
+            assert result is True
+            mock_menu.assert_called_once()
+
+    def test_plugins_list_returns_text(self):
         loaded = {"builtin": ["a"], "user": [], "project": []}
         with (
             patch(
@@ -123,10 +150,14 @@ class TestHandleCustomCommand:
                 return_value=None,
             ),
             patch(
+                f"{_PLUGINS_CONFIG_MOD}.get_disabled_plugins",
+                return_value=set(),
+            ),
+            patch(
                 "code_puppy.messaging.emit_info",
             ) as mock_emit,
         ):
-            result = _handle_custom_command("/plugins", "plugins")
+            result = _handle_custom_command("/plugins list", "plugins")
             assert result is True
             mock_emit.assert_called_once()
             assert "Loaded Plugins" in mock_emit.call_args[0][0]

--- a/tests/plugins/test_plugins_init_coverage.py
+++ b/tests/plugins/test_plugins_init_coverage.py
@@ -596,26 +596,27 @@ class TestLoadUserPlugins:
 
 
 class TestLoadPluginCallbacks:
-    """Test load_plugin_callbacks function."""
+    """Test load_plugin_callbacks function (three-tier: builtin, user, project)."""
 
     def test_idempotent_loading(self):
         """Test that plugins are only loaded once (idempotent)."""
-        # Reset the global flag for this test
         original_loaded = plugins_module._PLUGINS_LOADED
         plugins_module._PLUGINS_LOADED = True
 
         try:
             result = load_plugin_callbacks()
             # Should return empty since plugins are "already loaded"
-            assert result == {"builtin": [], "user": []}
+            assert result == {"builtin": [], "user": [], "project": []}
         finally:
             plugins_module._PLUGINS_LOADED = original_loaded
 
-    def test_calls_load_functions(self, tmp_path):
-        """Test that load_plugin_callbacks calls both load functions."""
-        # Reset the global flag
+    def test_calls_all_three_load_functions(self, tmp_path):
+        """Test that load_plugin_callbacks calls builtin, user, AND project loaders."""
         original_loaded = plugins_module._PLUGINS_LOADED
         plugins_module._PLUGINS_LOADED = False
+
+        project_dir = tmp_path / ".code_puppy" / "plugins"
+        project_dir.mkdir(parents=True)
 
         with (
             patch(
@@ -625,16 +626,52 @@ class TestLoadPluginCallbacks:
             patch(
                 "code_puppy.plugins._load_user_plugins", return_value=["user_plugin"]
             ) as mock_user,
+            patch(
+                "code_puppy.plugins.get_project_plugins_directory",
+                return_value=project_dir,
+            ),
+            patch(
+                "code_puppy.plugins._load_project_plugins",
+                return_value=["project_plugin"],
+            ) as mock_project,
         ):
             try:
                 result = load_plugin_callbacks()
 
                 assert result["builtin"] == ["builtin_plugin"]
                 assert result["user"] == ["user_plugin"]
+                assert result["project"] == ["project_plugin"]
                 mock_builtin.assert_called_once()
                 mock_user.assert_called_once()
-                # Check that the flag was set
+                mock_project.assert_called_once_with(
+                    project_dir,
+                    builtin_names={"builtin_plugin"},
+                    user_names={"user_plugin"},
+                )
                 assert plugins_module._PLUGINS_LOADED is True
+            finally:
+                plugins_module._PLUGINS_LOADED = original_loaded
+
+    def test_skips_project_when_dir_missing(self):
+        """Test that project loading is skipped when directory doesn't exist."""
+        original_loaded = plugins_module._PLUGINS_LOADED
+        plugins_module._PLUGINS_LOADED = False
+
+        with (
+            patch("code_puppy.plugins._load_builtin_plugins", return_value=[]),
+            patch("code_puppy.plugins._load_user_plugins", return_value=[]),
+            patch(
+                "code_puppy.plugins.get_project_plugins_directory",
+                return_value=None,
+            ),
+            patch(
+                "code_puppy.plugins._load_project_plugins",
+            ) as mock_project,
+        ):
+            try:
+                result = load_plugin_callbacks()
+                assert result["project"] == []
+                mock_project.assert_not_called()
             finally:
                 plugins_module._PLUGINS_LOADED = original_loaded
 
@@ -646,6 +683,10 @@ class TestLoadPluginCallbacks:
         with (
             patch("code_puppy.plugins._load_builtin_plugins", return_value=[]),
             patch("code_puppy.plugins._load_user_plugins", return_value=[]),
+            patch(
+                "code_puppy.plugins.get_project_plugins_directory",
+                return_value=None,
+            ),
         ):
             try:
                 load_plugin_callbacks()
@@ -666,6 +707,10 @@ class TestLoadPluginCallbacks:
                 return_value=["test_builtin"],
             ),
             patch("code_puppy.plugins._load_user_plugins", return_value=["test_user"]),
+            patch(
+                "code_puppy.plugins.get_project_plugins_directory",
+                return_value=None,
+            ),
             caplog.at_level(logging.DEBUG),
         ):
             try:

--- a/tests/test_project_plugins.py
+++ b/tests/test_project_plugins.py
@@ -1,0 +1,505 @@
+"""Tests for project-level plugin discovery (_load_project_plugins).
+
+Covers the feature implemented in code_puppy_oss-864:
+- Project plugin loading from <CWD>/.code_puppy/plugins/
+- Name collision warnings (builtin and user shadows)
+- Error handling (ImportError, RuntimeError)
+- get_project_plugins_directory() helper
+- Skipping dotfiles/underscore dirs
+- __init__.py fallback when no register_callbacks.py
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from code_puppy.plugins import (
+    _load_project_plugins,
+    get_project_plugins_directory,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_plugin(plugins_dir: Path, name: str, *, via_init: bool = False) -> Path:
+    """Create a minimal plugin directory with register_callbacks.py or __init__.py."""
+    plugin_dir = plugins_dir / name
+    plugin_dir.mkdir(parents=True)
+    target = "__init__.py" if via_init else "register_callbacks.py"
+    (plugin_dir / target).write_text(f"# {name} plugin\n")
+    return plugin_dir
+
+
+@pytest.fixture()
+def project_plugins_dir(tmp_path: Path) -> Path:
+    """Provide a fresh project plugins directory."""
+    d = tmp_path / ".code_puppy" / "plugins"
+    d.mkdir(parents=True)
+    return d
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_sys_path():
+    """Remove any tmp_path entries from sys.path after each test."""
+    before = list(sys.path)
+    yield
+    # Restore to pre-test state
+    for entry in sys.path[:]:
+        if entry not in before:
+            sys.path.remove(entry)
+
+
+# ---------------------------------------------------------------------------
+# 1. Project dir does not exist → no plugins loaded, no errors
+# ---------------------------------------------------------------------------
+
+
+class TestProjectDirMissing:
+    def test_nonexistent_dir_returns_empty(self, tmp_path: Path):
+        nonexistent = tmp_path / "nope"
+        result = _load_project_plugins(nonexistent, set(), set())
+        assert result == []
+
+    def test_nonexistent_dir_no_errors(self, tmp_path: Path, caplog):
+        nonexistent = tmp_path / "nope"
+        _load_project_plugins(nonexistent, set(), set())
+        assert "error" not in caplog.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# 2. Valid plugin with register_callbacks.py → loaded successfully
+# ---------------------------------------------------------------------------
+
+
+class TestValidPlugin:
+    def test_loads_register_callbacks(self, project_plugins_dir: Path):
+        _make_plugin(project_plugins_dir, "good_plugin")
+
+        mock_spec = MagicMock()
+        mock_spec.loader = MagicMock()
+
+        with (
+            patch(
+                "code_puppy.plugins.importlib.util.spec_from_file_location",
+                return_value=mock_spec,
+            ),
+            patch(
+                "code_puppy.plugins.importlib.util.module_from_spec",
+                return_value=MagicMock(),
+            ),
+        ):
+            result = _load_project_plugins(project_plugins_dir, set(), set())
+
+        assert "good_plugin" in result
+
+    def test_uses_project_plugins_namespace(self, project_plugins_dir: Path):
+        _make_plugin(project_plugins_dir, "ns_plugin")
+
+        mock_spec = MagicMock()
+        mock_spec.loader = MagicMock()
+
+        with (
+            patch(
+                "code_puppy.plugins.importlib.util.spec_from_file_location",
+                return_value=mock_spec,
+            ) as mock_sfl,
+            patch(
+                "code_puppy.plugins.importlib.util.module_from_spec",
+                return_value=MagicMock(),
+            ),
+        ):
+            _load_project_plugins(project_plugins_dir, set(), set())
+
+        # Should use the project_plugins.{name} namespace to avoid sys.modules clash
+        call_args = mock_sfl.call_args
+        assert call_args[0][0] == "project_plugins.ns_plugin.register_callbacks"
+
+
+# ---------------------------------------------------------------------------
+# 3. Name collision with builtin → warning logged, both load
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinCollision:
+    def test_warns_on_builtin_shadow(self, project_plugins_dir: Path, caplog):
+        _make_plugin(project_plugins_dir, "shell_safety")
+
+        mock_spec = MagicMock()
+        mock_spec.loader = MagicMock()
+
+        with (
+            patch(
+                "code_puppy.plugins.importlib.util.spec_from_file_location",
+                return_value=mock_spec,
+            ),
+            patch(
+                "code_puppy.plugins.importlib.util.module_from_spec",
+                return_value=MagicMock(),
+            ),
+        ):
+            result = _load_project_plugins(
+                project_plugins_dir, builtin_names={"shell_safety"}, user_names=set()
+            )
+
+        assert "shell_safety" in result
+        assert "shadows builtin plugin" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# 4. Name collision with user plugin → warning logged, both load
+# ---------------------------------------------------------------------------
+
+
+class TestUserCollision:
+    def test_user_plugin_skipped_when_project_overrides(self, project_plugins_dir: Path, caplog):
+        """When a project plugin has the same name as a user plugin,
+        the user plugin is skipped (dedup) and _load_project_plugins
+        does NOT see it in user_names at all."""
+        _make_plugin(project_plugins_dir, "my_tool")
+
+        mock_spec = MagicMock()
+        mock_spec.loader = MagicMock()
+
+        with (
+            patch(
+                "code_puppy.plugins.importlib.util.spec_from_file_location",
+                return_value=mock_spec,
+            ),
+            patch(
+                "code_puppy.plugins.importlib.util.module_from_spec",
+                return_value=MagicMock(),
+            ),
+        ):
+            # user_names is empty because _load_user_plugins already
+            # skipped the colliding plugin via the pre-scan dedup.
+            result = _load_project_plugins(
+                project_plugins_dir, builtin_names=set(), user_names=set()
+            )
+
+        assert "my_tool" in result
+        # No shadow warning — dedup happens at the user tier, not here.
+        assert "shadows user plugin" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# 5. Broken plugin → error caught, other plugins still load
+# ---------------------------------------------------------------------------
+
+
+class TestBrokenPlugin:
+    def test_import_error_caught(self, project_plugins_dir: Path, caplog):
+        _make_plugin(project_plugins_dir, "bad_import")
+        _make_plugin(project_plugins_dir, "healthy")
+
+        mock_spec_bad = MagicMock()
+        mock_spec_bad.loader = MagicMock()
+        mock_spec_bad.loader.exec_module.side_effect = ImportError("no such module")
+
+        mock_spec_ok = MagicMock()
+        mock_spec_ok.loader = MagicMock()
+
+        call_count = 0
+
+        def spec_side_effect(_name, _path):
+            nonlocal call_count
+            call_count += 1
+            # Return bad spec for first call, good for second
+            if "bad_import" in str(_path):
+                return mock_spec_bad
+            return mock_spec_ok
+
+        with (
+            patch(
+                "code_puppy.plugins.importlib.util.spec_from_file_location",
+                side_effect=spec_side_effect,
+            ),
+            patch(
+                "code_puppy.plugins.importlib.util.module_from_spec",
+                return_value=MagicMock(),
+            ),
+        ):
+            result = _load_project_plugins(project_plugins_dir, set(), set())
+
+        assert "bad_import" not in result
+        assert "healthy" in result
+        assert "Failed to import callbacks from project plugin" in caplog.text
+
+    def test_runtime_error_caught(self, project_plugins_dir: Path, caplog):
+        _make_plugin(project_plugins_dir, "exploder")
+
+        mock_spec = MagicMock()
+        mock_spec.loader = MagicMock()
+        mock_spec.loader.exec_module.side_effect = RuntimeError("boom")
+
+        with (
+            patch(
+                "code_puppy.plugins.importlib.util.spec_from_file_location",
+                return_value=mock_spec,
+            ),
+            patch(
+                "code_puppy.plugins.importlib.util.module_from_spec",
+                return_value=MagicMock(),
+            ),
+        ):
+            result = _load_project_plugins(project_plugins_dir, set(), set())
+
+        assert "exploder" not in result
+        assert "Unexpected error loading project plugin" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# 6. get_project_plugins_directory() returns None when dir missing
+# ---------------------------------------------------------------------------
+
+
+class TestGetProjectPluginsDirectory:
+    def test_returns_none_when_missing(self, tmp_path: Path):
+        with patch("code_puppy.plugins.Path.cwd", return_value=tmp_path):
+            assert get_project_plugins_directory() is None
+
+    # -----------------------------------------------------------------------
+    # 7. returns Path when dir exists
+    # -----------------------------------------------------------------------
+
+    def test_returns_path_when_exists(self, tmp_path: Path):
+        plugins_dir = tmp_path / ".code_puppy" / "plugins"
+        plugins_dir.mkdir(parents=True)
+
+        with patch("code_puppy.plugins.Path.cwd", return_value=tmp_path):
+            result = get_project_plugins_directory()
+            assert result is not None
+            assert result == plugins_dir
+
+
+# ---------------------------------------------------------------------------
+# 8. load_plugin_callbacks() includes "project" key in result dict
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPluginCallbacksProjectKey:
+    def test_result_dict_has_project_key(self):
+        import code_puppy.plugins as plugins_module
+
+        original_loaded = plugins_module._PLUGINS_LOADED
+        plugins_module._PLUGINS_LOADED = False
+
+        with (
+            patch("code_puppy.plugins._load_builtin_plugins", return_value=["bp"]),
+            patch("code_puppy.plugins._load_user_plugins", return_value=["up"]),
+            patch(
+                "code_puppy.plugins.get_project_plugins_directory",
+                return_value=None,
+            ),
+        ):
+            try:
+                result = plugins_module.load_plugin_callbacks()
+                assert "project" in result
+                assert result["project"] == []
+            finally:
+                plugins_module._PLUGINS_LOADED = original_loaded
+
+    def test_idempotent_returns_project_key(self):
+        import code_puppy.plugins as plugins_module
+
+        original_loaded = plugins_module._PLUGINS_LOADED
+        plugins_module._PLUGINS_LOADED = True
+
+        try:
+            result = plugins_module.load_plugin_callbacks()
+            assert "project" in result
+            assert result == {"builtin": [], "user": [], "project": []}
+        finally:
+            plugins_module._PLUGINS_LOADED = original_loaded
+
+
+# ---------------------------------------------------------------------------
+# 9. Skips dirs starting with _ or .
+# ---------------------------------------------------------------------------
+
+
+class TestSkipSpecialDirs:
+    def test_skips_underscore_dirs(self, project_plugins_dir: Path):
+        _make_plugin(project_plugins_dir, "_private")
+
+        result = _load_project_plugins(project_plugins_dir, set(), set())
+        assert result == []
+
+    def test_skips_dot_dirs(self, project_plugins_dir: Path):
+        _make_plugin(project_plugins_dir, ".hidden")
+
+        result = _load_project_plugins(project_plugins_dir, set(), set())
+        assert result == []
+
+    def test_skips_files_not_directories(self, project_plugins_dir: Path):
+        (project_plugins_dir / "not_a_plugin.py").write_text("# nope")
+
+        result = _load_project_plugins(project_plugins_dir, set(), set())
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# 10. Falls back to __init__.py when no register_callbacks.py
+# ---------------------------------------------------------------------------
+
+
+class TestInitFallback:
+    def test_loads_via_init_fallback(self, project_plugins_dir: Path):
+        _make_plugin(project_plugins_dir, "init_only", via_init=True)
+
+        mock_spec = MagicMock()
+        mock_spec.loader = MagicMock()
+
+        with (
+            patch(
+                "code_puppy.plugins.importlib.util.spec_from_file_location",
+                return_value=mock_spec,
+            ),
+            patch(
+                "code_puppy.plugins.importlib.util.module_from_spec",
+                return_value=MagicMock(),
+            ),
+        ):
+            result = _load_project_plugins(project_plugins_dir, set(), set())
+
+        assert "init_only" in result
+
+    def test_init_fallback_uses_project_namespace(self, project_plugins_dir: Path):
+        _make_plugin(project_plugins_dir, "init_ns", via_init=True)
+
+        mock_spec = MagicMock()
+        mock_spec.loader = MagicMock()
+
+        with (
+            patch(
+                "code_puppy.plugins.importlib.util.spec_from_file_location",
+                return_value=mock_spec,
+            ) as mock_sfl,
+            patch(
+                "code_puppy.plugins.importlib.util.module_from_spec",
+                return_value=MagicMock(),
+            ),
+        ):
+            _load_project_plugins(project_plugins_dir, set(), set())
+
+        call_args = mock_sfl.call_args
+        assert call_args[0][0] == "project_plugins.init_ns"
+
+    def test_init_fallback_error_caught(self, project_plugins_dir: Path, caplog):
+        _make_plugin(project_plugins_dir, "broken_init", via_init=True)
+
+        mock_spec = MagicMock()
+        mock_spec.loader = MagicMock()
+        mock_spec.loader.exec_module.side_effect = RuntimeError("init boom")
+
+        with (
+            patch(
+                "code_puppy.plugins.importlib.util.spec_from_file_location",
+                return_value=mock_spec,
+            ),
+            patch(
+                "code_puppy.plugins.importlib.util.module_from_spec",
+                return_value=MagicMock(),
+            ),
+        ):
+            result = _load_project_plugins(project_plugins_dir, set(), set())
+
+        assert "broken_init" not in result
+        assert "Unexpected error loading project plugin" in caplog.text
+
+    def test_init_fallback_spec_none_skips(self, project_plugins_dir: Path):
+        _make_plugin(project_plugins_dir, "no_spec_init", via_init=True)
+
+        with patch(
+            "code_puppy.plugins.importlib.util.spec_from_file_location",
+            return_value=None,
+        ):
+            result = _load_project_plugins(project_plugins_dir, set(), set())
+
+        assert "no_spec_init" not in result
+
+    def test_init_fallback_loader_none_skips(self, project_plugins_dir: Path):
+        _make_plugin(project_plugins_dir, "no_loader_init", via_init=True)
+
+        mock_spec = MagicMock()
+        mock_spec.loader = None
+
+        with patch(
+            "code_puppy.plugins.importlib.util.spec_from_file_location",
+            return_value=mock_spec,
+        ):
+            result = _load_project_plugins(project_plugins_dir, set(), set())
+
+        assert "no_loader_init" not in result
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_path_is_file_not_dir(self, tmp_path: Path, caplog):
+        fake_dir = tmp_path / "plugins_file"
+        fake_dir.write_text("oops")
+
+        result = _load_project_plugins(fake_dir, set(), set())
+        assert result == []
+        assert "not a directory" in caplog.text
+
+    def test_spec_none_skips_register_callbacks(
+        self, project_plugins_dir: Path, caplog
+    ):
+        _make_plugin(project_plugins_dir, "no_spec")
+
+        with patch(
+            "code_puppy.plugins.importlib.util.spec_from_file_location",
+            return_value=None,
+        ):
+            result = _load_project_plugins(project_plugins_dir, set(), set())
+
+        assert "no_spec" not in result
+        assert "Could not create module spec for project plugin" in caplog.text
+
+    def test_spec_loader_none_skips(self, project_plugins_dir: Path, caplog):
+        _make_plugin(project_plugins_dir, "no_loader")
+
+        mock_spec = MagicMock()
+        mock_spec.loader = None
+
+        with patch(
+            "code_puppy.plugins.importlib.util.spec_from_file_location",
+            return_value=mock_spec,
+        ):
+            result = _load_project_plugins(project_plugins_dir, set(), set())
+
+        assert "no_loader" not in result
+        assert "Could not create module spec for project plugin" in caplog.text
+
+    def test_dir_without_callbacks_or_init_skipped(self, project_plugins_dir: Path):
+        empty = project_plugins_dir / "empty_plugin"
+        empty.mkdir()
+
+        result = _load_project_plugins(project_plugins_dir, set(), set())
+        assert result == []
+
+    def test_adds_project_dir_to_sys_path(self, project_plugins_dir: Path):
+        project_str = str(project_plugins_dir)
+        if project_str in sys.path:
+            sys.path.remove(project_str)
+
+        _load_project_plugins(project_plugins_dir, set(), set())
+        assert project_str in sys.path
+
+    def test_no_duplicate_sys_path_entries(self, project_plugins_dir: Path):
+        project_str = str(project_plugins_dir)
+        if project_str not in sys.path:
+            sys.path.insert(0, project_str)
+
+        count_before = sys.path.count(project_str)
+        _load_project_plugins(project_plugins_dir, set(), set())
+        assert sys.path.count(project_str) == count_before

--- a/tests/test_project_plugins.py
+++ b/tests/test_project_plugins.py
@@ -156,7 +156,9 @@ class TestBuiltinCollision:
 
 
 class TestUserCollision:
-    def test_user_plugin_skipped_when_project_overrides(self, project_plugins_dir: Path, caplog):
+    def test_user_plugin_skipped_when_project_overrides(
+        self, project_plugins_dir: Path, caplog
+    ):
         """When a project plugin has the same name as a user plugin,
         the user plugin is skipped (dedup) and _load_project_plugins
         does NOT see it in user_names at all."""


### PR DESCRIPTION
Add a third plugin discovery tier — <CWD>/.code_puppy/plugins/ — so teams can ship project-scoped plugins that auto-load when working in the repo, closing the gap with agents and skills which already support this pattern.

Load order: builtin → user → project (project has highest precedence). Project wins on name collision: user plugins with the same name are skipped, matching the agents dedup strategy in discover_json_agents().

Project plugins use a 'project_plugins.' namespace in sys.modules to avoid import-level collisions. Synthetic parent packages are created before loading each plugin so that relative imports (from . import X) resolve correctly.

Also adds a /plugins slash command that shows loaded plugins by tier.