### PR TITLE
feat(plugins): optional yantrik_memory — semantic memory + supersession (opt-in)

### DIFF
--- a/code_puppy/plugins/yantrik_memory/.gitignore
+++ b/code_puppy/plugins/yantrik_memory/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/code_puppy/plugins/yantrik_memory/__init__.py
+++ b/code_puppy/plugins/yantrik_memory/__init__.py
@@ -1,0 +1,19 @@
+"""Yantrik Memory — a YantrikDB-backed semantic/learning memory for Code Puppy.
+
+Where the ``puppy_kennel`` plugin stores *verbatim* drawers in SQLite + FTS5,
+this plugin layers a **learning** memory on top of YantrikDB:
+
+* Every user turn is logged verbatim as an ``episodic`` memory.
+* A local distiller (Ollama) reads the turn and extracts the durable facts /
+  preferences worth keeping, writing them as ``semantic`` memories.
+* When a new turn *updates* a prior fact, the old fact is superseded via
+  ``correct()`` so only the authoritative value surfaces in recall.
+
+Recall is **banded**: a "current" band of authoritative facts/prefs (always
+surfaced into the system prompt) and a "history" band of query-relevant
+episodic context.
+
+The plugin is **opt-in** — disabled by default. Run ``/yantrik enable`` to
+turn it on. If YantrikDB (or its ONNX embedder) isn't installed, the plugin
+silently disables itself and never touches the host app.
+"""

--- a/code_puppy/plugins/yantrik_memory/commands.py
+++ b/code_puppy/plugins/yantrik_memory/commands.py
@@ -1,0 +1,176 @@
+"""Slash commands for humans interacting with yantrik_memory.
+
+Sub-commands under ``/yantrik``:
+
+* ``/yantrik``         — show status + stats
+* ``/yantrik status``  — is memory enabled?
+* ``/yantrik enable``  — turn learned memory on (opt-in)
+* ``/yantrik disable`` — turn it off (stored memories preserved)
+* ``/yantrik stats``   — store totals + enabled state
+* ``/yantrik help``    — usage hint
+
+Handlers return ``True`` to mark a command handled (per callback contract) or
+``None`` to let other plugins try.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from code_puppy.messaging import emit_error, emit_info, emit_success, emit_warning
+
+from . import substrate
+from .config import DB_PATH
+from .state import is_enabled, set_enabled
+
+_COMMAND = "yantrik"
+_HELP_LINES: tuple[tuple[str, str], ...] = (
+    ("yantrik", "Yantrik memory — YantrikDB-backed learning memory (opt-in)"),
+)
+
+
+def _reload_current_agent() -> None:
+    """Rebuild the active agent so its tool list reflects the new state.
+
+    Toggling memory on/off changes what ``register_agent_tools`` advertises;
+    the live agent baked its tools in at construction. Fail soft.
+    """
+    try:
+        from code_puppy.agents.agent_manager import get_current_agent
+
+        get_current_agent().reload_code_generation_agent()
+    except Exception as exc:  # noqa: BLE001
+        emit_error(f"Could not reload agent after yantrik toggle: {exc!r}")
+
+
+def _parse(command: str) -> tuple[str, str]:
+    """Split ``/yantrik <sub> <rest>`` into ``(sub, rest)``."""
+    body = command.lstrip("/").strip()
+    if body.startswith(_COMMAND):
+        body = body[len(_COMMAND) :].strip()
+    parts = body.split(None, 1)
+    sub = parts[0].lower() if parts else ""
+    rest = parts[1] if len(parts) > 1 else ""
+    return sub, rest
+
+
+def _namespace() -> str:
+    try:
+        return substrate.namespace_for_cwd()
+    except Exception:
+        return "default"
+
+
+def _cmd_stats() -> bool:
+    state = "enabled" if is_enabled() else "DISABLED"
+    available = "yes" if substrate.MEMORY_AVAILABLE else "NO (YantrikDB missing)"
+    emit_info(f"Yantrik memory at `{DB_PATH}`")
+    emit_info(f"  state     : {state}")
+    emit_info(f"  yantrikdb : {available}")
+    emit_info(f"  namespace : {_namespace()}")
+    if substrate.MEMORY_AVAILABLE and is_enabled():
+        mem = None
+        try:
+            from .tools import _open
+
+            mem = _open()
+            emit_info(f"  facts     : {len(mem.list_semantic(limit=10000))}")
+        except Exception as exc:  # noqa: BLE001
+            emit_warning(f"  facts     : (unavailable: {exc!r})")
+        finally:
+            if mem is not None:
+                mem.close()
+    return True
+
+
+def _cmd_status() -> bool:
+    if not substrate.MEMORY_AVAILABLE:
+        emit_warning(
+            "Yantrik memory is INERT — YantrikDB is not installed. "
+            "Install yantrikdb_mcp[onnx] to enable it."
+        )
+        return True
+    if is_enabled():
+        emit_success("Yantrik memory is ENABLED.")
+    else:
+        emit_warning(
+            "Yantrik memory is DISABLED (opt-in). Run /yantrik enable to turn it on."
+        )
+    return True
+
+
+def _cmd_enable() -> bool:
+    if not substrate.MEMORY_AVAILABLE:
+        emit_warning(
+            "Cannot enable — YantrikDB is not installed. "
+            "Install yantrikdb_mcp[onnx] first."
+        )
+        return True
+    if is_enabled():
+        emit_info("Yantrik memory is already enabled.")
+        return True
+    try:
+        set_enabled(True)
+    except Exception as exc:  # noqa: BLE001
+        emit_warning(f"Could not persist enabled state: {exc!r}")
+        return True
+    _reload_current_agent()
+    emit_success(
+        "Yantrik memory ENABLED. Turns will be distilled into learned facts "
+        "and recalled into the prompt."
+    )
+    return True
+
+
+def _cmd_disable() -> bool:
+    if not is_enabled():
+        emit_info("Yantrik memory is already disabled.")
+        return True
+    try:
+        set_enabled(False)
+    except Exception as exc:  # noqa: BLE001
+        emit_warning(f"Could not persist disabled state: {exc!r}")
+        return True
+    _reload_current_agent()
+    emit_success(
+        "Yantrik memory DISABLED. Stored memories remain on disk; distilling "
+        "and recall are paused. Run /yantrik enable to resume."
+    )
+    return True
+
+
+def _cmd_help() -> bool:
+    emit_info("Yantrik memory commands:")
+    emit_info("  /yantrik           - status + stats")
+    emit_info("  /yantrik status    - is memory enabled?")
+    emit_info("  /yantrik enable    - turn learned memory on (opt-in)")
+    emit_info("  /yantrik disable   - turn it off (memories preserved)")
+    emit_info("  /yantrik stats     - store totals + enabled state")
+    emit_info("  /yantrik help      - this message")
+    return True
+
+
+def handle(command: str, name: str) -> Any:
+    """Dispatch ``/yantrik``. Returns ``None`` for non-yantrik commands."""
+    if name != _COMMAND:
+        return None
+    sub, _rest = _parse(command)
+    if not sub:
+        return _cmd_status() and _cmd_stats()
+    if sub == "stats":
+        return _cmd_stats()
+    if sub == "status":
+        return _cmd_status()
+    if sub in ("enable", "on"):
+        return _cmd_enable()
+    if sub in ("disable", "off"):
+        return _cmd_disable()
+    if sub in ("help", "?"):
+        return _cmd_help()
+    emit_warning(f"Unknown /yantrik subcommand: '{sub}'")
+    return _cmd_help()
+
+
+def help_entries() -> list[tuple[str, str]]:
+    """``custom_command_help`` callback — list ``/yantrik`` in /help."""
+    return list(_HELP_LINES)

--- a/code_puppy/plugins/yantrik_memory/config.py
+++ b/code_puppy/plugins/yantrik_memory/config.py
@@ -1,0 +1,62 @@
+"""Configuration for the yantrik_memory plugin.
+
+Single source of truth for paths, defaults, and opt-out flags. All knobs are
+environment-overridable so the plugin can be relocated / tuned without code
+edits.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# Root directory for the memory store on disk.
+YANTRIK_MEM_ROOT = Path(
+    os.environ.get(
+        "YANTRIK_MEMORY_ROOT", Path.home() / ".code_puppy" / "yantrik_memory"
+    )
+)
+
+# The YantrikDB store lives inside the root. ``load_engine`` treats this as the
+# DB path (it manages its own file/dir layout underneath).
+DB_PATH = YANTRIK_MEM_ROOT / "memory"
+
+# Hard kill-switch: prevent the plugin from registering callbacks at all.
+DISABLED = os.environ.get("YANTRIK_MEMORY_DISABLED", "").lower() in {
+    "1",
+    "true",
+    "yes",
+}
+
+# --------------------------------------------------------------------------- #
+# Embedder — YantrikDB picks the embedding engine off this env var. We default
+# to the production ONNX MiniLM (384-dim) which is what the working-memory
+# substrate was tuned against. ``substrate`` sets this before importing the
+# engine so the choice actually takes effect.
+# --------------------------------------------------------------------------- #
+EMBEDDER = os.environ.get("YANTRIK_MEMORY_EMBEDDER", "onnx")
+
+# --------------------------------------------------------------------------- #
+# Distiller — local Ollama model that extracts durable facts from raw turns.
+# Set YANTRIK_MEMORY_DISTILL=0 to log episodic turns only (no fact extraction).
+# --------------------------------------------------------------------------- #
+DISTILLER_ENABLED = os.environ.get("YANTRIK_MEMORY_DISTILL", "1").lower() not in {
+    "0",
+    "false",
+    "no",
+}
+DISTILLER_MODEL = os.environ.get("YANTRIK_MEMORY_DISTILL_MODEL", "qwen3.5:4b-nothink")
+DISTILLER_URL = os.environ.get(
+    "YANTRIK_MEMORY_OLLAMA_URL", "http://localhost:11434/api/chat"
+)
+DISTILLER_TIMEOUT = float(os.environ.get("YANTRIK_MEMORY_DISTILL_TIMEOUT", "120"))
+
+# --------------------------------------------------------------------------- #
+# Recall packing knobs.
+# --------------------------------------------------------------------------- #
+# Size of the always-on "current" band (highest-importance durable facts).
+PREFS_BAND_SIZE = int(os.environ.get("YANTRIK_MEMORY_PREFS_BAND", "8"))
+# How many query-relevant history items to surface alongside.
+HISTORY_TOP_K = int(os.environ.get("YANTRIK_MEMORY_HISTORY_TOP_K", "5"))
+# Cap on how many known semantic facts we feed the distiller as update context.
+MAX_KNOWN_FACTS = int(os.environ.get("YANTRIK_MEMORY_MAX_KNOWN_FACTS", "60"))

