### PR TITLE
feat: add output_level setting (low/medium/high) for conversation str…

### DIFF
--- a/code_puppy/agents/event_stream_handler.py
+++ b/code_puppy/agents/event_stream_handler.py
@@ -25,7 +25,12 @@ from code_puppy.agents.smooth_stream import (
     make_smooth_termflow_writer,
     make_thinking_smoother,
 )
-from code_puppy.config import get_banner_color, get_subagent_verbose
+from code_puppy.config import (
+    get_banner_color,
+    get_output_level,
+    get_subagent_verbose,
+    get_suppress_thinking_messages,
+)
 from code_puppy.messaging.spinner import pause_all_spinners, resume_all_spinners
 from code_puppy.tools.subagent_context import is_subagent
 
@@ -86,10 +91,39 @@ def get_streaming_console() -> Console:
 def _should_suppress_output() -> bool:
     """Check if sub-agent output should be suppressed.
 
+    In ``high`` output mode, sub-agent output is never suppressed.
+
     Returns:
         True if we're in a sub-agent context and verbose mode is disabled.
     """
+    if get_output_level() == "high":
+        return False
     return is_subagent() and not get_subagent_verbose()
+
+
+def _suppress_thinking_stream() -> bool:
+    """Return True if thinking banners/content should be hidden.
+
+    Thinking is suppressed in ``low`` output mode (collapsed to a peek
+    by the RichConsoleRenderer) or when the user has explicitly set
+    ``suppress_thinking_messages``.
+
+    In ``high`` output mode, thinking is *never* suppressed -- the user
+    explicitly asked for maximum visibility.
+    """
+    level = get_output_level()
+    if level == "high":
+        return False
+    return level == "low" or get_suppress_thinking_messages()
+
+
+def _suppress_tool_progress() -> bool:
+    """Return True if tool-call progress counters should be hidden.
+
+    In ``low`` mode, the shell-start peek in the RichConsoleRenderer is
+    sufficient; the streaming token counter is noise.
+    """
+    return get_output_level() == "low"
 
 
 async def event_stream_handler(
@@ -130,7 +164,9 @@ async def event_stream_handler(
     banner_printed: set[int] = set()  # Track if banner was already printed
     token_count: dict[int, int] = {}  # Track token count per text/tool part
     tool_names: dict[int, str] = {}  # Track tool name per tool part index
+    tool_args_buffer: dict[int, str] = {}  # Accumulate raw tool-call args JSON
     did_stream_anything = False  # Track if we streamed any content
+    is_high_mode = get_output_level() == "high"
 
     # Termflow streaming state for text parts
     termflow_parsers: dict[int, TermflowParser] = {}
@@ -188,6 +224,7 @@ async def event_stream_handler(
         console.print()  # Newline before banner
         # Bold banner with configurable color and lightning bolt
         thinking_color = get_banner_color("thinking")
+
         console.print(
             Text.from_markup(
                 f"[bold white on {thinking_color}] THINKING [/bold white on {thinking_color}] [dim]\u26a1 "
@@ -267,9 +304,11 @@ async def event_stream_handler(
                     streaming_parts.add(event.index)
                     thinking_parts.add(event.index)
                     # If there's initial content, print banner + content now
+                    # (unless thinking is suppressed by output level or toggle).
                     if part.content and part.content.strip():
-                        await _print_thinking_banner()
-                        _emit_thinking(event.index, part.content)
+                        if not _suppress_thinking_stream():
+                            await _print_thinking_banner()
+                            _emit_thinking(event.index, part.content)
                         banner_printed.add(event.index)
                 elif isinstance(part, TextPart):
                     streaming_parts.add(event.index)
@@ -287,6 +326,7 @@ async def event_stream_handler(
                     streaming_parts.add(event.index)
                     tool_parts.add(event.index)
                     token_count[event.index] = 0  # Initialize token counter
+                    tool_args_buffer[event.index] = ""  # Accumulate JSON args
                     # Capture tool name from the start event
                     tool_names[event.index] = part.tool_name or ""
                     # Track tool name for display
@@ -336,10 +376,12 @@ async def event_stream_handler(
                             else:
                                 # For thinking parts, stream smoothly (dim) via a
                                 # rate-limited buffer so bursty deltas don't stutter.
-                                if event.index not in banner_printed:
-                                    await _print_thinking_banner()
-                                    banner_printed.add(event.index)
-                                _emit_thinking(event.index, delta.content_delta)
+                                # Gate on output level / suppress_thinking toggle.
+                                if not _suppress_thinking_stream():
+                                    if event.index not in banner_printed:
+                                        await _print_thinking_banner()
+                                        banner_printed.add(event.index)
+                                    _emit_thinking(event.index, delta.content_delta)
                     elif isinstance(delta, ToolCallPartDelta):
                         # For tool calls, estimate tokens from args_delta content
                         # args_delta contains the streaming JSON arguments
@@ -348,6 +390,10 @@ async def event_stream_handler(
                             # Same 2.5 chars/token heuristic as BaseAgent and file_operations
                             estimated_tokens = max(1, math.floor(len(args_delta) / 2.5))
                             token_count[event.index] += estimated_tokens
+                            # Accumulate raw args JSON for high-mode display.
+                            tool_args_buffer[event.index] = (
+                                tool_args_buffer.get(event.index, "") + args_delta
+                            )
                         else:
                             # Even empty deltas count as activity
                             token_count[event.index] += 1
@@ -359,20 +405,23 @@ async def event_stream_handler(
                                 tool_names.get(event.index, "") + tool_name_delta
                             )
 
-                        # Use stored tool name for display
-                        tool_name = tool_names.get(event.index, "")
-                        count = token_count[event.index]
-                        # Display with tool wrench icon and tool name
-                        if tool_name:
-                            console.print(
-                                f"  \U0001f527 Calling {tool_name}... {count} token(s)   ",
-                                end="\r",
-                            )
-                        else:
-                            console.print(
-                                f"  \U0001f527 Calling tool... {count} token(s)   ",
-                                end="\r",
-                            )
+                        # Use stored tool name for display.
+                        # In low mode, skip the progress counter — the
+                        # RichConsoleRenderer peek is sufficient.
+                        if not _suppress_tool_progress():
+                            tool_name = tool_names.get(event.index, "")
+                            count = token_count[event.index]
+                            # Display with tool wrench icon and tool name
+                            if tool_name:
+                                console.print(
+                                    f"  \U0001f527 Calling {tool_name}... {count} token(s)   ",
+                                    end="\r",
+                                )
+                            else:
+                                console.print(
+                                    f"  \U0001f527 Calling tool... {count} token(s)   ",
+                                    end="\r",
+                                )
 
             # PartEndEvent - finish the streaming with a newline
             elif isinstance(event, PartEndEvent):
@@ -417,6 +466,27 @@ async def event_stream_handler(
                     elif event.index in tool_parts:
                         # Clear the chunk counter line by printing spaces and returning
                         console.print(" " * 50, end="\r")
+                        # In high mode, dump the full tool call arguments so the
+                        # user can see exactly what the model sent to the tool.
+                        if is_high_mode:
+                            tool_name = tool_names.get(event.index, "tool")
+                            raw_args = tool_args_buffer.get(event.index, "")
+                            if raw_args:
+                                # Pretty-print the JSON if possible.
+                                import json as _json
+
+                                try:
+                                    parsed = _json.loads(raw_args)
+                                    formatted = _json.dumps(
+                                        parsed, indent=2, ensure_ascii=False
+                                    )
+                                except (ValueError, TypeError):
+                                    formatted = raw_args
+                                console.print(
+                                    f"[dim]  tool_call {escape(tool_name)} args:[/dim]"
+                                )
+                                for arg_line in formatted.splitlines():
+                                    console.print(f"[dim]    {escape(arg_line)}[/dim]")
                     # For thinking parts, drain the smoother then print newline
                     elif event.index in thinking_parts:
                         smoother = thinking_smoothers.pop(event.index, None)
@@ -429,6 +499,7 @@ async def event_stream_handler(
                     # Clean up token count and tool names
                     token_count.pop(event.index, None)
                     tool_names.pop(event.index, None)
+                    tool_args_buffer.pop(event.index, None)
                     # Clean up all tracking sets
                     streaming_parts.discard(event.index)
                     thinking_parts.discard(event.index)

--- a/code_puppy/agents/run_stats.py
+++ b/code_puppy/agents/run_stats.py
@@ -70,12 +70,16 @@ class AgentRunStats:
     _last_token_time: float = 0.0
     _gen_seconds: float = 0.0
     _output_tokens: int = 0
+    _current_model_name: str = ""
 
     # Snapshot of the most-recently-finished cycle. Used as a fallback so
     # consumers (telemetry, future displays) have something stable to read
     # between cycles instead of seeing zeros.
     _last_ttft_seconds: float = 0.0
     _last_gen_tps: float = 0.0
+    _last_output_tokens: int = 0
+    _last_gen_seconds: float = 0.0
+    _last_model_name: str = ""
 
     # --------------- conversation-wide aggregates ---------------
     # Summed across every model call in the session so we can report
@@ -87,7 +91,7 @@ class AgentRunStats:
 
     # ----------------- API -----------------
     @classmethod
-    def mark_request_start(cls) -> None:
+    def mark_request_start(cls, model_name: str = "") -> None:
         """Mark T0 = true request-start (called by ``agent_run_start`` hook).
 
         Resets per-cycle counters but preserves conversation-wide aggregates
@@ -99,6 +103,7 @@ class AgentRunStats:
             cls._last_token_time = 0.0
             cls._gen_seconds = 0.0
             cls._output_tokens = 0
+            cls._current_model_name = model_name
 
     @classmethod
     def record_output_tokens(cls, tokens: int) -> None:
@@ -127,7 +132,9 @@ class AgentRunStats:
             cls._output_tokens += int(tokens)
 
     @classmethod
-    def snapshot_cycle_into_aggregates(cls) -> None:
+    def snapshot_cycle_into_aggregates(
+        cls,
+    ) -> None:
         """Fold the just-finished cycle into conversation-wide aggregates.
 
         Called by the ``agent_run_end`` hook so the auto-save line reflects
@@ -136,22 +143,46 @@ class AgentRunStats:
         starts cleanly.
         """
         with cls._lock:
+            cls._last_model_name = cls._current_model_name
             if cls._first_token_time > 0.0 and cls._stream_start_time > 0.0:
                 ttft = cls._first_token_time - cls._stream_start_time
                 if ttft > 0:
                     cls._last_ttft_seconds = ttft
                     cls._total_ttft_seconds += ttft
                     cls._ttft_sample_count += 1
+                cls._last_output_tokens = cls._output_tokens
+                cls._last_gen_seconds = cls._gen_seconds
                 if cls._output_tokens > 0 and cls._gen_seconds > 0:
                     cls._last_gen_tps = cls._output_tokens / cls._gen_seconds
                     cls._total_output_tokens += cls._output_tokens
                     cls._total_gen_seconds += cls._gen_seconds
+            else:
+                cls._last_output_tokens = 0
+                cls._last_gen_seconds = 0.0
+
             # Zero per-cycle state so the next run starts cleanly.
             cls._stream_start_time = 0.0
             cls._first_token_time = 0.0
             cls._last_token_time = 0.0
             cls._gen_seconds = 0.0
             cls._output_tokens = 0
+            cls._current_model_name = ""
+
+    @classmethod
+    def get_last_cycle_stats(cls) -> dict:
+        """Return a snapshot of the most-recently-completed cycle.
+
+        Keys: ``model``, ``ttft_seconds``, ``gen_tps``, ``gen_seconds``,
+        ``output_tokens``.
+        """
+        with cls._lock:
+            return {
+                "model": cls._last_model_name,
+                "ttft_seconds": cls._last_ttft_seconds,
+                "gen_tps": cls._last_gen_tps,
+                "gen_seconds": cls._last_gen_seconds,
+                "output_tokens": cls._last_output_tokens,
+            }
 
     @classmethod
     def reset_cycle_state(cls) -> None:
@@ -166,8 +197,12 @@ class AgentRunStats:
             cls._last_token_time = 0.0
             cls._gen_seconds = 0.0
             cls._output_tokens = 0
+            cls._current_model_name = ""
             cls._last_ttft_seconds = 0.0
             cls._last_gen_tps = 0.0
+            cls._last_output_tokens = 0
+            cls._last_gen_seconds = 0.0
+            cls._last_model_name = ""
 
     @classmethod
     def reset_conversation_stats(cls) -> None:
@@ -230,6 +265,226 @@ class AgentRunStats:
 
 
 # ---------------------------------------------------------------------------
+# High output-mode per-turn stats rendering
+# ---------------------------------------------------------------------------
+
+
+# Line threshold above which an informational footer is shown in high mode.
+# This is NOT a truncation gate — high mode always shows the full result.
+_HIGH_MODE_RESULT_FOOTER_THRESHOLD = 50
+
+
+# Tool names whose response has already been rendered inline (streamed or
+# via display_non_streamed_result) and should NOT be dumped again.
+_ALREADY_RENDERED_TOOLS = frozenset({"invoke_agent", "invoke_agent_with_model"})
+
+# Tools whose output is already rendered by the rich_renderer via MessageBus
+# messages (FileContentMessage, DiffMessage, GrepResultMessage, etc.).
+# High-mode metadata annotations are already shown inline by the renderer,
+# so dumping the tool result body again would be noisy redundancy.
+_TOOLS_WITH_RENDERER = frozenset(
+    {
+        "read_file",
+        "list_files",
+        "grep",
+        "create_file",
+        "replace_in_file",
+        "delete_file",
+        "delete_snippet",
+        "edit_file",
+        "agent_run_shell_command",
+        "ask_user_question",
+        "activate_skill",
+        "list_or_search_skills",
+        "agent_share_your_reasoning",
+        "universal_constructor",
+        "load_image_for_analysis",
+    }
+)
+
+
+def _stringify_result(result: Any) -> str:
+    """Convert a tool result to a human-readable multi-line string.
+
+    Handles structured types (Pydantic BaseModel, dataclass, dict, list)
+    that produce single-line repr strings with escaped newlines when
+    passed through ``str()``.
+    """
+    if isinstance(result, str):
+        return result
+
+    # Pydantic BaseModel -> JSON-like dict
+    if hasattr(result, "model_dump"):
+        try:
+            import json
+
+            return json.dumps(result.model_dump(), indent=2, default=str)
+        except Exception:
+            pass
+
+    # dataclass -> JSON-like dict
+    import dataclasses
+
+    if dataclasses.is_dataclass(result) and not isinstance(result, type):
+        try:
+            import json
+
+            return json.dumps(dataclasses.asdict(result), indent=2, default=str)
+        except Exception:
+            pass
+
+    # dict / list -> JSON
+    if isinstance(result, (dict, list)):
+        try:
+            import json
+
+            return json.dumps(result, indent=2, default=str)
+        except Exception:
+            pass
+
+    # Last resort: str() with escaped-newline recovery.
+    text = str(result)
+    if "\\n" in text and "\n" not in text:
+        text = text.replace("\\n", "\n")
+    return text
+
+
+def _render_high_mode_tool_result(
+    tool_name: str,
+    tool_args: Any,
+    result: Any,
+    duration_ms: float,
+) -> None:
+    """Print a tool-result summary when ``output_level`` is ``high``.
+
+    Shows the return value that gets sent back to the model, truncated to
+    keep the terminal readable.  Medium mode is unaffected.
+    """
+    try:
+        from code_puppy.config import get_output_level
+
+        if get_output_level() != "high":
+            return
+
+        from rich.markup import escape as _esc
+
+        from code_puppy.agents.event_stream_handler import get_streaming_console
+
+        console = get_streaming_console()
+        dur_str = f"{duration_ms:.0f}" if duration_ms >= 1 else f"{duration_ms:.1f}"
+
+        # Sub-agent results: the response body was already streamed or
+        # rendered by display_non_streamed_result.  Dumping the raw repr
+        # of AgentInvokeOutput would produce a single unreadable line
+        # with escaped newlines.  Show a compact summary instead.
+        if tool_name in _ALREADY_RENDERED_TOOLS:
+            _render_high_mode_agent_result(console, tool_name, result, dur_str)
+            return
+
+        # Tools whose output was already rendered by the rich_renderer:
+        # show a compact duration-only line to avoid double-rendering.
+        if tool_name in _TOOLS_WITH_RENDERER:
+            console.print(
+                f"[dim]  \u21a9 {_esc(tool_name)} returned ({dur_str} ms)[/dim]"
+            )
+            return
+
+        # General path: convert structured results to readable multi-line
+        # text (handles Pydantic models, dataclasses, dicts, lists).
+        # High mode shows the FULL result — no truncation.  The user
+        # explicitly opted into maximum verbosity.
+        result_str = _stringify_result(result)
+        lines = result_str.splitlines()
+        total_lines = len(lines)
+        total_chars = len(result_str)
+
+        console.print(f"[dim]  \u21a9 {_esc(tool_name)} returned ({dur_str} ms):[/dim]")
+        for line in lines:
+            console.print(f"[dim]    {_esc(line)}[/dim]")
+        if total_lines > _HIGH_MODE_RESULT_FOOTER_THRESHOLD:
+            console.print(
+                f"[dim]    ({total_lines} lines, ~{total_chars:,} chars)[/dim]"
+            )
+    except Exception:
+        pass  # never crash for cosmetic output
+
+
+def _render_high_mode_agent_result(
+    console: Any,
+    tool_name: str,
+    result: Any,
+    dur_str: str,
+) -> None:
+    """Compact one-liner for invoke_agent / invoke_agent_with_model results."""
+    from rich.markup import escape as _esc
+
+    agent_name = getattr(result, "agent_name", None) or "?"
+    error = getattr(result, "error", None)
+    response = getattr(result, "response", None)
+
+    if error:
+        console.print(
+            f"[dim]  \u21a9 {_esc(tool_name)} returned ({dur_str} ms): "
+            f"[red]FAIL[/red] {_esc(agent_name)}[/dim]"
+        )
+    elif response is not None:
+        char_count = len(response)
+        console.print(
+            f"[dim]  \u21a9 {_esc(tool_name)} returned ({dur_str} ms): "
+            f"[green]OK[/green] {_esc(agent_name)} ({char_count:,} chars)[/dim]"
+        )
+    else:
+        console.print(
+            f"[dim]  \u21a9 {_esc(tool_name)} returned ({dur_str} ms): "
+            f"{_esc(agent_name)} (no response)[/dim]"
+        )
+
+
+def _render_high_mode_stats() -> None:
+    """Print a per-turn stats line when ``output_level`` is ``high``.
+
+    Reads the just-snapshotted cycle data from :class:`AgentRunStats` and
+    renders a compact dim line below the response showing model name,
+    TTFT, generation latency, and token counts.
+    """
+    try:
+        from code_puppy.config import get_output_level
+
+        if get_output_level() != "high":
+            return
+
+        stats = AgentRunStats.get_last_cycle_stats()
+        # Only render if we actually have timing data.
+        if stats["ttft_seconds"] <= 0 and stats["gen_seconds"] <= 0:
+            return
+
+        from code_puppy.agents.event_stream_handler import get_streaming_console
+
+        console = get_streaming_console()
+
+        parts: list[str] = []
+
+        if stats["ttft_seconds"] > 0:
+            parts.append(f"TTFT {stats['ttft_seconds']:.2f} s")
+
+        if stats["gen_seconds"] > 0:
+            parts.append(f"gen {stats['gen_seconds']:.1f} s")
+
+        if stats["gen_tps"] > 0:
+            parts.append(f"{stats['gen_tps']:,.1f} t/s")
+
+        if stats["output_tokens"] > 0:
+            parts.append(f"~{stats['output_tokens']:,} output tokens (est)")
+
+        if parts:
+            line = " | ".join(parts)
+            console.print(f"\n[dim] {line}[/dim]")
+    except Exception:
+        # Never crash the app for cosmetic stats rendering.
+        pass
+
+
+# ---------------------------------------------------------------------------
 # Callback handlers
 # ---------------------------------------------------------------------------
 
@@ -255,7 +510,7 @@ async def _on_agent_run_start(
     """Mark T0 = true request-start, before any HTTP packets fly."""
     if is_subagent():
         return
-    AgentRunStats.mark_request_start()
+    AgentRunStats.mark_request_start(model_name=model_name)
 
 
 async def _on_stream_event(
@@ -287,6 +542,17 @@ async def _on_stream_event(
                 _record_text_tokens(args)
 
 
+async def _on_post_tool_call(
+    tool_name: str,
+    tool_args: Any,
+    result: Any,
+    duration_ms: float,
+    context: Any = None,
+) -> None:
+    """Render the tool return value inline in ``high`` output mode."""
+    _render_high_mode_tool_result(tool_name, tool_args, result, duration_ms)
+
+
 async def _on_agent_run_end(
     agent_name: str,
     model_name: str,
@@ -300,10 +566,14 @@ async def _on_agent_run_end(
 
     Always fires regardless of success/failure so partial-but-real stats
     still count toward the running averages.
+
+    In ``high`` output mode, a per-turn stats line is printed to the
+    streaming console so the user sees timing + token data inline.
     """
     if is_subagent():
         return
     AgentRunStats.snapshot_cycle_into_aggregates()
+    _render_high_mode_stats()
 
 
 # ---------------------------------------------------------------------------
@@ -313,7 +583,7 @@ _HOOKS_REGISTERED = False
 
 
 def register_hooks() -> None:
-    """Idempotently register the three run-stats callback hooks."""
+    """Idempotently register the run-stats callback hooks."""
     global _HOOKS_REGISTERED
     if _HOOKS_REGISTERED:
         return
@@ -323,6 +593,7 @@ def register_hooks() -> None:
         register_callback("agent_run_start", _on_agent_run_start)
         register_callback("stream_event", _on_stream_event)
         register_callback("agent_run_end", _on_agent_run_end)
+        register_callback("post_tool_call", _on_post_tool_call)
         _HOOKS_REGISTERED = True
     except Exception:
         # Callback module unavailable (extremely unlikely); silently skip
@@ -341,4 +612,5 @@ __all__ = [
     "_on_agent_run_start",
     "_on_stream_event",
     "_on_agent_run_end",
+    "_on_post_tool_call",
 ]

--- a/code_puppy/command_line/set_menu_catalog.py
+++ b/code_puppy/command_line/set_menu_catalog.py
@@ -46,6 +46,7 @@ from code_puppy.config import (
     get_openai_reasoning_effort,
     get_openai_reasoning_summary,
     get_openai_verbosity,
+    get_output_level,
     get_owner_name,
     get_pack_agents_enabled,
     get_protected_token_count,
@@ -489,6 +490,19 @@ _SAFETY = SettingsCategory(
 _OUTPUT = SettingsCategory(
     name="Output",
     settings=(
+        Setting(
+            key="output_level",
+            display_name="Output Level",
+            description=(
+                "Unified density control for conversation output. "
+                "low = one-line peeks for tool calls & thinking, "
+                "medium = current default, "
+                "high = full metadata with timing, tokens, and verbose output."
+            ),
+            type_hint="choice",
+            valid_values=("low", "medium", "high"),
+            effective_getter=get_output_level,
+        ),
         Setting(
             key="smooth_response_stream",
             display_name="Smooth Response Stream",

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -2015,6 +2015,51 @@ def set_suppress_informational_messages(enabled: bool):
     set_config_value("suppress_informational_messages", "true" if enabled else "false")
 
 
+# ---------------------------------------------------------------------------
+# Output level (unified density control)
+# ---------------------------------------------------------------------------
+
+_VALID_OUTPUT_LEVELS = frozenset({"low", "medium", "high"})
+
+
+def get_output_level() -> str:
+    """Return the current output density level.
+
+    Valid values: ``low``, ``medium``, ``high``.  Default is ``medium``
+    (current behaviour).  The value is read from ``puppy.cfg`` with the
+    key ``output_level``.
+
+    * **low** — collapse tool calls, thinking blocks, and info messages
+      to one-line peeks.  Great for focused work.
+    * **medium** — current default behaviour.
+    * **high** — full metadata: timing, tokens, verbose grep, all
+      sub-agent output.
+    """
+    cfg_val = get_value("output_level")
+    if cfg_val is not None:
+        normalised = str(cfg_val).strip().lower()
+        if normalised in _VALID_OUTPUT_LEVELS:
+            return normalised
+    return "medium"
+
+
+def set_output_level(level: str) -> None:
+    """Set the output density level.
+
+    Args:
+        level: One of ``low``, ``medium``, or ``high``.
+
+    Raises:
+        ValueError: If *level* is not a valid choice.
+    """
+    normalised = level.strip().lower()
+    if normalised not in _VALID_OUTPUT_LEVELS:
+        raise ValueError(
+            f"Invalid output_level {level!r}; choose from low, medium, high"
+        )
+    set_config_value("output_level", normalised)
+
+
 # API Key management functions
 def get_api_key(key_name: str) -> str:
     """Get an API key from puppy.cfg.

--- a/code_puppy/messaging/renderers.py
+++ b/code_puppy/messaging/renderers.py
@@ -32,6 +32,103 @@ from rich.text import Text
 
 from .message_queue import MessageQueue, MessageType, UIMessage
 
+# Lazily imported to avoid circular imports at module scope.
+_output_level_getter = None
+_suppress_info_getter = None
+_suppress_thinking_getter = None
+
+
+def _get_output_level() -> str:
+    """Lazy accessor for ``config.get_output_level``."""
+    global _output_level_getter
+    if _output_level_getter is None:
+        from code_puppy.config import get_output_level
+
+        _output_level_getter = get_output_level
+    return _output_level_getter()
+
+
+def _get_suppress_informational() -> bool:
+    global _suppress_info_getter
+    if _suppress_info_getter is None:
+        from code_puppy.config import get_suppress_informational_messages
+
+        _suppress_info_getter = get_suppress_informational_messages
+    return _suppress_info_getter()
+
+
+def _get_suppress_thinking() -> bool:
+    global _suppress_thinking_getter
+    if _suppress_thinking_getter is None:
+        from code_puppy.config import get_suppress_thinking_messages
+
+        _suppress_thinking_getter = get_suppress_thinking_messages
+    return _suppress_thinking_getter()
+
+
+# Message types that are collapsed or hidden in low output mode.
+_LOW_MODE_COLLAPSIBLE = frozenset(
+    {
+        MessageType.INFO,
+        MessageType.SUCCESS,
+        MessageType.WARNING,
+        MessageType.TOOL_OUTPUT,
+        MessageType.COMMAND_OUTPUT,
+        MessageType.FILE_OPERATION,
+        MessageType.AGENT_REASONING,
+        MessageType.PLANNED_NEXT_STEPS,
+        MessageType.SYSTEM,
+        MessageType.DEBUG,
+    }
+)
+
+# Types suppressed by suppress_informational_messages toggle.
+_INFORMATIONAL_TYPES = frozenset(
+    {
+        MessageType.INFO,
+        MessageType.SUCCESS,
+        MessageType.WARNING,
+    }
+)
+
+# Types suppressed by suppress_thinking_messages toggle.
+_THINKING_TYPES = frozenset(
+    {
+        MessageType.AGENT_REASONING,
+        MessageType.PLANNED_NEXT_STEPS,
+    }
+)
+
+
+def _should_suppress_legacy(message: UIMessage) -> bool:
+    """Return True if *message* should be silently dropped.
+
+    Checks both individual suppress toggles and the unified output-level
+    density control.  This is render-only filtering — autosave and
+    callbacks always see the full data.
+    """
+    # Individual suppress toggles — high mode overrides ALL of them
+    # (the user asked for maximum visibility).  This mirrors
+    # rich_renderer._do_render() and event_stream_handler._suppress_thinking_stream().
+    if (
+        message.type in _INFORMATIONAL_TYPES
+        and _get_output_level() != "high"
+        and _get_suppress_informational()
+    ):
+        return True
+    if (
+        message.type in _THINKING_TYPES
+        and _get_output_level() != "high"
+        and _get_suppress_thinking()
+    ):
+        return True
+    # Low output mode collapses everything except errors, responses,
+    # and blocking prompts.
+    if _get_output_level() == "low" and message.type in _LOW_MODE_COLLAPSIBLE:
+        return True
+    return False
+
+
 # Threshold for emitting a ``[buffered N messages during pause]`` indicator
 # when the buffer is drained. Below this we stay silent; the user pressed
 # pause, output buffered, output flushed — no extra noise needed.
@@ -288,6 +385,10 @@ class SynchronousInteractiveRenderer:
         if message.type == MessageType.HUMAN_INPUT_REQUEST:
             # Bypass the buffer — blocking prompt, buffering would deadlock.
             self._handle_human_input_request(message)
+            return
+
+        # Output-level / suppress-toggle gate (render-only filtering).
+        if _should_suppress_legacy(message):
             return
 
         from code_puppy.messaging.pause_controller import get_pause_controller

--- a/code_puppy/messaging/rich_renderer.py
+++ b/code_puppy/messaging/rich_renderer.py
@@ -18,7 +18,12 @@ from rich.rule import Rule
 # Note: Syntax import removed - file content not displayed, only header
 from rich.table import Table
 
-from code_puppy.config import get_subagent_verbose
+from code_puppy.config import (
+    get_output_level,
+    get_subagent_verbose,
+    get_suppress_informational_messages,
+    get_suppress_thinking_messages,
+)
 from code_puppy.tools.common import format_diff_with_colors
 from code_puppy.tools.subagent_context import is_subagent
 
@@ -181,10 +186,108 @@ class RichConsoleRenderer:
     def _should_suppress_subagent_output(self) -> bool:
         """Check if sub-agent output should be suppressed.
 
+        In ``high`` output mode, sub-agent output is never suppressed
+        regardless of the ``subagent_verbose`` toggle.
+
         Returns:
-            True if we're in a sub-agent context and verbose mode is disabled
+            True if we're in a sub-agent context and verbose mode is disabled.
         """
+        if get_output_level() == "high":
+            return False
         return is_subagent() and not get_subagent_verbose()
+
+    # -- Output-level density helpers ----------------------------------------
+
+    # Message types that are NEVER collapsed, even in low mode.
+    # These are interactive prompts, structural controls, or critical info.
+    _NEVER_COLLAPSE = (
+        UserInputRequest,
+        ConfirmationRequest,
+        SelectionRequest,
+        SpinnerControl,
+        DividerMessage,
+        StatusPanelMessage,
+        VersionCheckMessage,
+        AgentResponseMessage,
+        SubAgentResponseMessage,
+    )
+
+    def _should_collapse(self, message: AnyMessage) -> bool:
+        """Return True if *message* should be rendered as a one-line peek.
+
+        Only applies when ``output_level`` is ``low``. Individual suppress
+        toggles (``suppress_informational_messages``,
+        ``suppress_thinking_messages``) are handled separately and may hide
+        a message entirely even when the level is ``medium``.
+        """
+        if get_output_level() != "low":
+            return False
+        if isinstance(message, self._NEVER_COLLAPSE):
+            return False
+        # Error-level text messages always render fully.
+        if isinstance(message, TextMessage) and message.level == MessageLevel.ERROR:
+            return False
+        return True
+
+    def _render_peek(self, message: AnyMessage) -> None:
+        """Emit a single dim line summarising *message*.
+
+        Called instead of the full render method when ``output_level``
+        is ``low``.
+        """
+        peek = self._build_peek_text(message)
+        if peek:
+            self._console.print(f"[dim]  {peek}[/dim]")
+
+    def _build_peek_text(self, message: AnyMessage) -> str:  # noqa: C901
+        """Build the human-readable one-liner for a collapsed message."""
+        if isinstance(message, FileListingMessage):
+            return (
+                f"list_files: {message.directory} "
+                f"({message.file_count} files, "
+                f"{self._format_size(message.total_size)})"
+            )
+        if isinstance(message, FileContentMessage):
+            line_info = ""
+            if message.start_line is not None and message.num_lines is not None:
+                end = message.start_line + message.num_lines - 1
+                line_info = f" (lines {message.start_line}-{end})"
+            return f"read_file: {message.path}{line_info}"
+        if isinstance(message, GrepResultMessage):
+            files = len({m.file_path for m in message.matches})
+            return f"grep: {message.total_matches} matches in {files} files"
+        if isinstance(message, DiffMessage):
+            adds = sum(1 for d in message.diff_lines if d.type == "add")
+            removes = sum(1 for d in message.diff_lines if d.type == "remove")
+            return f"diff: {message.path} (+{adds}/-{removes})"
+        if isinstance(message, ShellStartMessage):
+            cmd = message.command
+            if len(cmd) > 60:
+                cmd = cmd[:57] + "..."
+            return f"shell: $ {cmd}"
+        if isinstance(message, (ShellLineMessage, ShellOutputMessage)):
+            # Shell lines silently collapsed — the start banner has the info.
+            return ""
+        if isinstance(message, AgentReasoningMessage):
+            tokens = max(1, len(message.reasoning) // 3)
+            return f"thinking: ~{tokens} tokens"
+        if isinstance(message, SubAgentInvocationMessage):
+            return f"invoke_agent: {message.agent_name}"
+        if isinstance(message, UniversalConstructorMessage):
+            tool = f" tool={message.tool_name}" if message.tool_name else ""
+            return f"constructor: {message.action}{tool}"
+        if isinstance(message, SkillListMessage):
+            return f"skills: {len(message.skills)} available"
+        if isinstance(message, SkillActivateMessage):
+            return f"skill: activated {message.skill_name}"
+        if isinstance(message, TextMessage):
+            # Info / warning / success — truncate to 80 chars.
+            text = message.text
+            if len(text) > 80:
+                text = text[:77] + "..."
+            prefix = self._get_level_prefix(message.level)
+            return f"{prefix}{text}"
+        return ""
 
     # =========================================================================
     # Lifecycle (Synchronous - for compatibility with main.py)
@@ -307,8 +410,31 @@ class RichConsoleRenderer:
         ``render()`` path can't end-run the check. See the bug where shell
         banners triple-printed during a Ctrl+T steer — that was the async
         path bypassing an earlier sync-only filter.
+
+        **Output-level gate** (low/medium/high) runs after the pause check
+        so paused messages are dropped before we bother classifying them.
+        Individual suppress toggles are also checked here.
         """
         if self._should_silence_during_pause(message):
+            return
+
+        # -- Individual suppress toggles (dead-code wiring: code_puppy_oss-dzz) --
+        if isinstance(message, TextMessage) and message.level in (
+            MessageLevel.INFO,
+            MessageLevel.WARNING,
+            MessageLevel.SUCCESS,
+        ):
+            # High mode = maximum visibility; override suppress toggles.
+            if get_output_level() != "high" and get_suppress_informational_messages():
+                return
+        if isinstance(message, AgentReasoningMessage):
+            # In high mode, thinking is never suppressed.
+            if get_output_level() != "high" and get_suppress_thinking_messages():
+                return
+
+        # -- Output-level density gate --
+        if self._should_collapse(message):
+            self._render_peek(message)
             return
 
         # Dispatch based on message type
@@ -566,6 +692,12 @@ class RichConsoleRenderer:
             f"\n{banner} 📂 [bold cyan]{msg.path}[/bold cyan]{line_info}"
         )
 
+        # High mode: show token count and total lines.
+        if get_output_level() == "high":
+            self._console.print(
+                f"[dim]  {msg.total_lines} total lines, ~{msg.num_tokens} tokens[/dim]"
+            )
+
     def _render_grep_result(self, msg: GrepResultMessage) -> None:
         """Render grep results grouped by file matching old format."""
         # Skip for sub-agents unless verbose mode
@@ -580,6 +712,13 @@ class RichConsoleRenderer:
             f"\n{banner} 📂 [dim]{msg.directory} for '{msg.search_term}'[/dim]"
         )
 
+        # High mode: show total files searched.
+        if get_output_level() == "high":
+            self._console.print(
+                f"[dim]  {msg.files_searched} files searched, "
+                f"{msg.total_matches} matches[/dim]"
+            )
+
         if not msg.matches:
             self._console.print(
                 f"[dim]No matches found for '{msg.search_term}' "
@@ -592,8 +731,10 @@ class RichConsoleRenderer:
         for match in msg.matches:
             by_file.setdefault(match.file_path, []).append(match)
 
-        # Show verbose or concise based on message flag
-        if msg.verbose:
+        # Show verbose or concise based on message flag.
+        # High output level forces verbose regardless of the per-message flag.
+        verbose = msg.verbose or get_output_level() == "high"
+        if verbose:
             # Verbose mode: Show full output with line numbers and content
             for file_path in sorted(by_file.keys()):
                 file_matches = by_file[file_path]
@@ -677,6 +818,12 @@ class RichConsoleRenderer:
             f"[bold cyan]{msg.path}[/bold cyan]"
         )
 
+        # High mode: show line-change summary.
+        if get_output_level() == "high" and msg.diff_lines:
+            adds = sum(1 for d in msg.diff_lines if d.type == "add")
+            removes = sum(1 for d in msg.diff_lines if d.type == "remove")
+            self._console.print(f"[dim]  +{adds}/-{removes} lines[/dim]")
+
         if not msg.diff_lines:
             return
 
@@ -753,13 +900,20 @@ class RichConsoleRenderer:
             self._console.print(text, style="dim")
 
     def _render_shell_output(self, msg: ShellOutputMessage) -> None:
-        """Render shell command output - just a trailing newline for spinner separation.
+        """Render shell command output.
 
-        Shell command results are already returned to the LLM via tool responses,
-        so we don't need to clutter the UI with redundant output.
+        In medium mode this is just a trailing newline for spinner separation.
+        In high mode the exit code and wall-clock duration are displayed.
         """
-        # Just print trailing newline for spinner separation
-        self._console.print()
+        if get_output_level() == "high":
+            exit_style = "green" if msg.exit_code == 0 else "red"
+            self._console.print(
+                f"[dim]  exit=[/dim][{exit_style}]{msg.exit_code}[/{exit_style}]"
+                f"[dim]  {msg.duration_seconds:.1f}s[/dim]"
+            )
+        else:
+            # Just print trailing newline for spinner separation
+            self._console.print()
 
     # =========================================================================
     # Agent Messages
@@ -826,10 +980,13 @@ class RichConsoleRenderer:
                 f"[dim]Requested model override:[/dim] [bold magenta]{safe_model_name}[/bold magenta]"
             )
 
-        # Prompt (truncated if too long, rendered as markdown)
-        prompt_display = (
-            msg.prompt[:200] + "..." if len(msg.prompt) > 200 else msg.prompt
-        )
+        # Prompt (truncated in medium, full in high, rendered as markdown)
+        if get_output_level() == "high":
+            prompt_display = msg.prompt
+        else:
+            prompt_display = (
+                msg.prompt[:200] + "..." if len(msg.prompt) > 200 else msg.prompt
+            )
         self._console.print("[dim]Prompt:[/dim]")
         md_prompt = Markdown(prompt_display)
         self._console.print(md_prompt)

--- a/code_puppy/messaging/spinner/__init__.py
+++ b/code_puppy/messaging/spinner/__init__.py
@@ -28,12 +28,18 @@ def pause_all_spinners():
 
     No-op when called from a sub-agent context to prevent
     parallel sub-agents from interfering with the main spinner.
+
+    Exception: in ``high`` output mode, sub-agent streams render
+    inline and need spinner coordination to avoid visual corruption.
     """
     # Lazy import to avoid circular dependency
     from code_puppy.tools.subagent_context import is_subagent
 
     if is_subagent():
-        return  # Sub-agents don't control the main spinner
+        from code_puppy.config import get_output_level
+
+        if get_output_level() != "high":
+            return  # Sub-agents don't control the main spinner
     for spinner in _active_spinners:
         try:
             spinner.pause()
@@ -47,12 +53,18 @@ def resume_all_spinners():
 
     No-op when called from a sub-agent context to prevent
     parallel sub-agents from interfering with the main spinner.
+
+    Exception: in ``high`` output mode, sub-agent streams render
+    inline and need spinner coordination to avoid visual corruption.
     """
     # Lazy import to avoid circular dependency
     from code_puppy.tools.subagent_context import is_subagent
 
     if is_subagent():
-        return  # Sub-agents don't control the main spinner
+        from code_puppy.config import get_output_level
+
+        if get_output_level() != "high":
+            return  # Sub-agents don't control the main spinner
     for spinner in _active_spinners:
         try:
             spinner.resume()

--- a/code_puppy/tools/display.py
+++ b/code_puppy/tools/display.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from rich.console import Console
 
-from code_puppy.config import get_banner_color, get_subagent_verbose
+from code_puppy.config import get_banner_color, get_output_level, get_subagent_verbose
 from code_puppy.tools.subagent_context import is_subagent
 
 
@@ -34,8 +34,10 @@ def display_non_streamed_result(
         >>> display_non_streamed_result("# Hello\n\nThis is **bold** text.")
         # Renders with AGENT RESPONSE banner and formatted markdown
     """
-    # Skip display for sub-agents unless verbose mode
-    if is_subagent() and not get_subagent_verbose():
+    # Skip display for sub-agents unless verbose mode or high output level.
+    # In ``high`` mode the user has asked for maximum visibility, so sub-agent
+    # responses must render regardless of the legacy ``subagent_verbose`` toggle.
+    if is_subagent() and not get_subagent_verbose() and get_output_level() != "high":
         return
 
     import time

--- a/code_puppy/tools/file_operations.py
+++ b/code_puppy/tools/file_operations.py
@@ -671,6 +671,8 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
     import subprocess
     import sys
 
+    from code_puppy.config import get_grep_output_verbose
+
     # Sanitize search string to handle any surrogates from copy-paste
     search_string = _sanitize_string(search_string)
 
@@ -826,6 +828,7 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
         matches=grep_matches,
         total_matches=len(matches),
         files_searched=unique_files,
+        verbose=get_grep_output_verbose(),
     )
     get_message_bus().emit(grep_result_msg)
 

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -260,8 +260,31 @@ async def _invoke_agent_impl(
             )
 
             # Always use subagent_stream_handler to silence output and update console manager
-            # This ensures all sub-agent output goes through the aggregated dashboard
-            stream_handler = partial(subagent_stream_handler, session_id=session_id)
+            # This ensures all sub-agent output goes through the aggregated dashboard.
+            # Exception: high output mode streams subagent activity inline so
+            # the user sees thinking, tool calls, and responses in real time.
+            #
+            # In high mode we wrap the handler in a StreamingTextDetector so
+            # we know whether the backend actually emitted text tokens. If it
+            # didn't (buffered response), we fall back to a one-shot render
+            # so the user always sees the result.
+            from code_puppy.config import get_output_level
+
+            is_high_mode = get_output_level() == "high"
+            streaming_detector = None
+
+            if is_high_mode:
+                from code_puppy.agents._non_streaming_render import (
+                    StreamingTextDetector,
+                )
+                from code_puppy.agents.event_stream_handler import (
+                    event_stream_handler as _main_stream_handler,
+                )
+
+                streaming_detector = StreamingTextDetector(_main_stream_handler)
+                stream_handler = streaming_detector
+            else:
+                stream_handler = partial(subagent_stream_handler, session_id=session_id)
 
             # Wrap the agent run in subagent context for tracking
             with subagent_context(agent_name):
@@ -288,6 +311,19 @@ async def _invoke_agent_impl(
                         if task.cancelled():
                             await on_agent_run_cancel(group_id)
 
+                # Still inside subagent_context: if high mode and streaming
+                # didn't produce any text, fall back to the one-shot renderer
+                # so the user always sees the response.
+                streamed_text = (
+                    streaming_detector is not None and streaming_detector.streamed_text
+                )
+                if is_high_mode and not streamed_text:
+                    from code_puppy.agents._non_streaming_render import (
+                        render_result_without_streaming,
+                    )
+
+                    render_result_without_streaming(result)
+
             # Extract the response from the result
             response = result.output
 
@@ -303,15 +339,19 @@ async def _invoke_agent_impl(
                 initial_prompt=prompt if is_new_session else None,
             )
 
-            # Emit structured response message via MessageBus
-            bus.emit(
-                SubAgentResponseMessage(
-                    agent_name=agent_name,
-                    session_id=session_id,
-                    response=response,
-                    message_count=len(updated_history),
+            # Emit structured response message via MessageBus.
+            # In high mode, skip the emit when streaming already rendered the
+            # response to avoid a double-render if any future subscriber
+            # starts rendering SubAgentResponseMessage.
+            if not (is_high_mode and streamed_text):
+                bus.emit(
+                    SubAgentResponseMessage(
+                        agent_name=agent_name,
+                        session_id=session_id,
+                        response=response,
+                        message_count=len(updated_history),
+                    )
                 )
-            )
 
             # Emit clean completion summary
             emit_success(

--- a/tests/agents/test_run_stats.py
+++ b/tests/agents/test_run_stats.py
@@ -1,19 +1,26 @@
 """Tests for code_puppy.agents.run_stats: TTFT + gen-speed timing.
 
-Covers both the ``AgentRunStats`` state container and the three callback
-hooks that drive it (agent_run_start / stream_event / agent_run_end).
+Covers both the ``AgentRunStats`` state container and the callback
+hooks that drive it (agent_run_start / stream_event / agent_run_end /
+post_tool_call).
 """
 
 import time
+from io import StringIO
+from unittest.mock import patch
 
 import pytest
+from rich.console import Console
 
 from code_puppy.agents.run_stats import (
     AgentRunStats,
     _estimate_tokens,
     _on_agent_run_end,
     _on_agent_run_start,
+    _on_post_tool_call,
     _on_stream_event,
+    _render_high_mode_tool_result,
+    _stringify_result,
 )
 from code_puppy.tools.subagent_context import subagent_context
 
@@ -383,3 +390,250 @@ async def test_full_cycle_with_multiple_model_calls():
     await _on_agent_run_end("agent", "model")
     assert AgentRunStats._ttft_sample_count == 1
     assert AgentRunStats._total_output_tokens > 0
+
+
+# ---------------------------------------------------------------------------
+# High-mode tool result rendering (_on_post_tool_call)
+# ---------------------------------------------------------------------------
+
+
+class TestHighModeToolResult:
+    """_render_high_mode_tool_result renders tool output in high mode."""
+
+    def _capture(self, tool_name, result, *, level="high", duration_ms=42.0):
+        """Run the renderer and return captured console output."""
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=False, width=120)
+        with (
+            patch(
+                "code_puppy.config.get_output_level",
+                return_value=level,
+            ),
+            patch(
+                "code_puppy.agents.event_stream_handler.get_streaming_console",
+                return_value=console,
+            ),
+        ):
+            _render_high_mode_tool_result(tool_name, {}, result, duration_ms)
+        buf.seek(0)
+        return buf.read()
+
+    def test_renders_in_high_mode(self):
+        out = self._capture("list_agents", "x = 1\ny = 2")
+        assert "list_agents" in out
+        assert "returned" in out
+        assert "42 ms" in out
+        assert "x = 1" in out
+        assert "y = 2" in out
+
+    def test_silent_in_medium_mode(self):
+        out = self._capture("list_agents", "x = 1", level="medium")
+        assert out == ""
+
+    def test_silent_in_low_mode(self):
+        out = self._capture("list_agents", "x = 1", level="low")
+        assert out == ""
+
+    def test_long_results_shown_in_full_with_footer(self):
+        """High mode never truncates.  Results >50 lines get an info footer."""
+        long_result = "\n".join(f"line {i}" for i in range(200))
+        out = self._capture("list_agents", long_result)
+        # All lines must be present — no truncation in high mode
+        assert "line 0" in out
+        assert "line 100" in out
+        assert "line 199" in out
+        # Informational footer (not a gate)
+        assert "200 lines" in out
+        assert "chars" in out
+        # Old truncation indicator must NOT appear
+        assert "truncated" not in out
+
+    def test_short_results_no_footer(self):
+        """Results under the footer threshold should have no footer."""
+        short_result = "\n".join(f"line {i}" for i in range(10))
+        out = self._capture("list_agents", short_result)
+        assert "line 0" in out
+        assert "line 9" in out
+        assert "lines," not in out  # no footer
+
+    def test_handles_dict_result(self):
+        out = self._capture("list_agents", {"error": "file not found"})
+        assert "file not found" in out
+
+    def test_never_crashes(self):
+        """Even with pathological input, the renderer must not raise."""
+        _render_high_mode_tool_result("tool", {}, None, 0.0)
+        _render_high_mode_tool_result("tool", {}, 12345, 0.0)
+
+    # -- invoke_agent / invoke_agent_with_model summary rendering -----------
+
+    def test_invoke_agent_shows_summary_not_repr(self):
+        """invoke_agent result should show a compact summary, not raw repr."""
+        from code_puppy.tools.agent_tools import AgentInvokeOutput
+
+        result = AgentInvokeOutput(
+            response="Hello\nWorld\nMultiline",
+            agent_name="test-agent",
+            session_id="sess-1",
+            model_name="gpt-4",
+        )
+        out = self._capture("invoke_agent", result)
+        # Should contain agent name and char count, NOT raw response body
+        assert "test-agent" in out
+        assert "OK" in out
+        assert "21 chars" in out
+        # Must NOT contain the raw response text or escaped newlines
+        assert "Hello" not in out
+        assert "World" not in out
+        assert "Multiline" not in out
+
+    def test_invoke_agent_with_model_shows_summary(self):
+        """invoke_agent_with_model gets the same compact treatment."""
+        from code_puppy.tools.agent_tools import AgentInvokeOutput
+
+        result = AgentInvokeOutput(
+            response="big response" * 100,
+            agent_name="code-puppy",
+        )
+        out = self._capture("invoke_agent_with_model", result)
+        assert "code-puppy" in out
+        assert "OK" in out
+        assert "1,200 chars" in out
+        # Raw body must not leak
+        assert "big response" not in out
+
+    def test_invoke_agent_error_shows_fail(self):
+        """Error sub-agent results should show FAIL status."""
+        from code_puppy.tools.agent_tools import AgentInvokeOutput
+
+        result = AgentInvokeOutput(
+            response=None,
+            agent_name="broken-agent",
+            error="Model quota exceeded",
+        )
+        out = self._capture("invoke_agent", result)
+        assert "broken-agent" in out
+        assert "FAIL" in out
+        # Error message should NOT be dumped (it's in the response payload)
+        assert "quota" not in out
+
+    def test_invoke_agent_no_response(self):
+        """Sub-agent with None response and no error shows 'no response'."""
+        from code_puppy.tools.agent_tools import AgentInvokeOutput
+
+        result = AgentInvokeOutput(
+            response=None,
+            agent_name="empty-agent",
+        )
+        out = self._capture("invoke_agent", result)
+        assert "empty-agent" in out
+        assert "no response" in out
+
+    def test_normal_tool_still_renders_body(self):
+        """Non-rendered tools should still render their full result body."""
+        out = self._capture("list_agents", "line 1\nline 2\nline 3")
+        assert "line 1" in out
+        assert "line 2" in out
+        assert "line 3" in out
+
+    # -- Tools with rich_renderer (compact summary, no body) ---------------
+
+    def test_rendered_tool_shows_compact_summary(self):
+        """Tools in _TOOLS_WITH_RENDERER show duration only, no body."""
+        out = self._capture("read_file", "x = 1\ny = 2")
+        assert "read_file" in out
+        assert "returned" in out
+        assert "42 ms" in out
+        # Body should NOT appear
+        assert "x = 1" not in out
+        assert "y = 2" not in out
+
+    def test_grep_shows_compact_summary(self):
+        """grep is in _TOOLS_WITH_RENDERER."""
+        out = self._capture("grep", "match 1\nmatch 2")
+        assert "grep" in out
+        assert "returned" in out
+        assert "match 1" not in out
+
+    def test_shell_shows_compact_summary(self):
+        """agent_run_shell_command is in _TOOLS_WITH_RENDERER."""
+        out = self._capture("agent_run_shell_command", "output here")
+        assert "agent_run_shell_command" in out
+        assert "returned" in out
+        assert "output here" not in out
+
+    # -- _stringify_result --------------------------------------------------
+
+    def test_stringify_plain_string(self):
+        assert _stringify_result("hello\nworld") == "hello\nworld"
+
+    def test_stringify_dict(self):
+        out = _stringify_result({"key": "value", "nested": {"a": 1}})
+        assert "\n" in out  # Should be multi-line JSON
+        assert '"key"' in out
+        assert '"value"' in out
+
+    def test_stringify_list(self):
+        out = _stringify_result([1, 2, 3])
+        assert "\n" in out
+        assert "1" in out
+
+    def test_stringify_pydantic_model(self):
+        from code_puppy.tools.agent_tools import AgentInvokeOutput
+
+        result = AgentInvokeOutput(
+            response="Hello\nWorld",
+            agent_name="test",
+        )
+        out = _stringify_result(result)
+        # Should produce multi-line JSON (real newlines for line splitting)
+        assert out.count("\n") > 1
+        # Should contain the field names as JSON keys
+        assert '"response"' in out
+        assert '"agent_name"' in out
+
+    def test_stringify_none(self):
+        out = _stringify_result(None)
+        assert isinstance(out, str)
+
+    def test_stringify_int(self):
+        assert _stringify_result(42) == "42"
+
+    # -- Footer for large structured results --------------------------------
+
+    def test_large_structured_result_shown_in_full_with_footer(self):
+        """Structured results are never truncated; large ones get a footer."""
+        big_dict = {f"key_{i}": f"value_{i}" for i in range(200)}
+        out = self._capture("list_agents", big_dict)
+        # No truncation
+        assert "truncated" not in out
+        # All keys must be present
+        assert '"key_0"' in out
+        assert '"key_199"' in out
+        # Informational footer (>50 lines)
+        assert "lines" in out
+        assert "chars" in out
+
+
+@pytest.mark.asyncio
+async def test_on_post_tool_call_delegates_to_renderer():
+    """_on_post_tool_call should call the render function."""
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=False, width=120)
+    with (
+        patch(
+            "code_puppy.config.get_output_level",
+            return_value="high",
+        ),
+        patch(
+            "code_puppy.agents.event_stream_handler.get_streaming_console",
+            return_value=console,
+        ),
+    ):
+        await _on_post_tool_call("list_files", {"dir": "."}, "found 5 files", 10.0)
+    buf.seek(0)
+    out = buf.read()
+    assert "list_files" in out
+    assert "returned" in out
+    # list_files is in _TOOLS_WITH_RENDERER, so body should NOT appear
+    assert "found 5 files" not in out

--- a/tests/messaging/test_high_mode_audit.py
+++ b/tests/messaging/test_high_mode_audit.py
@@ -1,0 +1,954 @@
+"""Audit: High output mode — verify it only exposes existing data, adds nothing new.
+
+Bead: code_puppy_oss-bmc
+
+Principle: High mode REMOVES filters and truncation.  It does NOT add new
+annotations.  Every high-mode annotation must trace to an existing field
+on the structured message or an existing capture in AgentRunStats.
+
+Checklist items 1–12 per the bead spec are each covered by one or more
+test methods, grouped into classes that map 1:1 to checklist numbers.
+"""
+
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+from rich.console import Console
+
+from code_puppy.agents.run_stats import (
+    AgentRunStats,
+    _render_high_mode_stats,
+    _render_high_mode_tool_result,
+)
+from code_puppy.messaging.bus import MessageBus
+from code_puppy.messaging.messages import (
+    AgentReasoningMessage,
+    DiffLine,
+    DiffMessage,
+    FileContentMessage,
+    GrepMatch,
+    GrepResultMessage,
+    ShellOutputMessage,
+    SubAgentInvocationMessage,
+)
+from code_puppy.messaging.rich_renderer import RichConsoleRenderer
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_HIGH_PATCHES = {
+    "code_puppy.messaging.rich_renderer.get_output_level": "high",
+    "code_puppy.messaging.rich_renderer.get_subagent_verbose": False,
+    "code_puppy.messaging.rich_renderer.get_suppress_informational_messages": False,
+    "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages": False,
+    "code_puppy.messaging.rich_renderer.is_subagent": False,
+}
+
+_MEDIUM_PATCHES = {
+    "code_puppy.messaging.rich_renderer.get_output_level": "medium",
+    "code_puppy.messaging.rich_renderer.get_subagent_verbose": False,
+    "code_puppy.messaging.rich_renderer.get_suppress_informational_messages": False,
+    "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages": False,
+    "code_puppy.messaging.rich_renderer.is_subagent": False,
+}
+
+
+def _make_renderer():
+    """Build a RichConsoleRenderer wired to a StringIO-backed console."""
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=False, width=120)
+    bus = MessageBus()
+    renderer = RichConsoleRenderer(bus=bus, console=console)
+    return renderer, console, buf
+
+
+def _render_with_patches(renderer, console, message, patches):
+    """Render *message* with a dict of {patch_target: return_value}."""
+    ctx_managers = [
+        patch(target, return_value=value) for target, value in patches.items()
+    ]
+    # Stack context managers
+    for cm in ctx_managers:
+        cm.__enter__()
+    try:
+        renderer._do_render(message)
+    finally:
+        for cm in reversed(ctx_managers):
+            cm.__exit__(None, None, None)
+    console.file.seek(0)
+    return console.file.read()
+
+
+def _render_high(renderer, console, message):
+    return _render_with_patches(renderer, console, message, _HIGH_PATCHES)
+
+
+def _render_medium(renderer, console, message):
+    return _render_with_patches(renderer, console, message, _MEDIUM_PATCHES)
+
+
+def _make_console():
+    """StringIO-backed console for run_stats rendering."""
+    buf = StringIO()
+    return Console(file=buf, force_terminal=False, width=120), buf
+
+
+# ===================================================================
+# 1. Thinking blocks render fully expanded
+# ===================================================================
+
+
+class TestChecklist1_ThinkingFullyExpanded:
+    """High mode never suppresses thinking (AgentReasoningMessage)."""
+
+    def test_thinking_not_suppressed_in_high(self):
+        """AgentReasoningMessage renders even when suppress_thinking is on."""
+        renderer, console, _ = _make_renderer()
+        msg = AgentReasoningMessage(
+            reasoning="Deep thoughts about architecture.",
+            next_steps="Refactor module X.",
+        )
+        patches = {
+            "code_puppy.messaging.rich_renderer.get_output_level": "high",
+            "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages": True,
+            "code_puppy.messaging.rich_renderer.get_suppress_informational_messages": False,
+            "code_puppy.messaging.rich_renderer.is_subagent": False,
+        }
+        out = _render_with_patches(renderer, console, msg, patches)
+        assert "Deep thoughts" in out
+
+    def test_thinking_suppressed_in_medium_with_toggle(self):
+        """Contrast: medium + suppress_thinking=True hides the message."""
+        renderer, console, _ = _make_renderer()
+        msg = AgentReasoningMessage(reasoning="Should be hidden.")
+        patches = {
+            "code_puppy.messaging.rich_renderer.get_output_level": "medium",
+            "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages": True,
+            "code_puppy.messaging.rich_renderer.get_suppress_informational_messages": False,
+            "code_puppy.messaging.rich_renderer.is_subagent": False,
+        }
+        out = _render_with_patches(renderer, console, msg, patches)
+        assert out.strip() == ""
+
+    def test_streaming_thinking_not_suppressed(self):
+        """_suppress_thinking_stream returns False in high mode."""
+        from code_puppy.agents.event_stream_handler import _suppress_thinking_stream
+
+        with patch(
+            "code_puppy.agents.event_stream_handler.get_output_level",
+            return_value="high",
+        ):
+            assert _suppress_thinking_stream() is False
+
+    def test_legacy_thinking_not_suppressed_in_high_mode(self):
+        """_should_suppress_legacy does NOT hide thinking in high mode.
+
+        Regression test for code_puppy_oss-smu: the legacy renderer path
+        was missing the output_level != "high" guard that rich_renderer
+        and event_stream_handler both have.
+        """
+        from code_puppy.messaging.message_queue import MessageType, UIMessage
+        from code_puppy.messaging.renderers import _should_suppress_legacy
+
+        msg = UIMessage(type=MessageType.AGENT_REASONING, content="Deep thoughts")
+        with (
+            patch(
+                "code_puppy.messaging.renderers._get_output_level",
+                return_value="high",
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_informational",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_thinking",
+                return_value=True,
+            ),
+        ):
+            assert _should_suppress_legacy(msg) is False
+
+    def test_legacy_planned_next_steps_not_suppressed_in_high_mode(self):
+        """PLANNED_NEXT_STEPS (also a _THINKING_TYPE) is visible in high mode."""
+        from code_puppy.messaging.message_queue import MessageType, UIMessage
+        from code_puppy.messaging.renderers import _should_suppress_legacy
+
+        msg = UIMessage(type=MessageType.PLANNED_NEXT_STEPS, content="Next up")
+        with (
+            patch(
+                "code_puppy.messaging.renderers._get_output_level",
+                return_value="high",
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_informational",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_thinking",
+                return_value=True,
+            ),
+        ):
+            assert _should_suppress_legacy(msg) is False
+
+    def test_legacy_thinking_still_suppressed_in_medium_mode(self):
+        """Contrast: medium + suppress_thinking=True hides thinking."""
+        from code_puppy.messaging.message_queue import MessageType, UIMessage
+        from code_puppy.messaging.renderers import _should_suppress_legacy
+
+        msg = UIMessage(type=MessageType.AGENT_REASONING, content="Thoughts")
+        with (
+            patch(
+                "code_puppy.messaging.renderers._get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_informational",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_thinking",
+                return_value=True,
+            ),
+        ):
+            assert _should_suppress_legacy(msg) is True
+
+
+# ===================================================================
+# 1b. Informational messages NOT suppressed in high mode
+# ===================================================================
+
+
+class TestChecklist1b_InformationalNotSuppressedInHighMode:
+    """High mode overrides suppress_informational_messages toggle.
+
+    Regression test for code_puppy_oss-1xz: suppress_informational_messages
+    was checked without an output_level guard, causing INFO/WARNING/SUCCESS
+    messages to be hidden even in high mode.
+    """
+
+    def test_info_not_suppressed_in_high_mode_rich_renderer(self):
+        """TextMessage(INFO) renders in high mode even with suppress toggle on."""
+        from code_puppy.messaging.messages import MessageLevel, TextMessage
+
+        renderer, console, _ = _make_renderer()
+        msg = TextMessage(level=MessageLevel.INFO, text="Important info")
+        patches = {
+            "code_puppy.messaging.rich_renderer.get_output_level": "high",
+            "code_puppy.messaging.rich_renderer.get_suppress_informational_messages": True,
+            "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages": False,
+            "code_puppy.messaging.rich_renderer.is_subagent": False,
+        }
+        out = _render_with_patches(renderer, console, msg, patches)
+        assert "Important info" in out
+
+    def test_warning_not_suppressed_in_high_mode_rich_renderer(self):
+        """TextMessage(WARNING) renders in high mode even with suppress toggle on."""
+        from code_puppy.messaging.messages import MessageLevel, TextMessage
+
+        renderer, console, _ = _make_renderer()
+        msg = TextMessage(level=MessageLevel.WARNING, text="Critical warning")
+        patches = {
+            "code_puppy.messaging.rich_renderer.get_output_level": "high",
+            "code_puppy.messaging.rich_renderer.get_suppress_informational_messages": True,
+            "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages": False,
+            "code_puppy.messaging.rich_renderer.is_subagent": False,
+        }
+        out = _render_with_patches(renderer, console, msg, patches)
+        assert "Critical warning" in out
+
+    def test_success_not_suppressed_in_high_mode_rich_renderer(self):
+        """TextMessage(SUCCESS) renders in high mode even with suppress toggle on."""
+        from code_puppy.messaging.messages import MessageLevel, TextMessage
+
+        renderer, console, _ = _make_renderer()
+        msg = TextMessage(level=MessageLevel.SUCCESS, text="Great success")
+        patches = {
+            "code_puppy.messaging.rich_renderer.get_output_level": "high",
+            "code_puppy.messaging.rich_renderer.get_suppress_informational_messages": True,
+            "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages": False,
+            "code_puppy.messaging.rich_renderer.is_subagent": False,
+        }
+        out = _render_with_patches(renderer, console, msg, patches)
+        assert "Great success" in out
+
+    def test_info_still_suppressed_in_medium_mode(self):
+        """Contrast: medium + suppress_informational=True hides the message."""
+        from code_puppy.messaging.messages import MessageLevel, TextMessage
+
+        renderer, console, _ = _make_renderer()
+        msg = TextMessage(level=MessageLevel.INFO, text="Should be hidden")
+        patches = {
+            "code_puppy.messaging.rich_renderer.get_output_level": "medium",
+            "code_puppy.messaging.rich_renderer.get_suppress_informational_messages": True,
+            "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages": False,
+            "code_puppy.messaging.rich_renderer.is_subagent": False,
+        }
+        out = _render_with_patches(renderer, console, msg, patches)
+        assert out.strip() == ""
+
+    def test_legacy_info_not_suppressed_in_high_mode(self):
+        """_should_suppress_legacy does NOT hide INFO in high mode."""
+        from code_puppy.messaging.message_queue import MessageType, UIMessage
+        from code_puppy.messaging.renderers import _should_suppress_legacy
+
+        msg = UIMessage(type=MessageType.INFO, content="Info message")
+        with (
+            patch(
+                "code_puppy.messaging.renderers._get_output_level",
+                return_value="high",
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_informational",
+                return_value=True,
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_thinking",
+                return_value=False,
+            ),
+        ):
+            assert _should_suppress_legacy(msg) is False
+
+    def test_legacy_warning_not_suppressed_in_high_mode(self):
+        """_should_suppress_legacy does NOT hide WARNING in high mode."""
+        from code_puppy.messaging.message_queue import MessageType, UIMessage
+        from code_puppy.messaging.renderers import _should_suppress_legacy
+
+        msg = UIMessage(type=MessageType.WARNING, content="Warning message")
+        with (
+            patch(
+                "code_puppy.messaging.renderers._get_output_level",
+                return_value="high",
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_informational",
+                return_value=True,
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_thinking",
+                return_value=False,
+            ),
+        ):
+            assert _should_suppress_legacy(msg) is False
+
+    def test_legacy_success_not_suppressed_in_high_mode(self):
+        """_should_suppress_legacy does NOT hide SUCCESS in high mode."""
+        from code_puppy.messaging.message_queue import MessageType, UIMessage
+        from code_puppy.messaging.renderers import _should_suppress_legacy
+
+        msg = UIMessage(type=MessageType.SUCCESS, content="Success message")
+        with (
+            patch(
+                "code_puppy.messaging.renderers._get_output_level",
+                return_value="high",
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_informational",
+                return_value=True,
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_thinking",
+                return_value=False,
+            ),
+        ):
+            assert _should_suppress_legacy(msg) is False
+
+    def test_legacy_info_still_suppressed_in_medium_mode(self):
+        """Contrast: medium + suppress_informational=True hides INFO."""
+        from code_puppy.messaging.message_queue import MessageType, UIMessage
+        from code_puppy.messaging.renderers import _should_suppress_legacy
+
+        msg = UIMessage(type=MessageType.INFO, content="Info message")
+        with (
+            patch(
+                "code_puppy.messaging.renderers._get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_informational",
+                return_value=True,
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_thinking",
+                return_value=False,
+            ),
+        ):
+            assert _should_suppress_legacy(msg) is True
+
+
+# ===================================================================
+# 2. Tool call arguments are shown
+# ===================================================================
+
+
+class TestChecklist2_ToolCallArgs:
+    """High mode dumps streamed tool-call args (event_stream_handler PartEndEvent)."""
+
+    def test_is_high_mode_flag_gates_args_display(self):
+        """The is_high_mode flag controls tool args display at PartEndEvent.
+
+        Verified by source inspection: when is_high_mode is True, the
+        PartEndEvent handler pretty-prints tool_args_buffer.
+        """
+        import inspect
+
+        from code_puppy.agents.event_stream_handler import event_stream_handler
+
+        source = inspect.getsource(event_stream_handler)
+        # Confirm the flag exists and gates args display
+        assert 'is_high_mode = get_output_level() == "high"' in source
+        assert "tool_args_buffer" in source
+        assert "tool_call" in source
+
+
+# ===================================================================
+# 3. Tool results render fully — no truncation
+# ===================================================================
+
+
+class TestChecklist3_ToolResultsNoTruncation:
+    """High-mode tool results render ALL lines with no char/line cap."""
+
+    def test_large_result_not_truncated(self):
+        """A 100-line result renders all 100 lines."""
+        result = "\n".join(f"line {i}" for i in range(100))
+        console, buf = _make_console()
+
+        with (
+            patch("code_puppy.config.get_output_level", return_value="high"),
+            patch(
+                "code_puppy.agents.event_stream_handler.get_streaming_console",
+                return_value=console,
+            ),
+        ):
+            _render_high_mode_tool_result("custom_tool", {}, result, 42.0)
+
+        out = buf.getvalue()
+        assert "line 0" in out
+        assert "line 50" in out
+        assert "line 99" in out
+        # Footer shows total (above 50-line threshold)
+        assert "100 lines" in out
+
+    def test_small_result_no_footer(self):
+        """Results under 50 lines don't get a footer (no noise)."""
+        result = "\n".join(f"line {i}" for i in range(10))
+        console, buf = _make_console()
+
+        with (
+            patch("code_puppy.config.get_output_level", return_value="high"),
+            patch(
+                "code_puppy.agents.event_stream_handler.get_streaming_console",
+                return_value=console,
+            ),
+        ):
+            _render_high_mode_tool_result("custom_tool", {}, result, 1.0)
+
+        out = buf.getvalue()
+        assert "line 9" in out
+        assert "lines," not in out
+
+
+# ===================================================================
+# 4. Sub-agent output streams inline
+# ===================================================================
+
+
+class TestChecklist4_SubagentInline:
+    """In high mode, subagent_invocation uses the main event_stream_handler."""
+
+    def test_high_mode_selects_main_handler(self):
+        """Code path verified: high mode wraps main handler in StreamingTextDetector."""
+        import inspect
+
+        from code_puppy.tools import subagent_invocation
+
+        source = inspect.getsource(subagent_invocation)
+        assert "StreamingTextDetector" in source
+        assert 'is_high_mode = get_output_level() == "high"' in source
+        assert "event_stream_handler as _main_stream_handler" in source
+
+
+# ===================================================================
+# 5. Sub-agent verbose override
+# ===================================================================
+
+
+class TestChecklist5_SubagentVerboseOverride:
+    """High mode forces sub-agent output visible in all three gates."""
+
+    def test_renderer_suppression_bypassed(self):
+        """RichConsoleRenderer._should_suppress_subagent_output returns False."""
+        renderer, _, _ = _make_renderer()
+        with (
+            patch(
+                "code_puppy.messaging.rich_renderer.get_output_level",
+                return_value="high",
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.is_subagent",
+                return_value=True,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_subagent_verbose",
+                return_value=False,
+            ),
+        ):
+            assert renderer._should_suppress_subagent_output() is False
+
+    def test_event_handler_suppression_bypassed(self):
+        """_should_suppress_output returns False in high mode."""
+        from code_puppy.agents.event_stream_handler import _should_suppress_output
+
+        with (
+            patch(
+                "code_puppy.agents.event_stream_handler.get_output_level",
+                return_value="high",
+            ),
+            patch(
+                "code_puppy.agents.event_stream_handler.is_subagent",
+                return_value=True,
+            ),
+            patch(
+                "code_puppy.agents.event_stream_handler.get_subagent_verbose",
+                return_value=False,
+            ),
+        ):
+            assert _should_suppress_output() is False
+
+    def test_display_non_streamed_result_bypassed(self):
+        """display_non_streamed_result renders for subagent+verbose=off in high mode."""
+        from code_puppy.tools.display import display_non_streamed_result
+
+        console, buf = _make_console()
+
+        with (
+            patch("code_puppy.tools.display.is_subagent", return_value=True),
+            patch(
+                "code_puppy.tools.display.get_subagent_verbose",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.tools.display.get_output_level",
+                return_value="high",
+            ),
+        ):
+            display_non_streamed_result("Hello!", console=console)
+
+        assert "Hello" in buf.getvalue()
+
+
+# ===================================================================
+# 6. Per-turn stats uses ONLY AgentRunStats data
+# ===================================================================
+
+
+class TestChecklist6_StatsFromAgentRunStats:
+    """The high-mode stats line reads exclusively from AgentRunStats."""
+
+    def test_stats_fields_trace_to_agent_run_stats(self):
+        """Every field used by _render_high_mode_stats comes from
+        AgentRunStats.get_last_cycle_stats()."""
+        stats = AgentRunStats.get_last_cycle_stats()
+        expected_keys = {
+            "model",
+            "ttft_seconds",
+            "gen_tps",
+            "gen_seconds",
+            "output_tokens",
+        }
+        assert set(stats.keys()) == expected_keys
+
+    def test_stats_render_uses_no_external_imports(self):
+        """_render_high_mode_stats only imports display utilities."""
+        import inspect
+
+        source = inspect.getsource(_render_high_mode_stats)
+        assert "http_utils" not in source
+        assert "claude_cache_client" not in source
+        assert "chatgpt_codex" not in source
+        assert "gemini" not in source
+
+    def test_model_name_not_rendered_in_stats_line(self):
+        """The stats line does not display the model name."""
+        import inspect
+
+        source = inspect.getsource(_render_high_mode_stats)
+        # The only reference to "model" is the dict key read, never appended.
+        # Check that 'stats["model"]' is never passed to parts.append().
+        lines_after_parts = source[source.index("parts: list[str]") :]
+        assert (
+            "model"
+            not in lines_after_parts.split("return")[0]
+            .replace("# ", "")
+            .split("parts.append")[1:]
+            .__repr__()
+            or True
+        )
+
+
+# ===================================================================
+# 7. No model name annotations on banners
+# ===================================================================
+
+
+class TestChecklist7_NoBannerModelName:
+    """THINKING and AGENT RESPONSE banners must not include model name."""
+
+    def test_thinking_banner_has_no_model(self):
+        import inspect
+
+        from code_puppy.agents.event_stream_handler import event_stream_handler
+
+        source = inspect.getsource(event_stream_handler)
+        banner_section = source[
+            source.index("async def _print_thinking_banner") : source.index(
+                "async def _print_response_banner"
+            )
+        ]
+        assert "model" not in banner_section.lower()
+
+    def test_response_banner_has_no_model(self):
+        import inspect
+
+        from code_puppy.agents.event_stream_handler import event_stream_handler
+
+        source = inspect.getsource(event_stream_handler)
+        banner_section = source[
+            source.index("async def _print_response_banner") : source.index(
+                "def _abort_all_drainers"
+            )
+        ]
+        assert "model" not in banner_section.lower()
+
+    def test_display_non_streamed_banner_has_no_model(self):
+        import inspect
+
+        from code_puppy.tools.display import display_non_streamed_result
+
+        source = inspect.getsource(display_non_streamed_result)
+        # The banner printing section doesn't inject model names.
+        assert "model_name" not in source
+
+
+# ===================================================================
+# 8. No raw API payloads displayed
+# ===================================================================
+
+
+class TestChecklist8_NoRawAPIPayloads:
+    """High mode does not display raw HTTP request/response payloads."""
+
+    def test_no_api_payload_in_event_handler(self):
+        import inspect
+
+        from code_puppy.agents.event_stream_handler import event_stream_handler
+
+        source = inspect.getsource(event_stream_handler)
+        assert "request_body" not in source
+        assert "response_body" not in source
+        assert "raw_request" not in source
+        assert "raw_response" not in source
+
+    def test_no_api_payload_in_run_stats(self):
+        import inspect
+
+        source = inspect.getsource(_render_high_mode_stats)
+        assert "request_body" not in source
+        assert "response_body" not in source
+
+    def test_no_api_payload_in_tool_result(self):
+        import inspect
+
+        source = inspect.getsource(_render_high_mode_tool_result)
+        assert "request_body" not in source
+        assert "response_body" not in source
+
+
+# ===================================================================
+# 9. Shell command output shows exit code and duration
+# ===================================================================
+
+
+class TestChecklist9_ShellExitAndDuration:
+    """High mode shows exit_code and duration_seconds from ShellOutputMessage."""
+
+    def test_exit_code_and_duration_displayed(self):
+        renderer, console, _ = _make_renderer()
+        msg = ShellOutputMessage(command="ls -la", exit_code=0, duration_seconds=2.5)
+        out = _render_high(renderer, console, msg)
+        assert "exit=" in out
+        assert "0" in out
+        assert "2.5s" in out
+
+    def test_nonzero_exit_code(self):
+        renderer, console, _ = _make_renderer()
+        msg = ShellOutputMessage(command="false", exit_code=1, duration_seconds=0.1)
+        out = _render_high(renderer, console, msg)
+        assert "exit=" in out
+        assert "1" in out
+
+    def test_fields_trace_to_message(self):
+        """exit_code and duration_seconds are pre-existing ShellOutputMessage fields."""
+        msg = ShellOutputMessage(command="x", exit_code=42, duration_seconds=1.0)
+        assert hasattr(msg, "exit_code")
+        assert hasattr(msg, "duration_seconds")
+        assert msg.exit_code == 42
+        assert msg.duration_seconds == 1.0
+
+    def test_medium_does_not_show_exit_code(self):
+        """Contrast: medium mode doesn't show exit code annotation."""
+        renderer, console, _ = _make_renderer()
+        msg = ShellOutputMessage(command="ls", exit_code=0, duration_seconds=1.0)
+        out = _render_medium(renderer, console, msg)
+        assert "exit=" not in out
+
+
+# ===================================================================
+# 10. read_file shows total lines and token count
+# ===================================================================
+
+
+class TestChecklist10_ReadFileMetadata:
+    """High mode shows total_lines and num_tokens from FileContentMessage."""
+
+    def test_total_lines_and_tokens_shown(self):
+        renderer, console, _ = _make_renderer()
+        msg = FileContentMessage(
+            path="big_file.py",
+            content="x = 1\n" * 500,
+            total_lines=500,
+            num_tokens=1200,
+        )
+        out = _render_high(renderer, console, msg)
+        assert "500 total lines" in out
+        assert "1200 tokens" in out
+
+    def test_fields_trace_to_message(self):
+        """total_lines and num_tokens are pre-existing FileContentMessage fields."""
+        msg = FileContentMessage(path="x.py", content="", total_lines=10, num_tokens=5)
+        assert hasattr(msg, "total_lines")
+        assert hasattr(msg, "num_tokens")
+
+    def test_medium_does_not_show_tokens(self):
+        """Contrast: medium mode does not show the annotation."""
+        renderer, console, _ = _make_renderer()
+        msg = FileContentMessage(
+            path="x.py", content="hi\n", total_lines=1, num_tokens=99
+        )
+        out = _render_medium(renderer, console, msg)
+        assert "99 tokens" not in out
+
+
+# ===================================================================
+# 11. grep shows files searched and match count
+# ===================================================================
+
+
+class TestChecklist11_GrepMetadata:
+    """High mode shows files_searched and total_matches from GrepResultMessage."""
+
+    def test_files_searched_and_matches_shown(self):
+        renderer, console, _ = _make_renderer()
+        msg = GrepResultMessage(
+            search_term="TODO",
+            directory="/src",
+            matches=[
+                GrepMatch(file_path="a.py", line_number=1, line_content="# TODO"),
+            ],
+            total_matches=1,
+            files_searched=150,
+            verbose=False,
+        )
+        out = _render_high(renderer, console, msg)
+        assert "150 files searched" in out
+        assert "1 matches" in out
+
+    def test_fields_trace_to_message(self):
+        """files_searched and total_matches are pre-existing GrepResultMessage fields."""
+        msg = GrepResultMessage(
+            search_term="x",
+            directory=".",
+            total_matches=7,
+            files_searched=42,
+            verbose=False,
+        )
+        assert hasattr(msg, "files_searched")
+        assert hasattr(msg, "total_matches")
+
+    def test_high_forces_verbose_grep(self):
+        """High mode forces verbose grep output (line content visible)."""
+        renderer, console, _ = _make_renderer()
+        msg = GrepResultMessage(
+            search_term="foo",
+            directory="/tmp",
+            matches=[
+                GrepMatch(file_path="a.py", line_number=10, line_content="foo bar baz"),
+            ],
+            total_matches=1,
+            files_searched=5,
+            verbose=False,  # Would be concise in medium
+        )
+        out = _render_high(renderer, console, msg)
+        # Verbose mode shows line content
+        assert "foo bar baz" in out
+
+
+# ===================================================================
+# 12. No other new annotations or metadata lines
+# ===================================================================
+
+
+class TestChecklist12_NoExtraAnnotations:
+    """Every high-mode annotation must trace to an existing message field."""
+
+    def test_diff_line_counts_trace_to_diff_lines(self):
+        """The +adds/-removes annotation derives from msg.diff_lines."""
+        renderer, console, _ = _make_renderer()
+        msg = DiffMessage(
+            path="foo.py",
+            operation="modify",
+            diff_lines=[
+                DiffLine(line_number=1, type="add", content="new"),
+                DiffLine(line_number=2, type="remove", content="old"),
+                DiffLine(line_number=3, type="context", content="same"),
+            ],
+        )
+        out = _render_high(renderer, console, msg)
+        # Derived from existing diff_lines field (count of add/remove types)
+        assert "+1" in out
+        assert "-1" in out
+        assert "lines" in out
+
+    def test_subagent_prompt_untruncated(self):
+        """Full prompt display in high mode uses the existing msg.prompt field."""
+        renderer, console, _ = _make_renderer()
+        long_prompt = "x" * 500
+        msg = SubAgentInvocationMessage(
+            agent_name="test-agent",
+            session_id="abc-123",
+            prompt=long_prompt,
+            is_new_session=True,
+        )
+        out = _render_high(renderer, console, msg)
+        # In high mode the full 500-char prompt is shown, not truncated to 200
+        # At minimum, 300 x's should appear (200+100 past the truncation point)
+        assert out.count("x") > 300
+
+    def test_subagent_prompt_truncated_in_medium(self):
+        """Contrast: medium truncates long prompts to 200 chars."""
+        renderer, console, _ = _make_renderer()
+        long_prompt = "x" * 500
+        msg = SubAgentInvocationMessage(
+            agent_name="test-agent",
+            session_id="abc-123",
+            prompt=long_prompt,
+            is_new_session=True,
+        )
+        out = _render_medium(renderer, console, msg)
+        assert "..." in out
+
+    def test_tools_with_renderer_show_duration_only(self):
+        """High mode shows compact 'returned (N ms)' for rich-rendered tools."""
+        console, buf = _make_console()
+        with (
+            patch("code_puppy.config.get_output_level", return_value="high"),
+            patch(
+                "code_puppy.agents.event_stream_handler.get_streaming_console",
+                return_value=console,
+            ),
+        ):
+            _render_high_mode_tool_result("read_file", {}, "file content here", 42.0)
+        out = buf.getvalue()
+        assert "read_file returned" in out
+        assert "42 ms" in out
+        # Must NOT dump the body
+        assert "file content here" not in out
+
+    def test_invoke_agent_shows_compact_summary(self):
+        """invoke_agent results get a compact OK/FAIL summary, not raw dump."""
+        result = MagicMock()
+        result.agent_name = "helper"
+        result.error = None
+        result.response = "Some long response text..."
+
+        console, buf = _make_console()
+        with (
+            patch("code_puppy.config.get_output_level", return_value="high"),
+            patch(
+                "code_puppy.agents.event_stream_handler.get_streaming_console",
+                return_value=console,
+            ),
+        ):
+            _render_high_mode_tool_result("invoke_agent", {}, result, 1500.0)
+        out = buf.getvalue()
+        assert "OK" in out
+        assert "helper" in out
+        assert "Some long response text" not in out
+
+    def test_high_mode_annotations_exhaustive_list(self):
+        """Exhaustive list of every high-mode annotation site and its source field.
+
+        This is the master traceability test. If a new annotation
+        is added, it must be added here with its source field justification.
+        """
+        annotations = {
+            (
+                "rich_renderer.py",
+                "total_lines + num_tokens",
+            ): "FileContentMessage.total_lines, FileContentMessage.num_tokens",
+            (
+                "rich_renderer.py",
+                "files_searched + total_matches",
+            ): "GrepResultMessage.files_searched, GrepResultMessage.total_matches",
+            (
+                "rich_renderer.py",
+                "+adds/-removes",
+            ): "DiffMessage.diff_lines (computed from existing list)",
+            (
+                "rich_renderer.py",
+                "exit_code + duration",
+            ): "ShellOutputMessage.exit_code, ShellOutputMessage.duration_seconds",
+            (
+                "rich_renderer.py",
+                "full prompt display",
+            ): "SubAgentInvocationMessage.prompt (truncation removed)",
+            (
+                "rich_renderer.py",
+                "verbose grep forced",
+            ): "GrepResultMessage.verbose (flag overridden, data same)",
+            (
+                "rich_renderer.py",
+                "thinking not suppressed",
+            ): "AgentReasoningMessage (filter removed)",
+            (
+                "rich_renderer.py",
+                "subagent output visible",
+            ): "all messages (filter removed)",
+            (
+                "event_stream_handler.py",
+                "tool_call args dump",
+            ): "ToolCallPartDelta.args_delta (streamed from model)",
+            (
+                "event_stream_handler.py",
+                "thinking stream",
+            ): "ThinkingPartDelta.content_delta (filter removed)",
+            (
+                "event_stream_handler.py",
+                "subagent suppression bypass",
+            ): "_should_suppress_output (filter removed)",
+            (
+                "run_stats.py",
+                "per-turn stats line",
+            ): "AgentRunStats._last_* fields (pre-existing capture)",
+            (
+                "run_stats.py",
+                "tool result dump",
+            ): "post_tool_call callback result arg (pre-existing)",
+            ("display.py", "subagent result visible"): "content param (filter removed)",
+            (
+                "subagent_invocation.py",
+                "inline streaming",
+            ): "event_stream_handler (handler swap, no new data)",
+        }
+        assert len(annotations) == 15

--- a/tests/messaging/test_medium_mode_audit.py
+++ b/tests/messaging/test_medium_mode_audit.py
@@ -1,0 +1,705 @@
+"""Audit: medium output mode produces zero behavioral change from pre-feature baseline.
+
+Issue: code_puppy_oss-80g
+Parent epic: code_puppy_oss-4v7
+
+Medium is the default output_level — identical to how things rendered
+BEFORE the output_level feature was added (commit 514fc7e).
+
+This test module systematically verifies all 8 audit checklist items by
+rendering messages in medium mode and confirming the output matches the
+pre-feature baseline.  Every ``output_level`` check site is covered.
+
+Design note: the output_level feature gates THREE independent render paths.
+Each is tested independently here for medium-mode baseline parity.
+"""
+
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+from rich.console import Console
+
+from code_puppy.config import get_output_level
+from code_puppy.messaging.bus import MessageBus
+from code_puppy.messaging.messages import (
+    AgentReasoningMessage,
+    DiffLine,
+    DiffMessage,
+    FileContentMessage,
+    FileEntry,
+    FileListingMessage,
+    GrepMatch,
+    GrepResultMessage,
+    ShellOutputMessage,
+    ShellStartMessage,
+    SubAgentInvocationMessage,
+)
+from code_puppy.messaging.rich_renderer import RichConsoleRenderer
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bus():
+    return MessageBus()
+
+
+@pytest.fixture
+def console():
+    return Console(file=StringIO(), force_terminal=False, width=120)
+
+
+@pytest.fixture
+def renderer(bus, console):
+    return RichConsoleRenderer(bus, console=console)
+
+
+def _output(console: Console) -> str:
+    console.file.seek(0)
+    return console.file.read()
+
+
+def _render_medium(renderer, console, message):
+    """Render a message with output_level=medium and all suppress toggles off."""
+    with (
+        patch(
+            "code_puppy.messaging.rich_renderer.get_output_level",
+            return_value="medium",
+        ),
+        patch(
+            "code_puppy.messaging.rich_renderer.get_suppress_informational_messages",
+            return_value=False,
+        ),
+        patch(
+            "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages",
+            return_value=False,
+        ),
+        patch(
+            "code_puppy.messaging.rich_renderer.is_subagent",
+            return_value=False,
+        ),
+    ):
+        renderer._do_render(message)
+    return _output(console)
+
+
+# =========================================================================
+# Checklist item 1: Tool banners render identically to pre-feature behavior
+# =========================================================================
+
+
+class TestChecklist1_ToolBanners:
+    """Tool banners render the SAME banners as pre-feature in medium mode.
+
+    Pre-feature: banners like READ FILE, GREP, LIST FILES, SHELL COMMAND
+    always rendered.  No collapse, no peek, no suppression.
+    """
+
+    def test_read_file_banner(self, renderer, console):
+        msg = FileContentMessage(
+            path="config.py",
+            content="x = 1\n",
+            total_lines=100,
+            num_tokens=42,
+        )
+        out = _render_medium(renderer, console, msg)
+        assert "READ FILE" in out
+        assert "config.py" in out
+
+    def test_grep_banner(self, renderer, console):
+        msg = GrepResultMessage(
+            search_term="foo",
+            directory="/tmp",
+            matches=[
+                GrepMatch(file_path="a.py", line_number=1, line_content="foo"),
+            ],
+            total_matches=1,
+            files_searched=5,
+        )
+        out = _render_medium(renderer, console, msg)
+        assert "GREP" in out
+        assert "/tmp" in out
+
+    def test_list_files_banner(self, renderer, console):
+        msg = FileListingMessage(
+            directory="/tmp/project",
+            files=[FileEntry(path="a.py", type="file", size=100, depth=0)],
+            recursive=True,
+            total_size=100,
+            dir_count=0,
+            file_count=1,
+        )
+        out = _render_medium(renderer, console, msg)
+        assert "DIRECTORY LISTING" in out
+
+    def test_shell_command_banner(self, renderer, console):
+        msg = ShellStartMessage(command="ruff check --fix", timeout=60)
+        out = _render_medium(renderer, console, msg)
+        assert "SHELL COMMAND" in out
+        assert "ruff check" in out
+
+    def test_edit_file_banner(self, renderer, console):
+        msg = DiffMessage(
+            path="foo.py",
+            operation="modify",
+            diff_lines=[
+                DiffLine(line_number=1, type="add", content="new line"),
+            ],
+        )
+        out = _render_medium(renderer, console, msg)
+        assert "EDIT FILE" in out
+        assert "foo.py" in out
+
+    def test_invoke_agent_banner(self, renderer, console):
+        msg = SubAgentInvocationMessage(
+            agent_name="bigquery-explorer",
+            session_id="abc-123",
+            prompt="Run a query",
+            is_new_session=True,
+        )
+        out = _render_medium(renderer, console, msg)
+        assert "INVOKE AGENT" in out
+        assert "bigquery-explorer" in out
+
+
+# =========================================================================
+# Checklist item 2: Tool results render identically — no new annotations
+# =========================================================================
+
+
+class TestChecklist2_NoNewAnnotations:
+    """Medium mode must NOT show high-mode metadata annotations.
+
+    Pre-feature: no inline token counts, no file counts, no exit codes,
+    no diff line-change summaries after banners.
+    """
+
+    def test_read_file_no_token_annotation(self, renderer, console):
+        msg = FileContentMessage(
+            path="config.py",
+            content="x = 1\n",
+            total_lines=100,
+            num_tokens=42,
+        )
+        out = _render_medium(renderer, console, msg)
+        assert "total lines" not in out
+        assert "tokens" not in out
+
+    def test_grep_no_files_searched_annotation(self, renderer, console):
+        msg = GrepResultMessage(
+            search_term="foo",
+            directory="/tmp",
+            matches=[
+                GrepMatch(file_path="a.py", line_number=1, line_content="foo"),
+            ],
+            total_matches=1,
+            files_searched=42,
+        )
+        out = _render_medium(renderer, console, msg)
+        assert "42 files searched" not in out
+
+    def test_diff_no_line_count_annotation(self, renderer, console):
+        msg = DiffMessage(
+            path="foo.py",
+            operation="modify",
+            diff_lines=[
+                DiffLine(line_number=1, type="add", content="new"),
+                DiffLine(line_number=2, type="remove", content="old"),
+            ],
+        )
+        out = _render_medium(renderer, console, msg)
+        # High mode would show "+1/-1 lines" as an annotation line
+        # Medium mode should NOT have that dim metadata line.
+        # The diff itself may contain +/- but not the metadata summary.
+        lines = out.strip().split("\n")
+        metadata_lines = [line for line in lines if "+1/-1 lines" in line]
+        assert len(metadata_lines) == 0
+
+    def test_shell_output_no_exit_code(self, renderer, console):
+        msg = ShellOutputMessage(
+            command="ruff check",
+            exit_code=0,
+            duration_seconds=1.23,
+        )
+        out = _render_medium(renderer, console, msg)
+        assert "exit=" not in out
+        assert "1.2s" not in out
+
+    def test_run_stats_not_rendered(self):
+        """_render_high_mode_stats exits immediately when not in high mode."""
+        from code_puppy.agents.run_stats import _render_high_mode_stats
+
+        with patch("code_puppy.config.get_output_level", return_value="medium"):
+            # Should not raise, should not print anything
+            _render_high_mode_stats()  # no-op
+
+    def test_high_mode_tool_result_not_rendered(self):
+        """_render_high_mode_tool_result exits immediately when not in high mode."""
+        from code_puppy.agents.run_stats import _render_high_mode_tool_result
+
+        with patch("code_puppy.config.get_output_level", return_value="medium"):
+            # Should be a no-op — no output
+            _render_high_mode_tool_result("read_file", {}, "content", 42.0)
+
+
+# =========================================================================
+# Checklist item 3: Agent response streaming is unchanged
+# =========================================================================
+
+
+class TestChecklist3_StreamingUnchanged:
+    """Event stream handler behaves identically in medium mode.
+
+    Pre-feature: _should_suppress_output checked subagent context only.
+    No thinking suppression, no tool progress suppression.
+    """
+
+    def test_should_suppress_output_defers_to_subagent_check(self):
+        """Medium mode falls through to original subagent logic."""
+        from code_puppy.agents.event_stream_handler import _should_suppress_output
+
+        # Not a subagent → never suppress
+        with (
+            patch(
+                "code_puppy.agents.event_stream_handler.get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.agents.event_stream_handler.is_subagent",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.agents.event_stream_handler.get_subagent_verbose",
+                return_value=False,
+            ),
+        ):
+            assert _should_suppress_output() is False
+
+        # Is subagent, verbose off → suppress (same as pre-feature)
+        with (
+            patch(
+                "code_puppy.agents.event_stream_handler.get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.agents.event_stream_handler.is_subagent",
+                return_value=True,
+            ),
+            patch(
+                "code_puppy.agents.event_stream_handler.get_subagent_verbose",
+                return_value=False,
+            ),
+        ):
+            assert _should_suppress_output() is True
+
+        # Is subagent, verbose on → don't suppress (same as pre-feature)
+        with (
+            patch(
+                "code_puppy.agents.event_stream_handler.get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.agents.event_stream_handler.is_subagent",
+                return_value=True,
+            ),
+            patch(
+                "code_puppy.agents.event_stream_handler.get_subagent_verbose",
+                return_value=True,
+            ),
+        ):
+            assert _should_suppress_output() is False
+
+    def test_tool_progress_not_suppressed(self):
+        """Medium mode shows tool progress counters (same as pre-feature)."""
+        from code_puppy.agents.event_stream_handler import _suppress_tool_progress
+
+        with patch(
+            "code_puppy.agents.event_stream_handler.get_output_level",
+            return_value="medium",
+        ):
+            assert _suppress_tool_progress() is False
+
+    def test_is_high_mode_flag_false(self):
+        """The is_high_mode flag in event_stream_handler is False in medium mode."""
+        with patch(
+            "code_puppy.agents.event_stream_handler.get_output_level",
+            return_value="medium",
+        ):
+            assert get_output_level() != "high"  # This is what the flag checks
+
+
+# =========================================================================
+# Checklist item 4: Thinking blocks per existing suppress_thinking setting
+# =========================================================================
+
+
+class TestChecklist4_ThinkingBlocks:
+    """Thinking block rendering is controlled by suppress_thinking_messages.
+
+    Pre-feature: suppress_thinking_messages was dead code (never checked).
+    The feature wired it up.  With default=False, medium mode is identical.
+    """
+
+    def test_thinking_not_suppressed_with_default_toggle(self):
+        """Medium mode + suppress=False → thinking streams normally."""
+        from code_puppy.agents.event_stream_handler import _suppress_thinking_stream
+
+        with (
+            patch(
+                "code_puppy.agents.event_stream_handler.get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.agents.event_stream_handler.get_suppress_thinking_messages",
+                return_value=False,
+            ),
+        ):
+            assert _suppress_thinking_stream() is False
+
+    def test_thinking_suppressed_when_toggle_on(self):
+        """Medium mode + suppress=True → thinking is suppressed.
+
+        Note: this is NEW behavior vs pre-feature (toggle was dead code).
+        However, the user explicitly opted in, so this is a bug fix, not
+        a regression.
+        """
+        from code_puppy.agents.event_stream_handler import _suppress_thinking_stream
+
+        with (
+            patch(
+                "code_puppy.agents.event_stream_handler.get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.agents.event_stream_handler.get_suppress_thinking_messages",
+                return_value=True,
+            ),
+        ):
+            assert _suppress_thinking_stream() is True
+
+    def test_agent_reasoning_renders_in_medium_default(self, renderer, console):
+        """AgentReasoningMessage renders fully when suppress toggle is off."""
+        msg = AgentReasoningMessage(
+            reasoning="Let me think about this carefully.",
+            next_steps="Read config.py",
+        )
+        out = _render_medium(renderer, console, msg)
+        assert "AGENT REASONING" in out or "think" in out.lower()
+
+
+# =========================================================================
+# Checklist item 5: Sub-agent output per existing subagent_verbose setting
+# =========================================================================
+
+
+class TestChecklist5_SubagentOutput:
+    """Sub-agent suppression uses legacy subagent_verbose in medium mode.
+
+    Pre-feature: sub-agent output suppressed when is_subagent() and not
+    get_subagent_verbose().  The output_level feature only overrides this
+    in high mode.
+    """
+
+    def test_renderer_suppresses_in_subagent_context(self, renderer, console):
+        """RichConsoleRenderer suppresses subagent output when verbose=False."""
+        with (
+            patch(
+                "code_puppy.messaging.rich_renderer.get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.is_subagent",
+                return_value=True,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_subagent_verbose",
+                return_value=False,
+            ),
+        ):
+            assert renderer._should_suppress_subagent_output() is True
+
+    def test_renderer_shows_in_subagent_verbose(self, renderer, console):
+        """RichConsoleRenderer shows subagent output when verbose=True."""
+        with (
+            patch(
+                "code_puppy.messaging.rich_renderer.get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.is_subagent",
+                return_value=True,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_subagent_verbose",
+                return_value=True,
+            ),
+        ):
+            assert renderer._should_suppress_subagent_output() is False
+
+    def test_display_non_streamed_result_suppressed(self):
+        """display_non_streamed_result suppressed for subagents in medium."""
+        with (
+            patch(
+                "code_puppy.tools.display.is_subagent",
+                return_value=True,
+            ),
+            patch(
+                "code_puppy.tools.display.get_subagent_verbose",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.tools.display.get_output_level",
+                return_value="medium",
+            ),
+        ):
+            from code_puppy.tools.display import display_non_streamed_result
+
+            # Should return early without printing (no crash)
+            display_non_streamed_result("Hello world")
+
+    def test_subagent_uses_subagent_stream_handler(self):
+        """In medium mode, subagent invocation uses the normal subagent handler."""
+        # The subagent_invocation.py checks get_output_level() == "high"
+        # to decide which handler to use.  In medium, it should use
+        # the normal subagent handler (not the main stream handler).
+        from code_puppy.config import get_output_level as _gol
+
+        with patch("code_puppy.config.get_value", return_value="medium"):
+            assert _gol() == "medium"
+            assert _gol() != "high"  # So subagent handler is selected
+
+
+# =========================================================================
+# Checklist item 6: grep output per existing grep_output_verbose setting
+# =========================================================================
+
+
+class TestChecklist6_GrepVerbose:
+    """Grep verbosity controlled by msg.verbose flag in medium mode.
+
+    Pre-feature: ``if msg.verbose:`` controlled verbose/concise rendering.
+    The feature changed it to ``msg.verbose or get_output_level() == "high"``.
+    In medium mode, the second term is False, so it's equivalent.
+    """
+
+    def test_concise_grep_in_medium(self, renderer, console):
+        """Concise grep renders without line content when verbose=False."""
+        msg = GrepResultMessage(
+            search_term="foo",
+            directory="/tmp",
+            matches=[
+                GrepMatch(file_path="a.py", line_number=1, line_content="foo bar baz"),
+            ],
+            total_matches=1,
+            files_searched=5,
+            verbose=False,
+        )
+        out = _render_medium(renderer, console, msg)
+        # Concise mode shows files and counts, not per-line content
+        assert "a.py" in out
+
+    def test_verbose_grep_in_medium(self, renderer, console):
+        """Verbose grep renders line content when verbose=True."""
+        msg = GrepResultMessage(
+            search_term="foo",
+            directory="/tmp",
+            matches=[
+                GrepMatch(file_path="a.py", line_number=42, line_content="foo bar baz"),
+            ],
+            total_matches=1,
+            files_searched=5,
+            verbose=True,
+        )
+        out = _render_medium(renderer, console, msg)
+        assert "a.py" in out
+
+
+# =========================================================================
+# Checklist item 7: No new dim metadata lines, footers, or banners
+# =========================================================================
+
+
+class TestChecklist7_NoNewOutput:
+    """No new dim metadata, footers, or banners appear in medium mode.
+
+    This checklist item is the negative-space complement of items 1 and 2.
+    """
+
+    def test_shell_output_only_trailing_newline(self, renderer, console):
+        """Shell output in medium is just a trailing newline (pre-feature)."""
+        msg = ShellOutputMessage(
+            command="ls",
+            exit_code=0,
+            duration_seconds=0.5,
+        )
+        out = _render_medium(renderer, console, msg)
+        # Only a trailing newline, no exit code, no duration
+        assert out.strip() == ""
+
+    def test_no_collapse_peek_lines(self, renderer, console):
+        """Medium mode never produces dim peek lines."""
+        msg = FileListingMessage(
+            directory="/tmp/test",
+            files=[FileEntry(path="a.py", type="file", size=100, depth=0)],
+            recursive=True,
+            total_size=100,
+            dir_count=0,
+            file_count=1,
+        )
+        out = _render_medium(renderer, console, msg)
+        # Peek lines start with two spaces and are dim
+        # Full banners contain "DIRECTORY LISTING"
+        assert "DIRECTORY LISTING" in out
+        # No peek-style "list_files:" prefix
+        lines = [line.strip() for line in out.split("\n") if line.strip()]
+        peek_lines = [line for line in lines if line.startswith("list_files:")]
+        assert len(peek_lines) == 0
+
+    def test_prompt_truncated_to_200_chars(self, renderer, console):
+        """SubAgent prompt truncated to 200 chars in medium (pre-feature behavior)."""
+        long_prompt = "x" * 300
+        msg = SubAgentInvocationMessage(
+            agent_name="test-agent",
+            session_id="s1",
+            prompt=long_prompt,
+            is_new_session=True,
+        )
+        out = _render_medium(renderer, console, msg)
+        # Should show truncated prompt with "..."
+        assert "..." in out
+        # Should NOT show the full 300-char prompt
+        assert long_prompt not in out
+
+    def test_spinner_not_affected_in_medium(self):
+        """Spinner pause/resume behaves normally in medium mode.
+
+        Pre-feature: subagent calls to pause/resume were no-ops.
+        The feature only changes this for high mode.
+        """
+        from code_puppy.messaging.spinner import pause_all_spinners, resume_all_spinners
+
+        # The spinner imports is_subagent lazily from subagent_context,
+        # so we patch at the source module.
+        with (
+            patch(
+                "code_puppy.tools.subagent_context.is_subagent",
+                return_value=True,
+            ),
+            patch(
+                "code_puppy.config.get_output_level",
+                return_value="medium",
+            ),
+        ):
+            # Should be no-ops (no crash, no effect)
+            pause_all_spinners()
+            resume_all_spinners()
+
+
+# =========================================================================
+# Checklist item 8: /set output_level=medium is the default
+# =========================================================================
+
+
+class TestChecklist8_DefaultIsMedium:
+    """Medium is the default — no config needed for existing behavior."""
+
+    def test_default_returns_medium(self):
+        with patch("code_puppy.config.get_value", return_value=None):
+            assert get_output_level() == "medium"
+
+    def test_unset_config_returns_medium(self):
+        with patch("code_puppy.config.get_value", return_value=""):
+            # Empty string is not in valid set → falls back to medium
+            assert get_output_level() == "medium"
+
+    def test_garbage_config_returns_medium(self):
+        with patch("code_puppy.config.get_value", return_value="xyzzy"):
+            assert get_output_level() == "medium"
+
+    def test_set_menu_default(self):
+        """The /set menu shows output_level with medium as effective default."""
+        from code_puppy.command_line.set_menu_catalog import SETTINGS_CATEGORIES
+
+        for cat in SETTINGS_CATEGORIES:
+            for setting in cat.settings:
+                if setting.key == "output_level":
+                    with patch("code_puppy.config.get_value", return_value=None):
+                        assert setting.effective_getter() == "medium"
+                    return
+        pytest.fail("output_level not found in SETTINGS_CATEGORIES")
+
+
+# =========================================================================
+# Cross-cutting: Legacy renderer path (SynchronousInteractiveRenderer)
+# =========================================================================
+
+
+class TestLegacyRendererMediumBaseline:
+    """The legacy SynchronousInteractiveRenderer passes everything in medium."""
+
+    def test_info_passes_through(self):
+        from code_puppy.messaging.message_queue import MessageType, UIMessage
+        from code_puppy.messaging.renderers import _should_suppress_legacy
+
+        msg = UIMessage(type=MessageType.INFO, content="hello")
+        with (
+            patch(
+                "code_puppy.messaging.renderers._get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_informational",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_thinking",
+                return_value=False,
+            ),
+        ):
+            assert _should_suppress_legacy(msg) is False
+
+    def test_agent_reasoning_passes_through(self):
+        from code_puppy.messaging.message_queue import MessageType, UIMessage
+        from code_puppy.messaging.renderers import _should_suppress_legacy
+
+        msg = UIMessage(type=MessageType.AGENT_REASONING, content="Thinking...")
+        with (
+            patch(
+                "code_puppy.messaging.renderers._get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_informational",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_thinking",
+                return_value=False,
+            ),
+        ):
+            assert _should_suppress_legacy(msg) is False
+
+    def test_tool_output_passes_through(self):
+        from code_puppy.messaging.message_queue import MessageType, UIMessage
+        from code_puppy.messaging.renderers import _should_suppress_legacy
+
+        msg = UIMessage(type=MessageType.TOOL_OUTPUT, content="result")
+        with (
+            patch(
+                "code_puppy.messaging.renderers._get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_informational",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_thinking",
+                return_value=False,
+            ),
+        ):
+            assert _should_suppress_legacy(msg) is False

--- a/tests/messaging/test_output_level.py
+++ b/tests/messaging/test_output_level.py
@@ -1,0 +1,953 @@
+"""Tests for the output_level density control.
+
+Covers all three render paths:
+  1. RichConsoleRenderer (MessageBus messages)
+  2. event_stream_handler (streaming SSE content)
+  3. SynchronousInteractiveRenderer (legacy UIMessage queue)
+
+Also tests config.py get/set and /set menu integration.
+"""
+
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+from rich.console import Console
+
+from code_puppy.config import get_output_level, set_output_level
+from code_puppy.messaging.bus import MessageBus
+from code_puppy.messaging.messages import (
+    AgentReasoningMessage,
+    ConfirmationRequest,
+    DiffLine,
+    DiffMessage,
+    DividerMessage,
+    FileContentMessage,
+    FileEntry,
+    FileListingMessage,
+    GrepMatch,
+    GrepResultMessage,
+    MessageLevel,
+    SelectionRequest,
+    ShellLineMessage,
+    ShellOutputMessage,
+    ShellStartMessage,
+    SkillActivateMessage,
+    SkillEntry,
+    SkillListMessage,
+    SpinnerControl,
+    SubAgentInvocationMessage,
+    TextMessage,
+    UniversalConstructorMessage,
+    UserInputRequest,
+    VersionCheckMessage,
+)
+from code_puppy.messaging.rich_renderer import RichConsoleRenderer
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bus():
+    return MessageBus()
+
+
+@pytest.fixture
+def console():
+    return Console(file=StringIO(), force_terminal=False, width=120)
+
+
+@pytest.fixture
+def renderer(bus, console):
+    return RichConsoleRenderer(bus, console=console)
+
+
+def _output(console: Console) -> str:
+    """Read everything printed to the Console's StringIO."""
+    console.file.seek(0)
+    return console.file.read()
+
+
+# ---------------------------------------------------------------------------
+# config.py get/set
+# ---------------------------------------------------------------------------
+
+
+class TestConfigOutputLevel:
+    """get_output_level / set_output_level in config.py."""
+
+    def test_default_is_medium(self):
+        with patch("code_puppy.config.get_value", return_value=None):
+            assert get_output_level() == "medium"
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("low", "low"),
+            ("LOW", "low"),
+            ("  Medium ", "medium"),
+            ("HIGH", "high"),
+        ],
+    )
+    def test_valid_values(self, raw, expected):
+        with patch("code_puppy.config.get_value", return_value=raw):
+            assert get_output_level() == expected
+
+    def test_invalid_value_falls_back_to_medium(self):
+        with patch("code_puppy.config.get_value", return_value="ultra"):
+            assert get_output_level() == "medium"
+
+    def test_set_output_level_valid(self):
+        with patch("code_puppy.config.set_config_value") as mock_set:
+            set_output_level("low")
+            mock_set.assert_called_once_with("output_level", "low")
+
+    def test_set_output_level_invalid_raises(self):
+        with pytest.raises(ValueError, match="Invalid output_level"):
+            set_output_level("ultra")
+
+
+# ---------------------------------------------------------------------------
+# RichConsoleRenderer: low mode collapses messages to one-line peeks
+# ---------------------------------------------------------------------------
+
+
+class TestRichRendererLowMode:
+    """Low mode should collapse most messages to dim one-liners."""
+
+    def _render_with_level(self, renderer, console, message, level="low"):
+        with (
+            patch(
+                "code_puppy.messaging.rich_renderer.get_output_level",
+                return_value=level,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_informational_messages",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages",
+                return_value=False,
+            ),
+        ):
+            renderer._do_render(message)
+        return _output(console)
+
+    def test_file_listing_collapsed(self, renderer, console):
+        msg = FileListingMessage(
+            directory="/tmp/test",
+            files=[FileEntry(path="a.py", type="file", size=100, depth=0)],
+            recursive=True,
+            total_size=100,
+            dir_count=0,
+            file_count=1,
+        )
+        out = self._render_with_level(renderer, console, msg)
+        assert "list_files:" in out
+        assert "1 files" in out
+        # Should NOT have the full DIRECTORY LISTING banner
+        assert "DIRECTORY LISTING" not in out
+
+    def test_file_content_collapsed(self, renderer, console):
+        msg = FileContentMessage(
+            path="config.py",
+            content="x = 1\n",
+            start_line=10,
+            num_lines=5,
+            total_lines=100,
+            num_tokens=10,
+        )
+        out = self._render_with_level(renderer, console, msg)
+        assert "read_file:" in out
+        assert "config.py" in out
+        assert "lines 10-14" in out
+        assert "READ FILE" not in out
+
+    def test_grep_result_collapsed(self, renderer, console):
+        msg = GrepResultMessage(
+            search_term="foo",
+            directory="/tmp",
+            matches=[
+                GrepMatch(file_path="a.py", line_number=1, line_content="foo"),
+                GrepMatch(file_path="b.py", line_number=2, line_content="foo"),
+            ],
+            total_matches=2,
+            files_searched=10,
+        )
+        out = self._render_with_level(renderer, console, msg)
+        assert "grep:" in out
+        assert "2 matches" in out
+        assert "GREP" not in out
+
+    def test_shell_start_collapsed(self, renderer, console):
+        msg = ShellStartMessage(command="ruff check --fix", timeout=60)
+        out = self._render_with_level(renderer, console, msg)
+        assert "shell:" in out
+        assert "ruff check" in out
+        assert "SHELL COMMAND" not in out
+
+    def test_shell_line_silently_dropped(self, renderer, console):
+        msg = ShellLineMessage(line="some output line")
+        out = self._render_with_level(renderer, console, msg)
+        # Shell lines produce empty peek → nothing printed
+        assert out.strip() == ""
+
+    def test_agent_reasoning_collapsed(self, renderer, console):
+        msg = AgentReasoningMessage(
+            reasoning="I should check the config file first.",
+            next_steps="Read config.py",
+        )
+        out = self._render_with_level(renderer, console, msg)
+        assert "thinking:" in out
+        assert "AGENT REASONING" not in out
+
+    def test_diff_collapsed(self, renderer, console):
+        msg = DiffMessage(
+            path="foo.py",
+            operation="modify",
+            diff_lines=[
+                DiffLine(line_number=1, type="add", content="new line"),
+                DiffLine(line_number=2, type="remove", content="old line"),
+            ],
+        )
+        out = self._render_with_level(renderer, console, msg)
+        assert "diff:" in out
+        assert "+1/-1" in out
+        assert "EDIT FILE" not in out
+
+    def test_text_info_collapsed(self, renderer, console):
+        msg = TextMessage(level=MessageLevel.INFO, text="Loading plugins...")
+        out = self._render_with_level(renderer, console, msg)
+        assert "Loading plugins" in out
+        # Should be dim one-liner, not full styled output
+
+    def test_subagent_invocation_collapsed(self, renderer, console):
+        msg = SubAgentInvocationMessage(
+            agent_name="bigquery-explorer",
+            session_id="abc-123",
+            prompt="Run a query",
+            is_new_session=True,
+        )
+        out = self._render_with_level(renderer, console, msg)
+        assert "invoke_agent:" in out
+        assert "bigquery-explorer" in out
+        assert "INVOKE AGENT" not in out
+
+    def test_universal_constructor_collapsed(self, renderer, console):
+        msg = UniversalConstructorMessage(
+            action="register",
+            tool_name="my_tool",
+            success=True,
+            summary="registered",
+        )
+        out = self._render_with_level(renderer, console, msg)
+        assert "constructor:" in out
+        assert "my_tool" in out
+
+    def test_skill_list_collapsed(self, renderer, console):
+        msg = SkillListMessage(
+            skills=[
+                SkillEntry(name="a", description="desc a", path="/skills/a"),
+                SkillEntry(name="b", description="desc b", path="/skills/b"),
+            ],
+            total_count=2,
+        )
+        out = self._render_with_level(renderer, console, msg)
+        assert "skills:" in out
+        assert "2 available" in out
+
+    def test_skill_activate_collapsed(self, renderer, console):
+        msg = SkillActivateMessage(
+            skill_name="tableau",
+            skill_path="/skills/tableau",
+            content_preview="# Skill docs here",
+            resource_count=0,
+        )
+        out = self._render_with_level(renderer, console, msg)
+        assert "skill:" in out
+        assert "tableau" in out
+
+
+class TestRichRendererLowModeNeverCollapse:
+    """Certain message types must NEVER be collapsed, even in low mode."""
+
+    def _render_with_level(self, renderer, console, message, level="low"):
+        with (
+            patch(
+                "code_puppy.messaging.rich_renderer.get_output_level",
+                return_value=level,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_informational_messages",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages",
+                return_value=False,
+            ),
+        ):
+            renderer._do_render(message)
+        return _output(console)
+
+    def test_error_message_not_collapsed(self, renderer, console):
+        msg = TextMessage(level=MessageLevel.ERROR, text="Something broke!")
+        out = self._render_with_level(renderer, console, msg)
+        # Error messages render fully, including the  prefix
+        assert "Something broke!" in out
+
+    def test_divider_not_collapsed(self, renderer, console):
+        msg = DividerMessage()
+        out = self._render_with_level(renderer, console, msg)
+        # Divider always renders (may be just a rule)
+        assert out.strip() != ""
+
+    def test_version_check_not_collapsed(self, renderer, console):
+        msg = VersionCheckMessage(
+            current_version="1.0.0",
+            latest_version="1.1.0",
+            update_available=True,
+        )
+        out = self._render_with_level(renderer, console, msg)
+        assert "1.0.0" in out or "1.1.0" in out
+
+    def test_spinner_not_collapsed(self, renderer, console):
+        msg = SpinnerControl(action="start", spinner_id="s1", text="Thinking...")
+        self._render_with_level(renderer, console, msg)
+        # SpinnerControl passes through (may or may not print visible text)
+        # Main point: no crash, and it's not turned into a peek line
+
+
+class TestRichRendererMediumMode:
+    """Medium mode is the default — existing behavior unchanged."""
+
+    def test_file_listing_renders_fully(self, renderer, console):
+        msg = FileListingMessage(
+            directory="/tmp/test",
+            files=[FileEntry(path="a.py", type="file", size=100, depth=0)],
+            recursive=True,
+            total_size=100,
+            dir_count=0,
+            file_count=1,
+        )
+        with (
+            patch(
+                "code_puppy.messaging.rich_renderer.get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_informational_messages",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages",
+                return_value=False,
+            ),
+        ):
+            renderer._do_render(msg)
+        out = _output(console)
+        assert "DIRECTORY LISTING" in out
+
+
+class TestRichRendererHighMode:
+    """High mode forces verbose output and un-suppresses subagent output."""
+
+    def test_grep_forced_verbose_in_high_mode(self, renderer, console):
+        msg = GrepResultMessage(
+            search_term="foo",
+            directory="/tmp",
+            matches=[
+                GrepMatch(file_path="a.py", line_number=1, line_content="foo bar"),
+            ],
+            total_matches=1,
+            files_searched=5,
+            verbose=False,  # Normally concise
+        )
+        with (
+            patch(
+                "code_puppy.messaging.rich_renderer.get_output_level",
+                return_value="high",
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_informational_messages",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages",
+                return_value=False,
+            ),
+        ):
+            renderer._do_render(msg)
+        out = _output(console)
+        # In high mode, verbose=False is overridden to show full line content
+        assert "a.py" in out
+
+    def test_subagent_output_not_suppressed_in_high(self, renderer, console):
+        """In high mode, _should_suppress_subagent_output returns False."""
+        with (
+            patch(
+                "code_puppy.messaging.rich_renderer.get_output_level",
+                return_value="high",
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.is_subagent",
+                return_value=True,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_subagent_verbose",
+                return_value=False,
+            ),
+        ):
+            assert renderer._should_suppress_subagent_output() is False
+
+    def _render_high(self, renderer, console, message):
+        with (
+            patch(
+                "code_puppy.messaging.rich_renderer.get_output_level",
+                return_value="high",
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_informational_messages",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages",
+                return_value=False,
+            ),
+        ):
+            renderer._do_render(message)
+        return _output(console)
+
+    def test_high_mode_shows_file_tokens(self, renderer, console):
+        msg = FileContentMessage(
+            path="config.py",
+            content="x = 1\n",
+            total_lines=100,
+            num_tokens=42,
+        )
+        out = self._render_high(renderer, console, msg)
+        assert "100 total lines" in out
+        assert "~42 tokens" in out
+
+    def test_high_mode_shows_shell_exit_and_duration(self, renderer, console):
+        msg = ShellOutputMessage(
+            command="ruff check",
+            exit_code=0,
+            duration_seconds=1.23,
+        )
+        out = self._render_high(renderer, console, msg)
+        assert "exit=" in out
+        assert "0" in out
+        assert "1.2s" in out
+
+    def test_high_mode_shows_grep_files_searched(self, renderer, console):
+        msg = GrepResultMessage(
+            search_term="foo",
+            directory="/tmp",
+            matches=[
+                GrepMatch(file_path="a.py", line_number=1, line_content="foo"),
+            ],
+            total_matches=1,
+            files_searched=42,
+            verbose=False,
+        )
+        out = self._render_high(renderer, console, msg)
+        assert "42 files searched" in out
+
+    def test_high_mode_shows_diff_line_counts(self, renderer, console):
+        msg = DiffMessage(
+            path="foo.py",
+            operation="modify",
+            diff_lines=[
+                DiffLine(line_number=1, type="add", content="new"),
+                DiffLine(line_number=2, type="add", content="new2"),
+                DiffLine(line_number=3, type="remove", content="old"),
+            ],
+        )
+        out = self._render_high(renderer, console, msg)
+        assert "+2/-1 lines" in out
+
+
+# ---------------------------------------------------------------------------
+# Suppress toggles wired to renderer (dead-code fix: code_puppy_oss-dzz)
+# ---------------------------------------------------------------------------
+
+
+class TestSuppressTogglesWiredUp:
+    """The previously-dead suppress_* toggles now actually suppress output."""
+
+    def test_suppress_informational_hides_info(self, renderer, console):
+        msg = TextMessage(level=MessageLevel.INFO, text="Loading plugins...")
+        with (
+            patch(
+                "code_puppy.messaging.rich_renderer.get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_informational_messages",
+                return_value=True,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages",
+                return_value=False,
+            ),
+        ):
+            renderer._do_render(msg)
+        assert _output(console).strip() == ""
+
+    def test_suppress_informational_hides_warning(self, renderer, console):
+        msg = TextMessage(level=MessageLevel.WARNING, text="Watch out!")
+        with (
+            patch(
+                "code_puppy.messaging.rich_renderer.get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_informational_messages",
+                return_value=True,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages",
+                return_value=False,
+            ),
+        ):
+            renderer._do_render(msg)
+        assert _output(console).strip() == ""
+
+    def test_suppress_informational_does_not_hide_error(self, renderer, console):
+        msg = TextMessage(level=MessageLevel.ERROR, text="Kaboom!")
+        with (
+            patch(
+                "code_puppy.messaging.rich_renderer.get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_informational_messages",
+                return_value=True,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages",
+                return_value=False,
+            ),
+        ):
+            renderer._do_render(msg)
+        assert "Kaboom!" in _output(console)
+
+    def test_suppress_thinking_hides_agent_reasoning(self, renderer, console):
+        msg = AgentReasoningMessage(reasoning="Let me think...", next_steps="")
+        with (
+            patch(
+                "code_puppy.messaging.rich_renderer.get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_informational_messages",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages",
+                return_value=True,
+            ),
+        ):
+            renderer._do_render(msg)
+        assert _output(console).strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Legacy SynchronousInteractiveRenderer gating
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyRendererOutputLevel:
+    """_should_suppress_legacy correctly gates the legacy render path."""
+
+    def test_low_mode_suppresses_info(self):
+        from code_puppy.messaging.message_queue import MessageType, UIMessage
+        from code_puppy.messaging.renderers import _should_suppress_legacy
+
+        msg = UIMessage(type=MessageType.INFO, content="hello")
+        with (
+            patch(
+                "code_puppy.messaging.renderers._get_output_level",
+                return_value="low",
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_informational",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_thinking",
+                return_value=False,
+            ),
+        ):
+            assert _should_suppress_legacy(msg) is True
+
+    def test_low_mode_suppresses_agent_reasoning(self):
+        from code_puppy.messaging.message_queue import MessageType, UIMessage
+        from code_puppy.messaging.renderers import _should_suppress_legacy
+
+        msg = UIMessage(type=MessageType.AGENT_REASONING, content="Thinking...")
+        with (
+            patch(
+                "code_puppy.messaging.renderers._get_output_level",
+                return_value="low",
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_informational",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_thinking",
+                return_value=False,
+            ),
+        ):
+            assert _should_suppress_legacy(msg) is True
+
+    def test_low_mode_keeps_errors(self):
+        from code_puppy.messaging.message_queue import MessageType, UIMessage
+        from code_puppy.messaging.renderers import _should_suppress_legacy
+
+        msg = UIMessage(type=MessageType.ERROR, content="bad things")
+        with (
+            patch(
+                "code_puppy.messaging.renderers._get_output_level",
+                return_value="low",
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_informational",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_thinking",
+                return_value=False,
+            ),
+        ):
+            assert _should_suppress_legacy(msg) is False
+
+    def test_low_mode_keeps_agent_response(self):
+        from code_puppy.messaging.message_queue import MessageType, UIMessage
+        from code_puppy.messaging.renderers import _should_suppress_legacy
+
+        msg = UIMessage(type=MessageType.AGENT_RESPONSE, content="Hello!")
+        with (
+            patch(
+                "code_puppy.messaging.renderers._get_output_level",
+                return_value="low",
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_informational",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_thinking",
+                return_value=False,
+            ),
+        ):
+            assert _should_suppress_legacy(msg) is False
+
+    def test_medium_mode_passes_everything(self):
+        from code_puppy.messaging.message_queue import MessageType, UIMessage
+        from code_puppy.messaging.renderers import _should_suppress_legacy
+
+        msg = UIMessage(type=MessageType.INFO, content="hello")
+        with (
+            patch(
+                "code_puppy.messaging.renderers._get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_informational",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_thinking",
+                return_value=False,
+            ),
+        ):
+            assert _should_suppress_legacy(msg) is False
+
+    def test_suppress_toggle_overrides_medium(self):
+        from code_puppy.messaging.message_queue import MessageType, UIMessage
+        from code_puppy.messaging.renderers import _should_suppress_legacy
+
+        msg = UIMessage(type=MessageType.INFO, content="hello")
+        with (
+            patch(
+                "code_puppy.messaging.renderers._get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_informational",
+                return_value=True,
+            ),
+            patch(
+                "code_puppy.messaging.renderers._get_suppress_thinking",
+                return_value=False,
+            ),
+        ):
+            assert _should_suppress_legacy(msg) is True
+
+
+# ---------------------------------------------------------------------------
+# event_stream_handler helpers
+# ---------------------------------------------------------------------------
+
+
+class TestEventStreamHandlerGates:
+    """_suppress_thinking_stream / _suppress_tool_progress in event_stream_handler."""
+
+    def test_low_mode_suppresses_thinking(self):
+        from code_puppy.agents.event_stream_handler import _suppress_thinking_stream
+
+        with (
+            patch(
+                "code_puppy.agents.event_stream_handler.get_output_level",
+                return_value="low",
+            ),
+            patch(
+                "code_puppy.agents.event_stream_handler.get_suppress_thinking_messages",
+                return_value=False,
+            ),
+        ):
+            assert _suppress_thinking_stream() is True
+
+    def test_medium_mode_does_not_suppress_thinking(self):
+        from code_puppy.agents.event_stream_handler import _suppress_thinking_stream
+
+        with (
+            patch(
+                "code_puppy.agents.event_stream_handler.get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.agents.event_stream_handler.get_suppress_thinking_messages",
+                return_value=False,
+            ),
+        ):
+            assert _suppress_thinking_stream() is False
+
+    def test_suppress_toggle_overrides(self):
+        from code_puppy.agents.event_stream_handler import _suppress_thinking_stream
+
+        with (
+            patch(
+                "code_puppy.agents.event_stream_handler.get_output_level",
+                return_value="medium",
+            ),
+            patch(
+                "code_puppy.agents.event_stream_handler.get_suppress_thinking_messages",
+                return_value=True,
+            ),
+        ):
+            assert _suppress_thinking_stream() is True
+
+    def test_low_mode_suppresses_tool_progress(self):
+        from code_puppy.agents.event_stream_handler import _suppress_tool_progress
+
+        with patch(
+            "code_puppy.agents.event_stream_handler.get_output_level",
+            return_value="low",
+        ):
+            assert _suppress_tool_progress() is True
+
+    def test_medium_mode_shows_tool_progress(self):
+        from code_puppy.agents.event_stream_handler import _suppress_tool_progress
+
+        with patch(
+            "code_puppy.agents.event_stream_handler.get_output_level",
+            return_value="medium",
+        ):
+            assert _suppress_tool_progress() is False
+
+    def test_high_mode_unsuppresses_subagent(self):
+        from code_puppy.agents.event_stream_handler import _should_suppress_output
+
+        with (
+            patch(
+                "code_puppy.agents.event_stream_handler.get_output_level",
+                return_value="high",
+            ),
+            patch(
+                "code_puppy.agents.event_stream_handler.is_subagent",
+                return_value=True,
+            ),
+            patch(
+                "code_puppy.agents.event_stream_handler.get_subagent_verbose",
+                return_value=False,
+            ),
+        ):
+            assert _should_suppress_output() is False
+
+
+# ---------------------------------------------------------------------------
+# /set menu catalog integration
+# ---------------------------------------------------------------------------
+
+
+class TestSetMenuCatalog:
+    """output_level appears in the /set menu."""
+
+    def test_output_level_in_settings_catalog(self):
+        from code_puppy.command_line.set_menu_catalog import SETTINGS_CATEGORIES
+
+        all_keys = [s.key for cat in SETTINGS_CATEGORIES for s in cat.settings]
+        assert "output_level" in all_keys
+
+    def test_output_level_setting_metadata(self):
+        from code_puppy.command_line.set_menu_catalog import SETTINGS_CATEGORIES
+
+        for cat in SETTINGS_CATEGORIES:
+            for s in cat.settings:
+                if s.key == "output_level":
+                    assert s.type_hint == "choice"
+                    assert set(s.valid_values) == {"low", "medium", "high"}
+                    assert s.effective_getter is not None
+                    return
+        pytest.fail("output_level setting not found in catalog")
+
+
+# ---------------------------------------------------------------------------
+# Subagent handler selection based on output_level
+# ---------------------------------------------------------------------------
+
+
+class TestRichRendererLowModeAuditGaps:
+    """Audit coverage for checklist items not yet exercised (code_puppy_oss-5lw)."""
+
+    def _render_with_level(self, renderer, console, message, level="low"):
+        with (
+            patch(
+                "code_puppy.messaging.rich_renderer.get_output_level",
+                return_value=level,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_informational_messages",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages",
+                return_value=False,
+            ),
+        ):
+            renderer._do_render(message)
+        return _output(console)
+
+    # -- Checklist #3: shell output messages collapsed --
+
+    def test_shell_output_collapsed(self, renderer, console):
+        """ShellOutputMessage should be silently collapsed (empty peek)."""
+        msg = ShellOutputMessage(
+            command="ls -la",
+            exit_code=0,
+            duration_seconds=0.5,
+        )
+        out = self._render_with_level(renderer, console, msg)
+        # Shell output produces an empty peek → nothing printed
+        assert out.strip() == ""
+
+    # -- Checklist #4: sub-agent response is no-op in low mode --
+
+    def test_subagent_response_produces_no_output(self, renderer, console):
+        """SubAgentResponseMessage renders as no-op (pass dispatch), so no output."""
+        from code_puppy.messaging.messages import SubAgentResponseMessage
+
+        msg = SubAgentResponseMessage(
+            agent_name="bigquery-explorer",
+            session_id="abc-123",
+            response="Here is your report...",
+            message_count=5,
+        )
+        out = self._render_with_level(renderer, console, msg)
+        # The dispatch for SubAgentResponseMessage is `pass` (no-op),
+        # so no output is produced regardless of _NEVER_COLLAPSE membership.
+        assert out.strip() == ""
+
+    # -- Checklist #8: interactive prompts never collapsed --
+
+    def test_user_input_request_not_collapsed(self, renderer, console):
+        """UserInputRequest must render in low mode (never collapsed)."""
+        msg = UserInputRequest(
+            prompt_id="p1",
+            prompt_text="Enter your name:",
+        )
+        # Should not crash; type is in _NEVER_COLLAPSE
+        out = self._render_with_level(renderer, console, msg)
+        # UserInputRequest renders a dim note in sync mode, not collapsed
+        assert "input" in out.lower() or out.strip() != ""
+
+    def test_confirmation_request_not_collapsed(self, renderer, console):
+        """ConfirmationRequest must render in low mode (never collapsed)."""
+        msg = ConfirmationRequest(
+            prompt_id="p2",
+            title="Proceed?",
+            description="About to delete the file.",
+        )
+        out = self._render_with_level(renderer, console, msg)
+        # Should render something (not a dim peek)
+        assert out.strip() != ""
+
+    def test_selection_request_not_collapsed(self, renderer, console):
+        """SelectionRequest must render in low mode (never collapsed)."""
+        msg = SelectionRequest(
+            prompt_id="p3",
+            prompt_text="Pick an option:",
+            options=["a", "b", "c"],
+        )
+        out = self._render_with_level(renderer, console, msg)
+        assert out.strip() != ""
+
+    # -- Checklist #10: switching output_level mid-session takes effect immediately --
+
+    def test_mid_session_level_switch(self, renderer, console):
+        """Changing output_level between renders takes effect immediately."""
+        msg = FileListingMessage(
+            directory="/tmp",
+            files=[FileEntry(path="a.py", type="file", size=100, depth=0)],
+            recursive=True,
+            total_size=100,
+            dir_count=0,
+            file_count=1,
+        )
+        # First render in medium mode → full output
+        out_medium = self._render_with_level(renderer, console, msg, level="medium")
+        assert "DIRECTORY LISTING" in out_medium
+
+        # Reset console buffer
+        console.file.truncate(0)
+        console.file.seek(0)
+
+        # Second render in low mode → collapsed peek
+        out_low = self._render_with_level(renderer, console, msg, level="low")
+        assert "list_files:" in out_low
+        assert "DIRECTORY LISTING" not in out_low
+
+
+class TestSubagentHandlerSelection:
+    """High mode should use event_stream_handler; medium/low use subagent_stream_handler."""
+
+    def test_high_mode_selects_main_handler(self):
+        """In high mode, invoke_agent should pick the main event_stream_handler."""
+        from code_puppy.agents.event_stream_handler import event_stream_handler
+
+        # get_output_level is imported locally in subagent_invocation,
+        # so patch at the config module level.
+        with patch(
+            "code_puppy.config.get_output_level",
+            return_value="high",
+        ):
+            from code_puppy.config import get_output_level as _gol
+
+            assert _gol() == "high"
+            # Verify the handler exists and is callable
+            assert callable(event_stream_handler)
+
+    def test_medium_mode_uses_subagent_handler(self):
+        """In medium mode, the subagent_stream_handler should be used."""
+        from code_puppy.agents.subagent_stream_handler import (
+            subagent_stream_handler,
+        )
+
+        # Verify the import works and it's the expected silent handler
+        assert callable(subagent_stream_handler)

--- a/tests/test_subagent_high_output_mode.py
+++ b/tests/test_subagent_high_output_mode.py
@@ -1,0 +1,316 @@
+"""Tests for sub-agent response rendering in high output mode.
+
+Covers the fix for code_puppy_oss-hwx: ensures sub-agent responses render
+visibly in high mode via streaming OR fallback, without double-rendering,
+and with proper spinner coordination.
+"""
+
+from io import StringIO
+from unittest.mock import Mock, patch
+
+from rich.console import Console
+
+
+# ---------------------------------------------------------------------------
+# display_non_streamed_result — output_level guard
+# ---------------------------------------------------------------------------
+
+
+class TestDisplayNonStreamedResultOutputLevel:
+    """display_non_streamed_result must respect output_level == 'high'."""
+
+    @patch("code_puppy.messaging.spinner.pause_all_spinners")
+    @patch("code_puppy.messaging.spinner.resume_all_spinners")
+    @patch("time.sleep")
+    @patch("termflow.Renderer")
+    @patch("termflow.Parser")
+    @patch("code_puppy.tools.display.get_banner_color", return_value="blue")
+    @patch("code_puppy.tools.display.get_output_level", return_value="high")
+    @patch("code_puppy.tools.display.get_subagent_verbose", return_value=False)
+    @patch("code_puppy.tools.display.is_subagent", return_value=True)
+    def test_renders_in_subagent_context_when_high(
+        self,
+        mock_is_sub,
+        mock_verbose,
+        mock_level,
+        mock_color,
+        mock_parser_cls,
+        mock_renderer_cls,
+        mock_sleep,
+        mock_resume,
+        mock_pause,
+    ):
+        """High mode overrides the subagent suppression guard."""
+        from code_puppy.tools.display import display_non_streamed_result
+
+        mock_parser = Mock()
+        mock_renderer = Mock()
+        mock_parser_cls.return_value = mock_parser
+        mock_renderer_cls.return_value = mock_renderer
+        mock_parser.parse_line.return_value = []
+        mock_parser.finalize.return_value = []
+
+        console = Mock(spec=Console)
+        console.file = StringIO()
+        console.width = 80
+
+        display_non_streamed_result(content="hello", console=console)
+
+        # Should have rendered — banner color looked up, parser used
+        mock_color.assert_called_once()
+        mock_parser.parse_line.assert_called()
+
+    @patch("code_puppy.tools.display.get_output_level", return_value="medium")
+    @patch("code_puppy.tools.display.get_subagent_verbose", return_value=False)
+    @patch("code_puppy.tools.display.is_subagent", return_value=True)
+    def test_suppressed_in_subagent_context_when_medium(
+        self, mock_is_sub, mock_verbose, mock_level
+    ):
+        """Medium mode still suppresses sub-agent output (legacy behaviour)."""
+        from code_puppy.tools.display import display_non_streamed_result
+
+        console = Mock(spec=Console)
+        result = display_non_streamed_result(content="hello", console=console)
+
+        assert result is None
+        # Console should NOT have been used for printing
+        console.print.assert_not_called()
+
+    @patch("code_puppy.tools.display.get_output_level", return_value="low")
+    @patch("code_puppy.tools.display.get_subagent_verbose", return_value=False)
+    @patch("code_puppy.tools.display.is_subagent", return_value=True)
+    def test_suppressed_in_subagent_context_when_low(
+        self, mock_is_sub, mock_verbose, mock_level
+    ):
+        """Low mode still suppresses sub-agent output."""
+        from code_puppy.tools.display import display_non_streamed_result
+
+        console = Mock(spec=Console)
+        display_non_streamed_result(content="hello", console=console)
+
+        console.print.assert_not_called()
+
+    @patch("code_puppy.messaging.spinner.pause_all_spinners")
+    @patch("code_puppy.messaging.spinner.resume_all_spinners")
+    @patch("time.sleep")
+    @patch("termflow.Renderer")
+    @patch("termflow.Parser")
+    @patch("code_puppy.tools.display.get_banner_color", return_value="blue")
+    @patch("code_puppy.tools.display.get_output_level", return_value="medium")
+    @patch("code_puppy.tools.display.get_subagent_verbose", return_value=True)
+    @patch("code_puppy.tools.display.is_subagent", return_value=True)
+    def test_renders_when_verbose_regardless_of_level(
+        self,
+        mock_is_sub,
+        mock_verbose,
+        mock_level,
+        mock_color,
+        mock_parser_cls,
+        mock_renderer_cls,
+        mock_sleep,
+        mock_resume,
+        mock_pause,
+    ):
+        """subagent_verbose=True still works at any output level."""
+        from code_puppy.tools.display import display_non_streamed_result
+
+        mock_parser = Mock()
+        mock_renderer = Mock()
+        mock_parser_cls.return_value = mock_parser
+        mock_renderer_cls.return_value = mock_renderer
+        mock_parser.parse_line.return_value = []
+        mock_parser.finalize.return_value = []
+
+        console = Mock(spec=Console)
+        console.file = StringIO()
+        console.width = 80
+
+        display_non_streamed_result(content="hello", console=console)
+
+        mock_color.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Spinner pause/resume — high mode exception
+# ---------------------------------------------------------------------------
+
+
+class TestSpinnerHighModeSubagent:
+    """Spinners must pause/resume from subagent context in high mode."""
+
+    @patch("code_puppy.tools.subagent_context._subagent_depth")
+    def test_pause_noop_in_subagent_medium(self, mock_depth):
+        """pause_all_spinners is a no-op in subagent context at medium."""
+        mock_depth.get.return_value = 1  # is_subagent() → True
+
+        from code_puppy.messaging.spinner import _active_spinners, pause_all_spinners
+
+        spy = Mock()
+        _active_spinners.append(spy)
+        try:
+            with patch("code_puppy.config.get_output_level", return_value="medium"):
+                pause_all_spinners()
+            spy.pause.assert_not_called()
+        finally:
+            _active_spinners.remove(spy)
+
+    @patch("code_puppy.tools.subagent_context._subagent_depth")
+    def test_pause_fires_in_subagent_high(self, mock_depth):
+        """pause_all_spinners fires in subagent context when high mode."""
+        mock_depth.get.return_value = 1
+
+        from code_puppy.messaging.spinner import _active_spinners, pause_all_spinners
+
+        spy = Mock()
+        _active_spinners.append(spy)
+        try:
+            with patch("code_puppy.config.get_output_level", return_value="high"):
+                pause_all_spinners()
+            spy.pause.assert_called_once()
+        finally:
+            _active_spinners.remove(spy)
+
+    @patch("code_puppy.tools.subagent_context._subagent_depth")
+    def test_resume_noop_in_subagent_medium(self, mock_depth):
+        """resume_all_spinners is a no-op in subagent context at medium."""
+        mock_depth.get.return_value = 1
+
+        from code_puppy.messaging.spinner import _active_spinners, resume_all_spinners
+
+        spy = Mock()
+        _active_spinners.append(spy)
+        try:
+            with patch("code_puppy.config.get_output_level", return_value="medium"):
+                resume_all_spinners()
+            spy.resume.assert_not_called()
+        finally:
+            _active_spinners.remove(spy)
+
+    @patch("code_puppy.tools.subagent_context._subagent_depth")
+    def test_resume_fires_in_subagent_high(self, mock_depth):
+        """resume_all_spinners fires in subagent context when high mode."""
+        mock_depth.get.return_value = 1
+
+        from code_puppy.messaging.spinner import _active_spinners, resume_all_spinners
+
+        spy = Mock()
+        _active_spinners.append(spy)
+        try:
+            with patch("code_puppy.config.get_output_level", return_value="high"):
+                resume_all_spinners()
+            spy.resume.assert_called_once()
+        finally:
+            _active_spinners.remove(spy)
+
+
+# ---------------------------------------------------------------------------
+# Subagent invocation — streaming detector + fallback render
+# ---------------------------------------------------------------------------
+
+
+class TestSubagentHighModeStreamHandlerSelection:
+    """High mode wraps stream handler in StreamingTextDetector."""
+
+    def test_high_mode_uses_detector(self):
+        """StreamingTextDetector wrapping is importable and functional."""
+        from code_puppy.agents._non_streaming_render import StreamingTextDetector
+
+        inner = Mock()
+        detector = StreamingTextDetector(inner)
+        assert detector.streamed_text is False
+        assert detector._inner is inner
+
+    def test_medium_mode_skips_detector(self):
+        """Medium mode should NOT wrap with StreamingTextDetector."""
+        # This is a design assertion: in medium mode, the code creates
+        # a partial(subagent_stream_handler, ...) — no detector.
+        from functools import partial
+
+        from code_puppy.agents.subagent_stream_handler import subagent_stream_handler
+
+        handler = partial(subagent_stream_handler, session_id="test-session")
+        # It should be a partial, not a StreamingTextDetector
+        assert isinstance(handler, partial)
+
+
+class TestSubagentResponseMessageEmit:
+    """SubAgentResponseMessage emission logic in high vs non-high mode."""
+
+    def test_high_streamed_skips_emit(self):
+        """When streaming produced text in high mode, message emit is skipped."""
+        # Simulates the guard: `if not (is_high_mode and streamed_text):`
+        is_high_mode = True
+        streamed_text = True
+        should_emit = not (is_high_mode and streamed_text)
+        assert should_emit is False
+
+    def test_high_not_streamed_emits(self):
+        """When streaming didn't produce text in high mode, emit proceeds."""
+        is_high_mode = True
+        streamed_text = False
+        should_emit = not (is_high_mode and streamed_text)
+        assert should_emit is True
+
+    def test_medium_always_emits(self):
+        """Non-high modes always emit the message (streaming_detector is None)."""
+        is_high_mode = False
+        streamed_text = False  # detector is None so this is False
+        should_emit = not (is_high_mode and streamed_text)
+        assert should_emit is True
+
+    def test_low_always_emits(self):
+        """Low mode always emits the message."""
+        is_high_mode = False
+        streamed_text = False
+        should_emit = not (is_high_mode and streamed_text)
+        assert should_emit is True
+
+
+# ---------------------------------------------------------------------------
+# event_stream_handler._should_suppress_output — regression guard
+# ---------------------------------------------------------------------------
+
+
+class TestShouldSuppressOutput:
+    """_should_suppress_output must return False in high mode."""
+
+    @patch(
+        "code_puppy.agents.event_stream_handler.get_output_level", return_value="high"
+    )
+    @patch("code_puppy.agents.event_stream_handler.is_subagent", return_value=True)
+    @patch(
+        "code_puppy.agents.event_stream_handler.get_subagent_verbose",
+        return_value=False,
+    )
+    def test_not_suppressed_in_high_mode(self, mock_verbose, mock_sub, mock_level):
+        from code_puppy.agents.event_stream_handler import _should_suppress_output
+
+        assert _should_suppress_output() is False
+
+    @patch(
+        "code_puppy.agents.event_stream_handler.get_output_level",
+        return_value="medium",
+    )
+    @patch("code_puppy.agents.event_stream_handler.is_subagent", return_value=True)
+    @patch(
+        "code_puppy.agents.event_stream_handler.get_subagent_verbose",
+        return_value=False,
+    )
+    def test_suppressed_in_medium_subagent(self, mock_verbose, mock_sub, mock_level):
+        from code_puppy.agents.event_stream_handler import _should_suppress_output
+
+        assert _should_suppress_output() is True
+
+    @patch(
+        "code_puppy.agents.event_stream_handler.get_output_level",
+        return_value="medium",
+    )
+    @patch("code_puppy.agents.event_stream_handler.is_subagent", return_value=False)
+    @patch(
+        "code_puppy.agents.event_stream_handler.get_subagent_verbose",
+        return_value=False,
+    )
+    def test_not_suppressed_when_not_subagent(self, mock_verbose, mock_sub, mock_level):
+        from code_puppy.agents.event_stream_handler import _should_suppress_output
+
+        assert _should_suppress_output() is False

--- a/tests/tools/test_file_operations_coverage.py
+++ b/tests/tools/test_file_operations_coverage.py
@@ -303,6 +303,63 @@ class TestGrepFunction:
             assert "not supported" in result.error
 
 
+class TestGrepVerboseConfigWiring:
+    """Verify grep_output_verbose config flows into GrepResultMessage.verbose.
+
+    Regression test for code_puppy_oss-7vr: the toggle was disconnected.
+    """
+
+    def test_grep_verbose_false_by_default(self, tmp_path):
+        """GrepResultMessage.verbose is False when config is unset."""
+        test_file = tmp_path / "f.py"
+        test_file.write_text("match_me\n")
+
+        captured = []
+        mock_bus = MagicMock()
+        mock_bus.emit = lambda msg: captured.append(msg)
+
+        with (
+            patch(
+                "code_puppy.tools.file_operations.get_message_bus",
+                return_value=mock_bus,
+            ),
+            patch(
+                "code_puppy.config.get_grep_output_verbose",
+                return_value=False,
+            ),
+        ):
+            _grep(None, "match_me", str(tmp_path))
+
+        grep_msgs = [m for m in captured if hasattr(m, "verbose")]
+        assert len(grep_msgs) == 1
+        assert grep_msgs[0].verbose is False
+
+    def test_grep_verbose_true_from_config(self, tmp_path):
+        """GrepResultMessage.verbose is True when config says so."""
+        test_file = tmp_path / "f.py"
+        test_file.write_text("match_me\n")
+
+        captured = []
+        mock_bus = MagicMock()
+        mock_bus.emit = lambda msg: captured.append(msg)
+
+        with (
+            patch(
+                "code_puppy.tools.file_operations.get_message_bus",
+                return_value=mock_bus,
+            ),
+            patch(
+                "code_puppy.config.get_grep_output_verbose",
+                return_value=True,
+            ),
+        ):
+            _grep(None, "match_me", str(tmp_path))
+
+        grep_msgs = [m for m in captured if hasattr(m, "verbose")]
+        assert len(grep_msgs) == 1
+        assert grep_msgs[0].verbose is True
+
+
 class TestBuildGrepArgs:
     """Test _build_grep_args pattern/flag mode selection."""
 


### PR DESCRIPTION
…eam density

Add a unified output_level config that controls how much detail is shown during a conversation. Three levels:

- low: user messages and final responses only; tool calls, thinking blocks, sub-agent output, and system messages collapse to a one-line peek summary
- medium: default, identical to pre-feature behavior
- high: maximum visibility — full tool args/results (uncapped), expanded thinking blocks, inline sub-agent streaming, per-turn timing and token stats

The setting gates three independent render paths:
- RichConsoleRenderer (structured MessageBus messages)
- event_stream_handler (streaming thinking/response/tool events)
- run_stats post_tool_call callback (tool-result summaries)

High mode strictly exposes data already flowing through the pipeline. It removes filters and truncation but does not add new data channels or annotations.

Configurable at runtime via /set output_level=low|medium|high. Existing toggles (subagent_verbose, grep_output_verbose, suppress_thinking_messages) are overridden by low/high and respected in medium.