### PR TITLE
feat(plugins): warn users to restart after enable/disable changes

### DIFF
--- a/code_puppy/plugins/plugin_list/plugins_menu.py
+++ b/code_puppy/plugins/plugin_list/plugins_menu.py
@@ -46,6 +46,7 @@ class PluginsMenu:
         self.selected_idx = 0
         self.current_page = 0
         self.result: Optional[str] = None
+        self._changed = False
 
         self.menu_control: Optional[FormattedTextControl] = None
         self.detail_control: Optional[FormattedTextControl] = None
@@ -80,6 +81,7 @@ class PluginsMenu:
 
         is_disabled = entry.name in self.disabled
         set_plugin_disabled(entry.name, not is_disabled)
+        self._changed = True
         self._refresh_data()
         self.update_display()
 
@@ -179,6 +181,12 @@ class PluginsMenu:
         lines.append(("", "\n\n"))
 
         lines.append(("fg:ansibrightblack", "  Press Enter to toggle."))
+
+        if self._changed:
+            lines.append(("", "\n\n"))
+            lines.append(("fg:ansiyellow bold", "  Restart Code Puppy for"))
+            lines.append(("", "\n"))
+            lines.append(("fg:ansiyellow bold", "  changes to take effect."))
 
         return lines
 
@@ -309,5 +317,12 @@ class PluginsMenu:
 
 def run_plugins_menu() -> Optional[str]:
     """Entry point: create and run the plugins TUI, return the result."""
+    from code_puppy.messaging import emit_warning
+
     menu = PluginsMenu()
-    return menu.run()
+    result = menu.run()
+
+    if menu._changed:
+        emit_warning("Restart Code Puppy for plugin changes to take effect.")
+
+    return result

--- a/code_puppy/plugins/plugin_list/register_callbacks.py
+++ b/code_puppy/plugins/plugin_list/register_callbacks.py
@@ -91,7 +91,7 @@ def _all_loaded_plugin_names() -> set[str]:
 
 def _handle_disable(plugin_name: str) -> bool:
     """Disable a plugin by name."""
-    from code_puppy.messaging import emit_error, emit_info, emit_success
+    from code_puppy.messaging import emit_error, emit_info, emit_success, emit_warning
     from code_puppy.plugins.config import set_plugin_disabled
 
     all_names = _all_loaded_plugin_names()
@@ -103,8 +103,8 @@ def _handle_disable(plugin_name: str) -> bool:
         return True
 
     if set_plugin_disabled(plugin_name, disabled=True):
-        emit_success(f"Plugin '{plugin_name}' disabled. Its callbacks will be skipped.")
-        emit_info("This takes effect immediately -- no restart required.")
+        emit_success(f"Plugin '{plugin_name}' disabled.")
+        emit_warning("Restart Code Puppy for this change to take effect.")
     else:
         emit_info(f"Plugin '{plugin_name}' is already disabled.")
     return True
@@ -112,7 +112,7 @@ def _handle_disable(plugin_name: str) -> bool:
 
 def _handle_enable(plugin_name: str) -> bool:
     """Enable a previously disabled plugin."""
-    from code_puppy.messaging import emit_error, emit_info, emit_success
+    from code_puppy.messaging import emit_error, emit_info, emit_success, emit_warning
     from code_puppy.plugins.config import set_plugin_disabled
 
     all_names = _all_loaded_plugin_names()
@@ -125,7 +125,7 @@ def _handle_enable(plugin_name: str) -> bool:
 
     if set_plugin_disabled(plugin_name, disabled=False):
         emit_success(f"Plugin '{plugin_name}' re-enabled.")
-        emit_info("This takes effect immediately -- no restart required.")
+        emit_warning("Restart Code Puppy for this change to take effect.")
     else:
         emit_info(f"Plugin '{plugin_name}' is already enabled.")
     return True


### PR DESCRIPTION
- TUI: track _changed flag on toggle, show yellow restart banner in detail panel while browsing, emit_warning after TUI exit
- CLI: /plugins enable|disable emit restart warning instead of the old 'takes effect immediately' message