### PR TITLE
fix: don't make a recoverable connection drop look like a crash

### DIFF
--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -105,9 +105,18 @@ _RETRYABLE_SNIPPETS = (
     "internal server error",
 )
 
+# Transient transport failures worth a silent retry rather than a crash.
+# We list the umbrella base classes instead of individual error types so a
+# dropped socket in any guise -- ReadError, WriteError, ConnectError,
+# CloseError (all httpx.NetworkError) or any of the *Timeout variants
+# (httpx.TimeoutException) -- is covered without us chasing each subclass.
+# A flaky VPN/WiFi blip mid-stream is recoverable, never fatal.
 _RETRYABLE_EXCEPTIONS: tuple = (
+    httpx.NetworkError,
+    httpx.TimeoutException,
     httpx.RemoteProtocolError,
-    httpx.ReadTimeout,
+    httpcore.NetworkError,
+    httpcore.TimeoutException,
     httpcore.RemoteProtocolError,
 )
 

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -51,6 +51,36 @@ from code_puppy.version_checker import default_version_mismatch_behavior
 plugins.load_plugin_callbacks()
 
 
+def _render_turn_exception(exc: Exception) -> None:
+    """Render a turn-level exception without ever taking down the REPL.
+
+    Transient model/connection failures (a dropped socket, a VPN/WiFi blip, a
+    provider rate limit) are environment hiccups, not Code Puppy bugs. They get
+    a friendly one-liner instead of a 60-line traceback, because a wall of
+    stack frames makes a recoverable blip look fatal. Genuine errors still get
+    the full traceback so they stay debuggable.
+
+    The transient/not-transient decision reuses the same classifier that drives
+    streaming auto-retries, so the two stay in lock-step by construction.
+    """
+    from code_puppy.agents.base_agent import should_retry_streaming_exception
+
+    if should_retry_streaming_exception(exc):
+        from code_puppy.messaging import emit_error
+
+        emit_error(
+            f"\U0001f50c The model connection hit a transient error "
+            f"({type(exc).__name__}) and didn't recover after auto-retries. "
+            "This is almost always a VPN/WiFi/provider blip \u2014 just re-run "
+            "your last prompt. Your session history is intact."
+        )
+        return
+
+    from code_puppy.messaging.queue_console import get_queue_console
+
+    get_queue_console().print_exception()
+
+
 def _resume_session_from_path(raw_path: str) -> None:
     """Restore agent message history from a saved .pkl session file.
 
@@ -853,9 +883,7 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
 
             except Exception as e:
                 turn_error = e
-                from code_puppy.messaging.queue_console import get_queue_console
-
-                get_queue_console().print_exception()
+                _render_turn_exception(e)
 
             # Auto-save session if enabled (moved outside the try block to avoid being swallowed)
             from code_puppy.config import auto_save_session_if_enabled
@@ -947,9 +975,7 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
                     break
                 except Exception as e:
                     continuation_error = e
-                    from code_puppy.messaging.queue_console import get_queue_console
-
-                    get_queue_console().print_exception()
+                    _render_turn_exception(e)
                     auto_save_session_if_enabled()
 
             # Re-disable Ctrl+C if needed (uvx mode) - must be done after

--- a/tests/agents/test_streaming_retry.py
+++ b/tests/agents/test_streaming_retry.py
@@ -87,6 +87,54 @@ class TestStreamingRetry:
         assert factory.await_count == 2
 
     @pytest.mark.asyncio
+    async def test_retries_on_httpx_read_error(self):
+        # Regression: a dropped socket mid-stream (e.g. VPN/WiFi blip) raises
+        # httpx.ReadError. It used to escape the retry classifier and crash
+        # the whole REPL. A connection-management hiccup must never be fatal.
+        factory = AsyncMock(
+            side_effect=[
+                httpx.ReadError("connection dropped mid-stream"),
+                "recovered",
+            ]
+        )
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await _run_with_streaming_retry(factory)
+
+        assert result == "recovered"
+        assert factory.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retries_on_httpx_connect_error(self):
+        factory = AsyncMock(
+            side_effect=[
+                httpx.ConnectError("failed to establish connection"),
+                "recovered",
+            ]
+        )
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await _run_with_streaming_retry(factory)
+
+        assert result == "recovered"
+        assert factory.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retries_on_httpcore_read_error(self):
+        factory = AsyncMock(
+            side_effect=[
+                httpcore.ReadError("connection dropped mid-stream"),
+                "recovered",
+            ]
+        )
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await _run_with_streaming_retry(factory)
+
+        assert result == "recovered"
+        assert factory.await_count == 2
+
+    @pytest.mark.asyncio
     async def test_retries_on_httpcore_remote_protocol_error(self):
         factory = AsyncMock(
             side_effect=[
@@ -191,7 +239,19 @@ class TestStreamingRetry:
         )
         assert should_retry_streaming_exception(httpx.ReadTimeout("timed out"))
         assert should_retry_streaming_exception(
+            httpx.ReadError("connection dropped mid-stream")
+        )
+        assert should_retry_streaming_exception(
+            httpx.ConnectError("failed to establish connection")
+        )
+        assert should_retry_streaming_exception(
+            httpx.ConnectTimeout("connect timed out")
+        )
+        assert should_retry_streaming_exception(
             httpcore.RemoteProtocolError("peer closed connection")
+        )
+        assert should_retry_streaming_exception(
+            httpcore.ReadError("connection dropped mid-stream")
         )
         assert should_retry_streaming_exception(
             UnexpectedModelBehavior("streamed response ended without content")

--- a/tests/test_cli_runner_turn_exception.py
+++ b/tests/test_cli_runner_turn_exception.py
@@ -1,0 +1,61 @@
+"""Tests for ``_render_turn_exception`` -- the REPL's turn-level error renderer.
+
+A connection-management hiccup must never look like (or behave like) a crash.
+Transient/connection errors should surface as a friendly one-liner; genuine
+bugs should still get the full, debuggable traceback. These tests pin both
+halves of that contract so we never regress back to dumping a 60-line stack
+trace for a dropped socket.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import httpcore
+import httpx
+import pytest
+
+from code_puppy.cli_runner import _render_turn_exception
+
+# Transient transport failures: friendly message, no traceback dump.
+TRANSIENT_ERRORS = [
+    httpx.ReadError("connection dropped mid-stream"),
+    httpx.ConnectError("failed to establish connection"),
+    httpx.ReadTimeout("read timed out"),
+    httpx.ConnectTimeout("connect timed out"),
+    httpx.RemoteProtocolError("peer closed connection"),
+    httpcore.ReadError("connection dropped mid-stream"),
+    httpcore.RemoteProtocolError("peer closed connection"),
+]
+
+
+@pytest.mark.parametrize("exc", TRANSIENT_ERRORS, ids=lambda e: type(e).__name__)
+def test_transient_errors_get_friendly_message_no_traceback(exc):
+    with (
+        patch("code_puppy.messaging.emit_error") as mock_emit,
+        patch(
+            "code_puppy.messaging.queue_console.get_queue_console"
+        ) as mock_console,
+    ):
+        _render_turn_exception(exc)
+
+    # Friendly message emitted, full traceback dump NOT triggered.
+    assert mock_emit.call_count == 1
+    msg = mock_emit.call_args.args[0]
+    assert type(exc).__name__ in msg
+    assert "re-run" in msg
+    mock_console.assert_not_called()
+
+
+def test_genuine_bug_gets_full_traceback():
+    fake_console = MagicMock()
+    with (
+        patch("code_puppy.messaging.emit_error") as mock_emit,
+        patch(
+            "code_puppy.messaging.queue_console.get_queue_console",
+            return_value=fake_console,
+        ),
+    ):
+        _render_turn_exception(ValueError("this is a real bug"))
+
+    # No friendly hand-waving for genuine bugs -- show the stack trace.
+    mock_emit.assert_not_called()
+    fake_console.print_exception.assert_called_once()

