### PR TITLE
fix(clipboard): neutralize termflow OSC 52 clipboard hijacking at the source

### DIFF
--- a/code_puppy/pydantic_patches.py
+++ b/code_puppy/pydantic_patches.py
@@ -1,7 +1,8 @@
-"""Monkey patches for pydantic-ai.
+"""Monkey patches for third-party libraries.
 
-This module contains all monkey patches needed to customize pydantic-ai behavior.
-These patches MUST be applied before any other pydantic-ai imports to work correctly.
+Historically pydantic-ai focused, this module now collects all runtime
+monkey patches code-puppy applies to its dependencies.  Each patch is
+idempotent and fails silently if the target library is absent.
 
 Usage:
     from code_puppy.pydantic_patches import apply_all_patches
@@ -502,8 +503,34 @@ def patch_prompt_toolkit_emoji_width() -> None:
         pass  # Don't crash on patch failure
 
 
+def patch_termflow_clipboard() -> None:
+    """Disable termflow's OSC 52 clipboard hijacking globally.
+
+    termflow's ``RenderFeatures.clipboard`` defaults to ``True``.  When a
+    code block finishes rendering, the renderer emits an OSC 52 escape
+    sequence (``\x1b]52;c;<base64>\x07``) that modern terminals interpret
+    as a silent clipboard-write command — clobbering whatever the user had.
+
+    PR #335 added explicit ``RenderFeatures(clipboard=False)`` at the two
+    known instantiation sites, but that's whack-a-mole: any future code path
+    (or a new termflow version with changed defaults) reintroduces the bug.
+
+    This patch kills the behaviour at the source by replacing
+    ``Renderer._copy_to_clipboard`` with a no-op, so it does not matter
+    whether any caller remembers to disable the feature flag.
+    """
+    try:
+        from termflow.render.renderer import Renderer
+
+        Renderer._copy_to_clipboard = lambda self, text: None  # type: ignore[method-assign]
+    except ImportError:
+        pass  # termflow not available
+    except Exception:
+        pass  # never crash on patch failure
+
+
 def apply_all_patches() -> None:
-    """Apply all pydantic-ai monkey patches.
+    """Apply all monkey patches.
 
     Call this at the very top of main.py, before any other imports.
     """
@@ -513,3 +540,4 @@ def apply_all_patches() -> None:
     patch_tool_call_json_repair()
     patch_tool_call_callbacks()
     patch_prompt_toolkit_emoji_width()
+    patch_termflow_clipboard()

--- a/tests/test_pydantic_patches_full_coverage.py
+++ b/tests/test_pydantic_patches_full_coverage.py
@@ -211,6 +211,70 @@ class TestWritebackToolArgs:
         assert json.loads(call.args) == {"content": "clean ascii"}
 
 
+class TestPatchTermflowClipboard:
+    """Regression guard: termflow must NEVER write to the system clipboard.
+
+    termflow's ``RenderFeatures.clipboard`` defaults to ``True``, which emits
+    OSC 52 escape sequences on every rendered code block — silently clobbering
+    the user's clipboard.  The patch replaces ``Renderer._copy_to_clipboard``
+    with a no-op so this can never happen, regardless of per-call feature flags.
+    """
+
+    def test_copy_to_clipboard_is_noop(self):
+        import io
+
+        from code_puppy.pydantic_patches import patch_termflow_clipboard
+
+        patch_termflow_clipboard()
+        from termflow.render.renderer import Renderer
+
+        buf = io.StringIO()
+        renderer = Renderer(output=buf, width=80)
+        renderer._copy_to_clipboard("secret clipboard payload")
+        assert buf.getvalue() == "", "_copy_to_clipboard must not write anything"
+
+    def test_code_block_render_emits_no_osc52(self):
+        """End-to-end: rendering a code block must not produce an OSC 52 seq."""
+        import io
+
+        from code_puppy.pydantic_patches import patch_termflow_clipboard
+
+        patch_termflow_clipboard()
+        from termflow import Parser as TermflowParser
+        from termflow import Renderer as TermflowRenderer
+        from termflow.render.style import RenderFeatures
+
+        # Even with clipboard=True explicitly, the patch must prevent writes.
+        buf = io.StringIO()
+        renderer = TermflowRenderer(
+            output=buf, width=80, features=RenderFeatures(clipboard=True)
+        )
+        parser = TermflowParser()
+        for line in ["```python", "print('hello')", "```"]:
+            for event in parser.parse_line(line):
+                renderer.render(event)
+        for event in parser.finalize():
+            renderer.render(event)
+        assert "\x1b]52" not in buf.getvalue(), (
+            "OSC 52 clipboard sequence leaked into output!"
+        )
+
+    def test_patch_does_not_crash_without_termflow(self):
+        import builtins
+
+        from code_puppy.pydantic_patches import patch_termflow_clipboard
+
+        _real_import = builtins.__import__
+
+        def _block_termflow(name, *args, **kwargs):
+            if name.startswith("termflow"):
+                raise ImportError("simulated: termflow not installed")
+            return _real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=_block_termflow):
+            patch_termflow_clipboard()  # must not raise
+
+
 class TestApplyAllPatches:
     def test_apply_all_patches(self):
         from code_puppy.pydantic_patches import apply_all_patches


### PR DESCRIPTION
## Problem

termflow's `RenderFeatures.clipboard` defaults to `True`. When the renderer
finishes a code block, it emits an **OSC 52 escape sequence**
(`\x1b]52;c;<base64>\x07`) that modern terminals (iTerm2, Kitty, Alacritty,
WezTerm, tmux) silently interpret as a clipboard-write command — clobbering
whatever the user had copied, with no prompt or consent.

PR #335 added explicit `RenderFeatures(clipboard=False)` at the two known
`TermflowRenderer` instantiation sites, but this is whack-a-mole: any future
code path, a new termflow version with changed defaults, or a missed
instantiation site reintroduces the bug.

## Fix

Added `patch_termflow_clipboard()` to `pydantic_patches.py`. It replaces
`termflow.render.renderer.Renderer._copy_to_clipboard` with a no-op at
startup (via the existing `apply_all_patches()` call in `cli_runner.py`).

This kills the behaviour at the source regardless of:
- Per-call `RenderFeatures(clipboard=...)` flags
- termflow config files (`~/.config/termflow/config.toml`)
- Future instantiation sites that forget the flag
- New termflow versions that change defaults

The existing per-site `clipboard=False` flags are left in place as
defense-in-depth and for documentation value.

## Testing

- `test_copy_to_clipboard_is_noop` — confirms the patched method writes nothing
- `test_code_block_render_emits_no_osc52` — end-to-end: renders a code block
  with `clipboard=True` and asserts no `\x1b]52` sequence leaks into output
- `test_patch_does_not_crash_without_termflow` — verifies graceful failure if
  termflow is not installed

All 26 tests in `test_pydantic_patches_full_coverage.py` pass.

## Files Changed

| File | Change |
|------|--------|
| `code_puppy/pydantic_patches.py` | +`patch_termflow_clipboard()` no-op patch, registered in `apply_all_patches()` |
| `tests/test_pydantic_patches_full_coverage.py` | +`TestPatchTermflowClipboard` class with 3 regression tests |
