### PR TITLE
New theme options added

### DIFF
--- a/code_puppy/plugins/theme/README.md
+++ b/code_puppy/plugins/theme/README.md
@@ -10,7 +10,7 @@ escape sequences (mure-style).
 ```
 /theme
 ```
-Launches a split-panel TUI with 10 themes (4 originals, 4 mure ports, surprise, reset).
+Launches a split-panel TUI with 14 themes (5 neon/dark themes, 7 palette-first/light themes, surprise, reset).
 
 ## What gets themed
 
@@ -33,18 +33,23 @@ Themes persist to your Code Puppy config and survive restarts. The OSC palette a
 | 2 | 🌲 Forest | earthy greens & olives |
 | 3 | 🌅 Sunset | warm reds, oranges & gold |
 | 4 | 🪩 Vaporwave | neon pinks & purples |
-| 5 | 🐱 Catppuccin Mocha | soothing pastel dark (mure default) |
-| 6 | ☕ Catppuccin Latte | soothing pastel light |
-| 7 | 🌃 Tokyo Night | neon-on-navy night |
-| 8 | 🍂 Gruvbox Dark | retro warm earth |
-| 9 | 🎲 Surprise Me | a fresh random remix every time |
-| 10 | 🔄 Restore Defaults | back to Code Puppy + terminal factory |
+| 5 | 🫧 Bubblegum Pink | sweet pinks, candy neon & glow |
+| 6 | 🐱 Catppuccin Mocha | soothing pastel dark (mure default) |
+| 7 | ☕ Catppuccin Latte | soothing pastel light |
+| 8 | 🌃 Tokyo Night | neon-on-navy night |
+| 9 | 🌑 Deep Black | inky noir with subtle neon edge |
+| 10 | ☀️ Solarized Light | classic warm beige with calm accents |
+| 11 | 📄 GitHub Light | crisp white, familiar code colors |
+| 12 | 🌸 Rose Pine Dawn | soft pastel rose light |
+| 13 | 🎲 Surprise Me | a fresh random remix every time |
+| 14 | 🔄 Restore Defaults | back to Code Puppy + terminal factory |
 
 ## Power-user shortcuts
 
 ```
-/theme 5            apply theme #5 (Catppuccin Mocha)
-/theme mocha        apply by alias (also: latte, tokyo, gruvbox)
+/theme 5            apply theme #5 (Bubblegum Pink)
+/theme bubblegum    apply by alias (also: pink, mocha, latte, tokyo,
+                    solarized, github, rose-pine)
 /theme tokyo-night  apply by canonical name
 /theme surprise     re-roll a random palette
 /theme default      restore Code Puppy + terminal factory colors
@@ -57,7 +62,7 @@ Themes persist to your Code Puppy config and survive restarts. The OSC palette a
 | File | Responsibility |
 |------|----------------|
 | `themes.py` | Theme catalog + banner/content/remap/palette construction |
-| `bundled_palettes.py` | Hex palette data (Catppuccin, Tokyo Night, Gruvbox, +4 originals) |
+| `bundled_palettes.py` | Hex palette data (Catppuccin, Tokyo Night, Deep Black, +5 originals) |
 | `content_styles.py` | Mutates `RichConsoleRenderer` style maps (Level 1) |
 | `rich_themes.py` | Monkey-patches `Console.get_style()` for inline remap (Level 2) |
 | `osc_palette.py` | OSC escape sequences for terminal-wide bg/fg/ANSI palette (Level 3) |

--- a/code_puppy/plugins/theme/README.md
+++ b/code_puppy/plugins/theme/README.md
@@ -12,6 +12,7 @@ escape sequences (mure-style).
 ```
 Launches a split-panel TUI with 14 themes (5 neon/dark themes, 7 palette-first/light themes, surprise, reset).
 
+
 ## What gets themed
 
 | Level | Surface | Themed? |

