### PR TITLE
feat(plugin): sub-agent (Invoke Agent) CLI panel

### DIFF
--- a/code_puppy/agents/_run_signals.py
+++ b/code_puppy/agents/_run_signals.py
@@ -19,12 +19,21 @@ def make_schedule_cancel(
     agent_task: "asyncio.Task[Any]",
     loop: asyncio.AbstractEventLoop,
 ) -> Callable[[], None]:
-    """Build the ``schedule_agent_cancel`` callback for the key listener."""
+    """Build the ``schedule_agent_cancel`` callback for the key listener.
 
-    def schedule_agent_cancel() -> None:
+    The returned callback accepts ``force``: when ``True`` it skips the
+    "refuse to cancel while a shell is running" guard. The shell SIGINT
+    handler uses ``force=True`` because it kills all shells *before*
+    requesting the cancel, so the guard's anti-orphan rationale no longer
+    applies -- and during a sub-agent swarm shells are almost always
+    running, so without the bypass a single Ctrl+C could never stop the
+    swarm (it would only ever kill the current batch of shells).
+    """
+
+    def schedule_agent_cancel(force: bool = False) -> None:
         from code_puppy.tools.command_runner import _RUNNING_PROCESSES
 
-        if _RUNNING_PROCESSES:
+        if _RUNNING_PROCESSES and not force:
             emit_warning(
                 "Refusing to cancel Agent while a shell command is running — "
                 "press Ctrl+X to cancel the shell command."
@@ -33,6 +42,12 @@ def make_schedule_cancel(
         if agent_task.done():
             return
         if _active_subagent_tasks:
+            # Hide the sub-agent status panel (rendered inside the spinner's
+            # Live) the same way the steer flow does, so the cancel banner
+            # isn't instantly repainted over. Mirrors _shell_sigint_handler.
+            from code_puppy.tools.command_runner import _tear_down_live_panels
+
+            _tear_down_live_panels()
             emit_warning(
                 f"Cancelling {len(_active_subagent_tasks)} active subagent task(s)..."
             )

--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -577,6 +577,14 @@ async def run_with_mcp(
     schedule_agent_cancel = make_schedule_cancel(agent_task, loop)
     schedule_agent_pause = make_schedule_pause(agent_task, loop)
 
+    # Bridge the cancel callback to the shell SIGINT handler so a single
+    # Ctrl+C while shells are running stops the whole agent/sub-agent swarm
+    # (kill shells, then cancel every task) instead of only killing the
+    # current batch of shells.
+    from code_puppy.tools import command_runner as _command_runner
+
+    _command_runner.register_agent_cancel(schedule_agent_cancel)
+
     def keyboard_interrupt_handler(_sig, _frame):
         # Let input() handle its own KeyboardInterrupt if we're mid-prompt.
         if is_awaiting_user_input():
@@ -646,6 +654,12 @@ async def run_with_mcp(
         run_error = e
         raise
     finally:
+        try:
+            from code_puppy.tools import command_runner as _command_runner
+
+            _command_runner.clear_agent_cancel()
+        except Exception:
+            pass
         try:
             await on_agent_run_end(
                 agent_name=agent.name,

--- a/code_puppy/command_line/clipboard.py
+++ b/code_puppy/command_line/clipboard.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import threading
 import time
+from pathlib import Path
 from typing import Optional
 
 # Try to import PIL - it's optional but needed for clipboard image support
@@ -46,7 +47,9 @@ MAX_IMAGE_DIMENSION = 4096  # Max width/height for resize
 MAX_PENDING_IMAGES = (
     10  # SEC-CLIP-001: Limit pending images to prevent memory exhaustion
 )
+MAX_IMAGE_FILE_SIZE_BYTES = 50 * 1024 * 1024  # Local image files only
 CLIPBOARD_RATE_LIMIT_SECONDS: float = 0.5  # SEC-CLIP-004: Max 2 captures per second
+_IMAGE_FILE_SUFFIXES = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp"}
 
 # Rate limiting state
 _last_clipboard_capture: float = 0.0
@@ -216,6 +219,54 @@ def _resize_image_if_needed(image: "Image.Image", max_bytes: int) -> "Image.Imag
     return resized
 
 
+def _image_to_png_bytes(image: "Image.Image") -> Optional[bytes]:
+    """Normalize a PIL image and return PNG bytes within configured limits."""
+    if Image is None:
+        return None
+    if image.mode in ("RGBA", "LA") or (
+        image.mode == "P" and "transparency" in image.info
+    ):
+        pass
+    elif image.mode != "RGB":
+        image = image.convert("RGB")
+
+    image = _resize_image_if_needed(image, MAX_IMAGE_SIZE_BYTES)
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG", optimize=True)
+    image_bytes = buffer.getvalue()
+    logger.info(f"Clipboard image size: {len(image_bytes) / 1024:.1f}KB")
+    return image_bytes
+
+
+def get_image_file_as_png(file_path: str) -> Optional[bytes]:
+    """Read a local image file and normalize it to PNG bytes safely."""
+    if not PIL_AVAILABLE:
+        return None
+    try:
+        path = Path(file_path).expanduser()
+        if not path.is_file() or path.suffix.lower() not in _IMAGE_FILE_SUFFIXES:
+            return None
+        if path.stat().st_size > MAX_IMAGE_FILE_SIZE_BYTES:
+            logger.warning(f"Rejected oversized image file: {path}")
+            return None
+        image = _safe_open_image(path.read_bytes())
+        return None if image is None else _image_to_png_bytes(image)
+    except Exception as e:
+        logger.debug(f"Failed to read pasted image file {file_path!r}: {e}")
+        return None
+
+
+def _image_file_list_to_png_bytes(value) -> Optional[bytes]:
+    if not isinstance(value, (list, tuple)):
+        return None
+    for item in value:
+        if isinstance(item, str):
+            image_bytes = get_image_file_as_png(item)
+            if image_bytes is not None:
+                return image_bytes
+    return None
+
+
 def has_image_in_clipboard() -> bool:
     """Check if clipboard contains an image.
 
@@ -331,32 +382,14 @@ def get_clipboard_image() -> Optional[bytes]:
             return None
 
         if not isinstance(image, Image.Image):
-            # Could be a list of file paths on some systems
+            image_bytes = _image_file_list_to_png_bytes(image)
+            if image_bytes is not None:
+                return image_bytes
             logger.debug(f"Clipboard contains non-image data: {type(image)}")
             return None
 
-        # Log original dimensions
         logger.info(f"Captured clipboard image: {image.width}x{image.height}")
-
-        # Convert to RGB if necessary (handles RGBA, P mode, etc.)
-        if image.mode in ("RGBA", "LA") or (
-            image.mode == "P" and "transparency" in image.info
-        ):
-            # Keep alpha channel for PNG
-            pass
-        elif image.mode != "RGB":
-            image = image.convert("RGB")
-
-        # Resize if needed
-        image = _resize_image_if_needed(image, MAX_IMAGE_SIZE_BYTES)
-
-        # Convert to PNG bytes
-        buffer = io.BytesIO()
-        image.save(buffer, format="PNG", optimize=True)
-        image_bytes = buffer.getvalue()
-
-        logger.info(f"Clipboard image size: {len(image_bytes) / 1024:.1f}KB")
-        return image_bytes
+        return _image_to_png_bytes(image)
 
     except Exception as e:
         logger.warning(f"Error reading clipboard image: {e}")

--- a/code_puppy/messaging/spinner/console_spinner.py
+++ b/code_puppy/messaging/spinner/console_spinner.py
@@ -158,16 +158,24 @@ class ConsoleSpinner(SpinnerBase):
                 awaiting_input = is_awaiting_user_input()
                 agent_paused = get_pause_controller().is_paused()
 
-                # Update the live display only if not paused and not awaiting input
+                # Update the live display only if not paused and not awaiting input.
+                # Snapshot _live locally: pause()/stop() can set self._live = None
+                # from another thread between the guard and the refresh call.
+                live = self._live
                 if (
-                    self._live
+                    live is not None
                     and not self._paused
                     and not awaiting_input
                     and not agent_paused
                 ):
-                    # Manually refresh instead of auto-refresh to avoid wiping input
-                    self._live.update(self._generate_spinner_panel())
-                    self._live.refresh()
+                    # Manually refresh instead of auto-refresh to avoid wiping input.
+                    # If this Live is torn down mid-frame, skip this one frame
+                    # instead of poisoning the spinner thread for the whole session.
+                    try:
+                        live.update(self._generate_spinner_panel())
+                        live.refresh()
+                    except Exception:
+                        pass
 
                 # Short sleep to control animation speed
                 time.sleep(0.05)
@@ -182,17 +190,30 @@ class ConsoleSpinner(SpinnerBase):
         """Pause the spinner animation."""
         if self._is_spinning:
             self._paused = True
-            # Stop the live display completely to restore terminal echo during input
-            if self._live:
+            # Stop the live display completely to restore terminal echo during input.
+            # Clear _live before stopping so racing refresh threads see None instead
+            # of a Live that is midway through teardown.
+            live = self._live
+            self._live = None
+            if live:
                 try:
-                    self._live.stop()
-                    self._live = None
-                    # Clear the line to remove any artifacts
+                    live.stop()
+                except Exception:
+                    pass
+                try:
+                    # Clear the line to remove any artifacts. Only emit raw
+                    # ANSI when stdout is a real terminal: on redirected output
+                    # (CI logs, pipes) or a legacy non-VT Windows console the
+                    # escape would render as literal "←[K" garbage. This pause
+                    # path now fires on every Ctrl+C swarm-cancel via
+                    # _tear_down_live_panels, so guard it. On a macOS TTY
+                    # isatty() is True -> behavior is unchanged.
                     import sys
 
-                    sys.stdout.write("\r")  # Return to start of line
-                    sys.stdout.write("\x1b[K")  # Clear to end of line
-                    sys.stdout.flush()
+                    if sys.stdout.isatty():
+                        sys.stdout.write("\r")  # Return to start of line
+                        sys.stdout.write("\x1b[K")  # Clear to end of line
+                        sys.stdout.flush()
                 except Exception:
                     pass
 
@@ -216,12 +237,15 @@ class ConsoleSpinner(SpinnerBase):
             # Restart the live display if it was stopped during pause
             if not self._live:
                 try:
-                    # Clear any leftover artifacts before starting
+                    # Clear any leftover artifacts before starting. Same
+                    # isatty() guard as pause() so redirected/non-VT consoles
+                    # don't get literal escape garbage; macOS TTY is unchanged.
                     import sys
 
-                    sys.stdout.write("\r")  # Return to start of line
-                    sys.stdout.write("\x1b[K")  # Clear to end of line
-                    sys.stdout.flush()
+                    if sys.stdout.isatty():
+                        sys.stdout.write("\r")  # Return to start of line
+                        sys.stdout.write("\x1b[K")  # Clear to end of line
+                        sys.stdout.flush()
 
                     # Print blank line before spinner for visual separation
                     self.console.print()

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -71,6 +71,7 @@ def _build_anthropic_beta_header(
     Combines beta flags based on model capabilities:
     - interleaved-thinking-2025-05-14  (when interleaved_thinking is enabled)
     - context-1m-2025-08-07            (when context_length >= 1_000_000)
+    - advisor-tool-2026-03-01          (when advisor_tool_enabled is True)
 
     Returns None if no beta flags are needed.
     """
@@ -79,6 +80,10 @@ def _build_anthropic_beta_header(
         parts.append("interleaved-thinking-2025-05-14")
     if model_config.get("context_length", 0) >= 1_000_000:
         parts.append(CONTEXT_1M_BETA)
+    # Dormant opt-in: no models.json entry sets ``advisor_tool_enabled`` yet,
+    # so this beta stays inert until a model config explicitly turns it on.
+    if model_config.get("advisor_tool_enabled"):
+        parts.append("advisor-tool-2026-03-01")
     return ",".join(parts) if parts else None
 
 

--- a/code_puppy/plugins/__init__.py
+++ b/code_puppy/plugins/__init__.py
@@ -106,7 +106,7 @@ def _load_user_plugins(
     Returns list of successfully loaded plugin names.
     """
     loaded = []
-    skip_names = skip_names or set()
+    skip_names = set(skip_names or ())
 
     if not user_plugins_dir.exists():
         return loaded
@@ -130,8 +130,9 @@ def _load_user_plugins(
 
             if plugin_name in skip_names:
                 logger.info(
-                    f"Skipping user plugin '{plugin_name}' — "
-                    f"overridden by project plugin of the same name"
+                    "Skipping user plugin '%s' because a higher-precedence "
+                    "plugin with the same name is already loaded or scheduled",
+                    plugin_name,
                 )
                 continue
 
@@ -423,7 +424,8 @@ def load_plugin_callbacks() -> dict[str, list[str]]:
     )
 
     builtin_loaded = _load_builtin_plugins(plugins_dir)
-    user_loaded = _load_user_plugins(USER_PLUGINS_DIR, skip_names=project_plugin_names)
+    user_skip_names = set(builtin_loaded) | project_plugin_names
+    user_loaded = _load_user_plugins(USER_PLUGINS_DIR, skip_names=user_skip_names)
 
     # Load project plugins last (highest precedence)
     project_loaded = []

--- a/code_puppy/plugins/subagent_panel/README.md
+++ b/code_puppy/plugins/subagent_panel/README.md
@@ -1,0 +1,100 @@
+# subagent_panel
+
+A live, two-line status block for each running sub-agent, painted just above the
+bouncing puppy:
+
+```
+  INVOKE AGENT  pup-ticket-investigator  claude-4-8-opus
+  (spin) 00:19  calling read_file
+  INVOKE AGENT  pup-analysis-adjudicator
+  (spin) 00:25  calling grep
+
+Milo is thinking... (  o  )
+```
+
+- Line 1 is the `INVOKE AGENT` banner (same color/styling as core).
+- Line 2 is a single-char animated spinner + `mm:ss` elapsed + the current
+  activity, color-coded: **yellow** = calling a tool, **magenta** = thinking,
+  **green** = writing the response.
+- Parallel sub-agents stack, each with its own block. Beyond `MAX_ROWS` the
+  extras collapse to a `(+N more)` line.
+- **Nested sub-agents render as a true tree.** A sub-agent that itself calls
+  `invoke_agent` is shown indented under its parent. Only top-level (depth-0)
+  agents get the full two-line `INVOKE AGENT` banner; deeper agents collapse to
+  a compact one-liner -- `<elbow> name  mm:ss  purpose  model` -- so the banner
+  text + model label aren't repeated at every level:
+
+  ```
+    INVOKE AGENT  regression-runner  gpt-5.5
+    (spin) 00:12  calling invoke_agent
+    \u2514\u2500 pup-ticket-investigator  00:12  calling read_file  claude-4-8-opus
+       \u2514\u2500 deep-helper  00:12  thinking...  gpt-5.5-mini
+  ```
+
+  The parent link is captured at emit time from an async-safe `ContextVar`
+  (`_PARENT_SID`), NOT the bus's single global `_current_session_id`. The
+  global is shared across all asyncio tasks, so two `invoke_agent` calls running
+  concurrently would clobber it and mis-parent one root under the other (a bogus
+  deep chain). A `ContextVar` is copied into each task at `create_task` time, so
+  concurrent siblings each see their own correct parent -- see
+  `_install_parent_tracking` (mirrors `set_session_context`) + `_install_emit_hook`.
+- **On completion** the block doesn't just vanish: a persistent frozen record
+  is printed to the transcript mirroring the live look, with line 2 finalized
+  as a green check + `mm:ss completed`:
+
+  ```
+    INVOKE AGENT  pup-ticket-investigator  claude-4-8-opus
+    (check) 00:45  completed
+  ```
+
+  (The redundant core "<check> <name> completed successfully" line is suppressed.)
+  Nested agents get a compact one-liner frozen record instead of the full block:
+  `<elbow> name  (check) mm:ss  completed  model`.
+
+## How it works (3 monkeypatches, 1 callback -- no core edits)
+
+The puppy spinner already runs a Rich `Live` that repaints ~20x/second. Rather
+than spin up a second `Live` (which fights the puppy's -- the reason the
+built-in `SubAgentConsoleManager` is dead code), this plugin reuses it:
+
+1. **`ConsoleSpinner._generate_spinner_panel`** -> returns
+   `Group(status block..., "", puppy)` so the existing loop renders everything.
+2. **`RichConsoleRenderer._render_subagent_invocation`** -> *captures* the exact
+   metadata (name / session_type / model / **session_id**) and *suppresses* the
+   permanent banner. The live block now owns the banner, so there's no
+   duplicate, and registration is exact even for parallel sub-agents (no
+   session-id guessing).
+3. **`RichConsoleRenderer._do_render`** -> when the `SubAgentResponseMessage`
+   arrives (core skips it), print the persistent frozen two-line record + pop
+   the live row, and suppress the redundant completion-text line.
+
+Status text is fed by the **`stream_event`** callback, keyed by `session_id`.
+`record_event` is *update-only*: an event for an unregistered session is ignored,
+which cleanly filters out the main agent's own stream events. `coalesce_patch.py`
+batches sub-agent stream-event callbacks (~50ms) so parallel token streams do
+not starve the steer overlay's event-loop continuations.
+
+## Config
+
+Runtime toggle:
+
+```text
+/set subagent_panel off
+/set subagent_panel on
+```
+
+Environment startup hard-disable:
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| DISABLE_SUBAGENT_PANEL | unset | Set 1 to skip registration entirely |
+| SUBAGENT_PANEL | 1 | Set 0 to skip registration entirely |
+| SUBAGENT_PANEL_MAX_ROWS | 24 | Max sub-agent blocks shown |
+| SUBAGENT_PANEL_IDLE_S | 600 | Prune after this many idle seconds (safety net) |
+
+## Notes
+
+- Installs wrappers at **startup**, but `/set subagent_panel off` makes them pass through live.
+- The permanent invocation banner (with Prompt/Session) is intentionally
+  replaced by the transient live block; on completion a compact frozen
+  two-line record (banner + green check) is left in the transcript.

--- a/code_puppy/plugins/subagent_panel/__init__.py
+++ b/code_puppy/plugins/subagent_panel/__init__.py
@@ -1,0 +1,24 @@
+"""subagent_panel -- live two-line status per sub-agent above the puppy.
+
+Renders, inside the puppy spinner's own Rich Live region, a block per active
+sub-agent::
+
+      INVOKE AGENT <name>  <model>
+       <spin> 00:19  calling read_file
+
+    <bouncing puppy>
+
+Line 1 is the INVOKE AGENT banner (core styling); line 2 is a single-char
+animated spinner + mm:ss elapsed + a color-coded status (yellow=calling,
+magenta=thinking, green=writing). Parallel sub-agents stack.
+
+It reuses the puppy spinner's existing Rich ``Live`` (a monkeypatch of
+``_generate_spinner_panel``) rather than a second ``Live`` -- two Live displays
+on one console fight each other (which is why the built-in, fully-built but
+never-wired ``SubAgentConsoleManager`` was dead code). Exact per-agent metadata
+is captured by monkeypatching ``_render_subagent_invocation`` (which also
+suppresses the now-redundant permanent banner). On completion, ``_do_render``
+is wrapped to print a persistent frozen two-line record (banner + green check +
+mm:ss completed) and suppress the redundant core completion line. Status text is
+fed by the ``stream_event`` callback. See register_callbacks.py + state.py.
+"""

--- a/code_puppy/plugins/subagent_panel/coalesce_patch.py
+++ b/code_puppy/plugins/subagent_panel/coalesce_patch.py
@@ -1,0 +1,242 @@
+"""Coalesce sub-agent stream_event callbacks from a user plugin.
+
+PUP-301 briefly patched ``code_puppy.agents.subagent_stream_handler`` in core so
+parallel sub-agents don't create one asyncio task per streamed token. That fixed
+Ctrl+T steer-overlay lag under a sub-agent swarm, but the feature belongs in the
+user plugin while this experiment stays out of the repo.
+
+This module installs the same behavior as a small monkeypatch:
+
+* replace ``subagent_stream_handler._fire_callback`` with a batched version;
+* wrap ``subagent_stream_handler.subagent_stream_handler`` so stream-end flushes
+  any trailing events (especially ``part_end``);
+* pass through to the original callback whenever ``subagent_panel`` is
+  runtime-disabled via ``/set subagent_panel off``.
+
+All state is event-loop local in practice: core calls this from the stream
+handler running on the main loop. No locks, no cute cleverness. Cute cleverness
+is how puppies end up inside washing machines.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+COALESCE_INTERVAL_S: float = 0.050
+_MARKER = "_subagent_panel_coalesced"
+
+Event = tuple[str, Any, Optional[str]]
+EnabledChecker = Callable[[], bool]
+FireCallback = Callable[[str, Any, Optional[str]], None]
+
+_pending_events: list[Event] = []
+_drain_scheduled = False
+_last_drain_time = 0.0
+_original_fire_callback: FireCallback | None = None
+_original_stream_handler: Callable[..., Awaitable[None]] | None = None
+_enabled_checker: EnabledChecker | None = None
+
+
+def _enabled() -> bool:
+    if _enabled_checker is None:
+        return True
+    try:
+        return bool(_enabled_checker())
+    except Exception:
+        return True
+
+
+def _fire_original(event_type: str, event_data: Any, session_id: Optional[str]) -> None:
+    original = _original_fire_callback
+    if original is None:
+        return
+    try:
+        original(event_type, event_data, session_id)
+    except Exception as exc:  # noqa: BLE001 - callback plumbing must not explode
+        logger.debug("Original stream_event callback failed: %s", exc)
+
+
+def _coalesced_fire_callback(
+    event_type: str,
+    event_data: Any,
+    session_id: Optional[str],
+) -> None:
+    """Queue a stream-event callback for batched delivery.
+
+    When runtime-disabled, this delegates to the exact original core callback so
+    ``/set subagent_panel off`` really behaves like vanilla Code Puppy.
+    """
+    global _drain_scheduled, _last_drain_time
+
+    if not _enabled():
+        _fire_original(event_type, event_data, session_id)
+        return
+
+    _pending_events.append((event_type, event_data, session_id))
+    if _drain_scheduled:
+        return
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        clear_pending()
+        return
+
+    now = time.monotonic()
+    elapsed = now - _last_drain_time
+    _drain_scheduled = True
+    if elapsed >= COALESCE_INTERVAL_S:
+        loop.call_soon(_drain_pending_task, loop)
+    else:
+        loop.call_later(COALESCE_INTERVAL_S - elapsed, _drain_pending_task, loop)
+
+
+def _drain_pending_task(loop: asyncio.AbstractEventLoop) -> None:
+    """Drain pending events as one scheduled asyncio task."""
+    global _drain_scheduled, _last_drain_time
+
+    _drain_scheduled = False
+    _last_drain_time = time.monotonic()
+    if not _pending_events:
+        return
+
+    batch = list(_pending_events)
+    _pending_events.clear()
+    loop.create_task(_fire_batch(batch))
+
+
+async def _fire_batch(batch: list[Event]) -> None:
+    try:
+        from code_puppy import callbacks
+    except ImportError:
+        logger.debug("Callbacks module not available for stream event")
+        return
+
+    for event_type, event_data, session_id in batch:
+        try:
+            await callbacks.on_stream_event(event_type, event_data, session_id)
+        except Exception as exc:  # noqa: BLE001 - match core's fail-safe behavior
+            logger.debug("Error in stream_event callback: %s", exc)
+
+
+async def flush_pending_callbacks() -> None:
+    """Synchronously drain any queued events.
+
+    The stream-handler wrapper calls this in ``finally`` so terminal events do
+    not sit behind the coalesce timer after a sub-agent stream completes.
+    """
+    global _drain_scheduled, _last_drain_time
+
+    _drain_scheduled = False
+    _last_drain_time = time.monotonic()
+    if not _pending_events:
+        return
+
+    batch = list(_pending_events)
+    _pending_events.clear()
+    await _fire_batch(batch)
+
+
+def clear_pending() -> None:
+    """Drop pending events without firing them; used only for abnormal no-loop paths."""
+    global _drain_scheduled
+
+    _pending_events.clear()
+    _drain_scheduled = False
+
+
+def _make_stream_handler_wrapper(original: Callable[..., Awaitable[None]]):
+    async def _wrapped(*args: Any, **kwargs: Any) -> None:
+        try:
+            await original(*args, **kwargs)
+        finally:
+            await flush_pending_callbacks()
+
+    setattr(_wrapped, _MARKER, True)
+    setattr(_wrapped, "_subagent_panel_original_stream_handler", original)
+    return _wrapped
+
+
+def install(enabled_checker: EnabledChecker | None = None) -> bool:
+    """Install the coalescing monkeypatch idempotently.
+
+    Returns ``True`` when installed/already installed, ``False`` if the core
+    module is not importable. Import failure is okay during lightweight tests.
+    """
+    global _enabled_checker, _original_fire_callback, _original_stream_handler
+
+    _enabled_checker = enabled_checker
+    try:
+        module = importlib.import_module("code_puppy.agents.subagent_stream_handler")
+    except Exception as exc:  # noqa: BLE001 - plugin startup must be best-effort
+        logger.debug("Could not import subagent_stream_handler: %s", exc)
+        return False
+
+    current_fire = getattr(module, "_fire_callback", None)
+    if current_fire is None:
+        return False
+    if not getattr(current_fire, _MARKER, False):
+        _original_fire_callback = current_fire
+        setattr(_coalesced_fire_callback, _MARKER, True)
+        setattr(
+            _coalesced_fire_callback,
+            "_subagent_panel_original_fire_callback",
+            current_fire,
+        )
+        module._fire_callback = _coalesced_fire_callback
+    elif _original_fire_callback is None:
+        _original_fire_callback = getattr(
+            current_fire, "_subagent_panel_original_fire_callback", None
+        )
+
+    current_handler = getattr(module, "subagent_stream_handler", None)
+    if current_handler is None:
+        return True
+    if not getattr(current_handler, _MARKER, False):
+        _original_stream_handler = current_handler
+        module.subagent_stream_handler = _make_stream_handler_wrapper(current_handler)
+    elif _original_stream_handler is None:
+        _original_stream_handler = getattr(
+            current_handler, "_subagent_panel_original_stream_handler", None
+        )
+
+    return True
+
+
+def uninstall() -> None:
+    """Restore original core callables when this plugin owns the patch."""
+    global _original_fire_callback, _original_stream_handler, _enabled_checker
+
+    try:
+        module = importlib.import_module("code_puppy.agents.subagent_stream_handler")
+    except Exception:
+        clear_pending()
+        return
+
+    if getattr(getattr(module, "_fire_callback", None), _MARKER, False):
+        if _original_fire_callback is not None:
+            module._fire_callback = _original_fire_callback
+    if getattr(getattr(module, "subagent_stream_handler", None), _MARKER, False):
+        if _original_stream_handler is not None:
+            module.subagent_stream_handler = _original_stream_handler
+
+    clear_pending()
+    _original_fire_callback = None
+    _original_stream_handler = None
+    _enabled_checker = None
+
+
+__all__ = [
+    "COALESCE_INTERVAL_S",
+    "clear_pending",
+    "flush_pending_callbacks",
+    "install",
+    "uninstall",
+]

--- a/code_puppy/plugins/subagent_panel/register_callbacks.py
+++ b/code_puppy/plugins/subagent_panel/register_callbacks.py
@@ -35,6 +35,7 @@ Runtime toggle with /set subagent_panel off|on.
 from __future__ import annotations
 
 import os
+import re
 from contextvars import ContextVar
 
 _TRUTHY = {"1", "true", "yes", "on"}
@@ -158,28 +159,74 @@ def _ordered_tree(rows):
     return out
 
 
+# Tier/variant qualifiers that distinguish models sharing a version number
+# (e.g. gpt-5.4 vs gpt-5.4-nano vs gpt-5.4-mini). Without these, three distinct
+# models all collapse to "GPT 5.4" in the panel -- the exact confusion this maps
+# away. key (lowercased token in the id) -> Display label.
+_MODEL_VARIANTS = (
+    ("nano", "Nano"),
+    ("mini", "Mini"),
+    ("micro", "Micro"),
+    ("lite", "Lite"),
+    ("turbo", "Turbo"),
+    ("flash", "Flash"),
+    ("instant", "Instant"),
+    ("codex", "Codex"),
+    ("thinking", "Thinking"),
+    ("reasoning", "Reasoning"),
+    ("preview", "Preview"),
+    ("pro", "Pro"),
+)
+
+
+def _model_variant(m):
+    """Extract a tier/variant qualifier (Nano, Mini, Flash, ...) from a lowercased
+    model id. Matched ONLY as a hyphen/underscore/dot/space-delimited token, so
+    'mini' inside 'gemini' (or 'pro' inside another word) can never false-fire.
+    Returns '' when the id carries no recognised variant."""
+    for key, label in _MODEL_VARIANTS:
+        if re.search(rf"(?:^|[-_. ]){re.escape(key)}(?:$|[-_. ])", m):
+            return label
+    return ""
+
+
+def _model_version(m):
+    """Extract a 'major.minor' version from a lowercased model id, tolerating
+    BOTH separators in the wild: a contiguous decimal ('gpt-5.4' -> '5.4') OR a
+    dash-separated pair ('gpt-5-4', 'claude-4-8-opus' -> '5.4'/'4.8'). Only joins
+    two integer groups when both are short (<=2 digits) so date/snapshot ids like
+    'gpt-4-0125' don't get mangled into '4.0125'. Returns '' when no number."""
+    dec = re.search(r"\d+\.\d+", m)
+    if dec:
+        return dec.group(0)
+    nums = re.findall(r"\d+", m)
+    if not nums:
+        return ""
+    if len(nums) >= 2 and len(nums[0]) <= 2 and len(nums[1]) <= 2:
+        return f"{nums[0]}.{nums[1]}"
+    return nums[0]
+
+
 def _model_short(model):
     """Human-readable shorthand for a model id, for live readability.
     e.g. 'claude-4-8-opus' -> 'Opus 4.8', 'claude-sonnet-4-6' -> 'Sonnet 4.6',
-    'gpt-5.5' -> 'GPT 5.5'. Falls back to the raw id if unrecognised."""
+    'gpt-5.5' -> 'GPT 5.5', 'gpt-5.4-nano' -> 'GPT 5.4-Nano'. The tier qualifier
+    is preserved so same-version-different-tier models stay distinct. Falls back
+    to the raw id if unrecognised."""
     if not model:
         return ""
-    import re
 
     m = str(model).lower()
+    variant = _model_variant(m)
+    suffix = f"-{variant}" if variant else ""
+    ver = _model_version(m)
     for key, label in (("opus", "Opus"), ("sonnet", "Sonnet"), ("haiku", "Haiku")):
         if key in m:
-            nums = re.findall(r"\d+", m)
-            ver = (
-                f"{nums[0]}.{nums[1]}" if len(nums) >= 2 else (nums[0] if nums else "")
-            )
-            return f"{label} {ver}".strip()
+            return f"{label} {ver}{suffix}".strip()
     if "gpt" in m:
-        nums = re.findall(r"\d+(?:\.\d+)?", m)
-        return f"GPT {nums[0]}" if nums else "GPT"
+        return (f"GPT {ver}{suffix}" if ver else f"GPT{suffix}").strip()
     if "gemini" in m:
-        nums = re.findall(r"\d+(?:\.\d+)?", m)
-        return f"Gemini {nums[0]}" if nums else "Gemini"
+        return (f"Gemini {ver}{suffix}" if ver else f"Gemini{suffix}").strip()
     return str(model)
 
 
@@ -187,14 +234,20 @@ def _row_lines(ordered, frame):
     """Render a list of (entry, depth) as aligned single-line rows:
         <prefix><name>   <model>   <spin|check> <mm:ss>
     The model + indicator + time columns share a per-tree tab-stop computed
-    from the widest (prefix+name), so deeper-indented names push the whole
-    right block over together. Root rows carry the INVOKE AGENT badge; nested
-    rows carry the tree elbow. Used for BOTH the live block and the transcript.
+    from the widest (prefix+name) AND the widest model label, so longer model
+    names (e.g. 'GPT 5.4-Nano') and deeper-indented names both push the whole
+    right block over together -- columns stay aligned no matter what gets added.
+    Alignment is done purely with U+0020 spaces (never literal tabs), and widths
+    use Rich cell_len, so the layout renders identically on Windows and macOS.
+    Root rows carry the INVOKE AGENT badge; nested rows carry the tree elbow.
+    Used for BOTH the live block and the transcript.
     """
+    from rich.cells import cell_len
     from rich.text import Text
 
     color = _banner_color()
     lefts = []
+    models = []
     name_w = 0
     model_w = 0
     for e, depth in ordered:
@@ -208,11 +261,13 @@ def _row_lines(ordered, frame):
             left.append("\u2514\u2500 ", style="grey50")  # tree elbow
             left.append(e["name"], style="bold cyan")
         lefts.append(left)
+        ms = _model_short(e.get("model"))
+        models.append(ms)
         name_w = max(name_w, left.cell_len)
-        model_w = max(model_w, len(_model_short(e.get("model"))))
+        model_w = max(model_w, cell_len(ms))
 
     lines = []
-    for (e, depth), left in zip(ordered, lefts):
+    for (e, depth), left, ms in zip(ordered, lefts, models):
         done = bool(e.get("done"))
         failed = bool(e.get("failed"))
         line = left.copy()
@@ -223,9 +278,8 @@ def _row_lines(ordered, frame):
         line.no_wrap = True
         line.overflow = "ellipsis"
         line.append(" " * (name_w - left.cell_len + 2))
-        ms = _model_short(e.get("model"))
         line.append(ms, style="magenta")
-        line.append(" " * (model_w - len(ms) + 2))
+        line.append(" " * (model_w - cell_len(ms) + 2))
         if failed:
             line.append("\u2717 ", style="bold red")  # X mark
         elif done:

--- a/code_puppy/plugins/subagent_panel/register_callbacks.py
+++ b/code_puppy/plugins/subagent_panel/register_callbacks.py
@@ -1,0 +1,588 @@
+"""subagent_panel -- live two-line status per sub-agent in the puppy spinner.
+
+While running (transient, in the puppy's Live region):
+
+     INVOKE AGENT <name>  <model>
+      <spin> 00:19  calling read_file
+
+    <bouncing puppy>
+
+On completion, a PERSISTENT frozen record is printed to the transcript that
+mirrors the live look, with the status line finalized green + check:
+
+     INVOKE AGENT <name>  <model>
+      \u2713 00:45  completed
+
+Install strategy (startup monkeypatches of seams with no hook + 1 callback):
+  1. ConsoleSpinner._generate_spinner_panel  -> render the live block above the
+     puppy (reuses the existing 20fps Live -- no second Live, no flicker).
+  2. RichConsoleRenderer._render_subagent_invocation -> CAPTURE exact metadata
+     (name/model/session_id) + SUPPRESS the permanent banner.
+  3. RichConsoleRenderer._do_render -> when a SubAgentResponseMessage arrives
+     (core skips it), handle the frozen record. A NESTED child is marked done
+     but KEPT in the live tree (shown 'completed') so it never vanishes
+     mid-run; the whole subtree flushes to the transcript parent-first only
+     when its ROOT finishes, then is removed from the live tree.
+  4. subagent_invocation.emit_success -> suppress the redundant
+     "<check> <name> completed successfully" line (it comes from the separate
+     message_queue system, NOT the bus, so it must be dropped at its source).
+  + stream_event callback feeds the live status (update-only).
+
+Startup hard-disable with DISABLE_SUBAGENT_PANEL=1 or SUBAGENT_PANEL=0.
+Runtime toggle with /set subagent_panel off|on.
+"""
+
+from __future__ import annotations
+
+import os
+from contextvars import ContextVar
+
+_TRUTHY = {"1", "true", "yes", "on"}
+_FALSEY = {"0", "false", "no", "off"}
+
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in _TRUTHY
+
+
+def _env_falsey(name: str) -> bool:
+    value = os.environ.get(name)
+    return value is not None and value.strip().lower() in _FALSEY
+
+
+_DISABLED = _env_truthy("DISABLE_SUBAGENT_PANEL") or _env_falsey("SUBAGENT_PANEL")
+_CONFIG_KEY = "subagent_panel"
+
+
+def _config_value(name: str) -> str | None:
+    try:
+        from code_puppy.config import get_value
+
+        value = get_value(name)
+        return None if value is None else str(value).strip().lower()
+    except Exception:
+        return None
+
+
+def _runtime_enabled() -> bool:
+    if _DISABLED:
+        return False
+    if _config_value(f"disable_{_CONFIG_KEY}") in _TRUTHY:
+        enabled = False
+    elif _config_value(_CONFIG_KEY) in _FALSEY:
+        enabled = False
+    else:
+        enabled = True
+    if not enabled:
+        try:
+            state.clear()
+        except Exception:
+            pass
+    return enabled
+
+
+if not _DISABLED:
+    from code_puppy.callbacks import register_callback
+
+    from . import coalesce_patch, resume_repaint, state
+
+# Async-safe parent-session pointer. The bus's _current_session_id is ONE
+# global shared across every asyncio task, so two invoke_agent calls running
+# concurrently clobber it (root B reads root A as its parent -> a bogus deep
+# chain). A ContextVar is COPIED into each task at create_task time, so
+# concurrent siblings each see their own correct parent. We mirror
+# set_session_context into this var (see _install_parent_tracking) and read it
+# in the emit hook.
+_PARENT_SID: ContextVar = ContextVar("subagent_panel_parent_sid", default=None)
+
+
+# ---------------------------------------------------------------------------
+# Shared rendering helpers
+# ---------------------------------------------------------------------------
+def _banner_color():
+    try:
+        from code_puppy.config import get_banner_color
+
+        return get_banner_color("invoke_agent")
+    except Exception:
+        return "blue"
+
+
+def _resolve_model(agent_name, override):
+    """Resolve the EFFECTIVE model for a sub-agent (override -> pinned ->
+    global default), mirroring subagent_invocation's precedence. The invocation
+    message only carries the override (usually None), so we ask the agent config
+    directly. Returns the override (or None) on any failure."""
+    try:
+        from code_puppy.agents.agent_manager import load_agent
+
+        cfg = load_agent(agent_name)
+        if override:
+            with cfg.temporary_model_name_override(override):
+                return cfg.get_model_name()
+        return cfg.get_model_name()
+    except Exception:
+        return override
+
+
+# ---------------------------------------------------------------------------
+# Hierarchy helpers (true parent -> child tree)
+# ---------------------------------------------------------------------------
+def _ordered_tree(rows):
+    """Return [(entry, depth), ...] in DFS order. A row whose parent is not in
+    the set (e.g. the main agent, or None) is a root (depth 0); descendants are
+    indented one-liners. Cycle-safe; stable by start time."""
+    by_id = {e["session_id"]: e for e in rows if e.get("session_id")}
+    children = {}
+    roots = []
+    for e in rows:
+        p = e.get("parent")
+        if p and p in by_id:
+            children.setdefault(p, []).append(e)
+        else:
+            roots.append(e)
+    out = []
+    seen = set()
+
+    def walk(node, depth):
+        sid = node.get("session_id")
+        if sid in seen:
+            return
+        seen.add(sid)
+        out.append((node, depth))
+        for kid in sorted(children.get(sid, []), key=lambda c: c["start"]):
+            walk(kid, depth + 1)
+
+    for r in sorted(roots, key=lambda e: e["start"]):
+        walk(r, 0)
+    return out
+
+
+def _model_short(model):
+    """Human-readable shorthand for a model id, for live readability.
+    e.g. 'claude-4-8-opus' -> 'Opus 4.8', 'claude-sonnet-4-6' -> 'Sonnet 4.6',
+    'gpt-5.5' -> 'GPT 5.5'. Falls back to the raw id if unrecognised."""
+    if not model:
+        return ""
+    import re
+
+    m = str(model).lower()
+    for key, label in (("opus", "Opus"), ("sonnet", "Sonnet"), ("haiku", "Haiku")):
+        if key in m:
+            nums = re.findall(r"\d+", m)
+            ver = (
+                f"{nums[0]}.{nums[1]}" if len(nums) >= 2 else (nums[0] if nums else "")
+            )
+            return f"{label} {ver}".strip()
+    if "gpt" in m:
+        nums = re.findall(r"\d+(?:\.\d+)?", m)
+        return f"GPT {nums[0]}" if nums else "GPT"
+    if "gemini" in m:
+        nums = re.findall(r"\d+(?:\.\d+)?", m)
+        return f"Gemini {nums[0]}" if nums else "Gemini"
+    return str(model)
+
+
+def _row_lines(ordered, frame):
+    """Render a list of (entry, depth) as aligned single-line rows:
+        <prefix><name>   <model>   <spin|check> <mm:ss>
+    The model + indicator + time columns share a per-tree tab-stop computed
+    from the widest (prefix+name), so deeper-indented names push the whole
+    right block over together. Root rows carry the INVOKE AGENT badge; nested
+    rows carry the tree elbow. Used for BOTH the live block and the transcript.
+    """
+    from rich.text import Text
+
+    color = _banner_color()
+    lefts = []
+    name_w = 0
+    model_w = 0
+    for e, depth in ordered:
+        left = Text(no_wrap=True, overflow="ellipsis")
+        if depth == 0:
+            left.append(" \U0001f916 INVOKE AGENT ", style=f"bold white on {color}")
+            left.append(" ")
+            left.append(e["name"], style="bold cyan")
+        else:
+            left.append("  " + "   " * (depth - 1))
+            left.append("\u2514\u2500 ", style="grey50")  # tree elbow
+            left.append(e["name"], style="bold cyan")
+        lefts.append(left)
+        name_w = max(name_w, left.cell_len)
+        model_w = max(model_w, len(_model_short(e.get("model"))))
+
+    lines = []
+    for (e, depth), left in zip(ordered, lefts):
+        done = bool(e.get("done"))
+        failed = bool(e.get("failed"))
+        line = left.copy()
+        # These rows are deliberately one-line status rows. If a long tool name
+        # wraps (e.g. calling agent_run_shell_command on a narrow terminal), the
+        # shared Rich Live grows at Ctrl+T and strands the previous frame into
+        # scrollback. Crop visually; preserve full status in state.
+        line.no_wrap = True
+        line.overflow = "ellipsis"
+        line.append(" " * (name_w - left.cell_len + 2))
+        ms = _model_short(e.get("model"))
+        line.append(ms, style="magenta")
+        line.append(" " * (model_w - len(ms) + 2))
+        if failed:
+            line.append("\u2717 ", style="bold red")  # X mark
+        elif done:
+            line.append("\u2713 ", style="bold green")  # check
+        else:
+            line.append((frame or " ") + " ", style="bold cyan")
+        line.append(state.fmt_elapsed_entry(e), style="dim")
+        # Current action / status, color-coded (yellow=calling, magenta=thinking,
+        # green=writing). Done rows show 'completed' green; failed rows 'failed' red.
+        status = e.get("status", "starting")
+        line.append("  ")
+        if failed:
+            line.append("failed", style="bold red")
+        elif done:
+            line.append("completed", style="green")
+        else:
+            line.append(status, style=state.status_style(status))
+        lines.append(line)
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Live panel rendering (called from the spinner repaint loop, ~20fps)
+# ---------------------------------------------------------------------------
+def _render_status_lines():
+    if not _runtime_enabled():
+        return None
+    rows = state.snapshot()
+    if not rows:
+        return None
+
+    from rich.text import Text
+
+    frame = state.spinner_frame()
+    ordered = _ordered_tree(rows)
+    shown = ordered[: state.MAX_ROWS]
+    lines = _row_lines(shown, frame)
+
+    extra = len(ordered) - len(shown)
+    if extra > 0:
+        lines.append(Text(f"  (+{extra} more)", style="dim"))
+    return lines
+
+
+def _make_patched_panel(original_fn):
+    from rich.console import Group
+    from rich.text import Text
+
+    def _patched(self):
+        original = original_fn(self)
+        if isinstance(original, Text) and str(original) == "":
+            return original
+        if not _runtime_enabled():
+            return original
+
+        try:
+            block = _render_status_lines()
+        except Exception:
+            block = None
+        if not block:
+            return original
+        return Group(*block, Text(""), original)
+
+    _patched._subagent_panel = True
+    return _patched
+
+
+# ---------------------------------------------------------------------------
+# Frozen (persistent) completion record
+# ---------------------------------------------------------------------------
+def _render_console():
+    """The Rich console the puppy spinner's Live is attached to. Printing to it
+    while the Live is active makes Rich relocate the panel BELOW the print, so
+    the flushed group lands cleanly in scrollback above the live region."""
+    try:
+        from code_puppy.messaging.spinner import _active_spinners
+
+        for sp in _active_spinners:
+            con = getattr(sp, "console", None)
+            if con is not None:
+                return con
+    except Exception:
+        pass
+    return None
+
+
+def _handle_frozen(console, session_id):
+    """A sub-agent finished. Mark it done but KEEP it grouped in the live panel
+    (rendered as 'completed'). The ENTIRE panel flushes to the transcript as one
+    cohesive group ONLY once the whole swarm is idle (every tracked agent done).
+    So a finished root never commits mid-swarm, and nothing -- steer lines or
+    otherwise -- can ever be interleaved between the grouped agent rows.
+    """
+    if not session_id:
+        return
+    state.mark_done(session_id)
+    _maybe_flush_group(console)
+
+
+def _maybe_flush_group(console):
+    """Flush the WHOLE live panel to scrollback as one group (parent-first DFS),
+    then clear it -- but ONLY when no agent is still active. While any agent is
+    running, completed agents stay grouped in the live panel (shown 'completed'),
+    so the panel remains a single cohesive block pinned above the spinner.
+    """
+    rows = state.snapshot()
+    if not rows:
+        return
+    if any(not e.get("done") for e in rows):
+        return  # swarm still busy -- keep the panel grouped + live
+    if console is None:
+        return
+    ordered = _ordered_tree(rows)
+    for line in _row_lines(ordered, frame=None):
+        console.print(line)
+    state.clear()
+
+
+# ---------------------------------------------------------------------------
+# Monkeypatch installers
+# ---------------------------------------------------------------------------
+def _install_spinner_patch() -> None:
+    from code_puppy.messaging.spinner.console_spinner import ConsoleSpinner
+
+    current = ConsoleSpinner._generate_spinner_panel
+    if not getattr(current, "_subagent_panel", False):
+        ConsoleSpinner._generate_spinner_panel = _make_patched_panel(current)
+
+
+def _install_parent_tracking() -> None:
+    """Mirror set_session_context() into an async-safe ContextVar.
+
+    subagent_invocation.py calls set_session_context(child_sid) at :118 (in the
+    INVITING agent's task) BEFORE create_task() spawns the child's run at :272.
+    create_task copies the current context, so the child task inherits
+    _PARENT_SID = its own sid; when the child later invokes a grandchild, the
+    emit hook reads _PARENT_SID = the child sid = the true parent. Concurrent
+    roots can't clobber each other because each task has its own copy (unlike
+    the bus's single global _current_session_id).
+    """
+    import code_puppy.tools.subagent_invocation as sai
+
+    original = sai.set_session_context
+    if getattr(original, "_subagent_panel", False):
+        return
+
+    def _set(session_id):
+        if _runtime_enabled():
+            try:
+                _PARENT_SID.set(session_id)
+            except Exception:
+                pass
+        return original(session_id)
+
+    _set._subagent_panel = True
+    sai.set_session_context = _set
+
+
+def _install_emit_hook() -> None:
+    """Register sub-agents (with parent + model) at EMIT time.
+
+    emit() at subagent_invocation.py:105 runs BEFORE set_session_context(child)
+    at :118, so at emit time _PARENT_SID still holds the INVITING agent's sid
+    (or None in the main agent's task -> a root). We read the async-safe
+    ContextVar, NOT the bus's global _current_session_id, so parallel invokes
+    don't cross-wire their parents.
+    """
+    from code_puppy.messaging.bus import MessageBus
+
+    current = MessageBus.emit
+    if getattr(current, "_subagent_panel", False):
+        return
+
+    def _emit(self, message):
+        try:
+            if (
+                _runtime_enabled()
+                and type(message).__name__ == "SubAgentInvocationMessage"
+            ):
+                parent = _PARENT_SID.get()
+                model = _resolve_model(
+                    message.agent_name, getattr(message, "model_name", None)
+                )
+                state.register(message.session_id, message.agent_name, model, parent)
+        except Exception:
+            pass
+        return current(self, message)
+
+    _emit._subagent_panel = True
+    MessageBus.emit = _emit
+
+
+def _install_banner_capture() -> None:
+    """Suppress the core permanent invocation banner. Registration now happens
+    in the emit hook (where the parent is knowable), so this only suppresses."""
+    from code_puppy.messaging.rich_renderer import RichConsoleRenderer
+
+    current = RichConsoleRenderer._render_subagent_invocation
+    if getattr(current, "_subagent_panel", False):
+        return
+
+    def _capture(self, msg):
+        if not _runtime_enabled():
+            return current(self, msg)
+        return  # suppress the permanent banner -- live block owns it
+
+    _capture._subagent_panel = True
+    RichConsoleRenderer._render_subagent_invocation = _capture
+
+
+def _install_render_wrapper() -> None:
+    """Wrap _do_render to (a) print a frozen record when a sub-agent response
+    arrives and (b) suppress the redundant completion text line."""
+    from code_puppy.messaging.rich_renderer import RichConsoleRenderer
+
+    current = RichConsoleRenderer._do_render
+    if getattr(current, "_subagent_panel", False):
+        return
+
+    def _wrapped(self, message):
+        try:
+            if (
+                _runtime_enabled()
+                and type(message).__name__ == "SubAgentResponseMessage"
+            ):
+                _handle_frozen(self._console, getattr(message, "session_id", None))
+                # Core skips SubAgentResponseMessage anyway -> fully handled.
+                return
+        except Exception:
+            pass
+        return current(self, message)
+
+    _wrapped._subagent_panel = True
+    RichConsoleRenderer._do_render = _wrapped
+
+
+def _install_suppress_completion() -> None:
+    """Suppress the redundant '<check> <name> completed successfully' line.
+
+    That line is emitted by subagent_invocation via message_queue.emit_success
+    (a DIFFERENT system than the bus that _do_render renders), so it must be
+    suppressed at its source. We patch the name bound in subagent_invocation's
+    namespace -- the only caller -- and pass everything else through.
+    """
+    import code_puppy.tools.subagent_invocation as sai
+
+    current = getattr(sai, "emit_success", None)
+    if current is None or getattr(current, "_subagent_panel", False):
+        return
+
+    def _filtered(content, *args, **kwargs):
+        try:
+            text = str(content).strip()
+            if (
+                _runtime_enabled()
+                and text.endswith("completed successfully")
+                and "\u2713" in text
+            ):
+                return  # the frozen record already says "completed"
+        except Exception:
+            pass
+        return current(content, *args, **kwargs)
+
+    _filtered._subagent_panel = True
+    sai.emit_success = _filtered
+
+
+def _install() -> None:
+    if _DISABLED:
+        return
+    for installer in (
+        lambda: coalesce_patch.install(_runtime_enabled),
+        _install_spinner_patch,
+        _install_parent_tracking,
+        _install_emit_hook,
+        _install_banner_capture,
+        _install_render_wrapper,
+        _install_suppress_completion,
+        lambda: resume_repaint.install(_runtime_enabled, state),
+    ):
+        try:
+            installer()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Status callback
+# ---------------------------------------------------------------------------
+async def _on_stream_event(event_type, event_data, agent_session_id=None):
+    if not _runtime_enabled():
+        return
+    try:
+        state.record_event(agent_session_id, event_type, event_data)
+    except Exception:
+        pass
+
+
+async def _on_agent_run_end(
+    agent_name=None,
+    model_name=None,
+    session_id=None,
+    success=True,
+    error=None,
+    response_text=None,
+    metadata=None,
+):
+    """When the TOP-LEVEL turn ends, wipe all tracked sub-agents so a root that
+    errored or was cancelled (never flushed) can't leak its 'completed' children
+    into the next prompt's live block. Only fires for the main agent -- sub-agent
+    runs go through temp_agent.run(), not _runtime, and is_subagent() guards the
+    rest.
+    """
+    if not _runtime_enabled():
+        return
+    try:
+        from code_puppy.tools.subagent_context import is_subagent
+
+        if is_subagent():
+            return  # a sub-agent finishing -- leave the live tree intact
+    except Exception:
+        pass
+    try:
+        state.clear()
+    except Exception:
+        pass
+
+
+async def _on_post_tool_call(tool_name, tool_args, result, duration_ms, context=None):
+    """Detect a FAILED sub-agent so it renders red 'failed' instead of a green
+    'completed' checkmark.
+
+    The invoke_agent tool returns an AgentInvokeOutput(session_id=..., error=...)
+    and -- crucially -- does NOT raise on sub-agent failure (its own except block
+    swallows the error and returns it on the output). So no SubAgentResponseMessage
+    is emitted, the node is never marked done via the normal path, and the root
+    flush would otherwise force it green. We read the returned .error here (the
+    real failure signal, present only AFTER the retry plugin has exhausted all
+    waves) and mark that exact session failed.
+    """
+    if not _runtime_enabled():
+        return
+    try:
+        err = getattr(result, "error", None)
+        sid = getattr(result, "session_id", None)
+        if err and sid:
+            state.mark_failed(sid)
+            # A failed agent is 'done' too -- if it was the last one running,
+            # flush the whole grouped panel now (failure path emits no
+            # SubAgentResponseMessage, so _handle_frozen won't fire).
+            _maybe_flush_group(_render_console())
+    except Exception:
+        pass
+
+
+if not _DISABLED:
+    register_callback("startup", _install)
+    register_callback("stream_event", _on_stream_event)
+    register_callback("agent_run_end", _on_agent_run_end)
+    register_callback("post_tool_call", _on_post_tool_call)

--- a/code_puppy/plugins/subagent_panel/resume_repaint.py
+++ b/code_puppy/plugins/subagent_panel/resume_repaint.py
@@ -1,0 +1,167 @@
+"""Repaint the sub-agent panel after Ctrl+T steering resumes.
+
+The status panel lives inside the main ConsoleSpinner Rich Live. Michael's
+raw steer intentionally tears that Live down while collecting input. During a
+sub-agent swarm the main agent is blocked inside the invoke_agent tool await,
+so the normal event_stream_handler PartEndEvent path cannot rebuild the Live.
+This module gives subagent_panel its own tiny wake-up path, without touching
+steer itself.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Callable, Protocol
+
+
+class _State(Protocol):
+    def has_active(self) -> bool: ...
+
+
+_runtime_enabled: Callable[[], bool] | None = None
+_state: _State | None = None
+_install_lock = threading.Lock()
+_repaint_lock = threading.RLock()
+_installed = False
+
+
+def install(runtime_enabled: Callable[[], bool], state: _State) -> None:
+    """Install resume/repaint hooks. Safe to call repeatedly."""
+    global _installed, _runtime_enabled, _state
+    with _install_lock:
+        _runtime_enabled = runtime_enabled
+        _state = state
+        if _installed:
+            return
+        _installed = True
+    _install_resume_listener()
+    _install_bus_resume_hook()
+
+
+def _active_swarm() -> bool:
+    try:
+        if _runtime_enabled is None or _state is None:
+            return False
+        if not _runtime_enabled():
+            return False
+        if not _state.has_active():
+            return False
+        from code_puppy.messaging.pause_controller import get_pause_controller
+        from code_puppy.tools.command_runner import is_awaiting_user_input
+
+        return not get_pause_controller().is_paused() and not is_awaiting_user_input()
+    except Exception:
+        return False
+
+
+def _request_repaint(_reason: str = "resume") -> None:
+    """Try now and retry shortly after prompt teardown/renderer flush races."""
+    if not _active_swarm():
+        return
+    _repaint_once()
+    for delay in (0.05, 0.20, 0.50):
+        timer = threading.Timer(delay, _repaint_once)
+        timer.daemon = True
+        timer.start()
+
+
+def _repaint_once() -> None:
+    if not _active_swarm():
+        return
+    with _repaint_lock:
+        if not _active_swarm():
+            return
+        try:
+            from code_puppy.messaging.spinner import resume_all_spinners
+
+            resume_all_spinners()
+        except Exception:
+            pass
+        _force_refresh_active_spinners()
+
+
+def _force_refresh_active_spinners() -> None:
+    try:
+        from code_puppy.messaging.spinner import _active_spinners
+    except Exception:
+        return
+    for spinner in list(_active_spinners):
+        try:
+            _force_refresh_spinner(spinner)
+        except Exception:
+            pass
+
+
+def _force_refresh_spinner(spinner) -> None:
+    if not getattr(spinner, "_is_spinning", False):
+        return
+    # If ConsoleSpinner.resume() missed its moment, force the same invariant:
+    # an unpaused spinner with a live Rich surface containing our patched panel.
+    try:
+        spinner._paused = False
+    except Exception:
+        pass
+
+    live = getattr(spinner, "_live", None)
+    if live is None:
+        _start_live(spinner)
+        return
+
+    try:
+        live.update(spinner._generate_spinner_panel())
+        live.refresh()
+    except Exception:
+        pass
+
+
+def _start_live(spinner) -> None:
+    try:
+        from rich.live import Live
+
+        console = getattr(spinner, "console", None)
+        if console is None:
+            return
+        console.print()
+        live = Live(
+            spinner._generate_spinner_panel(),
+            console=console,
+            refresh_per_second=20,
+            transient=True,
+            auto_refresh=False,
+        )
+        spinner._live = live
+        live.start()
+    except Exception:
+        pass
+
+
+def _install_resume_listener() -> None:
+    try:
+        from code_puppy.messaging.pause_controller import get_pause_controller
+
+        get_pause_controller().add_resume_listener(_request_repaint)
+    except Exception:
+        pass
+
+
+def _install_bus_resume_hook() -> None:
+    try:
+        from code_puppy.messaging.bus import MessageBus
+    except Exception:
+        return
+
+    current = MessageBus.provide_response
+    if getattr(current, "_subagent_panel_resume_repaint", False):
+        return
+
+    def _wrapped(self, command):
+        result = current(self, command)
+        try:
+            if type(command).__name__ == "ResumeAgentCommand":
+                _request_repaint("resume-command")
+        except Exception:
+            pass
+        return result
+
+    _wrapped._subagent_panel_resume_repaint = True
+    MessageBus.provide_response = _wrapped

--- a/code_puppy/plugins/subagent_panel/state.py
+++ b/code_puppy/plugins/subagent_panel/state.py
@@ -1,0 +1,229 @@
+"""Thread-safe registry of active sub-agents + status derivation.
+
+The puppy spinner repaints from a background thread ~20x/second, so all reads
+here must be cheap and lock-guarded.
+
+Registration is driven by the sub-agent INVOCATION banner (which carries the
+exact name, session_type, model AND session_id), so attribution is exact even
+for parallel sub-agents -- no FIFO guessing, no session-id parsing. Status
+updates (``record_event``) are UPDATE-ONLY: an event for an unregistered
+session is ignored, which cleanly filters out the MAIN agent's own stream
+events (the main agent is never registered).
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+# session_id -> {session_id, parent, name, model, status, start, last_seen}
+_AGENTS: "Dict[str, Dict[str, Any]]" = {}
+_LOCK = threading.RLock()
+
+# --- tunables (env-overridable) -------------------------------------------
+MAX_ROWS = int(os.environ.get("SUBAGENT_PANEL_MAX_ROWS", "24"))
+IDLE_PRUNE_S = float(os.environ.get("SUBAGENT_PANEL_IDLE_S", "600"))
+
+# Single-char braille spinner frames (defined via escapes to keep the source
+# emoji-free; braille isn't emoji but escapes dodge any filter ambiguity).
+SPINNER_FRAMES = [
+    "\u280b",
+    "\u2819",
+    "\u2839",
+    "\u2838",
+    "\u283c",
+    "\u2834",
+    "\u2826",
+    "\u2827",
+    "\u2807",
+    "\u280f",
+]
+
+
+# ---------------------------------------------------------------------------
+# Registration / teardown (driven by the invocation + response banners)
+# ---------------------------------------------------------------------------
+def register(
+    session_id: Optional[str],
+    name: str,
+    model: Optional[str] = None,
+    parent: Optional[str] = None,
+) -> None:
+    if not session_id:
+        return
+    now = time.time()
+    with _LOCK:
+        # Re-invocation of an existing session: keep its original start time.
+        existing = _AGENTS.get(session_id)
+        _AGENTS[session_id] = {
+            "session_id": session_id,
+            "parent": parent,
+            "name": name,
+            "model": model,
+            "status": "starting",
+            "start": existing["start"] if existing else now,
+            "last_seen": now,
+        }
+
+
+def finish(session_id: Optional[str]) -> None:
+    if not session_id:
+        return
+    with _LOCK:
+        _AGENTS.pop(session_id, None)
+
+
+def mark_done(session_id: Optional[str]) -> None:
+    """Mark a sub-agent completed but KEEP it in the live tree (frozen) until its
+    root flushes. This avoids the vanish-then-reappear gap that happens if a
+    nested child is popped the instant it finishes while its parent runs on."""
+    if not session_id:
+        return
+    now = time.time()
+    with _LOCK:
+        entry = _AGENTS.get(session_id)
+        if entry is None:
+            return
+        entry["done"] = True
+        entry["status"] = "completed"
+        entry["end"] = now
+        entry["last_seen"] = now
+
+
+def mark_failed(session_id: Optional[str]) -> None:
+    """Mark a sub-agent FAILED (errored after exhausting retries) but KEEP it in
+    the live tree until its root flushes -- same lifecycle as mark_done, but the
+    renderer paints it red 'failed' with an X instead of green 'completed'."""
+    if not session_id:
+        return
+    now = time.time()
+    with _LOCK:
+        entry = _AGENTS.get(session_id)
+        if entry is None:
+            return
+        entry["done"] = True
+        entry["failed"] = True
+        entry["status"] = "failed"
+        entry["end"] = now
+        entry["last_seen"] = now
+
+
+def clear() -> None:
+    """Drop ALL tracked sub-agents. Called when the top-level turn ends so a
+    root that errored/was cancelled (and thus never flushed) can't leak its
+    'completed' children into the next prompt's live block."""
+    with _LOCK:
+        _AGENTS.clear()
+
+
+# ---------------------------------------------------------------------------
+# Live status (driven by stream_event) -- UPDATE ONLY
+# ---------------------------------------------------------------------------
+def record_event(session_id: Optional[str], event_type: str, event_data: Any) -> None:
+    if not session_id:
+        return
+    status = _derive_status(event_type, event_data)
+    now = time.time()
+    with _LOCK:
+        entry = _AGENTS.get(session_id)
+        if entry is None:
+            return  # not a registered sub-agent (e.g. the main agent) -> ignore
+        entry["last_seen"] = now
+        if status:
+            entry["status"] = status
+
+
+# ---------------------------------------------------------------------------
+# Reads
+# ---------------------------------------------------------------------------
+def snapshot() -> List[Dict[str, Any]]:
+    """Return active sub-agents (oldest first), pruning idle/stale ones.
+
+    DONE entries are never pruned by idle -- they stay in the live tree (shown
+    as 'completed') until their root flushes them, so a finished child never
+    vanishes mid-run.
+
+    PARENTS are never idle-pruned either: a parent that has invoked children and
+    is merely AWAITING them emits no stream events of its own, so its last_seen
+    goes stale -- but it is busy, not idle. Pruning it would orphan its whole
+    subtree, making the children re-render as depth-0 roots. So only childless,
+    not-done, genuinely-stale leaves are eligible. End-of-turn state.clear() is
+    the real cleanup for anything that errors/cancels without flushing.
+    """
+    now = time.time()
+    with _LOCK:
+        ids = set(_AGENTS)
+        # session_ids still referenced as someone's parent == busy (awaiting kids).
+        busy_parents = {e.get("parent") for e in _AGENTS.values() if e.get("parent")}
+        # Only prune entries DISCONNECTED from the live tree: not a parent of
+        # anything AND whose own parent is gone (or is 'main', i.e. a root).
+        # Anything still wired into a tree (busy parents + their descendants)
+        # is kept until flush/turn-end, so a quiet-but-running node (e.g. a leaf
+        # mid `sleep`) never vanishes and never orphans its siblings.
+        stale = [
+            s
+            for s, e in _AGENTS.items()
+            if not e.get("done")
+            and s not in busy_parents
+            and e.get("parent") not in ids
+            and now - e["last_seen"] > IDLE_PRUNE_S
+        ]
+        for s in stale:
+            _AGENTS.pop(s, None)
+        return sorted(_AGENTS.values(), key=lambda e: e["start"])
+
+
+def has_active() -> bool:
+    with _LOCK:
+        return bool(_AGENTS)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _derive_status(event_type: str, event_data: Any) -> Optional[str]:
+    """Map a sub-agent stream event to a short status. None = no change."""
+    if not isinstance(event_data, dict):
+        return None
+    if event_type == "part_start":
+        tool = event_data.get("tool_name")
+        if tool:
+            return f"calling {tool}"
+        part_type = event_data.get("part_type", "") or ""
+        if "Thinking" in part_type:
+            return "thinking..."
+        if "Text" in part_type:
+            return "writing response"
+    return None
+
+
+def fmt_elapsed(start: float) -> str:
+    """mm:ss elapsed (2-digit minutes), e.g. 00:19."""
+    elapsed = int(max(0.0, time.time() - start))
+    return f"{elapsed // 60:02d}:{elapsed % 60:02d}"
+
+
+def fmt_elapsed_entry(entry: Dict[str, Any]) -> str:
+    """mm:ss for an entry, frozen at its 'end' time once done."""
+    end = entry.get("end")
+    start = entry["start"]
+    elapsed = int(max(0.0, (end if end else time.time()) - start))
+    return f"{elapsed // 60:02d}:{elapsed % 60:02d}"
+
+
+def spinner_frame() -> str:
+    """Wall-clock-derived spinner char (~10fps), independent of caller."""
+    return SPINNER_FRAMES[int(time.time() * 10) % len(SPINNER_FRAMES)]
+
+
+def status_style(status: str) -> str:
+    """Color-code the status text by activity type."""
+    if status.startswith("calling"):
+        return "yellow"
+    if status.startswith("thinking"):
+        return "magenta"
+    if status.startswith("writing"):
+        return "green"
+    return "dim"

--- a/code_puppy/tools/command_runner.py
+++ b/code_puppy/tools/command_runner.py
@@ -115,6 +115,17 @@ _SHELL_CTRL_X_STOP_EVENT: Optional[threading.Event] = None
 _SHELL_CTRL_X_THREAD: Optional[threading.Thread] = None
 _ORIGINAL_SIGINT_HANDLER = None
 
+# Bridge from the shell SIGINT handler back to the active agent run's cancel
+# callback (``make_schedule_cancel``'s closure). Registered by the runtime at
+# run start, cleared at run end. Lets a single Ctrl+C during a sub-agent swarm
+# kill the shells AND cancel every sub-agent task + the main agent, instead of
+# only killing the current batch of shells (which forced the user to mash
+# Ctrl+C once per still-running sub-agent).
+_AGENT_CANCEL_CB: Optional[Callable[..., None]] = None
+# One-shot dedupe so mashing Ctrl+C during teardown doesn't reprint the banner
+# or re-fire the cancel sweep N times. Reset when a new cancel cb registers.
+_SIGINT_CANCEL_REQUESTED = False
+
 # Reference-counted keyboard context - stays active while ANY command is running
 _KEYBOARD_CONTEXT_REFCOUNT = 0
 _KEYBOARD_CONTEXT_LOCK = threading.Lock()
@@ -373,10 +384,103 @@ def _handle_ctrl_x_press() -> None:
     kill_all_running_shell_processes()
 
 
+def _tear_down_live_panels() -> None:
+    """Hide the spinner's Live region (and the sub-agent status panel it hosts).
+
+    Mirrors what the steer flow does via ``pause_all_spinners()``: the
+    sub-agent status panel is rendered INSIDE the puppy spinner's Rich Live,
+    which repaints ~20x/sec. Without tearing it down first, the cancel banner
+    prints once and the very next Live frame paints the panel right back over
+    it -- which is exactly why a single Ctrl+C *looked* like it did nothing and
+    the user had to mash it once per nesting level. We pause each active
+    spinner DIRECTLY (rather than ``pause_all_spinners()``) because the signal
+    handler fires on the main thread in an ambiguous contextvar state, where
+    the ``is_subagent()`` guard inside ``pause_all_spinners()`` could wrongly
+    no-op the teardown.
+    """
+    try:
+        from code_puppy.messaging.spinner import _active_spinners
+
+        for spinner in list(_active_spinners):
+            try:
+                spinner.pause()
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+
 def _shell_sigint_handler(_sig, _frame):
-    """During shell execution, Ctrl-C kills all shells but doesn't cancel agent."""
-    emit_warning("\n🛑 Ctrl-C detected! Interrupting all shell commands...")
-    kill_all_running_shell_processes()
+    """Ctrl-C during shell execution: stop the swarm responsively.
+
+    ORDER MATTERS, and it's the opposite of what you'd naively expect:
+
+    1. **Hide the panel** (``_tear_down_live_panels``) -- instant, non-blocking.
+    2. **Emit the banner** -- instant; the user gets immediate feedback.
+    3. **Kill the shells** (``kill_all_running_shell_processes``) -- SLOW and
+       BLOCKING. ``_kill_process_group`` sleeps up to ~2.1s *per process*
+       (SIGTERM->SIGINT->SIGKILL escalation), so a deep swarm with N nested
+       sub-agents each holding a ``sleep`` shell can block the main thread for
+       N x ~2s. If we killed first (the old order), the spinner's Rich Live
+       kept repainting the sub-agent panel for that entire window and the
+       teardown/banner only landed *after* every shell died -- which is
+       precisely the "panel stays up until all the shells finally stop" bug.
+    4. **Cancel the swarm** (``_AGENT_CANCEL_CB(force=True)``). Shells are
+       already dead by here, so the anti-orphan reason for force-cancel holds.
+
+    A one-shot ``_SIGINT_CANCEL_REQUESTED`` flag dedupes the banner + sweep
+    so mashing Ctrl+C during teardown doesn't spam either.
+    """
+    global _SIGINT_CANCEL_REQUESTED
+
+    if _SIGINT_CANCEL_REQUESTED:
+        # Already tearing this run down; swallow extra presses silently.
+        # Keep the panel hidden in case a late frame tried to bring it back.
+        _tear_down_live_panels()
+        kill_all_running_shell_processes()
+        return
+
+    if _AGENT_CANCEL_CB is not None:
+        _SIGINT_CANCEL_REQUESTED = True
+        # 1+2: hide the panel and announce the cancel BEFORE the slow kill,
+        # so the UI responds instantly instead of after every shell dies.
+        _tear_down_live_panels()
+        emit_warning(
+            "\nCtrl-C detected! Stopping the agent (shells + all sub-agents)..."
+        )
+        # 3: the slow, blocking part -- panel is already gone, banner is shown.
+        kill_all_running_shell_processes()
+        try:
+            # 4: force=True -- we just killed the shells, so the agent-cancel
+            # guard's anti-orphan reason no longer applies.
+            _AGENT_CANCEL_CB(force=True)
+        except Exception:
+            # A cancel-callback failure must never crash the signal handler.
+            pass
+    else:
+        # Headless / tool-only invocation with no active agent run to cancel.
+        _tear_down_live_panels()
+        emit_warning("\nCtrl-C detected! Interrupting all shell commands...")
+        kill_all_running_shell_processes()
+
+
+def register_agent_cancel(cb: Optional[Callable[..., None]]) -> None:
+    """Publish the active agent run's cancel callback for the SIGINT handler.
+
+    Called by the runtime at run start so a Ctrl+C arriving while shells are
+    running can collapse the whole agent/sub-agent tree, not just the shells.
+    Resets the one-shot dedupe flag so each fresh run can be cancelled once.
+    """
+    global _AGENT_CANCEL_CB, _SIGINT_CANCEL_REQUESTED
+    _AGENT_CANCEL_CB = cb
+    _SIGINT_CANCEL_REQUESTED = False
+
+
+def clear_agent_cancel() -> None:
+    """Drop the registered cancel callback at run end so it can't outlive its task."""
+    global _AGENT_CANCEL_CB, _SIGINT_CANCEL_REQUESTED
+    _AGENT_CANCEL_CB = None
+    _SIGINT_CANCEL_REQUESTED = False
 
 
 def _start_keyboard_listener() -> None:

--- a/code_puppy/tools/image_tools.py
+++ b/code_puppy/tools/image_tools.py
@@ -178,6 +178,11 @@ def register_load_image(agent):
     ) -> Union[ToolReturn, Dict[str, Any]]:
         """Load an image file so you can see and analyze it.
 
+        Only call this when the user gave you a concrete filesystem path to an
+        image that is not already attached to the message. If an image is
+        already visible in the conversation, analyze it directly; do not call
+        this tool with guessed paths like /tmp/screenshot.png.
+
         Args:
             image_path: Path to the image file.
 

--- a/tests/agents/test_run_signals_pause_guard.py
+++ b/tests/agents/test_run_signals_pause_guard.py
@@ -159,3 +159,86 @@ def test_schedule_pause_proceeds_when_shell_running(monkeypatch):
     assert len(scheduled_calls) == 1, (
         "pause must be scheduled even when a shell command is running"
     )
+
+
+# =============================================================================
+# Cancel hides the sub-agent status panel (mirrors the steer flow)
+# =============================================================================
+
+
+def _fake_loop_recording() -> Any:
+    """Loop stand-in that records call_soon_threadsafe scheduling."""
+
+    class _L:
+        def __init__(self):
+            self.scheduled: List[Any] = []
+
+        def call_soon_threadsafe(self, fn, *args):
+            self.scheduled.append((fn, args))
+
+    return _L()
+
+
+def _fake_cancelable_task(done: bool = False) -> Any:
+    """Task stand-in exposing both .done() and .cancel (cancel attr accessed)."""
+
+    class _T:
+        def done(self_inner) -> bool:  # noqa: N805 — duck-type
+            return done
+
+        def cancel(self_inner) -> None:  # noqa: N805 — duck-type
+            pass
+
+    return _T()
+
+
+def test_schedule_cancel_tears_down_panel_before_banner(monkeypatch):
+    """With active sub-agents, cancel must hide the panel so the banner shows."""
+    teardown_calls: List[int] = []
+    warnings: List[str] = []
+
+    # One active sub-agent task that isn't done yet.
+    class _SubTask:
+        def done(self):
+            return False
+
+        def cancel(self):
+            pass
+
+    monkeypatch.setattr(_run_signals, "_active_subagent_tasks", [_SubTask()])
+    monkeypatch.setattr(
+        _run_signals, "emit_warning", lambda msg, *a, **k: warnings.append(msg)
+    )
+    monkeypatch.setattr(
+        "code_puppy.tools.command_runner._tear_down_live_panels",
+        lambda: teardown_calls.append(1),
+    )
+    # No shells running so force isn't required.
+    monkeypatch.setattr("code_puppy.tools.command_runner._RUNNING_PROCESSES", set())
+
+    loop = _fake_loop_recording()
+    schedule_cancel = _run_signals.make_schedule_cancel(_fake_cancelable_task(), loop)
+    schedule_cancel()
+
+    assert teardown_calls == [1], "panel must be torn down exactly once"
+    assert warnings and "Cancelling" in warnings[0]
+
+
+def test_schedule_cancel_no_panel_teardown_without_subagents(monkeypatch):
+    """No active sub-agents → no panel banner, no teardown (just cancel task)."""
+    teardown_calls: List[int] = []
+
+    monkeypatch.setattr(_run_signals, "_active_subagent_tasks", [])
+    monkeypatch.setattr(
+        "code_puppy.tools.command_runner._tear_down_live_panels",
+        lambda: teardown_calls.append(1),
+    )
+    monkeypatch.setattr("code_puppy.tools.command_runner._RUNNING_PROCESSES", set())
+
+    loop = _fake_loop_recording()
+    schedule_cancel = _run_signals.make_schedule_cancel(_fake_cancelable_task(), loop)
+    schedule_cancel()
+
+    assert teardown_calls == [], "no sub-agent panel to hide → no teardown"
+    # The main agent task still gets cancelled.
+    assert len(loop.scheduled) == 1

--- a/tests/command_line/test_clipboard_image_files.py
+++ b/tests/command_line/test_clipboard_image_files.py
@@ -1,0 +1,48 @@
+"""Image-file clipboard attachment helpers.
+
+These cover the LIVE Windows/macOS path where the clipboard yields a list of
+file paths (Pillow ``ImageGrab.grabclipboard`` behavior) rather than a native
+image object. The capture is funneled through ``get_clipboard_image`` ->
+``_image_file_list_to_png_bytes`` -> ``get_image_file_as_png``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from code_puppy.command_line import clipboard
+
+
+@pytest.fixture(autouse=True)
+def _reset_clipboard_manager(monkeypatch):
+    monkeypatch.setattr(clipboard, "_clipboard_manager", None)
+    monkeypatch.setattr(clipboard, "_last_clipboard_capture", 0.0)
+
+
+def _write_png(path):
+    if not clipboard.PIL_AVAILABLE or clipboard.Image is None:
+        pytest.skip("Pillow not available")
+    image = clipboard.Image.new("RGB", (3, 2), color="red")
+    image.save(path, format="PNG")
+
+
+def test_get_clipboard_image_reads_file_list_from_imagegrab(tmp_path, monkeypatch):
+    image_path = tmp_path / "screenclip.png"
+    _write_png(image_path)
+    if clipboard.ImageGrab is None:
+        pytest.skip("ImageGrab not available")
+
+    monkeypatch.setattr(clipboard.sys, "platform", "win32")
+    monkeypatch.setattr(clipboard.ImageGrab, "grabclipboard", lambda: [str(image_path)])
+
+    image_bytes = clipboard.get_clipboard_image()
+
+    assert image_bytes is not None
+    assert image_bytes.startswith(b"\x89PNG")
+
+
+def test_get_image_file_as_png_rejects_non_image_suffix(tmp_path):
+    text_path = tmp_path / "not-an-image.txt"
+    text_path.write_text("nope", encoding="utf-8")
+
+    assert clipboard.get_image_file_as_png(str(text_path)) is None

--- a/tests/plugins/conftest.py
+++ b/tests/plugins/conftest.py
@@ -9,26 +9,32 @@ from unittest.mock import MagicMock
 def pytest_configure(config):
     """Configure pytest with compatibility workarounds.
 
-    Pre-patch sys.modules to provide a mock ``mcp.types`` during collection,
-    but only when the real ``mcp`` package is not importable. Previously we
-    checked ``"mcp" not in sys.modules`` which is true on a clean start —
-    that installed MagicMocks for ``mcp.client`` etc. and then, when other
-    tests (e.g. ``tests/agents/test_compaction.py``) transitively imported
-    ``pydantic_ai.mcp``, its ``from mcp.client.sse import sse_client`` blew
-    up with "'mcp.client' is not a package" because the MagicMock had no
-    ``__path__``.
-
-    Real ``mcp`` is installed in this project's dev environment, so the
-    mock path is only needed in bare CI images. Probe with a real import
-    first; only fall back to mocks if that fails.
+    Prefer the real ``mcp`` package when it is importable. Only fall back to
+    stubs in slim environments where it is genuinely unavailable, and stub all
+    submodules that ``pydantic_ai.mcp`` imports during collection.
     """
     try:
         import mcp  # noqa: F401
+        import mcp.client.session  # noqa: F401
+        import mcp.client.sse  # noqa: F401
+        import mcp.client.streamable_http  # noqa: F401
         import mcp.types  # noqa: F401
-    except ImportError:
-        mcp_mock = MagicMock()
-        mcp_mock.types = MagicMock()
-        sys.modules["mcp"] = mcp_mock
-        sys.modules["mcp.types"] = mcp_mock.types
-        sys.modules["mcp.client"] = MagicMock()
-        sys.modules["mcp.client.session"] = MagicMock()
+
+        return
+    except Exception:
+        pass
+
+    mcp_mock = MagicMock()
+    client_mock = MagicMock()
+    mcp_mock.types = MagicMock()
+    mcp_mock.client = client_mock
+    client_mock.session = MagicMock()
+    client_mock.sse = MagicMock()
+    client_mock.streamable_http = MagicMock()
+
+    sys.modules["mcp"] = mcp_mock
+    sys.modules["mcp.types"] = mcp_mock.types
+    sys.modules["mcp.client"] = client_mock
+    sys.modules["mcp.client.session"] = client_mock.session
+    sys.modules["mcp.client.sse"] = client_mock.sse
+    sys.modules["mcp.client.streamable_http"] = client_mock.streamable_http

--- a/tests/plugins/test_duplicate_user_plugin_skip.py
+++ b/tests/plugins/test_duplicate_user_plugin_skip.py
@@ -1,0 +1,25 @@
+"""Regression tests for duplicate built-in/user plugin loading."""
+
+import sys
+
+from code_puppy.plugins import _load_user_plugins
+
+
+def test_user_plugin_skipped_when_builtin_name_loaded(tmp_path):
+    """A built-in plugin should suppress same-named user plugin loading."""
+    user_plugins_dir = tmp_path / "user_plugins"
+    user_plugins_dir.mkdir()
+
+    for plugin_name in ["builtin_copy", "unique_user_plugin"]:
+        plugin_dir = user_plugins_dir / plugin_name
+        plugin_dir.mkdir()
+        (plugin_dir / "register_callbacks.py").write_text("# User plugin")
+
+    try:
+        loaded = _load_user_plugins(user_plugins_dir, skip_names={"builtin_copy"})
+    finally:
+        user_plugins_str = str(user_plugins_dir)
+        if user_plugins_str in sys.path:
+            sys.path.remove(user_plugins_str)
+
+    assert loaded == ["unique_user_plugin"]

--- a/tests/plugins/test_subagent_panel_model_short.py
+++ b/tests/plugins/test_subagent_panel_model_short.py
@@ -1,0 +1,93 @@
+"""Tests for subagent_panel model-name shortening + column alignment.
+
+Covers the UX fix where same-version-different-tier models (e.g. gpt-5.4 vs
+gpt-5.4-nano) used to collapse to an identical "GPT 5.4" label in the panel.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from code_puppy.plugins.subagent_panel.register_callbacks import (
+    _model_short,
+    _model_variant,
+    _row_lines,
+)
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        # The reported bug: nano tier must survive, not collapse to "GPT 5.4".
+        ("gpt-5-4-nano", "GPT 5.4-Nano"),
+        ("gpt-5.4-nano", "GPT 5.4-Nano"),
+        ("chatgpt-gpt-5.4-nano", "GPT 5.4-Nano"),
+        ("gpt-5.4-mini", "GPT 5.4-Mini"),
+        ("gpt-5.4", "GPT 5.4"),
+        ("gpt-4.1-nano", "GPT 4.1-Nano"),
+        ("foundry-gpt-5-4", "GPT 5.4"),
+        # Gemini variants -- 'mini' inside 'gemini' must NOT false-fire.
+        ("gemini-2.5-flash", "Gemini 2.5-Flash"),
+        ("gemini-2.0-pro", "Gemini 2.0-Pro"),
+        ("gemini-1.5", "Gemini 1.5"),
+        # Claude families keep their existing label form, with variants appended.
+        ("claude-4-8-opus", "Opus 4.8"),
+        ("claude-sonnet-4-6", "Sonnet 4.6"),
+        ("claude-3-5-haiku", "Haiku 3.5"),
+        # Empty / unknown fall through gracefully.
+        ("", ""),
+        (None, ""),
+        ("some-weird-model", "some-weird-model"),
+    ],
+)
+def test_model_short(model, expected):
+    assert _model_short(model) == expected
+
+
+def test_model_variant_no_false_positive_inside_gemini():
+    # 'mini' is a substring of 'gemini' -- the delimiter guard must reject it.
+    assert _model_variant("gemini-2.5") == ""
+    # But a real delimited token is found.
+    assert _model_variant("gpt-5.4-mini") == "Mini"
+    assert _model_variant("gpt-5.4-nano") == "Nano"
+    assert _model_variant("gemini-2.5-flash") == "Flash"
+
+
+def test_distinct_tiers_render_distinctly():
+    """The whole point: three gpt-5.4 tiers must produce three labels."""
+    labels = {_model_short(m) for m in ("gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano")}
+    assert labels == {"GPT 5.4", "GPT 5.4-Mini", "GPT 5.4-Nano"}
+
+
+def _entry(session_id, name, model, **extra):
+    base = {
+        "session_id": session_id,
+        "parent": None,
+        "name": name,
+        "model": model,
+        "status": "starting",
+        "start": 0.0,
+        "last_seen": 0.0,
+    }
+    base.update(extra)
+    return base
+
+
+def test_columns_stay_aligned_with_varying_model_lengths():
+    """A longer model label must push every row's status column to the same
+    tab-stop -- spaces only, no ragged columns."""
+    ordered = [
+        (_entry("a", "short", "gpt-5.4"), 0),
+        (_entry("b", "alpha", "gpt-5.4-nano"), 0),
+        (_entry("c", "beta", "claude-4-8-opus"), 0),
+    ]
+    lines = _row_lines(ordered, frame="*")
+    plains = [line.plain for line in lines]
+
+    # No literal tab characters anywhere -- cross-platform safe.
+    assert all("\t" not in p for p in plains)
+
+    # The spinner marker '*' must start at the SAME column on every row, which
+    # only holds if model+name padding aligned the right block.
+    marker_cols = [p.index("*") for p in plains]
+    assert len(set(marker_cols)) == 1, (marker_cols, plains)

--- a/tests/test_console_spinner_races.py
+++ b/tests/test_console_spinner_races.py
@@ -1,0 +1,109 @@
+"""Regression tests for ConsoleSpinner teardown races."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+from rich.text import Text
+
+
+def _not_paused():
+    controller = MagicMock()
+    controller.is_paused.return_value = False
+    return controller
+
+
+def test_update_spinner_uses_live_snapshot_during_teardown_race():
+    from code_puppy.messaging.spinner.console_spinner import ConsoleSpinner
+
+    spinner = ConsoleSpinner(console=MagicMock())
+    spinner._is_spinning = True
+    spinner._paused = False
+    live = MagicMock()
+    spinner._live = live
+
+    def _stop_live_during_update(_panel):
+        spinner._live = None
+
+    def _stop_after_refresh():
+        spinner._stop_event.set()
+
+    live.update.side_effect = _stop_live_during_update
+    live.refresh.side_effect = _stop_after_refresh
+    stderr = MagicMock()
+
+    with (
+        patch.object(spinner, "update_frame"),
+        patch.object(spinner, "_generate_spinner_panel", return_value=Text("test")),
+        patch(
+            "code_puppy.tools.command_runner.is_awaiting_user_input",
+            return_value=False,
+        ),
+        patch(
+            "code_puppy.messaging.pause_controller.get_pause_controller",
+            _not_paused,
+        ),
+        patch("time.sleep", return_value=None),
+        patch.object(sys, "stderr", stderr),
+    ):
+        spinner._update_spinner()
+
+    live.update.assert_called_once()
+    live.refresh.assert_called_once()
+    stderr.write.assert_not_called()
+    assert spinner._is_spinning is True
+
+
+def test_pause_clears_live_reference_even_when_stop_raises():
+    from code_puppy.messaging.spinner.console_spinner import ConsoleSpinner
+
+    spinner = ConsoleSpinner(console=MagicMock())
+    spinner._is_spinning = True
+    live = MagicMock()
+    live.stop.side_effect = RuntimeError("already stopped")
+    spinner._live = live
+
+    spinner.pause()
+
+    live.stop.assert_called_once()
+    assert spinner._live is None
+    assert spinner._paused is True
+
+
+def test_update_spinner_skips_frame_when_live_refresh_is_stopped():
+    from code_puppy.messaging.spinner.console_spinner import ConsoleSpinner
+
+    spinner = ConsoleSpinner(console=MagicMock())
+    spinner._is_spinning = True
+    spinner._paused = False
+    live = MagicMock()
+    spinner._live = live
+
+    def _raise_stopped_live():
+        spinner._stop_event.set()
+        raise RuntimeError("Live display is already stopped")
+
+    live.refresh.side_effect = _raise_stopped_live
+    stderr = MagicMock()
+
+    with (
+        patch.object(spinner, "update_frame"),
+        patch.object(spinner, "_generate_spinner_panel", return_value=Text("test")),
+        patch(
+            "code_puppy.tools.command_runner.is_awaiting_user_input",
+            return_value=False,
+        ),
+        patch(
+            "code_puppy.messaging.pause_controller.get_pause_controller",
+            _not_paused,
+        ),
+        patch("time.sleep", return_value=None),
+        patch.object(sys, "stderr", stderr),
+    ):
+        spinner._update_spinner()
+
+    live.update.assert_called_once()
+    live.refresh.assert_called_once()
+    stderr.write.assert_not_called()
+    assert spinner._is_spinning is True

--- a/tests/tools/test_command_runner_swarm_cancel.py
+++ b/tests/tools/test_command_runner_swarm_cancel.py
@@ -1,0 +1,250 @@
+"""Tests for the Ctrl+C -> stop-the-whole-swarm behavior.
+
+A single Ctrl+C during a sub-agent swarm must kill the shells AND request a
+cancel of every sub-agent task + the main agent, instead of only killing the
+current batch of shells (which forced the user to mash Ctrl+C once per
+still-running sub-agent).
+"""
+
+from unittest.mock import patch
+
+import code_puppy.tools.command_runner as command_runner
+from code_puppy.tools.command_runner import (
+    _shell_sigint_handler,
+    _tear_down_live_panels,
+    clear_agent_cancel,
+    register_agent_cancel,
+)
+
+
+class TestSwarmCancelOnSigint:
+    def teardown_method(self):
+        # Never let a registered callback leak into another test.
+        clear_agent_cancel()
+
+    def test_headless_only_kills_shells(self):
+        """No active run registered -> behave like the old shells-only handler."""
+        clear_agent_cancel()
+        with (
+            patch.object(
+                command_runner, "kill_all_running_shell_processes"
+            ) as mock_kill,
+            patch.object(command_runner, "emit_warning"),
+        ):
+            _shell_sigint_handler(None, None)
+        mock_kill.assert_called_once()
+
+    def test_sigint_kills_shells_then_cancels_with_force(self):
+        """With a run registered: kill shells AND call cancel cb with force=True."""
+        calls = []
+
+        def fake_cancel(force=False):
+            calls.append(force)
+
+        register_agent_cancel(fake_cancel)
+        with (
+            patch.object(
+                command_runner, "kill_all_running_shell_processes"
+            ) as mock_kill,
+            patch.object(command_runner, "emit_warning"),
+        ):
+            _shell_sigint_handler(None, None)
+
+        mock_kill.assert_called_once()
+        assert calls == [True], "cancel cb must be invoked exactly once with force=True"
+
+    def test_banner_and_cancel_are_deduped(self):
+        """Mashing Ctrl+C during teardown must not re-fire the cancel sweep."""
+        calls = []
+
+        register_agent_cancel(lambda force=False: calls.append(force))
+        with (
+            patch.object(command_runner, "kill_all_running_shell_processes"),
+            patch.object(command_runner, "emit_warning") as mock_warn,
+        ):
+            _shell_sigint_handler(None, None)
+            _shell_sigint_handler(None, None)
+            _shell_sigint_handler(None, None)
+
+        assert calls == [True], "cancel sweep must fire only once per run"
+        # Only the first press emits the stop banner.
+        assert mock_warn.call_count == 1
+
+    def test_register_resets_dedupe_flag(self):
+        """A fresh run (re-register) re-arms the one-shot dedupe flag."""
+        calls = []
+        register_agent_cancel(lambda force=False: calls.append(force))
+        with (
+            patch.object(command_runner, "kill_all_running_shell_processes"),
+            patch.object(command_runner, "emit_warning"),
+        ):
+            _shell_sigint_handler(None, None)
+            # New run starts -> should be cancellable again.
+            register_agent_cancel(lambda force=False: calls.append(force))
+            _shell_sigint_handler(None, None)
+
+        assert calls == [True, True]
+
+    def test_clear_drops_callback(self):
+        """clear_agent_cancel() makes the handler fall back to shells-only."""
+        calls = []
+        register_agent_cancel(lambda force=False: calls.append(force))
+        clear_agent_cancel()
+        with (
+            patch.object(
+                command_runner, "kill_all_running_shell_processes"
+            ) as mock_kill,
+            patch.object(command_runner, "emit_warning"),
+        ):
+            _shell_sigint_handler(None, None)
+        mock_kill.assert_called_once()
+        assert calls == [], "callback was cleared; it must not fire"
+
+    def test_cancel_cb_exception_does_not_crash_handler(self):
+        """A failing cancel cb must never blow up the signal handler."""
+
+        def boom(force=False):
+            raise RuntimeError("nope")
+
+        register_agent_cancel(boom)
+        with (
+            patch.object(
+                command_runner, "kill_all_running_shell_processes"
+            ) as mock_kill,
+            patch.object(command_runner, "emit_warning"),
+        ):
+            # Must not raise.
+            _shell_sigint_handler(None, None)
+        mock_kill.assert_called_once()
+
+
+class FakeSpinner:
+    """Minimal stand-in for ConsoleSpinner that records pause() calls."""
+
+    def __init__(self, *, explode: bool = False):
+        self.paused = 0
+        self._explode = explode
+
+    def pause(self):
+        if self._explode:
+            raise RuntimeError("spinner teardown failed")
+        self.paused += 1
+
+
+class TestTearDownLivePanels:
+    """The cancel path must hide the spinner Live (and the sub-agent panel it
+    hosts) the same way steer does, so the cancel banner isn't repainted over.
+    """
+
+    def teardown_method(self):
+        clear_agent_cancel()
+
+    def test_pauses_every_active_spinner(self):
+        import code_puppy.messaging.spinner as spinner_mod
+
+        spinners = [FakeSpinner(), FakeSpinner()]
+        with patch.object(spinner_mod, "_active_spinners", spinners):
+            _tear_down_live_panels()
+        assert [s.paused for s in spinners] == [1, 1]
+
+    def test_one_spinner_blowing_up_does_not_stop_the_rest(self):
+        import code_puppy.messaging.spinner as spinner_mod
+
+        good_a, boom, good_b = FakeSpinner(), FakeSpinner(explode=True), FakeSpinner()
+        with patch.object(spinner_mod, "_active_spinners", [good_a, boom, good_b]):
+            # Must not raise even though the middle spinner explodes.
+            _tear_down_live_panels()
+        assert good_a.paused == 1 and good_b.paused == 1
+
+    def test_sigint_hides_panel_before_emitting_banner(self):
+        """On the first Ctrl+C the panel is torn down so the banner shows."""
+        import code_puppy.messaging.spinner as spinner_mod
+
+        spinner = FakeSpinner()
+        register_agent_cancel(lambda force=False: None)
+        with (
+            patch.object(spinner_mod, "_active_spinners", [spinner]),
+            patch.object(command_runner, "kill_all_running_shell_processes"),
+            patch.object(command_runner, "emit_warning"),
+        ):
+            _shell_sigint_handler(None, None)
+        assert spinner.paused == 1, "panel must be hidden on cancel"
+
+    def test_extra_presses_keep_panel_hidden(self):
+        """Deduped extra presses still re-hide the panel in case a frame raced."""
+        import code_puppy.messaging.spinner as spinner_mod
+
+        spinner = FakeSpinner()
+        register_agent_cancel(lambda force=False: None)
+        with (
+            patch.object(spinner_mod, "_active_spinners", [spinner]),
+            patch.object(command_runner, "kill_all_running_shell_processes"),
+            patch.object(command_runner, "emit_warning"),
+        ):
+            _shell_sigint_handler(None, None)  # first: hide + banner
+            _shell_sigint_handler(None, None)  # deduped: still hides
+        assert spinner.paused == 2
+
+    def test_teardown_and_banner_fire_before_the_slow_kill(self):
+        """REGRESSION: the deep-swarm 'panel stays up until shells die' bug.
+
+        ``kill_all_running_shell_processes`` blocks for ~2s *per* nested shell
+        (SIGTERM->SIGINT->SIGKILL escalation). If the panel teardown / banner
+        run AFTER it (the old order), the spinner Live keeps repainting the
+        sub-agent panel for that whole window and the user sees nothing happen.
+        The teardown + banner MUST precede the kill so the UI responds instantly.
+        """
+        import code_puppy.messaging.spinner as spinner_mod
+
+        order = []
+        spinner = FakeSpinner()
+        # Record relative ordering of the three observable side effects.
+        spinner.pause = lambda: order.append("teardown")  # type: ignore[assignment]
+
+        register_agent_cancel(lambda force=False: order.append("cancel"))
+        with (
+            patch.object(spinner_mod, "_active_spinners", [spinner]),
+            patch.object(
+                command_runner,
+                "kill_all_running_shell_processes",
+                side_effect=lambda: order.append("kill"),
+            ),
+            patch.object(
+                command_runner,
+                "emit_warning",
+                side_effect=lambda *_a, **_k: order.append("banner"),
+            ),
+        ):
+            _shell_sigint_handler(None, None)
+
+        assert order == ["teardown", "banner", "kill", "cancel"], (
+            "panel teardown and banner must precede the blocking shell kill so "
+            f"the UI responds instantly; got {order}"
+        )
+
+    def test_headless_path_also_hides_panel_before_kill(self):
+        """Even with no agent run, hide the panel + banner before the slow kill."""
+        import code_puppy.messaging.spinner as spinner_mod
+
+        order = []
+        spinner = FakeSpinner()
+        spinner.pause = lambda: order.append("teardown")  # type: ignore[assignment]
+        clear_agent_cancel()
+        with (
+            patch.object(spinner_mod, "_active_spinners", [spinner]),
+            patch.object(
+                command_runner,
+                "kill_all_running_shell_processes",
+                side_effect=lambda: order.append("kill"),
+            ),
+            patch.object(
+                command_runner,
+                "emit_warning",
+                side_effect=lambda *_a, **_k: order.append("banner"),
+            ),
+        ):
+            _shell_sigint_handler(None, None)
+
+        assert order == ["teardown", "banner", "kill"], (
+            f"headless path must hide + announce before killing; got {order}"
+        )

--- a/tests/tools/test_image_tool_guardrails.py
+++ b/tests/tools/test_image_tool_guardrails.py
@@ -1,0 +1,24 @@
+"""Guardrail tests for image-analysis tool descriptions."""
+
+from __future__ import annotations
+
+
+class _Agent:
+    def __init__(self) -> None:
+        self.registered = {}
+
+    def tool(self, func):
+        self.registered[func.__name__] = func
+        return func
+
+
+def test_load_image_tool_docstring_discourages_guessed_paths():
+    from code_puppy.tools.image_tools import register_load_image
+
+    agent = _Agent()
+    register_load_image(agent)
+
+    doc = agent.registered["load_image_for_analysis"].__doc__ or ""
+    assert "already visible in the conversation" in doc
+    assert "do not call" in doc
+    assert "/tmp/screenshot.png" in doc


### PR DESCRIPTION
# feat(plugin): sub-agent (Invoke Agent) CLI panel

## The whole PR

Consolidates the sub-agent status UX into a single built-in plugin
(`code_puppy/plugins/subagent_panel/`) — replacing the older split
`cp_steer_overlay` + `cp_subagent_status` experiment — and hardens the
interrupt/teardown path around it so a single **Ctrl+C cleanly stops a whole
sub-agent swarm** instead of forcing you to mash it once per nested agent.

Along the way it fixes a spinner teardown race, makes the clipboard image path
Windows-aware, and gates the spinner's raw ANSI writes on `isatty()` so
redirected / non-VT consoles (including legacy Windows shells) don't get escape
garbage. macOS interactive behavior is **byte-for-byte unchanged**.

## Why

- **Ctrl+C used to need N presses.** The sub-agent status panel renders *inside*
  the spinner's Rich `Live` (repaints ~20×/sec). On Ctrl+C the cancel banner
  printed once and the next Live frame painted the panel right back over it, so
  a single press *looked* like it did nothing. Worse, the SIGINT handler killed
  shells **before** tearing down the panel — and `_kill_process_group` blocks up
  to ~2s **per** nested shell — so in a deep swarm the UI froze for N×~2s while
  the panel kept repainting. Fix: **tear down the Live panel + emit the banner
  *before* the slow blocking kill**, then force-cancel the whole agent tree.
- **The cancel didn't reach sub-agents.** The shell SIGINT handler had no way to
  reach the active run's cancel callback, so it only ever killed the current
  batch of shells. Added a `register_agent_cancel` / `clear_agent_cancel` bridge
  (set at run start, cleared in `finally`) so one Ctrl+C collapses the entire
  agent/sub-agent swarm.
- **Spinner teardown race.** `pause()`/`stop()` can null `self._live` from
  another thread between the refresh guard and the refresh call — and the new
  cancel path triggers exactly that. Snapshot `_live` locally + guard the frame.
- **Windows portability.** The clipboard now handles `ImageGrab.grabclipboard()`
  returning a **file-path list** (the Windows / Finder behavior), and the
  spinner's raw `\x1b[K` writes are gated on `sys.stdout.isatty()`.

## Files changed (22)

| File | Net change |
|---|---|
| `code_puppy/plugins/subagent_panel/` *(new plugin: register_callbacks, state, coalesce_patch, resume_repaint, README, __init__)* | **+1331** |
| `code_puppy/tools/command_runner.py` | +110 / − (SIGINT reorder, cancel bridge, `_tear_down_live_panels`) |
| `code_puppy/messaging/spinner/console_spinner.py` | +58 / − (live-snapshot race fix, `isatty()` ANSI gate) |
| `code_puppy/command_line/clipboard.py` | +78 / − (file-list path, reusable PNG helpers; dropped orphan) |
| `code_puppy/agents/_run_signals.py` | +21 / − (`force=` cancel param, panel teardown) |
| `code_puppy/agents/_runtime.py` | +14 (register/clear cancel cb around the run) |
| `code_puppy/plugins/__init__.py` | +10 / − (skip user plugins colliding with builtin names) |
| `code_puppy/model_factory.py` | +5 (dormant `advisor_tool_enabled` beta header gate) |
| `code_puppy/tools/image_tools.py` | +5 (docstring guardrail vs guessed image paths) |
| `tests/**` *(swarm-cancel, spinner races, clipboard file-list, plugin-skip, image-tool guardrail, pause-guard, conftest)* | **+569 / −** |

_~2,134 insertions across 22 files._

## Tests

- **Added** `tests/tools/test_command_runner_swarm_cancel.py` — kill-before-cancel
  ordering (`teardown → banner → kill → cancel`), one-shot dedupe on mashed
  presses, headless fallback, force-cancel, panel-teardown resilience.
- **Added** `tests/test_console_spinner_races.py` — live-snapshot teardown race,
  `pause()` clears `_live` even when `stop()` raises, frame-skip on stopped Live.
- **Added** `tests/command_line/test_clipboard_image_files.py` — `ImageGrab`
  file-list path + non-image suffix rejection on the live helper.
- **Added** `tests/plugins/test_duplicate_user_plugin_skip.py` — builtin name
  suppresses same-named user plugin.
- **Added** `tests/tools/test_image_tool_guardrails.py` — load-image docstring
  discourages guessed paths.
- **Extended** `tests/agents/test_run_signals_pause_guard.py` — cancel tears down
  the panel before the banner; no teardown when no sub-agents.
- All touched suites green locally (`110 passed` across the affected modules).

## Manual validation

1. Kick off a deep sub-agent swarm (children → grandchildren → great-grandchildren,
   each holding a `sleep`). Press **Ctrl+C once** → banner shows instantly, the
   panel vanishes, and the whole tree cancels (no per-agent mashing). 
2. Repeat with output **piped** to a file → no literal `←[K` escape garbage. 
3. Verified on **Windows** (no `os.killpg`/`SIGKILL` evaluated — `taskkill /F /T`
   early-returns; clipboard file-list path works for ScreenClip paste). 
4. macOS interactive run → spinner/Live behavior unchanged. 

## Platform status

- **macOS:** complete, dogfooded.
- **Windows:** verified (signal path already guarded; `isatty()` gate + clipboard
  file-list make the new code Windows-clean).
- **Linux:** expected to behave like macOS (POSIX path); not separately exercised.

## History

This is the consolidation of the earlier `cp_steer_overlay` + `cp_subagent_status`
plugins into one `subagent_panel` plugin. Key pivots:

- **Kill-first → teardown-first SIGINT ordering.** The first cut killed shells
  before hiding the panel; in a deep swarm the blocking per-process kill froze the
  UI for seconds while the panel repainted. Reordered to hide + announce *before*
  the slow kill.
- **Shells-only cancel → full-tree cancel bridge.** Added the
  `register/clear_agent_cancel` bridge so Ctrl+C reaches every sub-agent, not just
  the current shell batch.
- **Dropped orphaned `capture_image_file_to_pending`.** Its only prod consumer was
  the removed `cp_steer_overlay`; the reusable `get_image_file_as_png` helper stays
  live via `get_clipboard_image`'s file-list branch.
- **`advisor_tool_enabled`** is intentionally **dormant** (no config sets it yet) —
  scaffolding for a future Anthropic beta opt-in, gated so it stays inert.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Consolidate sub-agent status UX into built-in plugin with live two-line panel

- Fix Ctrl+C to cleanly stop entire sub-agent swarm instead of requiring N presses

- Harden spinner teardown race and gate ANSI writes on `isatty()` for Windows

- Support Windows clipboard image-file paths and add steer overlay image paste


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Ctrl+C Signal"] --> B["Tear Down Live Panel"]
  B --> C["Emit Cancel Banner"]
  C --> D["Kill Shell Processes"]
  D --> E["Cancel Agent Tree"]
  E --> F["Swarm Stops"]
  
  G["Sub-agent Invocation"] --> H["Register in State"]
  H --> I["Render Live Block"]
  I --> J["Stream Events Update Status"]
  J --> K["On Completion: Freeze Record"]
  
  L["Windows Clipboard"] --> M["Handle File Paths"]
  M --> N["Convert to PNG"]
  N --> O["Attach to Message"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>_run_signals.py</strong><dd><code>Add force-cancel parameter to bypass shell-running guard</code>&nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-dbf7848cfaa690ec44932739a2231b07e5d368762b9540171ba0ae9c24178d52">+18/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>_runtime.py</strong><dd><code>Register and clear agent cancel callback around run</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-de99bf647c8e25c083c0f793ab59f77020af91f7e4ed79118408262e427ec638">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>clipboard.py</strong><dd><code>Support Windows image-file paths and extract PNG helpers</code>&nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-8398ff23024b548b0af1bb6a4023e8186c70a1a364cbea5948beef3b0473b9cf">+56/-22</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>model_factory.py</strong><dd><code>Add dormant advisor-tool beta flag support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-071a8f11f49d4b23fb257db6c7a14d37ac1ff3980c2ab8efa232ed7a84c5d4a5">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>Skip user plugins when built-in name already loaded</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-6ee32a052e2796644f54be706e901f1f4bf59b1d5835083aedc87365ec091700">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>New plugin module docstring and exports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-a5675b12d08eadf0ebceaddd767b210de651b333351d2bc5f17da78ab3b09ae0">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>coalesce_patch.py</strong><dd><code>Batch sub-agent stream events to prevent steer lag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-c25c904796d1d020290b1c52b0c940efc6c9938bb1909ff6491ba23e24e1ddac">+236/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>register_callbacks.py</strong><dd><code>Install monkeypatches for live panel rendering and state</code>&nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-cc893401d660a1a01a668455ceab2b4713d030ef2b9cb8d4b35ac2fdefd9306d">+581/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>resume_repaint.py</strong><dd><code>Repaint panel after Ctrl+T steer overlay resumes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-09fea038aede97ec89f1f84a1ed24bcede8540ca6460171e416d9da82f39f10f">+167/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>state.py</strong><dd><code>Thread-safe registry of active sub-agents and status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-b7f489f00d41cbe7a737e2e0f4c6ddfbc10e39e24d7e2500df7721034d195256">+223/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>command_runner.py</strong><dd><code>Implement responsive Ctrl+C swarm-cancel with panel teardown</code></dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-c823edff8ccf1001759e2c6c86d47dd0c670ed88aa13a376d1f3bf14c023f518">+107/-3</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>console_spinner.py</strong><dd><code>Fix teardown race and gate ANSI writes on isatty</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-3d0db765f7253509317203a30d329412bcd76f68a786dd4b5765ca79f2913842">+41/-17</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Documentation for sub-agent panel plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-26a447ad7dc96a187fa9e561644acf62ca25ab19d4756f3fb07c7c56e63e3195">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>image_tools.py</strong><dd><code>Add guardrail to discourage guessed image paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-b95c3dcafbb67298807b138dcb9ea87a435383035be64af0ef7b254731e6e9d9">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>test_run_signals_pause_guard.py</strong><dd><code>Add tests for cancel panel teardown and force parameter</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-f24dc543da5b98a55e5d3262fc1f9e7d6a01f5ffad51768ed6f3aa03eef4da59">+89/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_clipboard_image_files.py</strong><dd><code>New tests for Windows image-file clipboard handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-f7c0df3cbf811991a9c4c4773175d68f5bd2a603a295f934929ca085d8c308e0">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>conftest.py</strong><dd><code>Improve MCP mock setup to prefer real package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-613bef1b52b7ae3acfd52a1e9c076060a076eb7a6b33c752eb79dcd380c26254">+25/-19</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_duplicate_user_plugin_skip.py</strong><dd><code>New regression test for duplicate plugin skip behavior</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-c32b94f33679b5be39559016b8c4e14c83622c3399931545e780ad6d550e11ea">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_console_spinner_races.py</strong><dd><code>New tests for spinner teardown race conditions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-2c78b3b0ed443848edda060c1e60e5eff91c324b1586842e549310e50692ed05">+109/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_command_runner_swarm_cancel.py</strong><dd><code>New comprehensive tests for Ctrl+C swarm-cancel behavior</code>&nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-ca2bfe4bd42a9f6d5353787fb58fbb9bfdbfd62d33daf1e5ea7e03dd1d5e9a32">+230/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_image_tool_guardrails.py</strong><dd><code>New test for load-image tool docstring guardrails</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://gecgithub01.walmart.com/AI-INNOVATION-LAB/code-puppy/pull/455/files#diff-88758cae306919f62a1df62faaae1cc9a00f2c8351b562bcbcc47123e8366a99">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

