### PR TITLE
feat: desktop pet plugin (/pet) -- an animated terminal dog

### DIFF
--- a/code_puppy/plugins/pet/README.md
+++ b/code_puppy/plugins/pet/README.md
@@ -1,0 +1,41 @@
+# pet -- a desktop dog for your terminal
+
+Adopt a tiny ASCII pup that lounges in the **bottom-right of your prompt**,
+animates (blinks + wags), and barks fun quips while you think. It reflects the
+model you've set and gets out of the way the moment the agent starts working.
+
+> **Zero LLM tokens.** Quips are a static list; everything is local string
+> rendering. Your bill is identical whether the pup naps or does zoomies.
+
+## Usage
+
+```
+/pet on            Open the adoption picker, then summon your dog
+/pet off           Send the dog back to the yard
+/pet pick          Re-open the picker to swap breeds
+/pet <breed>       Adopt a breed directly (e.g. /pet shiba)
+/pet rename <name> Rename your pup (max 20 chars)
+/pet quip          Reroll the quip
+/pet list | grid   Show the rarity-colored list of all 19 breeds
+/pet               Status
+```
+
+## 19 breeds, 5 rarities
+
+corgi, shiba, pug, husky, poodle, dachshund, beagle, labrador, chihuahua,
+dalmatian, bulldog, greatdane, pomeranian, terrier, boxer, collie, samoyed,
+doberman, mutt -- each tinted by rarity (common -> legendary, gray -> gold).
+
+## How it works (no core edits)
+
+Like the `prompt_newline` plugin, this hooks core cleanly:
+
+* **`startup`** -- subclasses the `PromptSession` used by the main input prompt
+  so an adopted pet rides along as an animated `bottom_toolbar` (right-aligned,
+  so it sits bottom-right). prompt_toolkit renders/refreshes it itself, which is
+  why it never fights the REPL or smears escape codes.
+* **`custom_command` / `custom_command_help`** -- the `/pet` command and its
+  help entry.
+
+State (enabled / species / name) persists in `puppy.cfg` via the generic
+config API. Themed to Code Puppy's prompt palette (bright cyan / blue / green).

--- a/code_puppy/plugins/pet/__init__.py
+++ b/code_puppy/plugins/pet/__init__.py
@@ -1,0 +1,6 @@
+"""Code Puppy desktop pet plugin.
+
+A tiny ASCII dog that lounges in the bottom-right of your prompt (rendered as a
+prompt_toolkit bottom toolbar), animates, and barks fun quips while you think.
+Adopt one with ``/pet on``. Everything is local -- zero LLM tokens.
+"""