--- a/code_puppy/plugins/theme/bundled_palettes.py
+++ b/code_puppy/plugins/theme/bundled_palettes.py
@@ -5,8 +5,8 @@ Each palette ships:
     fg   = #rrggbb default foreground
     ansi = list of 16 #rrggbb hex strings (ANSI slots 0-15)
 
-The Catppuccin / Tokyo Night / Gruvbox palettes are the canonical
-upstream specs (same ones mure ships). The four original theme
+The Catppuccin / Tokyo Night palettes are the canonical
+upstream specs (same ones mure ships). The original theme
 palettes (ocean/forest/sunset/vaporwave) are coherent extensions
 of their existing Rich color schemes.
 """
@@ -42,21 +42,21 @@ CATPPUCCIN_LATTE = {
     "bg": "#eff1f5",
     "fg": "#4c4f69",
     "ansi": [
-        "#5c5f77",
+        "#4c4f69",
         "#d20f39",
         "#40a02b",
         "#df8e1d",
         "#1e66f5",
-        "#ea76cb",
+        "#8839ef",
         "#179299",
         "#acb0be",
-        "#6c6f85",
-        "#d20f39",
-        "#40a02b",
-        "#df8e1d",
-        "#1e66f5",
+        "#5c5f77",
+        "#e64553",
+        "#a6d189",
+        "#fe640b",
+        "#7287fd",
         "#ea76cb",
-        "#179299",
+        "#94e2d5",
         "#bcc0cc",
     ],
 }
@@ -84,26 +84,26 @@ TOKYO_NIGHT = {
     ],
 }
 
-GRUVBOX_DARK = {
-    "bg": "#282828",
-    "fg": "#ebdbb2",
+DEEP_BLACK = {
+    "bg": "#050505",
+    "fg": "#e6e6e6",
     "ansi": [
-        "#282828",
-        "#cc241d",
-        "#98971a",
-        "#d79921",
-        "#458588",
-        "#b16286",
-        "#689d6a",
-        "#a89984",
-        "#928374",
-        "#fb4934",
-        "#b8bb26",
-        "#fabd2f",
-        "#83a598",
-        "#d3869b",
-        "#8ec07c",
-        "#ebdbb2",
+        "#050505",
+        "#ff6b6b",
+        "#94d82d",
+        "#ffd166",
+        "#4dabf7",
+        "#b197fc",
+        "#63e6be",
+        "#adb5bd",
+        "#1f1f1f",
+        "#ff8787",
+        "#a9e34b",
+        "#ffe066",
+        "#74c0fc",
+        "#d0bfff",
+        "#96f2d7",
+        "#f1f3f5",
     ],
 }
 
@@ -269,5 +269,28 @@ VAPORWAVE = {
         "#f06292",
         "#80deea",
         "#fce4ec",
+    ],
+}
+
+BUBBLEGUM_PINK = {
+    "bg": "#2a0f1f",
+    "fg": "#fff1f7",
+    "ansi": [
+        "#2a0f1f",
+        "#ff5fa2",
+        "#ff8ec7",
+        "#ffd1e8",
+        "#ff4f93",
+        "#d96cff",
+        "#ff9fd2",
+        "#fff1f7",
+        "#4d1d39",
+        "#ff7ab2",
+        "#ffb3da",
+        "#ffe0ef",
+        "#ff6fb0",
+        "#eb8cff",
+        "#ffc4e1",
+        "#fff8fb",
     ],
 }

--- a/code_puppy/plugins/theme/register_callbacks.py
+++ b/code_puppy/plugins/theme/register_callbacks.py
@@ -2,14 +2,16 @@
 
 UX:
   /theme               → interactive split-panel picker with live preview
-  /theme <N>           → apply theme number N (1-6)
+  /theme <N>           → apply theme number N (1-14)
   /theme <name>        → apply by name (ocean, forest, sunset, vaporwave,
-                         surprise, default)
+                         bubblegum-pink, mocha, latte, tokyo-night,
+                         deep-black, solarized-light, github-light,
+                         rose-pine-dawn, surprise, default)
   /theme reset         → restore Code Puppy defaults (alias of /theme default)
   /theme show          → show current banner → color mapping
 
-The 5th option (🎲 Surprise Me) re-rolls a random palette every time.
-The 6th option (🔄 Restore Defaults) puts everything back to factory.
+The 13th option (🎲 Surprise Me) re-rolls a random palette every time.
+The 14th option (🔄 Restore Defaults) puts everything back to factory.
 
 Plays nice with /colors — same color pool, same config keys.
 """

