### PR TITLE
fix(agents): degrade gracefully on cross-task anyio cancel-scope errors

### DIFF
--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -53,18 +53,18 @@ except ImportError:  # pragma: no cover - 3.10 only
 
 from code_puppy.agents import _history, _key_listeners
 from code_puppy.agents._builder import build_pydantic_agent
+from code_puppy.agents._diagnostics import emit_exception_diagnostics
+from code_puppy.agents._non_streaming_render import (
+    StreamingTextDetector,
+    render_result_without_streaming,
+    should_render_fallback,
+)
 from code_puppy.agents._run_signals import (
     drain_pause_state_on_cancel,
     make_schedule_cancel,
     make_schedule_pause,
     prepare_queued_steer_injection,
     reset_pause_state_at_run_start,
-)
-from code_puppy.agents._diagnostics import emit_exception_diagnostics
-from code_puppy.agents._non_streaming_render import (
-    StreamingTextDetector,
-    render_result_without_streaming,
-    should_render_fallback,
 )
 from code_puppy.agents.event_stream_handler import event_stream_handler
 from code_puppy.callbacks import (
@@ -264,6 +264,23 @@ def _should_prepend_system_prompt(agent: Any, prompt: str) -> str:
         prepend_system_to_user=True,
     )
     return prepared.user_prompt
+
+
+def _is_cancel_scope_corruption(exc: BaseException) -> bool:
+    """True for anyio's cross-task cancel-scope ``RuntimeError``.
+
+    pydantic-ai MCP toolsets are refcounted: whichever task takes the
+    refcount 0->1 owns the underlying anyio cancel scope, and whichever
+    task drops it back to 0 closes it. When an MCP server's lifecycle task
+    dies mid-run (e.g. a flaky ``npx``-spawned stdio subprocess exits), the
+    agent run task ends up closing a scope owned by a dead task and anyio
+    raises ``RuntimeError: Attempted to exit a cancel scope that isn't the
+    current task's current cancel scope``. By that point the model's
+    response has already streamed — this is teardown noise, not a run
+    failure, so we detect it and degrade gracefully instead of dumping a
+    full exception group on the user.
+    """
+    return isinstance(exc, RuntimeError) and "cancel scope" in str(exc).lower()
 
 
 def _collect_exceptions(
@@ -492,6 +509,20 @@ async def run_with_mcp(
                     not isinstance(e, (asyncio.CancelledError, UsageLimitExceeded))
                 ),
             )
+            scope_noise = [e for e in unexpected if _is_cancel_scope_corruption(e)]
+            unexpected = [e for e in unexpected if e not in scope_noise]
+            if scope_noise:
+                import logging as _logging
+
+                _logging.getLogger(__name__).debug(
+                    "Suppressed cross-task cancel-scope error(s): %s", scope_noise
+                )
+                emit_warning(
+                    "An MCP server connection died during this run (its async "
+                    "teardown crossed task boundaries). The response above is "
+                    "intact, but this turn may not be saved to history. "
+                    "Check [cyan]/mcp status[/cyan] and restart the server if needed."
+                )
             for exc in unexpected:
                 emit_exception_diagnostics(exc, group_id=group_id)
             # Re-raise so the outer handler in run_with_mcp can propagate
@@ -518,6 +549,25 @@ async def run_with_mcp(
         )
     except Exception:
         # Hook failures never block the agent.
+        pass
+
+    # ``build_pydantic_agent`` may have kicked off fire-and-forget MCP
+    # autostarts (``start_server_sync``). Await them so each server's
+    # lifecycle task owns its anyio cancel scope BEFORE pydantic-ai enters
+    # the toolsets inside the run task below — otherwise the run task takes
+    # ownership and unwind crashes with a cross-task cancel-scope error.
+    # Mirrors the fix already applied to sub-agent invocation.
+    try:
+        from code_puppy.mcp_ import manager as _mcp_manager_module
+
+        # Peek at the singleton instead of get_mcp_manager() — if no manager
+        # exists yet there's nothing pending, and we shouldn't pay the cost
+        # of constructing one just to ask.
+        _existing_manager = _mcp_manager_module._manager_instance
+        if _existing_manager is not None:
+            await _existing_manager.wait_for_pending_starts()
+    except Exception:
+        # MCP trouble must never block the agent run itself.
         pass
 
     agent_task = asyncio.create_task(run_agent_task())

--- a/code_puppy/mcp_/manager.py
+++ b/code_puppy/mcp_/manager.py
@@ -639,6 +639,38 @@ class MCPManager:
                 return True
             return False
 