--- a/tests/test_cli_runner_turn_exception.py
+++ b/tests/test_cli_runner_turn_exception.py
@@ -31,9 +31,7 @@ TRANSIENT_ERRORS = [
 def test_transient_errors_get_friendly_message_no_traceback(exc):
     with (
         patch("code_puppy.messaging.emit_error") as mock_emit,
-        patch(
-            "code_puppy.messaging.queue_console.get_queue_console"
-        ) as mock_console,
+        patch("code_puppy.messaging.queue_console.get_queue_console") as mock_console,
     ):
         _render_turn_exception(exc)
 


### PR DESCRIPTION
## What

A connection dropped mid-stream (`httpx.ReadError`) escaped the streaming
retry classifier and bubbled all the way up to the interactive REPL, which
dumped a ~60-line traceback. The loop technically survived, but the wall of
stack frames made a transient VPN/WiFi blip look like a hard crash.

## Why it happened

`_RETRYABLE_EXCEPTIONS` enumerated individual transport error types:

```python
_RETRYABLE_EXCEPTIONS = (
    httpx.RemoteProtocolError,
    httpx.ReadTimeout,
    httpcore.RemoteProtocolError,
)
```

`httpx.ReadError` — the error you get when a socket dies mid-response — wasn't
in the list, so `should_retry_streaming()` returned `False` and the error
propagated instead of being retried. Classic whack-a-mole: one missing mole.

## The fix

1. **Broaden the retry net to umbrella base classes.** `httpx.NetworkError`
   is the parent of `ReadError`, `WriteError`, `ConnectError`, and
   `CloseError`; `httpx.TimeoutException` covers every `*Timeout` variant.
   Listing the bases (plus the `httpcore` twins) means *all* transient
   transport failures get the existing 3x backoff retry — no more chasing
   subclasses one funeral at a time.

2. **Stop scaring users with raw tracebacks for environment hiccups.** New
   `_render_turn_exception()` helper: transient/connection errors get a
   friendly one-liner ("connection blipped, re-run your prompt, your session
   is intact"); genuine bugs still get the full, debuggable traceback. It
   reuses the *same* retry classifier so the retry path and the render path
   can never drift out of sync (DRY).

## Tests

- Regression coverage in `test_streaming_retry.py` for `ReadError`,
  `ConnectError`, and `httpcore.ReadError` in the classifier.
- New `test_cli_runner_turn_exception.py` pins the friendly-message vs.
  full-traceback behavior of `_render_turn_exception`.
- 43 new/related tests pass; existing `cli_runner` suites (45) stay green.

## Behavior change

- Before: dropped socket → traceback dump that looks like a crash.
- After: dropped socket → silently retried 3x; if it still can't recover,
  a single friendly line, REPL keeps going.