--- a/code_puppy/plugins/yantrik_memory/distiller.py
+++ b/code_puppy/plugins/yantrik_memory/distiller.py
@@ -1,0 +1,96 @@
+"""Distiller — extract durable facts/preferences from NATURAL conversation turns.
+
+This is what makes the memory *learn*: instead of hand-tagged facts, a local
+model reads each user message and emits the atomic, durable facts worth
+remembering (brand, conventions, preferences), flags chatter as nothing, and
+detects when a message UPDATES a prior fact (so the recorder can supersede it
+via ``correct()``).
+
+Entirely fail-soft: any error — Ollama unreachable, bad JSON, distiller turned
+off — returns ``[]`` so the turn is logged episodically and nothing breaks.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from .config import (
+    DISTILLER_ENABLED,
+    DISTILLER_MODEL,
+    DISTILLER_TIMEOUT,
+    DISTILLER_URL,
+)
+
+SYSTEM = (
+    "You extract DURABLE facts and preferences worth remembering long-term from a "
+    "user's message: brand, conventions, standing rules, personal preferences, and "
+    "ONGOING STYLE preferences (e.g. 'keep charts minimalist, no gridlines'). "
+    "A message can mix small talk with a durable preference — extract the durable "
+    "part and ignore the rest. Ignore PURE small talk and one-off task requests. "
+    "Return ONLY a JSON array. Each item: "
+    '{"fact": "<concise durable fact>", "importance": <0.0-1.0>, '
+    '"updates": "<exact prior fact text this replaces, or null>"}. '
+    "If there is nothing durable, return []."
+)
+
+_ARR = re.compile(r"\[.*\]", re.DOTALL)
+
+
+def extract(message: str, existing_facts: list[str] | None = None) -> list[dict]:
+    """Return a list of ``{fact, importance, updates}`` dicts. Never raises."""
+    if not DISTILLER_ENABLED:
+        return []
+    if not message or not message.strip():
+        return []
+
+    ctx = ""
+    if existing_facts:
+        ctx = (
+            "Known facts (an update may replace one of these):\n"
+            + "\n".join(f"- {f}" for f in existing_facts)
+            + "\n\n"
+        )
+    prompt = f"{ctx}Message:\n{message}"
+
+    try:
+        import requests  # imported lazily so a missing dep doesn't break import.
+
+        r = requests.post(
+            DISTILLER_URL,
+            json={
+                "model": DISTILLER_MODEL,
+                "stream": False,
+                "think": False,
+                "options": {"temperature": 0.0},
+                "messages": [
+                    {"role": "system", "content": SYSTEM},
+                    {"role": "user", "content": prompt},
+                ],
+            },
+            timeout=DISTILLER_TIMEOUT,
+        )
+        r.raise_for_status()
+        text = r.json()["message"]["content"]
+    except Exception:
+        return []
+
+    m = _ARR.search(text)
+    if not m:
+        return []
+    try:
+        items = json.loads(m.group(0))
+    except Exception:
+        return []
+
+    out: list[dict] = []
+    for it in items if isinstance(items, list) else []:
+        if isinstance(it, dict) and it.get("fact"):
+            out.append(
+                {
+                    "fact": str(it["fact"]).strip(),
+                    "importance": float(it.get("importance", 0.7) or 0.7),
+                    "updates": (it.get("updates") or None),
+                }
+            )
+    return out

--- a/code_puppy/plugins/yantrik_memory/recorder.py
+++ b/code_puppy/plugins/yantrik_memory/recorder.py
@@ -114,9 +114,7 @@ def _ingest(mem: "substrate.Memory", fact_map: dict[str, Any], message: str) -> 
                 changed += 1
             except Exception:
                 rid = _rid_of(
-                    mem.remember(
-                        f["fact"], kind="semantic", importance=f["importance"]
-                    )
+                    mem.remember(f["fact"], kind="semantic", importance=f["importance"])
                 )
                 if rid is not None:
                     fact_map[f["fact"]] = rid

--- a/code_puppy/plugins/yantrik_memory/recorder.py
+++ b/code_puppy/plugins/yantrik_memory/recorder.py
@@ -1,0 +1,204 @@
+"""Recorder — turns conversation into learned memory.
+
+Two entry points:
+
+* ``distill_user_message(prompt, session_id)`` — fires on ``user_prompt_submit``.
+  Logs the raw turn as an ``episodic`` memory AND distills durable facts into
+  ``semantic`` memory (learning new facts, superseding updated ones).
+
+* ``record_response(...)`` — fires on ``agent_run_end``. Logs the agent's final
+  response as an ``episodic`` memory.
+
+The "fact -> rid" map needed for supersession is **reconstructed from the store
+on every turn** (each callback is a fresh process state): we list the namespace's
+semantic memories (text -> rid), feed those texts to the distiller as
+``existing_facts``, and when the distiller flags an ``updates`` match we call
+``substrate.correct(rid, new_text)`` instead of inserting a duplicate.
+
+Everything here is best-effort and fail-soft: the memory layer must never crash
+the host app or a turn.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from code_puppy.messaging.bus import emit_debug
+
+from . import substrate
+from .config import DB_PATH, MAX_KNOWN_FACTS, YANTRIK_MEM_ROOT
+from .distiller import extract
+from .state import is_enabled
+
+
+def _open_memory() -> "substrate.Memory | None":
+    """Open a namespace-scoped Memory handle for the current cwd. Fail-soft."""
+    if not substrate.MEMORY_AVAILABLE:
+        return None
+    try:
+        YANTRIK_MEM_ROOT.mkdir(parents=True, exist_ok=True)
+        ns = substrate.namespace_for_cwd()
+        return substrate.Memory(str(DB_PATH), namespace=ns)
+    except Exception as exc:  # noqa: BLE001
+        emit_debug(f"[yantrik_memory] open failed: {exc!r}")
+        return None
+
+
+def _rid_of(r: Any) -> Any:
+    """Normalize a record() return into a record id."""
+    if isinstance(r, str):
+        return r
+    if isinstance(r, dict):
+        return r.get("rid") or r.get("id")
+    return None
+
+
+def _known_facts(mem: "substrate.Memory") -> dict[str, Any]:
+    """Reconstruct the text -> rid map of durable facts from the store."""
+    fact_map: dict[str, Any] = {}
+    try:
+        for m in mem.list_semantic(limit=MAX_KNOWN_FACTS):
+            text = (m or {}).get("text")
+            rid = (m or {}).get("rid") or (m or {}).get("id")
+            if text and rid is not None:
+                fact_map[text] = rid
+    except Exception:
+        pass
+    return fact_map
+
+
+def _norm_fact(text: str) -> str:
+    """Normalize a fact for tolerant matching: lowercased, punctuation-stripped."""
+    cleaned = "".join(c if (c.isalnum() or c.isspace()) else " " for c in text.lower())
+    return " ".join(cleaned.split())
+
+
+def _match_known(upd: str, fact_map: dict[str, Any]) -> str | None:
+    """Resolve the distiller's ``updates`` text to a known-fact key.
+
+    The local distiller often echoes the prior fact with slight drift (a missing
+    trailing period, different casing). An exact dict lookup is too brittle, so
+    we fall back to a normalized match, then to bidirectional substring overlap.
+    Returns the matching key in ``fact_map`` or ``None``.
+    """
+    if not upd:
+        return None
+    if upd in fact_map:
+        return upd
+    upd_n = _norm_fact(upd)
+    for key in fact_map:
+        if _norm_fact(key) == upd_n:
+            return key
+    # Substring fallback: the longest known fact contained in / containing upd.
+    cand = None
+    for key in fact_map:
+        kn = _norm_fact(key)
+        if kn and (kn in upd_n or upd_n in kn):
+            if cand is None or len(key) > len(cand):
+                cand = key
+    return cand
+
+
+def _ingest(mem: "substrate.Memory", fact_map: dict[str, Any], message: str) -> int:
+    """Distill ``message`` -> learn new facts / correct() superseded ones.
+
+    Returns the number of durable facts written or updated.
+    """
+    changed = 0
+    for f in extract(message, list(fact_map.keys())):
+        match = _match_known(f.get("updates"), fact_map)
+        if match:  # update -> supersede the prior fact
+            try:
+                mem.correct(fact_map[match], f["fact"], importance=f["importance"])
+                fact_map[f["fact"]] = fact_map.pop(match)
+                changed += 1
+            except Exception:
+                rid = _rid_of(
+                    mem.remember(
+                        f["fact"], kind="semantic", importance=f["importance"]
+                    )
+                )
+                if rid is not None:
+                    fact_map[f["fact"]] = rid
+                changed += 1
+        else:  # new durable fact
+            rid = _rid_of(
+                mem.remember(f["fact"], kind="semantic", importance=f["importance"])
+            )
+            if rid is not None:
+                fact_map[f["fact"]] = rid
+            changed += 1
+    return changed
+
+
+def distill_user_message(prompt: str | None, session_id: str | None = None) -> None:
+    """Log the user turn (episodic) + distill durable facts (semantic).
+
+    Fires on ``user_prompt_submit``. Fail-soft, skips when disabled.
+    """
+    if not prompt or not prompt.strip():
+        return
+    if not is_enabled():
+        return
+
+    mem = _open_memory()
+    if mem is None:
+        return
+    try:
+        mem.remember(
+            prompt,
+            kind="episodic",
+            importance=0.5,
+            metadata={"role": "user", "session_id": session_id},
+        )
+        fact_map = _known_facts(mem)
+        n = _ingest(mem, fact_map, prompt)
+        # Reopen so the freshly-written semantic facts are queryable this turn.
+        mem.flush()
+        if n:
+            emit_debug(f"[yantrik_memory] distilled {n} durable fact(s)")
+    except Exception as exc:  # noqa: BLE001 — best-effort memory.
+        emit_debug(f"[yantrik_memory] distill skipped: {exc!r}")
+    finally:
+        mem.close()
+
+
+def record_response(
+    agent_name: str,
+    model_name: str,
+    session_id: str | None = None,
+    success: bool = True,
+    error: Exception | None = None,
+    response_text: str | None = None,
+    metadata: dict | None = None,
+) -> None:
+    """Log the agent's final response as an episodic memory.
+
+    Fires on ``agent_run_end``. Fail-soft, skips when disabled or on failure.
+    """
+    if not response_text or not response_text.strip():
+        return
+    if not success:
+        return
+    if not is_enabled():
+        return
+
+    mem = _open_memory()
+    if mem is None:
+        return
+    try:
+        drawer_meta: dict[str, Any] = {
+            "role": "assistant",
+            "agent": agent_name,
+            "model": model_name,
+            "session_id": session_id,
+        }
+        if metadata:
+            drawer_meta["run_metadata"] = metadata
+        mem.remember(
+            response_text, kind="episodic", importance=0.4, metadata=drawer_meta
+        )
+    except Exception as exc:  # noqa: BLE001
+        emit_debug(f"[yantrik_memory] record_response skipped: {exc!r}")
+    finally:
+        mem.close()