+    async def wait_for_pending_starts(self, timeout: float = 15.0) -> None:
+        """Wait for any background server starts scheduled by ``start_server_sync``.
+
+        ``start_server_sync`` is fire-and-forget: it schedules the actual
+        ``start_server`` coroutine as a background task and returns
+        immediately. If a pydantic-ai agent run begins before that task has
+        entered the MCP server's context, pydantic-ai's toolset ``__aenter__``
+        takes the refcount 0->1 inside the *run* task and becomes the anyio
+        cancel-scope owner — setting up the cross-task
+        ``Attempted to exit a cancel scope that isn't the current task's
+        current cancel scope`` crash on unwind.
+
+        Callers that are about to run an agent should await this first so the
+        lifecycle task owns each server's cancel scope before pydantic-ai
+        re-enters it (refcount no-op fast-path).
+
+        Uses ``asyncio.wait`` (NOT ``wait_for`` + ``gather``) so a timeout
+        never cancels the in-flight start tasks.
+        """
+        tasks = [
+            t
+            for t in getattr(self, "_pending_start_tasks", {}).values()
+            if not t.done()
+        ]
+        if not tasks:
+            return
+        _done, pending = await asyncio.wait(tasks, timeout=timeout)
+        if pending:
+            logger.warning(
+                "Timed out waiting for %d pending MCP server start(s)", len(pending)
+            )
+
     async def stop_server(self, server_id: str) -> bool:
         """
         Stop a server (disable it and stop the subprocess/connection).

--- a/tests/agents/test_runtime_cancel_scope_noise.py
+++ b/tests/agents/test_runtime_cancel_scope_noise.py
@@ -1,0 +1,142 @@
+"""Cross-task cancel-scope corruption is teardown noise, not a run failure.
+
+When an MCP server's lifecycle task dies mid-run (flaky ``npx`` stdio
+subprocess, dropped SSE connection, ...), the agent run task ends up closing
+an anyio cancel scope owned by a dead task and anyio raises::
+
+    RuntimeError: Attempted to exit a cancel scope that isn't the current
+    task's current cancel scope
+
+By then the model's response has already streamed to the user. ``_runtime``
+must swallow that specific error with a friendly warning instead of vomiting
+an exception group — while still propagating *real* RuntimeErrors.
+
+Also covers ``MCPManager.wait_for_pending_starts``, which closes the
+fire-and-forget autostart race on the main agent path (mirror of the
+sub-agent fix in ``subagent_invocation.py``).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from code_puppy.agents._runtime import _is_cancel_scope_corruption
+from code_puppy.agents.agent_code_puppy import CodePuppyAgent
+from code_puppy.mcp_.manager import MCPManager
+
+_CANCEL_SCOPE_MSG = (
+    "Attempted to exit a cancel scope that isn't the current task's "
+    "current cancel scope"
+)
+
+
+class TestIsCancelScopeCorruption:
+    def test_matches_anyio_cross_task_error(self):
+        assert _is_cancel_scope_corruption(RuntimeError(_CANCEL_SCOPE_MSG))
+
+    def test_matches_other_cancel_scope_phrasings(self):
+        assert _is_cancel_scope_corruption(
+            RuntimeError(
+                "Attempted to exit cancel scope in a different task "
+                "than it was entered in"
+            )
+        )
+
+    def test_rejects_unrelated_runtime_error(self):
+        assert not _is_cancel_scope_corruption(RuntimeError("event loop is closed"))
+
+    def test_rejects_non_runtime_error(self):
+        assert not _is_cancel_scope_corruption(ValueError(_CANCEL_SCOPE_MSG))
+
+
+class TestRunWithMcpSwallowsCancelScopeNoise:
+    @pytest.fixture
+    def agent(self):
+        return CodePuppyAgent()
+
+    @pytest.mark.asyncio
+    async def test_bare_cancel_scope_error_is_swallowed(self, agent):
+        with patch.object(agent, "_code_generation_agent") as mock_agent:
+            mock_agent.run = AsyncMock(side_effect=RuntimeError(_CANCEL_SCOPE_MSG))
+            with patch("code_puppy.agents._runtime.emit_warning") as mock_warn:
+                result = await agent.run_with_mcp("hello")
+
+        assert result is None
+        warned = " ".join(str(c.args[0]) for c in mock_warn.call_args_list)
+        assert "MCP server" in warned
+
+    @pytest.mark.asyncio
+    async def test_grouped_cancel_scope_error_is_swallowed(self, agent):
+        group = ExceptionGroup("unwind", [RuntimeError(_CANCEL_SCOPE_MSG)])
+        with patch.object(agent, "_code_generation_agent") as mock_agent:
+            mock_agent.run = AsyncMock(side_effect=group)
+            with patch("code_puppy.agents._runtime.emit_warning") as mock_warn:
+                result = await agent.run_with_mcp("hello")
+
+        assert result is None
+        assert mock_warn.called
+
+    @pytest.mark.asyncio
+    async def test_real_runtime_error_still_raises(self, agent):
+        with patch.object(agent, "_code_generation_agent") as mock_agent:
+            mock_agent.run = AsyncMock(side_effect=RuntimeError("boom"))
+            with pytest.raises(RuntimeError, match="boom"):
+                await agent.run_with_mcp("hello")
+
+    @pytest.mark.asyncio
+    async def test_mixed_group_raises_real_error_only(self, agent):
+        """Scope noise is filtered out; the genuine error still propagates."""
+        group = ExceptionGroup(
+            "unwind",
+            [RuntimeError(_CANCEL_SCOPE_MSG), ValueError("genuine bug")],
+        )
+        with patch.object(agent, "_code_generation_agent") as mock_agent:
+            mock_agent.run = AsyncMock(side_effect=group)
+            with pytest.raises(ValueError, match="genuine bug"):
+                await agent.run_with_mcp("hello")
+
+
+class TestWaitForPendingStarts:
+    """Exercise the unbound method against a minimal fake — constructing a
+    real MCPManager drags in config sync, which this logic doesn't need."""
+
+    @staticmethod
+    def _fake_manager(tasks):
+        fake = MagicMock(spec=[])
+        fake._pending_start_tasks = tasks
+        return fake
+
+    @pytest.mark.asyncio
+    async def test_no_pending_tasks_returns_immediately(self):
+        fake = self._fake_manager({})
+        await MCPManager.wait_for_pending_starts(fake)
+
+    @pytest.mark.asyncio
+    async def test_missing_attribute_is_fine(self):
+        fake = MagicMock(spec=[])
+        await MCPManager.wait_for_pending_starts(fake)
+
+    @pytest.mark.asyncio
+    async def test_waits_for_in_flight_start(self):
+        entered = asyncio.Event()
+
+        async def _start():
+            entered.set()
+
+        task = asyncio.create_task(_start())
+        fake = self._fake_manager({"srv": task})
+        await MCPManager.wait_for_pending_starts(fake)
+        assert entered.is_set()
+        assert task.done()
+
+    @pytest.mark.asyncio
+    async def test_timeout_does_not_cancel_start_task(self):
+        task = asyncio.create_task(asyncio.sleep(30))
+        fake = self._fake_manager({"srv": task})
+        await MCPManager.wait_for_pending_starts(fake, timeout=0.05)
+        assert not task.done()
+        assert not task.cancelled()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task


