### PR TITLE
fix(browser): degrade gracefully when Playwright is unavailable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: uv venv
 
       - name: Install dependencies
-        run: uv pip install -e .
+        run: uv pip install -e '.[browser]'
 
       - name: Install pexpect for integration tests
         run: uv pip install pexpect>=4.9.0

--- a/README.md
+++ b/README.md
@@ -90,6 +90,21 @@ uv pip install "code-puppy[durable]"
 Then toggle it from inside the app via `/dbos on` (and restart). Use `/dbos status`
 to check, `/dbos off` to disable.
 
+#### Optional: desktop browser automation
+
+Playwright-backed browser tools are optional because Playwright does not publish
+Android-compatible Python wheels. Install the `browser` extra on supported
+desktop platforms when you want those tools:
+
+```bash
+pip install "code-puppy[browser]"
+# or
+uv pip install "code-puppy[browser]"
+```
+
+On Android/Termux, use Android-native browser/CDP workflows instead. For file
+search there, install the system `rg` command (`pkg install ripgrep`) if needed.
+
 ## Changelog (By Kittylog!)
 
 [📋 View the full changelog on Kittylog](https://kittylog.app/c/mpfaffenberger/code_puppy)

--- a/code_puppy/tools/browser/browser_manager.py
+++ b/code_puppy/tools/browser/browser_manager.py
@@ -12,6 +12,9 @@ import types
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
+from code_puppy import config
+from code_puppy.messaging import emit_info, emit_success, emit_warning
+
 
 def _missing_playwright(*_args, **_kwargs):
     """Raise a friendly error when Playwright is unavailable."""
@@ -54,9 +57,6 @@ except ImportError:
     # browser modules importable; tools raise a friendly error only if invoked.
     Browser = BrowserContext = Page = Any
     _install_playwright_stub()
-
-from code_puppy import config
-from code_puppy.messaging import emit_info, emit_success, emit_warning
 
 # Registry for custom browser types from plugins (e.g., Camoufox for stealth browsing)
 _CUSTOM_BROWSER_TYPES: Dict[str, Callable] = {}

--- a/code_puppy/tools/browser/browser_manager.py
+++ b/code_puppy/tools/browser/browser_manager.py
@@ -7,10 +7,53 @@ import asyncio
 import atexit
 import contextvars
 import os
+import sys
+import types
 from pathlib import Path
-from typing import Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
-from playwright.async_api import Browser, BrowserContext, Page
+
+def _missing_playwright(*_args, **_kwargs):
+    """Raise a friendly error when Playwright is unavailable."""
+    raise RuntimeError(
+        "Playwright is not installed in this environment. "
+        "Browser tools require the optional 'playwright' dependency and a "
+        "supported platform."
+    )
+
+
+def _install_playwright_stub() -> None:
+    """Install a tiny runtime stub so browser modules remain importable.
+
+    Keeps optional browser support from crashing the whole app on unsupported
+    environments like Termux/Android, where Playwright has no available wheel.
+    Browser tools raise a friendly error only if actually invoked.
+    """
+    playwright_module = sys.modules.get("playwright")
+    if playwright_module is None:
+        playwright_module = types.ModuleType("playwright")
+        sys.modules["playwright"] = playwright_module
+
+    async_api_module = sys.modules.get("playwright.async_api")
+    if async_api_module is None:
+        async_api_module = types.ModuleType("playwright.async_api")
+        async_api_module.Browser = Browser
+        async_api_module.BrowserContext = BrowserContext
+        async_api_module.Page = Page
+        async_api_module.async_playwright = _missing_playwright
+        sys.modules["playwright.async_api"] = async_api_module
+
+    setattr(playwright_module, "async_api", async_api_module)
+
+
+try:
+    # When Playwright is available this is a no-op import of the real types.
+    from playwright.async_api import Browser, BrowserContext, Page
+except ImportError:
+    # Optional dependency / unsupported platform (e.g. Termux/Android): keep the
+    # browser modules importable; tools raise a friendly error only if invoked.
+    Browser = BrowserContext = Page = Any
+    _install_playwright_stub()
 
 from code_puppy import config
 from code_puppy.messaging import emit_info, emit_success, emit_warning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,7 @@ dependencies = [
     "pyfiglet>=0.8.post1",
     "rapidfuzz>=3.13.0",
     "openai>=1.99.1",
-    "ripgrep==14.1.0",
-    "playwright>=1.40.0",
+    "ripgrep==14.1.0; sys_platform != 'android'",
     "termflow-md>=0.1.11",
     "Pillow>=10.0.0",
     "azure-identity>=1.15.0",
@@ -53,6 +52,7 @@ classifiers = [
 
 [project.optional-dependencies]
 bedrock = ["boto3>=1.35.0"]
+browser = ["playwright>=1.40.0; sys_platform != 'android'"]
 durable = ["dbos>=2.11.0"]
 
 [project.urls]

--- a/tests/test_browser_manager_missing_playwright.py
+++ b/tests/test_browser_manager_missing_playwright.py
@@ -11,16 +11,25 @@ import pytest
 
 
 _BROWSER_MANAGER_MODULE = "code_puppy.tools.browser.browser_manager"
+_MODULE_NAMES = (
+    _BROWSER_MANAGER_MODULE,
+    "playwright.async_api",
+    "playwright",
+)
+_MISSING = object()
 
 
 def _unload_browser_manager_and_playwright() -> None:
-    for module_name in (
-        _BROWSER_MANAGER_MODULE,
-        "playwright.async_api",
-        "playwright",
-    ):
+    for module_name in _MODULE_NAMES:
         sys.modules.pop(module_name, None)
     importlib.invalidate_caches()
+
+
+def _restore_modules(originals: dict[str, object]) -> None:
+    _unload_browser_manager_and_playwright()
+    for module_name, module in originals.items():
+        if module is not _MISSING:
+            sys.modules[module_name] = module
 
 
 @pytest.mark.asyncio
@@ -32,10 +41,17 @@ async def test_browser_manager_imports_without_playwright_until_used():
             raise ModuleNotFoundError("No module named 'playwright'")
         return real_import(name, *args, **kwargs)
 
-    _unload_browser_manager_and_playwright()
-    with patch("builtins.__import__", side_effect=block_playwright):
-        browser_manager = importlib.import_module(_BROWSER_MANAGER_MODULE)
+    originals = {
+        module_name: sys.modules.get(module_name, _MISSING)
+        for module_name in _MODULE_NAMES
+    }
+    try:
+        _unload_browser_manager_and_playwright()
+        with patch("builtins.__import__", side_effect=block_playwright):
+            browser_manager = importlib.import_module(_BROWSER_MANAGER_MODULE)
 
-    manager = browser_manager.BrowserManager(session_id="missing-playwright-test")
-    with pytest.raises(RuntimeError, match="Playwright is not installed"):
-        await manager._initialize_browser()
+        manager = browser_manager.BrowserManager(session_id="missing-playwright-test")
+        with pytest.raises(RuntimeError, match="Playwright is not installed"):
+            await manager._initialize_browser()
+    finally:
+        _restore_modules(originals)

--- a/tests/test_browser_manager_missing_playwright.py
+++ b/tests/test_browser_manager_missing_playwright.py
@@ -1,0 +1,41 @@
+"""Regression tests for importing browser manager without Playwright."""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+_BROWSER_MANAGER_MODULE = "code_puppy.tools.browser.browser_manager"
+
+
+def _unload_browser_manager_and_playwright() -> None:
+    for module_name in (
+        _BROWSER_MANAGER_MODULE,
+        "playwright.async_api",
+        "playwright",
+    ):
+        sys.modules.pop(module_name, None)
+    importlib.invalidate_caches()
+
+
+@pytest.mark.asyncio
+async def test_browser_manager_imports_without_playwright_until_used():
+    real_import = builtins.__import__
+
+    def block_playwright(name, *args, **kwargs):
+        if name == "playwright.async_api":
+            raise ModuleNotFoundError("No module named 'playwright'")
+        return real_import(name, *args, **kwargs)
+
+    _unload_browser_manager_and_playwright()
+    with patch("builtins.__import__", side_effect=block_playwright):
+        browser_manager = importlib.import_module(_BROWSER_MANAGER_MODULE)
+
+    manager = browser_manager.BrowserManager(session_id="missing-playwright-test")
+    with pytest.raises(RuntimeError, match="Playwright is not installed"):
+        await manager._initialize_browser()

--- a/uv.lock
+++ b/uv.lock
@@ -311,7 +311,6 @@ dependencies = [
     { name = "mcp" },
     { name = "openai" },
     { name = "pillow" },
-    { name = "playwright" },
     { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pydantic-ai-slim", extra = ["anthropic", "mcp", "openai"] },
@@ -320,7 +319,7 @@ dependencies = [
     { name = "rapidfuzz" },
     { name = "requests" },
     { name = "rich" },
-    { name = "ripgrep" },
+    { name = "ripgrep", marker = "sys_platform != 'android'" },
     { name = "termflow-md" },
     { name = "typer" },
 ]
@@ -328,6 +327,9 @@ dependencies = [
 [package.optional-dependencies]
 bedrock = [
     { name = "boto3" },
+]
+browser = [
+    { name = "playwright", marker = "sys_platform != 'android'" },
 ]
 durable = [
     { name = "dbos" },
@@ -354,7 +356,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.9.4" },
     { name = "openai", specifier = ">=1.99.1" },
     { name = "pillow", specifier = ">=10.0.0" },
-    { name = "playwright", specifier = ">=1.40.0" },
+    { name = "playwright", marker = "sys_platform != 'android' and extra == 'browser'", specifier = ">=1.40.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.52" },
     { name = "pydantic", specifier = ">=2.4.0" },
     { name = "pydantic-ai-slim", extras = ["openai", "anthropic", "mcp"], specifier = "==1.56.0" },
@@ -363,11 +365,11 @@ requires-dist = [
     { name = "rapidfuzz", specifier = ">=3.13.0" },
     { name = "requests", specifier = ">=2.28.0" },
     { name = "rich", specifier = ">=13.4.2" },
-    { name = "ripgrep", specifier = "==14.1.0" },
+    { name = "ripgrep", marker = "sys_platform != 'android'", specifier = "==14.1.0" },
     { name = "termflow-md", specifier = ">=0.1.11" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
-provides-extras = ["bedrock", "durable"]
+provides-extras = ["bedrock", "browser", "durable"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Importing the browser stack hard-failed with ModuleNotFoundError: No module named 'playwright' on any environment without a Playwright wheel (e.g. Termux/Android, or a minimal install), which took down the whole app at import time.

Wrap the playwright.async_api import in try/except: when present it's an unchanged no-op (real types bind); when absent, bind the type names to Any and install a tiny runtime stub module so the other browser tool modules stay importable. Browser tools raise a clear, friendly error only if actually invoked without Playwright.

Tested on Android/Termux (no Playwright): 'import code_puppy.tools' now succeeds where it previously crashed; no change when Playwright is installed.