--- a/code_puppy/plugins/yantrik_memory/register_callbacks.py
+++ b/code_puppy/plugins/yantrik_memory/register_callbacks.py
@@ -53,9 +53,7 @@ def _on_load_prompt() -> str | None:
         return None
 
 
-async def _on_user_prompt_submit(
-    prompt: str, session_id: str | None = None
-) -> None:
+async def _on_user_prompt_submit(prompt: str, session_id: str | None = None) -> None:
     """Async hook — log + distill the user turn. Never modifies the prompt."""
     try:
         distill_user_message(prompt, session_id)

--- a/code_puppy/plugins/yantrik_memory/register_callbacks.py
+++ b/code_puppy/plugins/yantrik_memory/register_callbacks.py
@@ -1,0 +1,113 @@
+"""Register yantrik_memory with Code Puppy's callback system.
+
+Hooks wired:
+* ``load_prompt``          -> passive recall block in the system prompt
+* ``user_prompt_submit``   -> log user turn (episodic) + distill durable facts
+* ``agent_run_end``        -> record the agent's response (episodic)
+* ``register_tools``       -> defines yantrik tools in ``TOOL_REGISTRY``
+* ``register_agent_tools`` -> advertises yantrik tools to every agent's list
+* ``custom_command``       -> handles ``/yantrik`` and subcommands
+* ``custom_command_help``  -> advertises ``/yantrik`` in the /help menu
+
+Fail-soft and opt-in:
+* If ``YANTRIK_MEMORY_DISABLED`` is set, NO callbacks register.
+* If YantrikDB (the ONNX-backed engine) isn't importable, the plugin is
+  silently inert — no callbacks register, boot is untouched.
+* Memory itself defaults OFF; the user opts in via ``/yantrik enable``.
+"""
+
+from __future__ import annotations
+
+from code_puppy.callbacks import register_callback
+from code_puppy.messaging.bus import emit_debug
+
+from . import commands, substrate, tools
+from .config import DISABLED
+from .recorder import distill_user_message, record_response
+from .retriever import build_recall_block
+from .state import is_enabled
+
+
+def _initialize_once() -> bool:
+    """Confirm the YantrikDB engine is importable. Idempotent + fail-soft.
+
+    We don't open the store here (that happens lazily per turn, scoped to the
+    cwd namespace). We only verify the dependency is present — if it isn't, the
+    plugin stays inert.
+    """
+    if not substrate.MEMORY_AVAILABLE:
+        emit_debug(
+            f"[yantrik_memory] YantrikDB unavailable, plugin inert: "
+            f"{substrate.IMPORT_ERROR!r}"
+        )
+        return False
+    return True
+
+
+def _on_load_prompt() -> str | None:
+    """Sync hook — returns a passive recall fragment or None."""
+    try:
+        return build_recall_block()
+    except Exception as exc:  # noqa: BLE001
+        emit_debug(f"[yantrik_memory] load_prompt skipped: {exc!r}")
+        return None
+
+
+async def _on_user_prompt_submit(
+    prompt: str, session_id: str | None = None
+) -> None:
+    """Async hook — log + distill the user turn. Never modifies the prompt."""
+    try:
+        distill_user_message(prompt, session_id)
+    except Exception as exc:  # noqa: BLE001
+        emit_debug(f"[yantrik_memory] user_prompt_submit skipped: {exc!r}")
+    return None
+
+
+def _on_agent_run_end(
+    agent_name: str,
+    model_name: str,
+    session_id: str | None = None,
+    success: bool = True,
+    error: Exception | None = None,
+    response_text: str | None = None,
+    metadata: dict | None = None,
+) -> None:
+    """Sync-bodied hook — record the agent response as episodic memory."""
+    record_response(
+        agent_name=agent_name,
+        model_name=model_name,
+        session_id=session_id,
+        success=success,
+        error=error,
+        response_text=response_text,
+        metadata=metadata,
+    )
+
+
+_YANTRIK_TOOL_NAMES = (
+    "yantrik_recall",
+    "yantrik_remember",
+    "yantrik_stats",
+)
+
+
+def _advertise_tools_to_agent(agent_name: str | None = None) -> list[str]:
+    """``register_agent_tools`` callback — advertise yantrik tools when enabled.
+
+    When memory is toggled off (or never opted into), advertise NO tools so the
+    agent doesn't see (and try to call) memory tools that would just bounce.
+    """
+    if not is_enabled():
+        return []
+    return list(_YANTRIK_TOOL_NAMES)
+
+
+if not DISABLED and _initialize_once():
+    register_callback("load_prompt", _on_load_prompt)
+    register_callback("user_prompt_submit", _on_user_prompt_submit)
+    register_callback("agent_run_end", _on_agent_run_end)
+    register_callback("register_tools", tools.register_tools_callback)
+    register_callback("register_agent_tools", _advertise_tools_to_agent)
+    register_callback("custom_command", commands.handle)
+    register_callback("custom_command_help", commands.help_entries)