### PR DESCRIPTION
## Summary

Two fixes for the `RuntimeError: Attempted to exit a cancel scope that isn't
the current task's current cancel scope` exception that surfaces **after** a
successful agent run when an MCP server's lifecycle task dies mid-run.

## Root cause

pydantic-ai MCP toolsets are refcounted anyio cancel scopes — whichever task
takes refcount 0→1 *owns* the scope; whichever drops it to 0 *closes* it.
When a server (e.g. a flaky `npx -y tavily-mcp` stdio subprocess) exits mid-run,
the lifecycle task tries to unwind but the run task still holds a ref. When the
run finishes and drops the ref to 0, anyio raises the cross-task error.

## Changes

### `code_puppy/agents/_runtime.py`
- New `_is_cancel_scope_corruption(exc)` predicate. The `except* Exception`
  handler now partitions mixed groups: anyio cross-task scope noise is filtered
  out, a single friendly warning is emitted, and genuine errors still propagate.
  No real bugs are swallowed.

### `code_puppy/mcp_/manager.py`
- New `wait_for_pending_starts(timeout=15.0)` that drains any background starts
  scheduled by `start_server_sync` before an agent run begins.
- `_runtime.run_with_mcp` now awaits this before spawning the run task, closing
  the fire-and-forget autostart race on the main agent path (mirrors the fix
  already applied to sub-agent invocation in `subagent_invocation.py`).
- Uses `asyncio.wait` instead of `wait_for`+`gather` so a timeout never cancels
  in-flight start tasks.

### `tests/agents/test_runtime_cancel_scope_noise.py`
- 12 test cases covering: the filter predicate, bare vs grouped scope errors,
  real RuntimeErrors still raising, mixed-group partitioning, and the wait
  helper with timeout edge cases.

## Testing

- 12 new tests: PASS
- 60 adjacent runtime tests: PASS
- 1660 MCP tests: PASS
- ruff clean
