### PR TITLE
puppy_kennel: store /kennel toggle in puppy.cfg as single source of truth

### DIFF
--- a/code_puppy/plugins/puppy_kennel/README.md
+++ b/code_puppy/plugins/puppy_kennel/README.md
@@ -122,24 +122,26 @@ Plus a **`/kennel`** slash command suite for humans:
 | `/kennel disable` (or `off`) | turn memory off at runtime (drawers preserved) |
 | `/kennel help` | usage hint |
 
-## Enable / disable at runtime
+## Enable / disable
 
-The plugin is **enabled by default**. State is persisted to
-``<KENNEL_ROOT>/state.json`` and read on every callback so the toggle is
-live — no restart needed.
+The plugin is **enabled by default**. Flip it with the slash commands:
+
+- ``/kennel disable`` (or ``/kennel off``) — turn memory off
+- ``/kennel enable`` (or ``/kennel on``) — turn memory back on
+
+State is persisted to ``puppy.cfg`` under ``kennel_enabled`` and read on
+every callback, so the toggle is live — no restart needed, and the
+front end can read or write the same value.
 
 **When disabled:**
 
 - ``load_prompt`` returns ``None`` (no recall block in system prompt)
 - ``agent_run_end`` is a no-op (nothing recorded)
 - Agent-facing tools return a friendly ``error`` field explaining memory is off
-- **Human inspection commands** (`/kennel stats`, `/kennel wings`, `/kennel search`)
-  still work — the operator can always see what's stored.
-
-**Two layers of off:**
-
-1. ``PUPPY_KENNEL_DISABLED=1`` env var → **hard off**, plugin never registers callbacks at all.
-2. ``/kennel disable`` slash command → **soft off**, plugin loaded but features paused.
+- **The ``/kennel`` slash suite stays available** — ``/kennel stats``,
+  ``/kennel wings``, ``/kennel search`` all still work so the operator
+  can see what's stored, and ``/kennel enable`` is always reachable to
+  turn it back on.
 
 ## Known tech debt
 
@@ -159,9 +161,14 @@ live — no restart needed.
 | Variable | Default | Effect |
 |---|---|---|
 | `PUPPY_KENNEL_ROOT` | `~/.code_puppy/kennel` | Where the SQLite file lives |
-| `PUPPY_KENNEL_DISABLED` | unset | Set to `1` to skip plugin entirely |
 | `PUPPY_KENNEL_PASSIVE_LIMIT` | `5` | Drawers surfaced in passive recall |
 | `PUPPY_KENNEL_MAX_DRAWER_CHARS` | `32000` | Cap on stored drawer size |
+
+## puppy.cfg keys
+
+| Key | Default | Effect |
+|---|---|---|
+| `kennel_enabled` | unset → enabled | Single source of truth for the on/off toggle. Set to `false`/`0`/`no`/`off` (case-insensitive) to disable. Anything else — missing, blank, or garbage — leaves the kennel on. Flipped live by `/kennel enable` and `/kennel disable`. |
 
 ## How tools reach the agent
 

--- a/code_puppy/plugins/puppy_kennel/config.py
+++ b/code_puppy/plugins/puppy_kennel/config.py
@@ -1,6 +1,8 @@
 """Configuration for the puppy_kennel plugin.
 
-Single source of truth for paths, defaults, and opt-out flags.
+Single source of truth for paths, defaults, and tunable knobs. The
+on/off toggle lives in ``state.py`` and is persisted in ``puppy.cfg``
+under ``kennel_enabled`` -- see that module.
 """
 
 from __future__ import annotations
