### PR TITLE
feat: add suppress_directory_listing config flag

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,36 @@
+layout_uv() {
+  local venv_path=".venv"
+
+  # Create venv if missing
+  if [ ! -d "$venv_path" ]; then
+    echo "$(tput setaf 3)📦 Creating virtual environment...$(tput sgr0)"
+    uv venv
+  fi
+
+  # Smart dependency sync - auto-sync if deps are stale
+  # Checks if uv.lock or pyproject.toml are newer than .venv
+  #
+  # Cross-platform note: uv.lock is universal - contains deps for ALL platforms.
+  # uv sync automatically installs only the packages for YOUR platform:
+  #   - Windows: pywin32, pywinauto, winrt-* packages
+  #   - macOS: atomacos, pyobjc-* packages
+  # No merge conflicts, no manual platform detection needed!
+  if [ "uv.lock" -nt "$venv_path" ] || [ "pyproject.toml" -nt "$venv_path" ]; then
+    echo "$(tput setaf 3)🔄 Dependencies out of sync, running uv sync...$(tput sgr0)"
+    uv sync
+
+    if [ $? -eq 0 ]; then
+      echo "$(tput setaf 2)✓ Dependencies synced successfully!$(tput sgr0)"
+    else
+      echo "$(tput setaf 1)✗ Dependency sync failed - you may need to run 'uv sync' manually$(tput sgr0)"
+    fi
+  fi
+
+  # Activate the virtual environment
+  source "$venv_path/bin/activate"
+}
+
+layout uv
+
+PYTHON_VERSION="$(python --version)"
+echo "$(tput setaf 2)✓ Virtual env (.venv) $PYTHON_VERSION activated$(tput sgr0)"

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -184,6 +184,17 @@ def get_enable_streaming() -> bool:
     return str(val).lower() in ("1", "true", "yes", "on")
 
 
+def get_suppress_directory_listing() -> bool:
+    """
+    Get the suppress_directory_listing configuration value.
+    Returns True if directory listing displays should be suppressed, False otherwise.
+    """
+    val = get_value("suppress_directory_listing")
+    if val is None:
+        return True  # Default to True (suppress by default)
+    return str(val).lower() in ("1", "true", "yes", "on")
+
+
 DEFAULT_SECTION = "puppy"
 REQUIRED_KEYS = ["puppy_name", "owner_name"]
 
@@ -339,6 +350,8 @@ def get_config_keys():
     default_keys.append("max_hook_retries")
     # Add streaming control key
     default_keys.append("enable_streaming")
+    # Add suppress directory listing key
+    default_keys.append("suppress_directory_listing")
     # Add cancel agent key configuration
     default_keys.append("cancel_agent_key")
     # Add max pause seconds configuration (used by pause/steer feature to

--- a/code_puppy/messaging/rich_renderer.py
+++ b/code_puppy/messaging/rich_renderer.py
@@ -21,6 +21,7 @@ from rich.table import Table
 from code_puppy.config import (
     get_output_level,
     get_subagent_verbose,
+    get_suppress_directory_listing,
     get_suppress_informational_messages,
     get_suppress_thinking_messages,
 )