--- a/code_puppy/plugins/yantrik_memory/retriever.py
+++ b/code_puppy/plugins/yantrik_memory/retriever.py
@@ -1,0 +1,76 @@
+"""Retriever — surfaces learned memory into the system prompt.
+
+Fires on ``load_prompt``. Builds a banded recall block:
+
+* ``## Remembered (current)`` — the authoritative durable facts/prefs, sorted
+  by importance. A superseded value is absent here (it was ``correct()``-ed).
+* ``## Relevant history`` — query-relevant episodic context, only included when
+  a ``user_prompt`` is supplied (e.g. an explicit recall call).
+
+Returns ``None`` when disabled, when YantrikDB is unavailable, or when there's
+nothing worth surfacing. Fail-soft — any exception returns ``None`` so the host
+prompt is never broken.
+"""
+
+from __future__ import annotations
+
+from . import substrate
+from .config import DB_PATH, HISTORY_TOP_K, PREFS_BAND_SIZE, YANTRIK_MEM_ROOT
+from .state import is_enabled
+
+_EMPTY_RETURN = None  # Returning None tells the callback system "skip me."
+
+
+def _text_of(m: dict) -> str:
+    return str((m or {}).get("text", "")).strip()
+
+
+def build_recall_block(user_prompt: str | None = None) -> str | None:
+    """Return a system-prompt fragment from banded recall, or ``None``."""
+    if not is_enabled():
+        return _EMPTY_RETURN
+    if not substrate.MEMORY_AVAILABLE:
+        return _EMPTY_RETURN
+
+    mem = None
+    try:
+        YANTRIK_MEM_ROOT.mkdir(parents=True, exist_ok=True)
+        ns = substrate.namespace_for_cwd()
+        mem = substrate.Memory(str(DB_PATH), namespace=ns)
+
+        # A query is needed for the history band; for a passive load_prompt with
+        # no prompt we still surface the always-on "current" prefs band.
+        query = (user_prompt or "").strip()
+        current = mem.prefs(PREFS_BAND_SIZE)
+        history = []
+        if query:
+            cur_keys = {(m or {}).get("rid") for m in current}
+            history = [
+                m
+                for m in mem.recall(query, HISTORY_TOP_K)
+                if (m or {}).get("rid") not in cur_keys
+            ]
+
+        cur_lines = [t for t in (_text_of(m) for m in current) if t]
+        if not cur_lines and not history:
+            return _EMPTY_RETURN
+
+        sections: list[str] = []
+        if cur_lines:
+            body = "\n".join(f"- {t}" for t in cur_lines)
+            sections.append("## Remembered (current)\n" + body)
+
+        if query:
+            hist_lines = [t for t in (_text_of(m) for m in history) if t]
+            if hist_lines:
+                body = "\n".join(f"- {t}" for t in hist_lines)
+                sections.append("## Relevant history\n" + body)
+
+        if not sections:
+            return _EMPTY_RETURN
+        return "\n\n".join(sections)
+    except Exception:
+        return _EMPTY_RETURN
+    finally:
+        if mem is not None:
+            mem.close()