@@ -15,9 +17,6 @@ KENNEL_ROOT = Path(
 
 # The SQLite database file lives inside the kennel root.
 DB_PATH = KENNEL_ROOT / "kennel.db"
-
-# Disable the plugin entirely with PUPPY_KENNEL_DISABLED=1.
-DISABLED = os.environ.get("PUPPY_KENNEL_DISABLED", "").lower() in {"1", "true", "yes"}
 
 # --------------------------------------------------------------------------- #
 # Prompt-packing budget — how much of the system prompt we get to fill.

--- a/code_puppy/plugins/puppy_kennel/register_callbacks.py
+++ b/code_puppy/plugins/puppy_kennel/register_callbacks.py
@@ -15,7 +15,6 @@ from code_puppy.callbacks import register_callback
 from code_puppy.messaging.bus import emit_debug
 
 from . import commands, kennel, tools
-from .config import DISABLED
 from .recorder import record_run_end
 from .retriever import build_recall_block
 from .state import is_enabled
@@ -87,7 +86,7 @@ def _advertise_tools_to_agent(agent_name: str | None = None) -> list[str]:
     return list(_KENNEL_TOOL_NAMES)
 
 
-if not DISABLED and _initialize_once():
+if _initialize_once():
     register_callback("load_prompt", _on_load_prompt)
     register_callback("agent_run_end", _on_agent_run_end)
     register_callback("register_tools", tools.register_tools_callback)

--- a/code_puppy/plugins/puppy_kennel/state.py
+++ b/code_puppy/plugins/puppy_kennel/state.py
@@ -1,22 +1,28 @@
 """Runtime state for the puppy_kennel plugin.
 
-A tiny JSON file at ``<KENNEL_ROOT>/state.json`` records whether memory
-is currently enabled. The slash commands ``/kennel enable`` and
-``/kennel disable`` flip this flag; reads (recorder/retriever/tools)
-consult ``is_enabled()`` on every call so the toggle is live.
+Single source of truth for whether the kennel is on. Flipped by the
+``/kennel enable`` and ``/kennel disable`` slash commands. Persisted in
+``puppy.cfg`` under the key ``kennel_enabled`` so the front end can read
+and write the same value.
 
-The env var ``PUPPY_KENNEL_DISABLED=1`` is a separate, harder kill: it
-prevents the plugin from registering callbacks at all. That's handled in
-``register_callbacks``, not here.
+Default is **enabled** -- a missing key, blank value, or garbage value
+all leave the kennel on. Only the explicit-falsy tokens
+``{"false", "0", "no", "off"}`` (case-insensitive) turn it off. That
+asymmetry is on purpose: on a default-on system, a typo like
+``kennel_enabled = noep`` must not silently kill memory. In the face of
+ambiguity, refuse to guess.
+
+Reads and writes go through ``code_puppy.config.get_value`` /
+``set_config_value``, the same helpers every other plugin (statusline,
+prompt_newline, ...) uses for puppy.cfg interop.
 """
 
 from __future__ import annotations
 
-import json
+from code_puppy.config import get_value, set_config_value
 
-from .config import KENNEL_ROOT
-
-STATE_PATH = KENNEL_ROOT / "state.json"
+_CFG_KEY = "kennel_enabled"
+_FALSY = frozenset({"false", "0", "no", "off"})
 
 DISABLED_TOOL_ERROR = (
     "Puppy Kennel memory is currently disabled. "
@@ -25,18 +31,24 @@ DISABLED_TOOL_ERROR = (
 
 
 def is_enabled() -> bool:
-    """Read the persisted enabled flag. Defaults to True if no state file."""
-    try:
-        payload = json.loads(STATE_PATH.read_text(encoding="utf-8"))
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
+    """Return True if the kennel is on.
+
+    Defaults to True when the key is missing, blank, or set to anything
+    that isn't one of the explicit-falsy tokens. Evaluated on every call
+    so flipping the toggle takes effect immediately -- no relaunch
+    required.
+    """
+    raw = get_value(_CFG_KEY)
+    if raw is None:
         return True
-    value = payload.get("enabled", True)
-    return bool(value)
+    return str(raw).strip().lower() not in _FALSY
 
 
 def set_enabled(value: bool) -> None:
-    """Persist the enabled flag to the state file. Best-effort."""
-    KENNEL_ROOT.mkdir(parents=True, exist_ok=True)
-    STATE_PATH.write_text(
-        json.dumps({"enabled": bool(value)}, indent=2), encoding="utf-8"
-    )
+    """Persist the kennel enable flag to puppy.cfg (positive sense).
+
+    Writes the literal string ``"true"`` or ``"false"`` so the on-disk
+    representation is stable and any future FE consumer can parse the
+    cfg directly without going through this helper.
+    """
+    set_config_value(_CFG_KEY, "true" if value else "false")

--- a/tests/plugins/test_puppy_kennel.py
+++ b/tests/plugins/test_puppy_kennel.py
@@ -47,7 +47,7 @@ def kennel_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     for mod in (
         kennel_config,  # base: paths + budgets
         schema_mod,  # SQL constants
-        state_mod,  # STATE_PATH <- config.KENNEL_ROOT
+        state_mod,  # is_enabled() reads kennel_enabled from puppy.cfg
         wings_mod,  # cwd/repo helpers
         kennel_mod,  # DB_PATH <- config
         packer_mod,  # <- kennel, config, wings

--- a/tests/plugins/test_puppy_kennel_toggle.py
+++ b/tests/plugins/test_puppy_kennel_toggle.py
@@ -22,6 +22,9 @@ import pytest
 
 @pytest.fixture
 def kennel_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    # ``PUPPY_KENNEL_ROOT`` now ONLY controls where the SQLite DB lives;
+    # it has nothing to do with the on/off toggle, which lives in
+    # puppy.cfg (isolated to a temp file by the root tests/conftest.py).
     root = tmp_path / "kennel"
     monkeypatch.setenv("PUPPY_KENNEL_ROOT", str(root))
 
@@ -79,11 +82,12 @@ def test_set_enabled_persists(kennel_root: Path) -> None:
     assert state.is_enabled() is True
 
 
-def test_state_file_corruption_falls_back_to_enabled(kennel_root: Path) -> None:
+def test_garbage_cfg_value_falls_back_to_enabled(kennel_root: Path) -> None:
+    """Default-on means a typo in puppy.cfg must not silently kill memory."""
+    from code_puppy.config import set_config_value
     from code_puppy.plugins.puppy_kennel import state
 
-    state.STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    state.STATE_PATH.write_text("this is not json", encoding="utf-8")
+    set_config_value("kennel_enabled", "banana")
     assert state.is_enabled() is True
 
 


### PR DESCRIPTION
## puppy_kennel: store /kennel toggle in puppy.cfg as single source of truth

### What

The `/kennel enable` and `/kennel disable` slash commands now persist their state to `puppy.cfg` under the key `kennel_enabled` instead of `~/.code_puppy/kennel/state.json`. Default behaviour (enabled) is unchanged; only the storage location moves.

This puts the kennel toggle alongside every other user-tunable preference and lets any front-end / settings UI read and write the same value the CLI uses.

### Why

The kennel toggle previously lived in its own JSON file that nothing else in the config system knew about. Any tooling that wanted to show or flip the kennel state had to grow special-case knowledge of `state.json`. Moving the storage into `puppy.cfg` makes it a first-class preference like everything else, and lets external surfaces (settings UIs, dotfile sync, etc.) interoperate with the toggle via the same `get_value` / `set_config_value` helpers every other plugin uses.

### Removed

- `PUPPY_KENNEL_DISABLED` environment variable — no separate ops escape hatch
- `~/.code_puppy/kennel/state.json` — no separate runtime state file
- The "hard kill vs soft toggle" split inside the plugin — one toggle, one mental model

### Behaviour contract

| Input in `puppy.cfg` | Kennel state |
|---|---|
| key absent | enabled (default) |
| blank value | enabled |
| `false` / `0` / `no` / `off` (case-insensitive) | **disabled** |
| anything else (`banana`, `True`, `yes`, `disabled`, ...) | enabled |

The asymmetric falsy-only matching is on purpose: on a default-on feature, a typo in `puppy.cfg` must not silently kill memory. _"In the face of ambiguity, refuse the temptation to guess."_

The plugin always registers its callbacks, so the `/kennel` slash suite stays available even when disabled — `/kennel enable` is always reachable from the CLI, you can never lock yourself out. The on/off state is checked on every callback invocation, so flips take effect immediately without a relaunch.

### Files changed

| File | Change |
|---|---|
| `code_puppy/plugins/puppy_kennel/state.py` | Rewired `is_enabled()` / `set_enabled()` to read & write `kennel_enabled` via `code_puppy.config`. Public API surface unchanged so the 5 callers don't move. |
| `code_puppy/plugins/puppy_kennel/config.py` | Stripped of all toggle-related logic. Just paths now. |
| `code_puppy/plugins/puppy_kennel/register_callbacks.py` | Restored always-register behaviour. |
| `code_puppy/plugins/puppy_kennel/README.md` | Single-toggle docs; removed env-var row; rewrote enable/disable section. |
| `tests/plugins/test_puppy_kennel_toggle.py` | Replaced `state.STATE_PATH` corruption test with `test_garbage_cfg_value_falls_back_to_enabled` covering the new path. |
| `tests/plugins/test_puppy_kennel.py` | Fixed stale comment that referenced the deleted `STATE_PATH`. |

### Tests

- Kennel-specific: **80 passed**
- Full plugin suite: **2300 passed, 5 skipped** (2 pre-existing unrelated warnings)

### Known limitation — upgrade path

This PR does **not** include a migration shim for existing `state.json` files. Users who previously ran `/kennel disable` on an older CLI will have their kennel silently re-enabled after upgrade. The set of affected users is small (kennel feature is recent + disable is opt-in), but it is a silent default-on regression for the users who care most.

If desired, a follow-up can add a one-time migration: on first `is_enabled()` call, if `kennel_enabled` is absent from `puppy.cfg` and `~/.code_puppy/kennel/state.json` exists with `enabled: false`, write `kennel_enabled = false` to the cfg. ~15 lines + 2 tests. Happy to add it if the maintainers prefer.