@@ -552,6 +553,9 @@ class RichConsoleRenderer:
         """
         # Skip for sub-agents unless verbose mode
         if self._should_suppress_subagent_output():
+            return
+
+        if get_suppress_directory_listing():
             return
 
         import os

--- a/tests/messaging/test_medium_mode_audit.py
+++ b/tests/messaging/test_medium_mode_audit.py
@@ -79,6 +79,10 @@ def _render_medium(renderer, console, message):
             return_value=False,
         ),
         patch(
+            "code_puppy.messaging.rich_renderer.get_suppress_directory_listing",
+            return_value=False,
+        ),
+        patch(
             "code_puppy.messaging.rich_renderer.is_subagent",
             return_value=False,
         ),

--- a/tests/messaging/test_output_level.py
+++ b/tests/messaging/test_output_level.py
@@ -132,6 +132,10 @@ class TestRichRendererLowMode:
                 "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages",
                 return_value=False,
             ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_directory_listing",
+                return_value=False,
+            ),
         ):
             renderer._do_render(message)
         return _output(console)
@@ -288,6 +292,10 @@ class TestRichRendererLowModeNeverCollapse:
                 "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages",
                 return_value=False,
             ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_directory_listing",
+                return_value=False,
+            ),
         ):
             renderer._do_render(message)
         return _output(console)
@@ -343,6 +351,10 @@ class TestRichRendererMediumMode:
             ),
             patch(
                 "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_directory_listing",
                 return_value=False,
             ),
         ):
@@ -414,6 +426,10 @@ class TestRichRendererHighMode:
             ),
             patch(
                 "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_directory_listing",
                 return_value=False,
             ),
         ):
@@ -828,6 +844,10 @@ class TestRichRendererLowModeAuditGaps:
             ),
             patch(
                 "code_puppy.messaging.rich_renderer.get_suppress_thinking_messages",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.messaging.rich_renderer.get_suppress_directory_listing",
                 return_value=False,
             ),
         ):

--- a/tests/messaging/test_rich_renderer.py
+++ b/tests/messaging/test_rich_renderer.py
@@ -158,7 +158,11 @@ def test_get_level_prefix(renderer):
 
 
 @patch("code_puppy.messaging.rich_renderer.is_subagent", return_value=False)
-def test_render_file_listing(mock_sub, renderer, console):
+@patch(
+    "code_puppy.messaging.rich_renderer.get_suppress_directory_listing",
+    return_value=False,
+)
+def test_render_file_listing(mock_suppress, mock_sub, renderer, console):
     msg = FileListingMessage(
         directory="/tmp/test",
         files=[
@@ -1128,7 +1132,11 @@ def test_suppress_skill_activate(mv, ms, renderer, console):
 
 
 @patch("code_puppy.messaging.rich_renderer.is_subagent", return_value=False)
-def test_render_file_listing_nested_dirs(mock_sub, renderer, console):
+@patch(
+    "code_puppy.messaging.rich_renderer.get_suppress_directory_listing",
+    return_value=False,
+)
+def test_render_file_listing_nested_dirs(mock_suppress, mock_sub, renderer, console):
     msg = FileListingMessage(
         directory="/project",
         files=[
@@ -1149,7 +1157,13 @@ def test_render_file_listing_nested_dirs(mock_sub, renderer, console):
 
 
 @patch("code_puppy.messaging.rich_renderer.is_subagent", return_value=False)
-def test_render_file_listing_root_files_only(mock_sub, renderer, console):
+@patch(
+    "code_puppy.messaging.rich_renderer.get_suppress_directory_listing",
+    return_value=False,
+)
+def test_render_file_listing_root_files_only(
+    mock_suppress, mock_sub, renderer, console
+):
     msg = FileListingMessage(
         directory="/project",
         files=[
@@ -1165,7 +1179,13 @@ def test_render_file_listing_root_files_only(mock_sub, renderer, console):
 
 
 @patch("code_puppy.messaging.rich_renderer.is_subagent", return_value=False)
-def test_render_file_listing_single_file_single_dir(mock_sub, renderer, console):
+@patch(
+    "code_puppy.messaging.rich_renderer.get_suppress_directory_listing",
+    return_value=False,
+)
+def test_render_file_listing_single_file_single_dir(
+    mock_suppress, mock_sub, renderer, console
+):
     """Test singular forms in summary."""
     msg = FileListingMessage(
         directory="/project",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -335,6 +335,7 @@ class TestGetConfigKeys:
                 "protected_token_count",
                 "resume_message_count",
                 "summarization_model",
+                "suppress_directory_listing",
                 "temperature",
                 "yolo_mode",
             ]
@@ -400,6 +401,7 @@ class TestGetConfigKeys:
                 "protected_token_count",
                 "resume_message_count",
                 "summarization_model",
+                "suppress_directory_listing",
                 "temperature",
                 "yolo_mode",
             ]


### PR DESCRIPTION
## Summary

Adds a `suppress_directory_listing` configuration flag to Code Puppy.

## Changes

- **`config.py`**: Added `suppress_directory_listing` boolean config option (defaults to `True`)
- **`rich_renderer.py`**: Renderer respects the flag and suppresses directory listing output when enabled

## Motivation

Directory listings in the rendered output can be noisy and rarely useful to the end user. This flag gives users an easy way to hide them without any loss of core functionality.

## Testing

- Config flag correctly defaults to `True` (suppress by default)
- Setting `suppress_directory_listing = false` in config re-enables directory listing output