--- a/code_puppy/plugins/pet/config.py
+++ b/code_puppy/plugins/pet/config.py
@@ -1,0 +1,48 @@
+"""Plugin-local config for the desktop pet, persisted in ``puppy.cfg``.
+
+Uses the generic ``get_value`` / ``set_config_value`` API so we never have to
+edit core's ``get_config_keys`` -- arbitrary keys round-trip just fine.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from code_puppy.config import get_value, set_config_value
+
+KEY_ENABLED = "pet_enabled"
+KEY_SPECIES = "pet_species"
+KEY_NAME = "pet_name"
+
+_TRUTHY = ("true", "1", "yes", "on")
+
+
+def is_enabled() -> bool:
+    val = get_value(KEY_ENABLED)
+    return bool(val) and str(val).strip().lower() in _TRUTHY
+
+
+def set_enabled(enabled: bool) -> None:
+    set_config_value(KEY_ENABLED, "true" if enabled else "false")
+
+
+def get_species() -> str:
+    from code_puppy.plugins.pet.species import DOG_SPECIES
+
+    sp = get_value(KEY_SPECIES)
+    return sp if sp in DOG_SPECIES else "mutt"
+
+
+def set_species(species: str) -> None:
+    set_config_value(KEY_SPECIES, species)
+
+
+def get_name() -> str:
+    from code_puppy.plugins.pet.species import DOG_SPECIES
+
+    return get_value(KEY_NAME) or DOG_SPECIES[get_species()].default_name
+
+
+def set_name(name: Optional[str]) -> None:
+    if name:
+        set_config_value(KEY_NAME, name)

--- a/code_puppy/plugins/pet/grid.py
+++ b/code_puppy/plugins/pet/grid.py
@@ -1,0 +1,59 @@
+"""The 'meet the breeds' list -- one tidy line per good boy.
+
+Renders all 19 dogs as compact one-liners (snoot + name + stars + rarity),
+each tinted by its rarity, as a Rich ``Text`` ready for ``emit_info``. Matches
+the one-liner the pet shows in the prompt toolbar.
+"""
+
+from __future__ import annotations
+
+from rich.text import Text
+
+from code_puppy.plugins.pet.species import DOG_SPECIES, list_species
+
+_FACE = "(\u00b7\u1d25\u00b7)"  # same compact snoot as the toolbar / picker
+
+# Hex twins of species.RARITY_RGB, in Rich-friendly form.
+RARITY_HEX = {
+    "common": "#999999",
+    "uncommon": "#4eba65",
+    "rare": "#b1b9f9",
+    "epic": "#af87ff",
+    "legendary": "#ffc107",
+}
+
+_RARITY_ORDER = ["common", "uncommon", "rare", "epic", "legendary"]
+
+
+def render_grid() -> Text:
+    """Build the one-line-per-breed list + rarity legend as a Rich ``Text``."""
+    names = list_species()
+    out = Text()
+    out.append("  The 19 Very Good Boys ", style="bold magenta")
+    out.append("(/pet on to adopt)\n\n", style="dim")
+
+    for name in names:
+        dog = DOG_SPECIES[name]
+        color = RARITY_HEX.get(dog.rarity, "#999999")
+        out.append("  ")
+        out.append(f"{_FACE} ", style="bold #5fd7ff")  # code-puppy cyan snoot
+        out.append(f"{name:<11} ", style=color)
+        out.append(f"{dog.stars:<5} ", style=color)
+        out.append(dog.rarity, style="dim")
+        out.append("\n")
+
+    # ── Rarity legend ──────────────────────────────────────────────────────
+    out.append("\n  Rarities  ", style="bold magenta")
+    counts = {r: 0 for r in _RARITY_ORDER}
+    for n in names:
+        counts[DOG_SPECIES[n].rarity] += 1
+    bits = []
+    for r in _RARITY_ORDER:
+        stars = "\u2605" * (_RARITY_ORDER.index(r) + 1)
+        bits.append((f"{stars} {r} ({counts[r]})", RARITY_HEX[r]))
+    for idx, (label, color) in enumerate(bits):
+        out.append(label, style=color)
+        if idx < len(bits) - 1:
+            out.append("  ", style="dim")
+    out.append("\n")
+    return out

--- a/code_puppy/plugins/pet/picker.py
+++ b/code_puppy/plugins/pet/picker.py
@@ -1,0 +1,186 @@
+"""Interactive 'adopt a pet' picker.
+
+Same look-and-feel as Code Puppy's ``/model`` picker (paginated-ish arrow-key
+list, type-to-filter, Enter to choose) but for dogs, with a live ASCII preview
+of the highlighted breed so you can see who you're adopting.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import List, Optional
+
+from prompt_toolkit import Application
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.layout import Layout, Window
+from prompt_toolkit.layout.controls import FormattedTextControl
+
+from code_puppy.plugins.pet.species import DOG_SPECIES, list_species
+
+_RARITY_PT_STYLE = {
+    "common": "fg:ansiwhite",
+    "uncommon": "fg:ansigreen",
+    "rare": "fg:ansiblue",
+    "epic": "fg:ansimagenta",
+    "legendary": "fg:ansiyellow",
+}
+
+
+class PetPickerMenu:
+    """Arrow-key dog adoption menu returning the chosen species name."""
+
+    def __init__(self) -> None:
+        self.species: List[str] = list_species()
+        self.filter_text = ""
+        self.selected_index = 0
+        self.result: Optional[str] = None
+
+    @property
+    def visible(self) -> List[str]:
+        if not self.filter_text:
+            return self.species
+        needle = self.filter_text.lower()
+        return [s for s in self.species if needle in s.lower()]
+
+    def _selected_name(self) -> Optional[str]:
+        vis = self.visible
+        if 0 <= self.selected_index < len(vis):
+            return vis[self.selected_index]
+        return None
+
+    def _clamp(self) -> None:
+        vis = self.visible
+        if not vis:
+            self.selected_index = 0
+        else:
+            self.selected_index = max(0, min(self.selected_index, len(vis) - 1))
+
+    def _render(self):
+        lines = [("bold cyan", " \U0001f436 Adopt a Pet  "), ("", "\n")]
+        filter_label = self.filter_text or "type to filter breeds"
+        lines.append(("fg:ansibrightblack", f"  Filter: {filter_label}\n\n"))
+
+        vis = self.visible
+        if not vis:
+            lines.append(("fg:ansiyellow", "  No breeds match that filter.\n\n"))
+            lines.append(("fg:ansibrightblack", "  Backspace "))
+            lines.append(("", "clear a char   "))
+            lines.append(("fg:ansiyellow", "Esc "))
+            lines.append(("", "cancel\n"))
+            return lines
+
+        # ── List (left) ────────────────────────────────────────────────────
+        for idx, name in enumerate(vis):
+            dog = DOG_SPECIES[name]
+            is_sel = idx == self.selected_index
+            prefix = " \u203a " if is_sel else "   "
+            style = "fg:ansiwhite bold" if is_sel else "fg:ansibrightblack"
+            lines.append((style, f"{prefix}{name:<11}"))
+            lines.append((_RARITY_PT_STYLE.get(dog.rarity, ""), f" {dog.stars}"))
+            lines.append(("fg:ansibrightblack", f"  ({dog.rarity})"))
+            lines.append(("", "\n"))
+
+        # ── Preview (selected dog) — the one-liner the pet actually shows ───
+        sel = self._selected_name()
+        if sel:
+            dog = DOG_SPECIES[sel]
+            pstyle = _RARITY_PT_STYLE.get(dog.rarity, "")
+            face = "(\u00b7\u1d25\u00b7)"  # same compact snoot as the toolbar
+            lines.append(("", "\n"))
+            lines.append(("fg:ansibrightblack", "  preview: "))
+            lines.append(("fg:ansibrightcyan", f"{face} "))
+            lines.append(("fg:ansiwhite bold", f"{dog.default_name} "))
+            lines.append(("fg:ansibrightblack", f"the {sel} "))
+            lines.append((pstyle, f" {dog.stars}"))
+            lines.append(("fg:ansibrightblack", f"  ({dog.rarity})\n"))
+
+        lines.append(("", "\n"))
+        lines.append(("fg:ansibrightblack", "  \u2191/\u2193 "))
+        lines.append(("", "navigate   "))
+        lines.append(("fg:ansibrightblack", "type "))
+        lines.append(("", "filter   "))
+        lines.append(("fg:ansigreen", "Enter "))
+        lines.append(("", "adopt   "))
+        lines.append(("fg:ansiyellow", "Esc "))
+        lines.append(("", "cancel\n"))
+        return lines
+
+    async def run_async(self) -> Optional[str]:
+        control = FormattedTextControl(lambda: self._render())
+        kb = KeyBindings()
+
+        def refresh(event):
+            control.text = self._render()
+            event.app.invalidate()
+
+        @kb.add("up")
+        @kb.add("c-p")
+        def _(event):
+            self.selected_index -= 1
+            self._clamp()
+            refresh(event)
+
+        @kb.add("down")
+        @kb.add("c-n")
+        def _(event):
+            self.selected_index += 1
+            self._clamp()
+            refresh(event)
+
+        @kb.add("backspace")
+        def _(event):
+            if self.filter_text:
+                self.filter_text = self.filter_text[:-1]
+                self._clamp()
+                refresh(event)
+
+        @kb.add("c-u")
+        def _(event):
+            self.filter_text = ""
+            self._clamp()
+            refresh(event)
+
+        @kb.add("<any>")
+        def _(event):
+            if event.data and event.data.isprintable():
+                self.filter_text += event.data
+                self.selected_index = 0
+                refresh(event)
+
+        @kb.add("enter")
+        def _(event):
+            chosen = self._selected_name()
+            if chosen:
+                self.result = chosen
+                event.app.exit()
+
+        @kb.add("escape")
+        @kb.add("c-c")
+        def _(event):
+            self.result = None
+            event.app.exit()
+
+        sys.stdout.write("\x1b[?1049h\x1b[2J\x1b[H")  # enter alt buffer
+        sys.stdout.flush()
+        try:
+            app = Application(
+                layout=Layout(Window(content=control, wrap_lines=True)),
+                key_bindings=kb,
+                full_screen=False,
+            )
+            await app.run_async()
+        finally:
+            sys.stdout.write("\x1b[?1049l")  # leave alt buffer
+            sys.stdout.flush()
+        return self.result
+
+
+async def interactive_pet_picker() -> Optional[str]:
+    """Run the adoption picker, returning the chosen species (or ``None``)."""
+    from code_puppy.tools.command_runner import set_awaiting_user_input
+
+    set_awaiting_user_input(True)
+    try:
+        return await PetPickerMenu().run_async()
+    finally:
+        set_awaiting_user_input(False)