--- a/code_puppy/plugins/yantrik_memory/state.py
+++ b/code_puppy/plugins/yantrik_memory/state.py
@@ -1,0 +1,45 @@
+"""Runtime state for the yantrik_memory plugin.
+
+A tiny JSON file at ``<YANTRIK_MEM_ROOT>/state.json`` records whether memory
+is currently enabled. The slash commands ``/yantrik enable`` and
+``/yantrik disable`` flip this flag; reads (recorder/retriever/tools) consult
+``is_enabled()`` on every call so the toggle is live.
+
+IMPORTANT — this plugin is **opt-in**. Unlike the puppy_kennel (which defaults
+ON), ``is_enabled()`` returns ``False`` when no state file exists. A user must
+explicitly run ``/yantrik enable`` to turn it on.
+
+The env var ``YANTRIK_MEMORY_DISABLED=1`` is a separate, harder kill: it
+prevents the plugin from registering callbacks at all. That's handled in
+``register_callbacks``, not here.
+"""
+
+from __future__ import annotations
+
+import json
+
+from .config import YANTRIK_MEM_ROOT
+
+STATE_PATH = YANTRIK_MEM_ROOT / "state.json"
+
+DISABLED_TOOL_ERROR = (
+    "Yantrik memory is currently disabled. "
+    "Ask the user to run `/yantrik enable` to turn it on."
+)
+
+
+def is_enabled() -> bool:
+    """Read the persisted enabled flag. Defaults to ``False`` (opt-in)."""
+    try:
+        payload = json.loads(STATE_PATH.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return False
+    return bool(payload.get("enabled", False))
+
+
+def set_enabled(value: bool) -> None:
+    """Persist the enabled flag to the state file. Best-effort."""
+    YANTRIK_MEM_ROOT.mkdir(parents=True, exist_ok=True)
+    STATE_PATH.write_text(
+        json.dumps({"enabled": bool(value)}, indent=2), encoding="utf-8"
+    )

--- a/code_puppy/plugins/yantrik_memory/substrate.py
+++ b/code_puppy/plugins/yantrik_memory/substrate.py
@@ -1,0 +1,171 @@
+"""Single-substrate learning memory over YantrikDB (ported into the plugin).
+
+YantrikDB IS the whole memory: episodic (verbatim turns), semantic (durable
+facts/preferences), procedural (skills) — plus graph, importance, decay,
+reinforcement, and native consolidation/conflict. No SQLite layer.
+
+Lessons baked in: production ONNX MiniLM embedder, reopen-before-query (async
+HNSW), never-retry-on-queue-full, atomic units. We KEEP the default live-memory
+time-weights here (recency SHOULD matter for an agent's working memory).
+
+Self-contained: the only hard dependency is ``yantrikdb_mcp``. Import is
+fail-soft — if the engine isn't installable, ``MEMORY_AVAILABLE`` is ``False``
+and the rest of the plugin disables itself.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+from .config import EMBEDDER
+
+# YantrikDB reads the embedder choice off the environment at import time, so we
+# set it BEFORE importing the engine. Default is the production ONNX MiniLM.
+os.environ.setdefault("YANTRIKDB_EMBEDDER", EMBEDDER)
+
+try:  # fail-soft: a missing engine disables the whole plugin, never crashes boot.
+    from yantrikdb_mcp.embedder import load_engine
+
+    MEMORY_AVAILABLE = True
+    IMPORT_ERROR: Exception | None = None
+except Exception as exc:  # noqa: BLE001 — any import failure means "unavailable".
+    load_engine = None  # type: ignore[assignment]
+    MEMORY_AVAILABLE = False
+    IMPORT_ERROR = exc
+
+
+def namespace_for_cwd(cwd: str | os.PathLike | None = None) -> str:
+    """Slug the current working directory into a stable namespace.
+
+    Memory is partitioned per project directory (analogous to the kennel's
+    repo wings). The slug is filesystem-derived and stable across sessions so
+    a repo's learned facts persist and don't bleed into other projects.
+    """
+    raw = str(cwd) if cwd is not None else os.getcwd()
+    slug = "".join(c if c.isalnum() else "-" for c in raw.lower())
+    slug = "-".join(p for p in slug.split("-") if p)  # collapse runs of '-'
+    return slug or "default"
+
+
+class Memory:
+    """Thin wrapper over a YantrikDB engine instance, scoped to a namespace."""
+
+    def __init__(self, db_path: str, namespace: str = "default"):
+        self._path = db_path
+        self.ns = namespace
+        self.db = load_engine(db_path)
+
+    # ---- write ----
+    def remember(self, text, kind="episodic", importance=0.5, metadata=None):
+        """kind: 'episodic' (turns) | 'semantic' (durable facts) | 'procedural'."""
+        try:
+            return self.db.record(
+                text=text,
+                memory_type=kind,
+                importance=importance,
+                metadata=metadata or {},
+                namespace=self.ns,
+            )
+        except RuntimeError as e:
+            if "queue full" not in str(e):
+                raise
+            time.sleep(0.1)  # already enqueued; never retry (would duplicate)
+
+    def flush(self):
+        """Drain the async queue + reopen so the HNSW index is built before query."""
+        time.sleep(1.0)
+        self.db.close()
+        self.db = load_engine(self._path)
+
+    def think(self):
+        """Native cognitive cycle: conflict detection + episodic->semantic consolidation."""
+        try:
+            self.db.think()
+        except Exception:
+            pass
+
+    def correct(self, rid, new_text, importance=None):
+        self.db.correct(rid, new_text=new_text, new_importance=importance)
+
+    def reinforce(self, rid, outcome):
+        self.db.reinforce_procedural(rid, outcome)
+
+    def learn_skill(self, text, effectiveness=0.5, domain="general", metadata=None):
+        return self.db.record_procedural(
+            text=text, effectiveness=effectiveness, domain=domain, namespace=self.ns
+        )
+
+    def surface_skills(self, query, top_k=5, domain="general"):
+        emb = self.db.embed(query)
+        return self._norm(
+            self.db.surface_procedural(
+                query_embedding=emb,
+                query_text=query,
+                domain=domain,
+                top_k=top_k,
+                namespace=self.ns,
+            )
+        )
+
+    def relate(self, src, dst, rel="related_to"):
+        try:
+            self.db.relate(src, dst, rel)
+        except Exception:
+            pass
+
+    # ---- read ----
+    def _norm(self, r):
+        return r["results"] if isinstance(r, dict) and "results" in r else (r or [])
+
+    def recall(self, query, top_k=8):
+        return self._norm(
+            self.db.recall(
+                query=query, top_k=top_k, namespace=self.ns, skip_reinforce=True
+            )
+        )
+
+    def list_semantic(self, limit=100):
+        """Return all durable (semantic) memories in this namespace."""
+        r = self.db.list_memories(
+            memory_type="semantic", namespace=self.ns, limit=limit
+        )
+        return (r or {}).get("memories", []) if isinstance(r, dict) else (r or [])
+
+    def prefs(self, top_n=5):
+        """Always-include the highest-importance durable facts (a 'P0 prefs' band)."""
+        mems = self.list_semantic(limit=100)
+        mems = sorted(
+            mems, key=lambda m: (m or {}).get("importance", 0.0), reverse=True
+        )
+        return mems[:top_n]
+
+    def recall_for_prompt(self, query, top_k=8, n_prefs=5):
+        """What the agent actually sees: always-on prefs + query-relevant memories."""
+        out, seen = [], set()
+        for m in self.prefs(n_prefs) + self.recall(query, top_k):
+            key = (m or {}).get("rid") or (m or {}).get("text")
+            if key and key not in seen:
+                seen.add(key)
+                out.append(m)
+        return out
+
+    def recall_banded(self, query, top_k=8, n_prefs=5):
+        """Two bands: CURRENT (authoritative semantic facts/prefs, post-correction)
+        and HISTORY (query-relevant episodic/events, e.g. 'like last time'). A
+        superseded value stays OUT of CURRENT even though it still (truthfully)
+        exists in the verbatim episodic log."""
+        current = self.prefs(n_prefs)
+        cur_keys = {(m or {}).get("rid") for m in current}
+        history = [
+            m
+            for m in self.recall(query, top_k)
+            if (m or {}).get("rid") not in cur_keys
+        ]
+        return current, history
+
+    def close(self):
+        try:
+            self.db.close()
+        except Exception:
+            pass

--- a/code_puppy/plugins/yantrik_memory/substrate.py
+++ b/code_puppy/plugins/yantrik_memory/substrate.py
@@ -158,9 +158,7 @@ class Memory:
         current = self.prefs(n_prefs)
         cur_keys = {(m or {}).get("rid") for m in current}
         history = [
-            m
-            for m in self.recall(query, top_k)
-            if (m or {}).get("rid") not in cur_keys
+            m for m in self.recall(query, top_k) if (m or {}).get("rid") not in cur_keys
         ]
         return current, history
 

--- a/code_puppy/plugins/yantrik_memory/test_integration.py
+++ b/code_puppy/plugins/yantrik_memory/test_integration.py
@@ -1,0 +1,134 @@
+"""Standalone integration test for the yantrik_memory plugin.
+
+Does NOT need the Code Puppy TUI. It points the plugin at a temp store, enables
+it, drives the hook functions directly to simulate a conversation, and asserts:
+
+1. A durable fact is learned from a natural turn.
+2. A later "we rebranded" turn SUPERSEDES the old fact (current band shows the
+   new value, NOT the old one).
+3. Pure chatter adds nothing durable.
+
+Run directly (``python test_integration.py``) or under pytest. Requires Ollama
+running locally with the distiller model + yantrikdb_mcp[onnx] installed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+
+
+def _bootstrap_imports():
+    """Import the plugin modules whether run as a script or via pytest.
+
+    Sets a temp YANTRIK_MEMORY_ROOT BEFORE importing config-dependent modules so
+    the test never touches the user's real store.
+    """
+    tmp_root = tempfile.mkdtemp(prefix="yantrik_mem_test_")
+    os.environ["YANTRIK_MEMORY_ROOT"] = tmp_root
+
+    # Make the package importable when run as a bare script from its own dir.
+    here = os.path.dirname(os.path.abspath(__file__))
+    pkg_parent = os.path.abspath(os.path.join(here, "..", "..", ".."))
+    if pkg_parent not in sys.path:
+        sys.path.insert(0, pkg_parent)
+
+    from code_puppy.plugins.yantrik_memory import (  # noqa: E402
+        recorder,
+        retriever,
+        state,
+        substrate,
+    )
+
+    return tmp_root, recorder, retriever, state, substrate
+
+
+def run() -> int:
+    tmp_root, recorder, retriever, state, substrate = _bootstrap_imports()
+    print(f"[test] temp store: {tmp_root}")
+
+    if not substrate.MEMORY_AVAILABLE:
+        print(f"[SKIP] YantrikDB not available: {substrate.IMPORT_ERROR!r}")
+        return 0
+
+    failures: list[str] = []
+
+    # 1. Enable the plugin (opt-in default is OFF).
+    state.set_enabled(True)
+    assert state.is_enabled(), "plugin should be enabled after set_enabled(True)"
+    print("[test] enabled OK")
+
+    # 2. Simulate two user turns: an initial fact, then a rebrand that updates it.
+    print("[test] turn 1: initial brand color...")
+    recorder.distill_user_message(
+        "Our brand color is blue #1F4E79, logo top-right.", session_id="sess-1"
+    )
+    print("[test] turn 2: rebrand to green (should supersede)...")
+    recorder.distill_user_message(
+        "We rebranded, brand color is now green #2E7D32.", session_id="sess-1"
+    )
+
+    # 3. Build the recall block and check supersession.
+    block = retriever.build_recall_block("what is our brand color?")
+    print("\n----- recall block -----")
+    print(block)
+    print("------------------------\n")
+
+    if not block:
+        failures.append("recall block was empty (expected current-band facts)")
+    else:
+        if "#2E7D32" not in block:
+            failures.append("new color #2E7D32 missing from recall block")
+        # The current band must NOT carry the superseded value. We check the
+        # current section specifically (history/episodic may still hold it).
+        current_section = block.split("## Relevant history")[0]
+        if "#1F4E79" in current_section:
+            failures.append(
+                "superseded color #1F4E79 still present in CURRENT band "
+                "(supersession failed)"
+            )
+
+    # 4. A pure-chatter turn must add nothing durable.
+    print("[test] turn 3: pure chatter...")
+    from code_puppy.plugins.yantrik_memory.config import DB_PATH
+
+    ns = substrate.namespace_for_cwd()
+    mem = substrate.Memory(str(DB_PATH), namespace=ns)
+    before = len(mem.list_semantic(limit=10000))
+    mem.close()
+
+    recorder.distill_user_message(
+        "Did you catch the game last night? Wild finish.", session_id="sess-1"
+    )
+
+    mem = substrate.Memory(str(DB_PATH), namespace=ns)
+    after = len(mem.list_semantic(limit=10000))
+    mem.close()
+    print(f"[test] durable facts before chatter={before}, after={after}")
+    if after != before:
+        failures.append(
+            f"chatter added durable fact(s): {before} -> {after} (expected no change)"
+        )
+
+    # Report.
+    print()
+    if failures:
+        print("RESULT: FAIL")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("RESULT: PASS")
+    print("  - new color #2E7D32 present in current band")
+    print("  - superseded #1F4E79 absent from current band")
+    print(f"  - chatter added no durable facts ({before} == {after})")
+    return 0
+
+
+def test_yantrik_memory_supersession():
+    """pytest entrypoint."""
+    assert run() == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/code_puppy/plugins/yantrik_memory/tools.py
+++ b/code_puppy/plugins/yantrik_memory/tools.py
@@ -1,0 +1,258 @@
+"""Agent-facing tools for yantrik_memory.
+
+Tool surface (kept minimal but working):
+
+* ``yantrik_recall``   — semantic search over learned memory (banded)
+* ``yantrik_remember`` — explicit write of a durable fact
+* ``yantrik_stats``    — store totals + enabled state
+
+All tools share a single ``register_tools_callback`` plugin entrypoint and are
+fully fail-soft: a tool never raises, it returns an ``error`` string instead.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+from pydantic_ai import RunContext
+
+from . import substrate
+from .config import DB_PATH, HISTORY_TOP_K, PREFS_BAND_SIZE, YANTRIK_MEM_ROOT
+from .state import DISABLED_TOOL_ERROR, is_enabled
+
+
+class YantrikMemoryItem(BaseModel):
+    """A single recalled memory in tool-output form."""
+
+    text: str
+    band: str  # "current" | "history"
+    importance: float | None = None
+    memory_type: str | None = None
+    rid: str | None = None
+
+
+class YantrikRecallOutput(BaseModel):
+    query: str
+    total: int
+    memories: list[YantrikMemoryItem] = Field(default_factory=list)
+    error: str | None = None
+
+
+class YantrikRememberOutput(BaseModel):
+    text: str
+    importance: float
+    namespace: str
+    stored: bool = False
+    error: str | None = None
+
+
+class YantrikStatsOutput(BaseModel):
+    db_path: str
+    namespace: str
+    enabled: bool
+    total_semantic: int
+    error: str | None = None
+
+
+def _open() -> "substrate.Memory":
+    YANTRIK_MEM_ROOT.mkdir(parents=True, exist_ok=True)
+    ns = substrate.namespace_for_cwd()
+    return substrate.Memory(str(DB_PATH), namespace=ns)
+
+
+def _rid_of(m: dict) -> str | None:
+    v = (m or {}).get("rid") or (m or {}).get("id")
+    return str(v) if v is not None else None
+
+
+def register_yantrik_recall(agent: Any) -> None:
+    @agent.tool
+    async def yantrik_recall(
+        context: RunContext,
+        query: str,
+        top_k: int = HISTORY_TOP_K,
+    ) -> YantrikRecallOutput:
+        """Search learned memory (YantrikDB) for relevant facts and history.
+
+        Returns two bands: ``current`` (authoritative durable facts/prefs,
+        post-supersession) and ``history`` (query-relevant past context).
+
+        Args:
+            query: Free-form text to search for.
+            top_k: Number of history items to return (1-20).
+        """
+        if not is_enabled():
+            return YantrikRecallOutput(
+                query=query or "", total=0, error=DISABLED_TOOL_ERROR
+            )
+        if not substrate.MEMORY_AVAILABLE:
+            return YantrikRecallOutput(
+                query=query or "", total=0, error="YantrikDB is not available."
+            )
+        if not query or not query.strip():
+            return YantrikRecallOutput(
+                query=query or "", total=0, error="Empty query — nothing to search."
+            )
+        try:
+            top_k = max(1, min(int(top_k), 20))
+        except (TypeError, ValueError):
+            top_k = HISTORY_TOP_K
+
+        mem = None
+        try:
+            mem = _open()
+            current, history = mem.recall_banded(
+                query, top_k=top_k, n_prefs=PREFS_BAND_SIZE
+            )
+            items: list[YantrikMemoryItem] = []
+            for m in current:
+                items.append(
+                    YantrikMemoryItem(
+                        text=str((m or {}).get("text", "")),
+                        band="current",
+                        importance=(m or {}).get("importance"),
+                        memory_type=(m or {}).get("memory_type"),
+                        rid=_rid_of(m),
+                    )
+                )
+            for m in history:
+                items.append(
+                    YantrikMemoryItem(
+                        text=str((m or {}).get("text", "")),
+                        band="history",
+                        importance=(m or {}).get("importance"),
+                        memory_type=(m or {}).get("memory_type"),
+                        rid=_rid_of(m),
+                    )
+                )
+            return YantrikRecallOutput(
+                query=query, total=len(items), memories=items
+            )
+        except Exception as exc:  # noqa: BLE001
+            return YantrikRecallOutput(
+                query=query, total=0, error=f"yantrik_recall failed: {exc!r}"
+            )
+        finally:
+            if mem is not None:
+                mem.close()
+
+
+def register_yantrik_remember(agent: Any) -> None:
+    @agent.tool
+    async def yantrik_remember(
+        context: RunContext,
+        text: str,
+        importance: float = 0.7,
+    ) -> YantrikRememberOutput:
+        """Save a durable fact / preference to learned memory.
+
+        Use this when the user says "remember that..." or when you learn
+        something durable that future sessions should know. Stored as a
+        ``semantic`` memory in the current project's namespace.
+
+        Args:
+            text: The durable fact to remember. Required.
+            importance: 0.0-1.0 priority (default 0.7). Higher = surfaced first.
+        """
+        if not is_enabled():
+            return YantrikRememberOutput(
+                text=text or "",
+                importance=importance,
+                namespace="",
+                error=DISABLED_TOOL_ERROR,
+            )
+        if not substrate.MEMORY_AVAILABLE:
+            return YantrikRememberOutput(
+                text=text or "",
+                importance=importance,
+                namespace="",
+                error="YantrikDB is not available.",
+            )
+        if not text or not text.strip():
+            return YantrikRememberOutput(
+                text="",
+                importance=importance,
+                namespace="",
+                error="Empty text — nothing to remember.",
+            )
+        try:
+            importance = max(0.0, min(float(importance), 1.0))
+        except (TypeError, ValueError):
+            importance = 0.7
+
+        mem = None
+        try:
+            mem = _open()
+            mem.remember(
+                text.strip(),
+                kind="semantic",
+                importance=importance,
+                metadata={"explicit": True},
+            )
+            mem.flush()
+            return YantrikRememberOutput(
+                text=text.strip(),
+                importance=importance,
+                namespace=mem.ns,
+                stored=True,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return YantrikRememberOutput(
+                text=text,
+                importance=importance,
+                namespace="",
+                error=f"yantrik_remember failed: {exc!r}",
+            )
+        finally:
+            if mem is not None:
+                mem.close()
+
+
+def register_yantrik_stats(agent: Any) -> None:
+    @agent.tool
+    async def yantrik_stats(context: RunContext) -> YantrikStatsOutput:
+        """Return learned-memory totals for the current project namespace."""
+        ns = ""
+        try:
+            ns = substrate.namespace_for_cwd()
+        except Exception:
+            ns = "default"
+        if not substrate.MEMORY_AVAILABLE:
+            return YantrikStatsOutput(
+                db_path=str(DB_PATH),
+                namespace=ns,
+                enabled=is_enabled(),
+                total_semantic=0,
+                error="YantrikDB is not available.",
+            )
+        mem = None
+        try:
+            mem = _open()
+            total = len(mem.list_semantic(limit=10000))
+            return YantrikStatsOutput(
+                db_path=str(DB_PATH),
+                namespace=mem.ns,
+                enabled=is_enabled(),
+                total_semantic=total,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return YantrikStatsOutput(
+                db_path=str(DB_PATH),
+                namespace=ns,
+                enabled=is_enabled(),
+                total_semantic=0,
+                error=f"yantrik_stats failed: {exc!r}",
+            )
+        finally:
+            if mem is not None:
+                mem.close()
+
+
+def register_tools_callback() -> list[dict[str, Any]]:
+    """``register_tools`` callback — exposes the yantrik tool surface."""
+    return [
+        {"name": "yantrik_recall", "register_func": register_yantrik_recall},
+        {"name": "yantrik_remember", "register_func": register_yantrik_remember},
+        {"name": "yantrik_stats", "register_func": register_yantrik_stats},
+    ]

--- a/code_puppy/plugins/yantrik_memory/tools.py
+++ b/code_puppy/plugins/yantrik_memory/tools.py
@@ -126,9 +126,7 @@ def register_yantrik_recall(agent: Any) -> None:
                         rid=_rid_of(m),
                     )
                 )
-            return YantrikRecallOutput(
-                query=query, total=len(items), memories=items
-            )
+            return YantrikRecallOutput(query=query, total=len(items), memories=items)
         except Exception as exc:  # noqa: BLE001
             return YantrikRecallOutput(
                 query=query, total=0, error=f"yantrik_recall failed: {exc!r}"


### PR DESCRIPTION
## What this adds

An **optional, off-by-default** plugin (`code_puppy/plugins/yantrik_memory/`) that
adds a YantrikDB-backed semantic/learning memory layer **alongside** `puppy_kennel`
— not a replacement. Heads-up discussion: #464.

It mirrors the kennel's plugin contract (`load_prompt`, `user_prompt_submit`,
`agent_run_end`, `register_tools`, `/yantrik` command), and:

- **distills** durable facts/preferences from natural conversation (ignores chatter),
- **supersedes** outdated facts via `correct()` instead of accumulating them,
- surfaces **query-relevant** memories passively each turn,
- reinforces options that keep getting accepted.

## Why (honest framing)

The kennel's P0 prefs band already handles basic fact recall well — so on "is the
fact recalled," a prefs-band baseline **ties** this; I'm **not** claiming better
recall. What an append-only prefs store *can't* do, and this adds:

- **Supersession** — after "we rebranded blue→green", the kennel's P0 keeps **both**
  (it's append-only), so the agent gets contradictory context; this drops the stale
  value. Verified stable from 1k→10k memories (the append-only band still carries
  both at 10k; this carries only green).
- **Passive semantic recall** — the kennel's passive layer is "all prefs + recent";
  finding the right past artifact otherwise relies on recency or the agent calling
  the BM25 search tool.

## Safety / footprint

- **Opt-in**: default OFF; enable with `/yantrik enable`.
- **Fail-soft**: if `yantrikdb` isn't installed (or it's disabled), the plugin is
  inert — registers no callbacks, never crashes boot or a turn.
- **Zero changes to existing code** — a new plugin directory only.
- One optional dependency (`yantrikdb`); embedder is configurable down to a bundled
  no-ONNX option.

## Testing

- **Integration test** (`test_integration.py`): distills facts, supersession works
  (recall's current band = green, stale blue gone), chatter adds nothing.
- **Live load test**: loads cleanly alongside all 35 builtin plugins (incl. the
  kennel); via the real callback bus, `on_user_prompt_submit` distills and
  `on_load_prompt` injects the correct (superseded) recall block.

## Known limitations (full disclosure)

- The distiller runs a local-LLM call + a short flush per user turn — correct but
  not free; worth making async. Optional and model-configurable.
- Not yet run in a full interactive TUI session (validated via the real loader +
  callback dispatchers).
- YantrikDB's automatic conflict detection doesn't currently fire on free-text
  attribute-value updates, so supersession uses an explicit `correct()` at the app
  layer (the distiller detects the update). The engine side is being addressed
  separately.

Happy to adjust to your plugin/dependency conventions — flagging this as a starting
point for discussion as much as a merge candidate.