--- a/code_puppy/plugins/theme/themes.py
+++ b/code_puppy/plugins/theme/themes.py
@@ -184,6 +184,40 @@ CURATED_THEMES: dict[str, dict] = {
         ),
         "terminal_palette": bp.VAPORWAVE,
     },
+    "bubblegum-pink": {
+        "icon": "🫧",
+        "label": "Bubblegum Pink",
+        "blurb": "sweet pinks, candy neon & glow",
+        "colors": [
+            "hot_pink3",
+            "deep_pink4",
+            "pale_violet_red1",
+            "magenta",
+            "bright_magenta",
+            "dark_orchid",
+            "medium_purple4",
+            "violet",
+        ],
+        "content_styles": {
+            "info": "hot_pink3",
+            "warning": "deep_pink4",
+            "success": "bright_magenta",
+            "error": "bold red",
+            "debug": "dim magenta",
+            "diff_add": "bright_magenta",
+            "diff_remove": "red",
+            "diff_context": "dim magenta",
+        },
+        "color_remap": rt.make_remap(
+            cyan="hot_pink3",
+            blue="deep_pink4",
+            magenta="pale_violet_red1",
+            bright_cyan="#ff69b4",
+            bright_blue="medium_purple4",
+            bright_magenta="violet",
+        ),
+        "terminal_palette": bp.BUBBLEGUM_PINK,
+    },
     # --- Mure-port "palette-first" themes ---------------------------------
     # These rely primarily on the OSC ANSI palette swap (slot 6 = cyan, etc.)
     # so Rich's own [cyan]/[blue]/[magenta] tags automatically render in the
