### PR TITLE
fix: serialize DBOS startup so concurrent launches don't race the SQLite migration

### DIFF
--- a/code_puppy/plugins/dbos_durable_exec/lifecycle.py
+++ b/code_puppy/plugins/dbos_durable_exec/lifecycle.py
@@ -7,9 +7,11 @@ import time
 import traceback
 
 from code_puppy import __version__ as current_version
+from code_puppy.config import DATA_DIR
 from code_puppy.messaging import emit_error, emit_info
 
-from .config import DBOS_DATABASE_URL
+from .config import _DEFAULT_SQLITE_FILE, DBOS_DATABASE_URL
+from .startup_lock import enable_sqlite_wal, interprocess_lock
 
 # Module-level flag flipped True only after a successful DBOS.launch().
 # Other plugin modules (e.g. wrapper.py, runtime.py) MUST check this before
@@ -52,8 +54,20 @@ def on_startup() -> None:
     }
     try:
         emit_info(f"Initializing DBOS with database at: {DBOS_DATABASE_URL}")
-        DBOS(config=dbos_config)
-        DBOS.launch()
+        # Multiple instances (e.g. several Zellij panes) share one SQLite
+        # system database. DBOS.launch() runs schema migration + recovery,
+        # which take SQLite's single-writer lock. Without serialization the
+        # racers collide on the lock and all-but-one fail to launch. We:
+        #   1) flip the DB to WAL mode (persistent) so concurrent access is
+        #      far less likely to block once initialized, and
+        #   2) hold a cross-process file lock so launch/migration runs one
+        #      process at a time. Late starters wait instead of crashing.
+        if DBOS_DATABASE_URL.startswith("sqlite"):
+            enable_sqlite_wal(_DEFAULT_SQLITE_FILE)
+        launch_lock = os.path.join(DATA_DIR, "dbos_store.launch.lock")
+        with interprocess_lock(launch_lock, timeout=60.0):
+            DBOS(config=dbos_config)
+            DBOS.launch()
         _LAUNCHED = True
     except Exception as e:
         emit_error(

--- a/code_puppy/plugins/dbos_durable_exec/startup_lock.py
+++ b/code_puppy/plugins/dbos_durable_exec/startup_lock.py
@@ -1,0 +1,156 @@
+"""Cross-process startup serialization for the DBOS durable-exec plugin.
+
+Multiple Code Puppy instances launched at the same instant (e.g. several
+Zellij panes each spawning their own process) all open the *same* shared
+DBOS SQLite system database and run schema migration + workflow recovery
+during ``DBOS.launch()``. SQLite is single-writer, so the racers collide on
+the write lock, and the losers either raise ``database is locked`` (or an
+Alembic migration conflict) and disable durable execution -- or, on older
+builds, exit the whole process with code 1.
+
+This module provides:
+
+* :func:`interprocess_lock` -- a cross-platform advisory file lock so that
+  DBOS initialization happens one process at a time. Late starters *wait*
+  for the lock instead of racing the migration.
+* :func:`enable_sqlite_wal` -- flips the shared SQLite database into WAL
+  journal mode (a persistent, header-level setting) so that, once
+  initialized, concurrent reads/writes are far less likely to block.
+
+Both helpers fail soft: locking and PRAGMA tuning are best-effort
+optimizations, never correctness requirements, so any platform quirk
+degrades to the previous (racy) behavior rather than blocking startup.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+import time
+from typing import Iterator
+
+# Platform-specific locking primitives. We deliberately avoid adding a
+# third-party dependency (filelock/portalocker) since the stdlib already
+# gives us everything on both POSIX and Windows.
+try:  # POSIX
+    import fcntl
+
+    _HAVE_FCNTL = True
+except ImportError:  # pragma: no cover - Windows
+    _HAVE_FCNTL = False
+
+try:  # Windows
+    import msvcrt
+
+    _HAVE_MSVCRT = True
+except ImportError:  # pragma: no cover - POSIX
+    _HAVE_MSVCRT = False
+
+
+def _try_acquire(fd: int) -> bool:
+    """Attempt a single non-blocking exclusive lock on ``fd``.
+
+    Returns True on success, False if the lock is currently held elsewhere.
+    """
+    if _HAVE_FCNTL:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except OSError:
+            return False
+    if _HAVE_MSVCRT:
+        try:
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError:
+            return False
+    # No locking primitive available: behave as if always acquired.
+    return True
+
+
+def _release(fd: int) -> None:
+    """Best-effort release of a lock previously taken on ``fd``."""
+    try:
+        if _HAVE_FCNTL:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        elif _HAVE_MSVCRT:
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+    except OSError:
+        pass
+
+
+@contextlib.contextmanager
+def interprocess_lock(lock_path: str, timeout: float = 30.0) -> Iterator[bool]:
+    """Hold a cross-process advisory lock for the duration of the block.
+
+    Serializes a critical section across separate Code Puppy processes. Late
+    arrivals poll until the holder releases or ``timeout`` seconds elapse.
+
+    Yields:
+        True if the lock was actually acquired, False if it timed out (the
+        caller still runs -- we never want a cosmetic lock to *prevent*
+        startup, only to order it when possible).
+    """
+    os.makedirs(os.path.dirname(lock_path), exist_ok=True)
+
+    fd = None
+    acquired = False
+    try:
+        # Windows requires a real byte in the file to lock a region.
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o644)
+        if _HAVE_MSVCRT:
+            try:
+                os.write(fd, b"\0")
+                os.lseek(fd, 0, os.SEEK_SET)
+            except OSError:
+                pass
+
+        deadline = time.monotonic() + max(timeout, 0.0)
+        while True:
+            if _try_acquire(fd):
+                acquired = True
+                break
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(0.1)
+
+        yield acquired
+    finally:
+        if fd is not None:
+            if acquired:
+                _release(fd)
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def enable_sqlite_wal(sqlite_path: str) -> None:
+    """Switch the shared SQLite DB to WAL journal mode (best effort).
+
+    WAL is a persistent, header-level setting, so a single successful call
+    sticks for every future connection (including DBOS's own engine). It lets
+    readers and a writer coexist, dramatically reducing ``database is locked``
+    errors at runtime. Failures are swallowed -- this is pure optimization.
+    """
+    try:
+        import sqlite3
+    except ImportError:  # pragma: no cover - sqlite3 is stdlib
+        return
+
+    try:
+        os.makedirs(os.path.dirname(sqlite_path), exist_ok=True)
+        # busy_timeout here only affects *this* connection, but WAL is what
+        # we actually persist. timeout keeps this probe from hanging.
+        conn = sqlite3.connect(sqlite_path, timeout=5.0)
+        try:
+            conn.execute("PRAGMA journal_mode=WAL;")
+            conn.execute("PRAGMA busy_timeout=30000;")
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception as exc:  # noqa: BLE001 - cosmetic optimization, fail soft
+        # Surface a hint in debug mode but never block startup.
+        if os.environ.get("CODE_PUPPY_DEBUG"):
+            sys.stderr.write(f"[dbos_durable_exec] WAL setup skipped: {exc}\n")

--- a/tests/plugins/test_dbos_startup_lock.py
+++ b/tests/plugins/test_dbos_startup_lock.py
@@ -1,0 +1,91 @@
+"""Tests for the DBOS plugin's startup_lock helpers.
+
+These guard the simultaneous-launch fix: multiple Code Puppy instances
+(e.g. several Zellij panes) must serialize DBOS initialization instead of
+racing the shared SQLite system database and failing all-but-one.
+"""
+
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+from code_puppy.plugins.dbos_durable_exec.startup_lock import (
+    enable_sqlite_wal,
+    interprocess_lock,
+)
+
+_STARTUP_LOCK_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "code_puppy",
+    "plugins",
+    "dbos_durable_exec",
+    "startup_lock.py",
+)
+
+
+def test_enable_sqlite_wal_sets_wal_mode():
+    with tempfile.TemporaryDirectory() as d:
+        db = os.path.join(d, "dbos_store.sqlite")
+        enable_sqlite_wal(db)
+        mode = sqlite3.connect(db).execute("PRAGMA journal_mode;").fetchone()[0]
+        assert mode.lower() == "wal"
+
+
+def test_enable_sqlite_wal_fails_soft_on_bad_path():
+    # A path whose parent cannot be created must not raise.
+    enable_sqlite_wal("/proc/cannot/create/here/dbos.sqlite")
+
+
+def test_interprocess_lock_yields_acquired():
+    with tempfile.TemporaryDirectory() as d:
+        lock = os.path.join(d, "x.launch.lock")
+        with interprocess_lock(lock, timeout=5) as acquired:
+            assert acquired is True
+
+
+def test_interprocess_lock_serializes_across_processes():
+    """Two processes racing for the lock must NOT hold it simultaneously."""
+    with tempfile.TemporaryDirectory() as d:
+        lock = os.path.join(d, "race.launch.lock")
+        startup_lock_path = os.path.abspath(_STARTUP_LOCK_PATH)
+        script = textwrap.dedent(
+            f"""
+            import importlib.util, sys, time
+            spec = importlib.util.spec_from_file_location(
+                "startup_lock", {startup_lock_path!r}
+            )
+            m = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(m)
+            with m.interprocess_lock({lock!r}, timeout=10):
+                sys.stdout.write(f"ACQ {{time.time():.4f}}\\n")
+                sys.stdout.flush()
+                time.sleep(0.5)
+            """
+        )
+        procs = [
+            subprocess.Popen(
+                [sys.executable, "-c", script],
+                stdout=subprocess.PIPE,
+                text=True,
+            )
+            for _ in range(2)
+        ]
+        outs = [p.communicate(timeout=30)[0] for p in procs]
+
+        acquires = [
+            float(line.split()[1])
+            for out in outs
+            for line in out.splitlines()
+            if line.startswith("ACQ")
+        ]
+        assert len(acquires) == 2, f"expected 2 acquisitions, got {outs}"
+        # The second acquisition must wait for the first holder (>=0.4s gap,
+        # allowing slack under the 0.5s hold).
+        assert abs(acquires[0] - acquires[1]) >= 0.4, (
+            f"locks were not serialized: {acquires}"
+        )


### PR DESCRIPTION
## Problem

Launching multiple Code Puppy instances at the same instant — e.g. several Zellij panes each spawning their own process — crashes all-but-one. One starts fine, the rest die on startup.

## Root cause (reproduced)

DBOS durable execution is on by default, and **every instance shares one SQLite system database** (`~/.code_puppy/dbos_store.sqlite`). On startup, `DBOS.launch()` calls `run_migrations()`, which does a **non-atomic check-then-create** of the `dbos_migrations` table (`dbos/_sys_db_sqlite.py`). Two concurrent launches both pass the "table doesn't exist" check, both run `CREATE TABLE`, and the loser blows up:

```
sqlite3.OperationalError: table dbos_migrations already exists
[SQL: CREATE TABLE dbos_migrations (version INTEGER NOT NULL PRIMARY KEY)]
  File ".../dbos/_dbos.py", line 513, in _launch
    self._sys_db.run_migrations()
  File ".../dbos/_sys_db_sqlite.py", line 62, in run_migrations
    conn.execute(sa.text("CREATE TABLE dbos_migrations ..."))
```

- On **older builds**, this exception reached `sys.exit(1)` → hard process exit (the visible "crash").
- On **current `main`**, `dbos_durable_exec.lifecycle.on_startup()` catches it → logs an error and silently runs **without** durable execution.

Either way it's broken: you either lose the process or lose durability, purely because two puppies started at once.

## Fix

Serialize DBOS initialization across processes:

1. **Cross-process advisory file lock** (`startup_lock.interprocess_lock`) around `DBOS()` + `DBOS.launch()`. Late starters wait for the holder to finish migrating instead of racing it. Implemented with stdlib `fcntl` (POSIX) / `msvcrt` (Windows) — no new dependency — and fails soft (a missing lock primitive degrades to old behavior, never blocks startup).
2. **WAL journal mode** on the shared SQLite DB (`enable_sqlite_wal`), a persistent header-level setting that reduces runtime `database is locked` contention.

The **file lock is the essential fix** — WAL alone cannot resolve a check-then-create *logic* race.

## Verification

Two-process repro (same shared DB, started simultaneously):

- **Before:** one process `LAUNCH OK`, the other `OperationalError: table dbos_migrations already exists`.
- **After:** the second process waits for the lock, then both launch cleanly and serialized.

Plus `tests/plugins/test_dbos_startup_lock.py` (4 tests, incl. a real two-subprocess race asserting serialization). `ruff format --check .` clean, `ruff check` clean, full plugin DBOS suite green (46 passed).

## Scope

- `code_puppy/plugins/dbos_durable_exec/startup_lock.py` (new)
- `code_puppy/plugins/dbos_durable_exec/lifecycle.py` (wire lock + WAL into `on_startup`)
- `tests/plugins/test_dbos_startup_lock.py` (new)

Entirely contained within the DBOS plugin; no core changes.