--- a/code_puppy/plugins/pet/register_callbacks.py
+++ b/code_puppy/plugins/pet/register_callbacks.py
@@ -1,0 +1,224 @@
+"""Desktop pet plugin -- wires everything into Code Puppy via callbacks.
+
+Two integration points, both plugin-friendly (no core edits):
+
+* ``startup`` -- monkey-patches the ``PromptSession`` used by the main input
+  prompt so an adopted pet rides along as an animated ``bottom_toolbar``
+  (right-aligned -> bottom-right). Mirrors the ``prompt_newline`` plugin.
+* ``custom_command`` / ``custom_command_help`` -- exposes ``/pet`` for adopt /
+  dismiss / pick / rename / quip / grid.
+
+Everything is local string-rendering: zero LLM tokens, fails graceful.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+from code_puppy.callbacks import register_callback
+from code_puppy.plugins.pet import config as pet_config
+from code_puppy.plugins.pet.species import DOG_SPECIES, list_species
+
+_COMMAND = "pet"
+_PATCH_ATTR = "_pet_toolbar_original_session"
+
+_HELP = """\
+/pet on            Open the adoption picker, then summon your dog (prompt corner)
+/pet off           Send the dog back to the yard (hide it)
+/pet pick          Re-open the picker to swap breeds
+/pet <breed>       Adopt a specific breed directly (e.g. /pet shiba)
+/pet rename <name> Give your pup a new name
+/pet quip          Reroll your pup's quip
+/pet list | grid   Show the rarity-colored list of all 19 breeds
+/pet               Show status
+"""
+
+
+# ── messaging shims (lazy imports keep plugin load cheap) ──────────────────
+def _emit_info(msg) -> None:
+    from code_puppy.messaging import emit_info
+
+    emit_info(msg)
+
+
+def _emit_success(msg) -> None:
+    from code_puppy.messaging import emit_success
+
+    emit_success(msg)
+
+
+def _emit_warning(msg) -> None:
+    from code_puppy.messaging import emit_warning
+
+    emit_warning(msg)
+
+
+# ── startup: install the bottom-toolbar patch ──────────────────────────────
+def _install_toolbar_patch() -> None:
+    """Subclass the prompt's ``PromptSession`` to inject the pet toolbar.
+
+    Idempotent. Only the main input prompt's sessions are affected, and only
+    when a pet is actually adopted -- otherwise behaviour is untouched.
+    """
+    from code_puppy.command_line import prompt_toolkit_completion as ptc
+
+    if getattr(ptc, _PATCH_ATTR, None) is not None:
+        return
+
+    original_session = ptc.PromptSession
+    setattr(ptc, _PATCH_ATTR, original_session)
+
+    from code_puppy.plugins.pet.toolbar import (
+        PET_STYLE,
+        REFRESH_INTERVAL,
+        render_toolbar,
+    )
+
+    class PetPromptSession(original_session):  # type: ignore[misc, valid-type]
+        async def prompt_async(self, *args, **kwargs):
+            try:
+                if pet_config.is_enabled() and "bottom_toolbar" not in kwargs:
+                    kwargs["bottom_toolbar"] = render_toolbar
+                    kwargs["refresh_interval"] = REFRESH_INTERVAL
+                    from prompt_toolkit.styles import Style, merge_styles
+
+                    pet_style = Style.from_dict(PET_STYLE)
+                    base = kwargs.get("style")
+                    kwargs["style"] = (
+                        merge_styles([base, pet_style]) if base else pet_style
+                    )
+            except Exception:
+                pass  # never let the pet break the prompt
+            return await super().prompt_async(*args, **kwargs)
+
+    ptc.PromptSession = PetPromptSession
+
+
+def _on_startup() -> None:
+    try:
+        _install_toolbar_patch()
+    except Exception as exc:
+        _emit_warning(f"pet: failed to install toolbar patch -- {exc}")
+
+
+# ── /pet command ───────────────────────────────────────────────────────────
+def _run_picker():
+    import asyncio
+    import concurrent.futures
+
+    from code_puppy.plugins.pet.picker import interactive_pet_picker
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        future = executor.submit(lambda: asyncio.run(interactive_pet_picker()))
+        return future.result(timeout=300)
+
+
+def _adopt(species: str) -> bool:
+    if species not in DOG_SPECIES:
+        species = "mutt"
+    pet_config.set_species(species)
+    pet_config.set_enabled(True)
+    dog = DOG_SPECIES[species]
+    _emit_success(
+        f"Adopted {pet_config.get_name()} the {species} "
+        f"({dog.rarity} {dog.stars})! They'll wag in the corner of your prompt."
+    )
+    return True
+
+
+def _custom_help() -> List[Tuple[str, str]]:
+    return [(_COMMAND, "Adopt a desktop dog that lives in your prompt corner")]
+
+
+def _handle_pet_command(command: str, name: str) -> Optional[bool]:
+    if name != _COMMAND:
+        return None
+
+    tokens = command.split()
+
+    if len(tokens) == 1:
+        if pet_config.is_enabled():
+            _reroll_quip()
+            _emit_info(
+                f"{pet_config.get_name()} the {pet_config.get_species()} is on duty "
+                "(prompt corner). Try /pet quip, /pet off, or /pet pick."
+            )
+        else:
+            _emit_info("No pet adopted yet. Run /pet on to pick one!\n" + _HELP)
+        return True
+
+    sub = tokens[1].lower()
+
+    if sub == "off":
+        if not pet_config.is_enabled():
+            _emit_info("You don't have a pet out right now.")
+            return True
+        who = pet_config.get_name()
+        pet_config.set_enabled(False)
+        _emit_info(f"{who} trots off for a nap. Use /pet on to bring them back.")
+        return True
+
+    if sub in ("on", "pick", "adopt"):
+        try:
+            chosen = _run_picker()
+        except Exception as exc:
+            _emit_warning(f"Picker failed ({exc}). Try '/pet <breed>' directly.")
+            _emit_info("Breeds: " + ", ".join(list_species()))
+            return True
+        if not chosen:
+            _emit_warning("Adoption cancelled. The shelter understands.")
+            return True
+        return _adopt(chosen)
+
+    if sub in ("list", "grid", "breeds"):
+        from code_puppy.plugins.pet.grid import render_grid
+
+        _emit_info(render_grid())
+        return True
+
+    if sub == "rename":
+        if len(tokens) < 3:
+            _emit_warning("Usage: /pet rename <name>")
+            return True
+        new_name = " ".join(tokens[2:])[:20]
+        pet_config.set_name(new_name)
+        _emit_success(f"Your pet shall henceforth be known as {new_name}.")
+        return True
+
+    if sub == "quip":
+        if not pet_config.is_enabled():
+            _emit_info("Adopt a pet first with /pet on.")
+            return True
+        _emit_info(f"{pet_config.get_name()} says: \u201c{_reroll_quip()}\u201d")
+        return True
+
+    if sub in DOG_SPECIES:
+        return _adopt(sub)
+
+    _emit_warning(
+        f"Unknown pet command: '{sub}'. Try /pet on, /pet off, or a breed name.\n"
+        + _HELP
+    )
+    return True
+
+
+def _reroll_quip() -> str:
+    from code_puppy.plugins.pet.toolbar import current_quip, reroll_quip
+
+    reroll_quip()
+    return current_quip()
+
+
+register_callback("startup", _on_startup)
+register_callback("custom_command", _handle_pet_command)
+register_callback("custom_command_help", _custom_help)
+
+
+__all__ = [
+    "_adopt",
+    "_custom_help",
+    "_handle_pet_command",
+    "_install_toolbar_patch",
+    "_on_startup",
+    "_run_picker",
+]

--- a/code_puppy/plugins/pet/species.py
+++ b/code_puppy/plugins/pet/species.py
@@ -1,0 +1,203 @@
+"""The 19 good boys.
+
+Ported (and dog-ified) from claude-buddy's species catalog. One shared puppy
+template keeps things DRY -- the only thing that differs per breed is the ears
+(line 0). Snoot, eyes, and jowls are universal because all dogs are perfect.
+
+Each species exposes three idle animation frames (idle / tongue-out / blink),
+each frame being a list of 5 equal-width-ish lines. ``{E}`` is the eye
+placeholder, swapped for a real eye glyph at render time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+# ── Shared face lines (the bits every dog has) ─────────────────────────────
+_NOSE = "( \u1d25 )"  # ( ᴥ ) doge snoot
+_EYES_OPEN = "( {E}  {E} )"
+_EYES_BLINK = "( -  - )"
+_MOUTH_IDLE = "\\__/"
+_MOUTH_HAPPY = "\\_v_/"  # tongue out, mid-wag
+_CHIN = "\\____/"
+
+
+def _center(text: str, width: int = 12) -> str:
+    """Center ``text`` inside ``width`` columns (cosmetic alignment only)."""
+    if len(text) >= width:
+        return text
+    pad = width - len(text)
+    left = pad // 2
+    return " " * left + text + " " * (pad - left)
+
+
+def _make_dog(ears: str) -> List[List[str]]:
+    """Build the 3 idle frames for a breed from its distinctive ear art."""
+    e = _center(ears)
+    nose = _center(_NOSE)
+    chin = _center(_CHIN)
+    eyes_open = _center(_EYES_OPEN.replace("{E}", "\x00")).replace("\x00", "{E}")
+    eyes_blink = _center(_EYES_BLINK)
+    mouth_idle = _center(_MOUTH_IDLE)
+    mouth_happy = _center(_MOUTH_HAPPY)
+    return [
+        [e, eyes_open, nose, mouth_idle, chin],  # frame 0: idle
+        [e, eyes_open, nose, mouth_happy, chin],  # frame 1: happy / tongue
+        [e, eyes_blink, nose, mouth_idle, chin],  # frame 2: blink
+    ]
+
+
+# Per-breed ears. The whole personality of the silhouette lives here.
+_EARS: Dict[str, str] = {
+    "corgi": "/\\___/\\",
+    "shiba": "/^\\_/^\\",
+    "pug": "(_____)",
+    "husky": "/\\_^_/\\",
+    "poodle": "@@___@@",
+    "dachshund": "(_)_(_)",
+    "beagle": "(\\___/)",
+    "labrador": "(\\_ _/)",
+    "chihuahua": "/\\_ _/\\",
+    "dalmatian": "(\\.o./)",
+    "bulldog": "<_____>",
+    "greatdane": "/|___|\\",
+    "pomeranian": "{*___*}",
+    "terrier": "/v___v\\",
+    "boxer": "(|___|)",
+    "collie": "/\\~/\\",
+    "samoyed": "((___))",
+    "doberman": "/!___!\\",
+    "mutt": "(\\_o_/)",
+}
+
+# Rarity drives the border color + star count. Hand-tuned so the picker has a
+# nice spread of common pups and a few legends to chase.
+_RARITY: Dict[str, str] = {
+    "mutt": "common",
+    "beagle": "common",
+    "labrador": "common",
+    "pug": "common",
+    "terrier": "common",
+    "boxer": "uncommon",
+    "dachshund": "uncommon",
+    "chihuahua": "uncommon",
+    "bulldog": "uncommon",
+    "collie": "uncommon",
+    "corgi": "rare",
+    "husky": "rare",
+    "dalmatian": "rare",
+    "pomeranian": "rare",
+    "greatdane": "epic",
+    "doberman": "epic",
+    "poodle": "epic",
+    "shiba": "legendary",
+    "samoyed": "legendary",
+}
+
+# A friendly default name per breed (used until the user renames their pet).
+_DEFAULT_NAMES: Dict[str, str] = {
+    "corgi": "Biscuit",
+    "shiba": "Mochi",
+    "pug": "Sir Snorts",
+    "husky": "Blue",
+    "poodle": "Coco",
+    "dachshund": "Noodle",
+    "beagle": "Scout",
+    "labrador": "Buddy",
+    "chihuahua": "Taco",
+    "dalmatian": "Domino",
+    "bulldog": "Tank",
+    "greatdane": "Goliath",
+    "pomeranian": "Puff",
+    "terrier": "Pixel",
+    "boxer": "Rocky",
+    "collie": "Lassie",
+    "samoyed": "Marshmallow",
+    "doberman": "Zeus",
+    "mutt": "Good Boy",
+}
+
+
+@dataclass(frozen=True)
+class DogSpecies:
+    """A single breed: art frames + flavour metadata."""
+
+    name: str
+    rarity: str
+    default_name: str
+    frames: List[List[str]] = field(default_factory=list)
+
+    @property
+    def stars(self) -> str:
+        return _RARITY_STARS.get(self.rarity, "\u2605")
+
+    @property
+    def face(self) -> str:
+        """Compact one-liner snoot for the picker preview."""
+        return self.frames[0][1].replace("{E}", "\u00b7").strip()
+
+
+_RARITY_STARS: Dict[str, str] = {
+    "common": "\u2605",
+    "uncommon": "\u2605\u2605",
+    "rare": "\u2605\u2605\u2605",
+    "epic": "\u2605\u2605\u2605\u2605",
+    "legendary": "\u2605\u2605\u2605\u2605\u2605",
+}
+
+# 24-bit border colors keyed by rarity (matches claude-buddy's dark theme).
+RARITY_RGB: Dict[str, tuple] = {
+    "common": (153, 153, 153),
+    "uncommon": (78, 186, 101),
+    "rare": (177, 185, 249),
+    "epic": (175, 135, 255),
+    "legendary": (255, 193, 7),
+}
+
+# Build the catalog once. 19 dogs, deterministic order.
+DOG_SPECIES: Dict[str, DogSpecies] = {
+    name: DogSpecies(
+        name=name,
+        rarity=_RARITY[name],
+        default_name=_DEFAULT_NAMES[name],
+        frames=_make_dog(ears),
+    )
+    for name, ears in _EARS.items()
+}
+
+
+def list_species() -> List[str]:
+    """Return breed names in catalog order."""
+    return list(DOG_SPECIES.keys())
+
+
+# ── Quips: the whole point of having a desktop dog ─────────────────────────
+# ``{model}`` is interpolated with the active model name at render time, so the
+# pet genuinely reflects "the model the user set."
+QUIPS: List[str] = [
+    "did someone say walkies? i mean... deploy?",
+    "i sniffed a bug on line 42. it smells funny.",
+    "tests passed! good human! *wags*",
+    "that semicolon you forgot? mine now.",
+    "refactor later. belly rubs now.",
+    "i fetched the stack trace. who's a good boy?",
+    "10/10 would compile again.",
+    "your code is like a stick: i will chase it forever.",
+    "merge conflict? i'll bury it in the yard.",
+    "running on {model} and pure zoomies.",
+    "i didn't chew the cables. probably.",
+    "ship it! ship it! SHIP IT!",
+    "is that... a TODO? *growls softly*",
+    "you've been coding a while. drink some water, friend.",
+    "i believe in you. also, treats.",
+    "the linter and i are both judging you. lovingly.",
+    "off-by-one again? classic. *flops over*",
+    "{model} says hi. i say bork.",
+    "git push and then we go to the park, ok?",
+    "i guarded main from a force-push. you're welcome.",
+    "nap detected. resuming supervision of your code.",
+    "good news: it builds. bad news: i ate your mouse.",
+    "every PR is a treat if you believe hard enough.",
+    "*tilts head at your regex*",
+]