@@ -218,28 +252,35 @@ CURATED_THEMES: dict[str, dict] = {
     "catppuccin-latte": {
         "icon": "☕",
         "label": "Catppuccin Latte",
-        "blurb": "soothing pastel light",
+        "blurb": "soft pastel light with lavender & rose",
         "colors": [
-            "blue",
-            "magenta",
-            "green",
-            "yellow",
-            "cyan",
-            "red",
-            "bright_blue",
-            "bright_magenta",
+            "#1e66f5",
+            "#8839ef",
+            "#40a02b",
+            "#df8e1d",
+            "#04a5e5",
+            "#d20f39",
+            "#7287fd",
+            "#ea76cb",
         ],
         "content_styles": {
-            "info": "blue",
-            "warning": "yellow",
-            "success": "green",
-            "error": "bold red",
-            "debug": "dim white",
-            "diff_add": "green",
-            "diff_remove": "red",
-            "diff_context": "dim white",
+            "info": "#1e66f5",
+            "warning": "#df8e1d",
+            "success": "#40a02b",
+            "error": "bold #d20f39",
+            "debug": "dim #4c4f69",
+            "diff_add": "#40a02b",
+            "diff_remove": "#d20f39",
+            "diff_context": "dim #5c5f77",
         },
-        "color_remap": {},
+        "color_remap": rt.make_remap(
+            cyan="#04a5e5",
+            blue="#1e66f5",
+            magenta="#8839ef",
+            bright_cyan="#179299",
+            bright_blue="#7287fd",
+            bright_magenta="#ea76cb",
+        ),
         "terminal_palette": bp.CATPPUCCIN_LATTE,
     },
     "tokyo-night": {
@@ -269,32 +310,39 @@ CURATED_THEMES: dict[str, dict] = {
         "color_remap": {},
         "terminal_palette": bp.TOKYO_NIGHT,
     },
-    "gruvbox-dark": {
-        "icon": "🍂",
-        "label": "Gruvbox Dark",
-        "blurb": "retro warm earth",
+    "deep-black": {
+        "icon": "🌑",
+        "label": "Deep Black",
+        "blurb": "inky noir with subtle neon edge",
         "colors": [
-            "yellow",
-            "red",
-            "green",
-            "cyan",
-            "magenta",
-            "blue",
-            "bright_yellow",
-            "bright_red",
+            "#050505",
+            "#1f1f1f",
+            "#2b2b2b",
+            "#3a3a3a",
+            "#4dabf7",
+            "#b197fc",
+            "#63e6be",
+            "#ffd166",
         ],
         "content_styles": {
-            "info": "yellow",
-            "warning": "bright_yellow",
-            "success": "green",
-            "error": "bold red",
-            "debug": "dim white",
-            "diff_add": "green",
-            "diff_remove": "red",
-            "diff_context": "dim white",
+            "info": "#cfd8dc",
+            "warning": "#ffd166",
+            "success": "#96f2d7",
+            "error": "bold #ff6b6b",
+            "debug": "dim #6c757d",
+            "diff_add": "#96f2d7",
+            "diff_remove": "#ff6b6b",
+            "diff_context": "dim #adb5bd",
         },
-        "color_remap": {},
-        "terminal_palette": bp.GRUVBOX_DARK,
+        "color_remap": rt.make_remap(
+            cyan="#cfd8dc",
+            blue="#4dabf7",
+            magenta="#b197fc",
+            bright_cyan="#96f2d7",
+            bright_blue="#74c0fc",
+            bright_magenta="#d0bfff",
+        ),
+        "terminal_palette": bp.DEEP_BLACK,
     },
     # --- Light-mode themes ------------------------------------------------
     # For light themes, `debug` uses dim *black* (not white) so dim text stays
@@ -382,7 +430,7 @@ CURATED_THEMES: dict[str, dict] = {
     },
 }
 
-# The 5th option: surprise me — special case, regenerated each preview/apply.
+# The 13th option: surprise me — special case, regenerated each preview/apply.
 SURPRISE = {
     "icon": "🎲",
     "label": "Surprise Me",
@@ -393,7 +441,7 @@ SURPRISE = {
     "terminal_palette": None,  # randomized at apply time
 }
 
-# The 6th option: restore Code Puppy defaults (banners + content).
+# The 14th option: restore Code Puppy defaults (banners + content).
 DEFAULT = {
     "icon": "🔄",
     "label": "Restore Defaults",
@@ -404,16 +452,20 @@ DEFAULT = {
     "terminal_palette": None,  # handled specially (OSC reset)
 }
 
-# Ordered menu: 4 originals, 2 dark ports, 2 light themes, surprise, default.
-# (Catppuccin Mocha, Solarized Light, Rose Pine Dawn removed by request -
-# still resolvable by name as aliases for power users.)
+# Ordered menu: 5 vivid/dark themes, 7 palette-first/light themes, surprise, default.
 MENU: list[tuple[str, dict]] = [
     ("ocean", CURATED_THEMES["ocean"]),
     ("forest", CURATED_THEMES["forest"]),
     ("sunset", CURATED_THEMES["sunset"]),
     ("vaporwave", CURATED_THEMES["vaporwave"]),
+    ("bubblegum-pink", CURATED_THEMES["bubblegum-pink"]),
+    ("catppuccin-mocha", CURATED_THEMES["catppuccin-mocha"]),
     ("catppuccin-latte", CURATED_THEMES["catppuccin-latte"]),
+    ("tokyo-night", CURATED_THEMES["tokyo-night"]),
+    ("deep-black", CURATED_THEMES["deep-black"]),
+    ("solarized-light", CURATED_THEMES["solarized-light"]),
     ("github-light", CURATED_THEMES["github-light"]),
+    ("rose-pine-dawn", CURATED_THEMES["rose-pine-dawn"]),
     ("surprise", SURPRISE),
     ("default", DEFAULT),
 ]
@@ -427,7 +479,8 @@ MENU_BY_NAME["defaults"] = DEFAULT
 MENU_BY_NAME["mocha"] = CURATED_THEMES["catppuccin-mocha"]
 MENU_BY_NAME["latte"] = CURATED_THEMES["catppuccin-latte"]
 MENU_BY_NAME["tokyo"] = CURATED_THEMES["tokyo-night"]
-MENU_BY_NAME["gruvbox"] = CURATED_THEMES["gruvbox-dark"]
+MENU_BY_NAME["bubblegum"] = CURATED_THEMES["bubblegum-pink"]
+MENU_BY_NAME["pink"] = CURATED_THEMES["bubblegum-pink"]
 MENU_BY_NAME["solarized"] = CURATED_THEMES["solarized-light"]
 MENU_BY_NAME["github"] = CURATED_THEMES["github-light"]
 MENU_BY_NAME["rose-pine"] = CURATED_THEMES["rose-pine-dawn"]
@@ -586,7 +639,7 @@ def apply(
 
 
 def resolve_theme_arg(arg: str) -> str | None:
-    """Resolve '1'..'6' or a theme name to a canonical theme key.
+    """Resolve menu numbers or a theme name to a canonical theme key.
 
     Returns None if the argument is not recognized.
     """

--- a/tests/plugins/test_theme_plugin.py
+++ b/tests/plugins/test_theme_plugin.py
@@ -22,11 +22,12 @@ from code_puppy.plugins.theme.themes import (
     terminal_palette_for,
 )
 from code_puppy.plugins.theme.bundled_palettes import (
+    BUBBLEGUM_PINK,
     CATPPUCCIN_LATTE,
     CATPPUCCIN_MOCHA,
+    DEEP_BLACK,
     FOREST,
     GITHUB_LIGHT,
-    GRUVBOX_DARK,
     OCEAN,
     ROSE_PINE_DAWN,
     SOLARIZED_LIGHT,
@@ -58,25 +59,40 @@ from code_puppy.plugins.theme.osc_palette import (
 # ---------------------------------------------------------------------------
 class TestThemeCatalog:
     def test_curated_themes_count(self):
-        assert len(CURATED_THEMES) == 11
+        assert len(CURATED_THEMES) == 12
 
     def test_menu_has_expected_entries(self):
         names = [name for name, _ in MENU]
+        assert len(names) == 14
         assert "ocean" in names
         assert "forest" in names
         assert "sunset" in names
         assert "vaporwave" in names
+        assert "bubblegum-pink" in names
+        assert "catppuccin-mocha" in names
+        assert "tokyo-night" in names
+        assert "deep-black" in names
+        assert "solarized-light" in names
+        assert "github-light" in names
+        assert "rose-pine-dawn" in names
         assert "surprise" in names
         assert "default" in names
 
     def test_menu_by_index_maps_strings(self):
         assert MENU_BY_INDEX["1"] == "ocean"
+        assert MENU_BY_INDEX["5"] == "bubblegum-pink"
+        assert MENU_BY_INDEX["6"] == "catppuccin-mocha"
+        assert MENU_BY_INDEX["10"] == "solarized-light"
         assert MENU_BY_INDEX[str(len(MENU))] == "default"
 
     def test_aliases_resolve(self):
         assert MENU_BY_NAME["mocha"] is CURATED_THEMES["catppuccin-mocha"]
+        assert MENU_BY_NAME["bubblegum"] is CURATED_THEMES["bubblegum-pink"]
+        assert MENU_BY_NAME["pink"] is CURATED_THEMES["bubblegum-pink"]
         assert MENU_BY_NAME["tokyo"] is CURATED_THEMES["tokyo-night"]
-        assert MENU_BY_NAME["gruvbox"] is CURATED_THEMES["gruvbox-dark"]
+        assert MENU_BY_NAME["solarized"] is CURATED_THEMES["solarized-light"]
+        assert MENU_BY_NAME["github"] is CURATED_THEMES["github-light"]
+        assert MENU_BY_NAME["rose-pine"] is CURATED_THEMES["rose-pine-dawn"]
         assert MENU_BY_NAME["random"] is SURPRISE
         assert MENU_BY_NAME["reset"] is DEFAULT
 
@@ -155,8 +171,19 @@ class TestColorRemapFor:
         assert color_remap_for("default") == {}
 
     def test_palette_first_themes_have_empty_remap(self):
-        for name in ("mocha", "latte", "tokyo", "gruvbox"):
+        for name in (
+            "mocha",
+            "tokyo",
+            "solarized",
+            "github",
+            "rose-pine",
+        ):
             assert color_remap_for(name) == {}, name
+
+    def test_latte_has_remap_entries(self):
+        r = color_remap_for("latte")
+        assert isinstance(r, dict)
+        assert len(r) > 0
 
     def test_unknown_theme_raises(self):
         with pytest.raises(KeyError):
@@ -214,8 +241,10 @@ class TestResolveThemeArg:
 
     def test_alias_keys_are_accepted(self):
         assert resolve_theme_arg("mocha") is not None
+        assert resolve_theme_arg("bubblegum") is not None
+        assert resolve_theme_arg("pink") is not None
         assert resolve_theme_arg("tokyo") is not None
-        assert resolve_theme_arg("gruvbox") is not None
+        assert resolve_theme_arg("gruvbox") is None
 
 
 # ---------------------------------------------------------------------------
@@ -229,10 +258,11 @@ class TestBundledPalettes:
             FOREST,
             SUNSET,
             VAPORWAVE,
+            BUBBLEGUM_PINK,
             CATPPUCCIN_MOCHA,
             CATPPUCCIN_LATTE,
             TOKYO_NIGHT,
-            GRUVBOX_DARK,
+            DEEP_BLACK,
             SOLARIZED_LIGHT,
             GITHUB_LIGHT,
             ROSE_PINE_DAWN,
@@ -251,10 +281,11 @@ class TestBundledPalettes:
             FOREST,
             SUNSET,
             VAPORWAVE,
+            BUBBLEGUM_PINK,
             CATPPUCCIN_MOCHA,
             CATPPUCCIN_LATTE,
             TOKYO_NIGHT,
-            GRUVBOX_DARK,
+            DEEP_BLACK,
             SOLARIZED_LIGHT,
             GITHUB_LIGHT,
             ROSE_PINE_DAWN,


### PR DESCRIPTION
## Summary
- Added **Bubblegum Pink** to the `/theme` picker
- Added **Deep Black** and replaced **Gruvbox Dark** in the menu
- Expanded the theme catalog with **Catppuccin Mocha**, **Catppuccin Latte**, **Tokyo Night**, and **Rose Pine Dawn**
- Improved **Catppuccin Latte** with a softer pastel palette, richer ANSI mapping, and better contrast
- Added a new screenshot showcasing **Deep Black**, **Bubblegum Pink**, and **Catppuccin Latte**
- Updated `/theme` docs/help text and tests to match the new catalog

## New/updated themes
- Bubblegum Pink
- Catppuccin Mocha
- Catppuccin Latte (improved)
- Tokyo Night
- Rose Pine Dawn
- Deep Black

## Light theme improvement
- Catppuccin Latte now has a cleaner light-mode palette, stronger accent colors, and more readable content/body styling

## Notes
- Gruvbox Dark was removed from the theme menu
- Menu numbering and aliases were updated accordingly