--- a/code_puppy/plugins/pet/toolbar.py
+++ b/code_puppy/plugins/pet/toolbar.py
@@ -1,0 +1,122 @@
+"""Live pet, rendered the *right* way: as a prompt_toolkit bottom toolbar.
+
+A background thread scribbling raw ANSI fights prompt_toolkit's renderer and
+loses (escapes get echoed as literal text). Instead we let prompt_toolkit draw
+the pet itself via ``bottom_toolbar`` + ``refresh_interval`` -- right-aligned so
+it lounges in the bottom-right corner, animating and rotating quips while you
+think. It gets out of the way the moment the agent starts working.
+
+Styled to match Code Puppy's prompt palette: bright cyan / blue / green.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import List, Optional, Tuple
+
+from code_puppy.plugins.pet.species import DOG_SPECIES, QUIPS
+
+REFRESH_INTERVAL = 0.8  # seconds; how often prompt_toolkit re-asks for the pet
+_QUIP_PERIOD = 5.0  # seconds each quip stays up
+_BLINK_PERIOD = 6  # blink roughly every N ticks
+
+# Rarity -> prompt_toolkit style string for the stars (Code Puppy ANSI palette).
+_RARITY_STYLE = {
+    "common": "fg:ansiwhite",
+    "uncommon": "fg:ansigreen",
+    "rare": "fg:ansibrightblue",
+    "epic": "fg:ansimagenta",
+    "legendary": "fg:ansiyellow",
+}
+
+# Style classes merged into the prompt's Style so the toolbar bar isn't a
+# chunky reverse-video block but blends with Code Puppy's look.
+PET_STYLE = {
+    "bottom-toolbar": "noreverse bg:default",
+    "bottom-toolbar.text": "noreverse bg:default",
+}
+
+FormattedText = List[Tuple[str, str]]
+
+
+def _state():
+    """Return (enabled, species, name) without importing config at module load."""
+    from code_puppy.plugins.pet import config as pet_config
+
+    return pet_config.is_enabled(), pet_config.get_species(), pet_config.get_name()
+
+
+def _active_model() -> str:
+    try:
+        from code_puppy.command_line.model_picker_completion import get_active_model
+
+        return get_active_model() or ""
+    except Exception:
+        return ""
+
+
+# A nudge offset so "/pet quip" can force a fresh line immediately.
+_quip_offset = 0
+
+
+def reroll_quip() -> None:
+    """Advance to a new quip on the next refresh (used by /pet quip)."""
+    global _quip_offset
+    _quip_offset += 1
+
+
+def current_quip() -> str:
+    enabled, species, name = _state()
+    idx = (int(time.time() // _QUIP_PERIOD) + _quip_offset) % len(QUIPS)
+    return QUIPS[idx].replace("{model}", _active_model() or "your model")
+
+
+def _columns(default: int = 80) -> int:
+    try:
+        from prompt_toolkit.application import get_app
+
+        return get_app().output.get_size().columns
+    except Exception:
+        import shutil
+
+        return shutil.get_terminal_size(fallback=(default, 24)).columns
+
+
+def render_toolbar() -> Optional[FormattedText]:
+    """prompt_toolkit ``bottom_toolbar`` callback. Returns tokens or None."""
+    enabled, species, name = _state()
+    if not enabled:
+        return None
+
+    dog = DOG_SPECIES[species]
+    tick = int(time.time() / REFRESH_INTERVAL)
+    eye = "-" if tick % _BLINK_PERIOD == 0 else "\u00b7"
+    snoot = "\u1d25"  # doge nose
+    face = f"({eye}{snoot}{eye})"
+    model = _active_model()
+    quip = current_quip()
+
+    rarity_style = _RARITY_STYLE.get(dog.rarity, "fg:ansiwhite")
+
+    tokens: FormattedText = [
+        ("fg:ansibrightcyan", f"{face} "),
+        ("bold fg:ansibrightcyan", f"{name} "),
+        (rarity_style, f"{dog.stars}  "),
+        ("fg:ansibrightblack", "\u2502 "),
+        ("italic fg:ansibrightblack", f"\u201c{quip}\u201d "),
+    ]
+    if model:
+        tokens.append(("fg:ansibrightgreen", f"\u00b7 {model}"))
+
+    # Right-align: pad the left so the pet hugs the bottom-right corner.
+    visible = sum(len(t) for _, t in tokens)
+    pad = max(1, _columns() - visible - 1)
+    return [("", " " * pad)] + tokens
+
+
+def toolbar_kwargs() -> dict:
+    """Kwargs to splat into ``prompt_async`` only when a pet is adopted."""
+    enabled, _, _ = _state()
+    if not enabled:
+        return {}
+    return {"bottom_toolbar": render_toolbar, "refresh_interval": REFRESH_INTERVAL}


### PR DESCRIPTION
## What

Adds a **desktop pet** plugin: a tiny ASCII dog that lounges in the
bottom-right of your prompt, animates (blink + wag), and rotates fun quips
while you think. It reflects the model you've set and steps aside while the
agent works.

```
                    (.v.) Marshmallow  *****  | "i guarded main from a force-push" - gpt-4o
```

## Commands

| Command | Description |
|---|---|
| `/pet on` | Adoption picker (like `/model`), then summon your dog |
| `/pet off` | Hide the pet |
| `/pet pick` | Re-open the picker to swap breeds |
| `/pet <breed>` | Adopt a breed directly (e.g. `/pet shiba`) |
| `/pet rename <name>` | Rename your pup |
| `/pet quip` | Reroll the quip |
| `/pet list` / `grid` | Rarity-colored one-liner list of all 19 breeds |
| `/pet` | Status |

19 breeds across 5 rarities (common -> legendary, gray -> gold).

## How it's wired (no core edits)

Follows the `AGENTS.md` golden rule -- it's a self-contained plugin under
`code_puppy/plugins/pet/`, modeled on `prompt_newline`:

- **`startup`** -- subclasses the `PromptSession` used by the main input prompt
  so the pet rides along as an animated `bottom_toolbar`. prompt_toolkit
  renders/refreshes it itself, so it never fights the REPL or smears escape
  codes (an earlier background-thread approach did exactly that -- this is the
  fix).
- **`custom_command` / `custom_command_help`** -- the `/pet` command + help.

State (enabled / species / name) persists in `puppy.cfg` via the generic
config API. Styled to match the prompt palette (bright cyan / blue / green).

## Notes

- **Zero LLM tokens** -- quips are a static list; all rendering is local.
- Fails gracefully -- a rendering hiccup never breaks the prompt.
- `ruff check` + `ruff format` clean. No `command_line/` edits, no core diffs.
- Every file is well under the 600-line cap.
