### PR TITLE
fix: stop a fast Ctrl+C double-tap from exiting the whole REPL

### DIFF
--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -11,6 +11,7 @@ apply_all_patches()
 import argparse
 import asyncio
 import os
+import signal
 import sys
 import traceback
 from pathlib import Path
@@ -429,6 +430,32 @@ async def main():
         await callbacks.on_shutdown()
 
 
+def _interactive_sigint_guard(_sig, _frame):
+    """Baseline SIGINT handler for the interactive REPL.
+
+    Ctrl+C in Code Puppy is a *cancel* gesture, never a *quit* gesture
+    (Ctrl+D quits). During an agent run or a shell command the runtime
+    installs its own SIGINT handler that turns Ctrl+C into a task cancel /
+    shell kill, saving and later restoring whatever handler was in place.
+
+    Between those windows -- and, critically, during the brief unwind after a
+    run is cancelled but before the next handler is installed -- the handler
+    would otherwise be Python's default, which raises ``KeyboardInterrupt``.
+    A second fast Ctrl+C landing in that gap bubbles all the way up to
+    ``main_entry`` and exits the whole process. That is the
+    ``Ctrl+C Ctrl+C too fast`` crash.
+
+    Installing this no-op-ish guard for the lifetime of the REPL means the
+    saved/restored ``original`` handler is always benign: a stray Ctrl+C in
+    any gap is swallowed instead of killing the process. The per-run and
+    per-shell handlers still own cancellation while they're active.
+    """
+    # Nothing is running that owns cancellation (otherwise their handler would
+    # be installed instead of this one). Swallow the signal so a fast repeat
+    # tap can't escape to main_entry and exit the process.
+    return
+
+
 async def interactive_mode(message_renderer, initial_command: str = None) -> None:
     """Run the agent in interactive mode."""
     from code_puppy.command_line.command_handler import handle_command
@@ -618,6 +645,21 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
 
     # Track the current agent task for cancellation on quit
     current_agent_task = None
+
+    # Install a session-wide baseline SIGINT guard for the lifetime of the
+    # REPL. Ctrl+C is a *cancel* gesture here (Ctrl+D quits), and the per-run
+    # / per-shell handlers own cancellation while they're active, saving and
+    # restoring whatever handler preceded them. Without this baseline, the
+    # restored handler in the gap between those windows is Python's default,
+    # which raises KeyboardInterrupt -- so a fast Ctrl+C double-tap can slip
+    # through the unwind after the first cancel and exit the whole process.
+    # We deliberately do NOT restore the previous handler: when this loop
+    # exits the program is shutting down, so SIGINT ownership for the REPL's
+    # whole life belongs here. Best effort -- signal.signal is main-thread only.
+    try:
+        signal.signal(signal.SIGINT, _interactive_sigint_guard)
+    except (ValueError, OSError):
+        pass
 
     while True:
         from code_puppy.agents.agent_manager import get_current_agent
@@ -881,6 +923,20 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
                     0.1
                 )  # Brief pause to ensure all messages are rendered
 
+            except KeyboardInterrupt:
+                # Defense-in-depth: even with the session SIGINT guard, a
+                # bare KeyboardInterrupt during the unwind of a fast Ctrl+C
+                # double-tap must NOT escape to main_entry (that exits the
+                # whole process). Treat it as a turn cancel and keep the REPL
+                # alive -- Ctrl+D is the only way out.
+                if current_agent_task is not None and not current_agent_task.done():
+                    current_agent_task.cancel()
+                from code_puppy.callbacks import on_interactive_turn_cancel
+                from code_puppy.messaging import emit_warning
+
+                await on_interactive_turn_cancel(task, reason="Ctrl+C")
+                emit_warning("\nCancelled")
+                continue
             except Exception as e:
                 turn_error = e
                 _render_turn_exception(e)

--- a/tests/test_ctrl_c_guard.py
+++ b/tests/test_ctrl_c_guard.py
@@ -1,0 +1,72 @@
+"""Tests for the interactive-mode SIGINT guard (Ctrl+C double-tap fix).
+
+Ctrl+C in Code Puppy is a *cancel* gesture, never a *quit* gesture. A fast
+Ctrl+C double-tap used to exit the whole process: the second tap landed in
+the unwind window after the first cancel, hit Python's default SIGINT
+handler, raised KeyboardInterrupt, and bubbled to main_entry. The session
+guard installed by interactive_mode swallows SIGINT in those gaps.
+
+IMPORTANT: the behavioural tests run in *subprocesses*. Delivering a real
+SIGINT to the pytest process itself is a flaky landmine -- a slightly-late
+signal can be raised inside an unrelated later test and corrupt the whole
+run. Isolating each scenario in its own interpreter keeps signals from ever
+escaping into the test runner.
+"""
+
+import signal
+import subprocess
+import sys
+import textwrap
+
+from code_puppy.cli_runner import _interactive_sigint_guard
+
+
+def test_guard_returns_none_and_does_not_raise():
+    # The guard must be a benign no-op: never raise, never exit.
+    assert _interactive_sigint_guard(signal.SIGINT, None) is None
+
+
+def _run_signal_subprocess(handler_setup: str) -> subprocess.CompletedProcess:
+    """Run a child interpreter that installs a SIGINT handler and signals itself.
+
+    ``handler_setup`` is Python source that installs the desired SIGINT
+    handler. The child then raises SIGINT and prints SURVIVED if it lived.
+    """
+    script = textwrap.dedent(
+        """
+        import os, signal, time, sys
+        {handler_setup}
+        os.kill(os.getpid(), signal.SIGINT)
+        time.sleep(0.1)
+        print("SURVIVED")
+        """
+    ).format(handler_setup=handler_setup)
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_guard_swallows_real_sigint_signal():
+    """With the guard installed, a delivered SIGINT must NOT kill the process."""
+    proc = _run_signal_subprocess(
+        "from code_puppy.cli_runner import _interactive_sigint_guard\n"
+        "signal.signal(signal.SIGINT, _interactive_sigint_guard)"
+    )
+    assert proc.returncode == 0, f"guard let the process die: {proc.stderr}"
+    assert "SURVIVED" in proc.stdout
+
+
+def test_default_handler_would_kill_without_guard():
+    """Control: under the default handler the same SIGINT kills the process.
+
+    Proves the guard is what fixes the crash, not some unrelated quirk.
+    """
+    proc = _run_signal_subprocess(
+        "signal.signal(signal.SIGINT, signal.default_int_handler)"
+    )
+    assert proc.returncode != 0, "sanity: default handler should have raised"
+    assert "SURVIVED" not in proc.stdout
+    assert "KeyboardInterrupt" in proc.stderr


### PR DESCRIPTION
## Problem

While a task is running, pressing **Ctrl+C twice in quick succession** exits the entire process. This is especially annoying because Ctrl+C is *the* way to stop the running command/agent — so an over-eager double-tap kills your whole session instead of just cancelling the turn.

Intended behavior:
- **Ctrl+C #1:** cancel the running shell command.
- **Ctrl+C #2:** cancel the agent's thinking/inference.
- **Ctrl+D:** quit.

Process exit should never happen from Ctrl+C.

## Root cause

Ctrl+C handling juggles **three** different `SIGINT` handlers depending on state:

| State | SIGINT handler | Effect |
|---|---|---|
| Idle / between turns | Python default | **raises `KeyboardInterrupt`** |
| Agent run (`_runtime.py`) | `keyboard_interrupt_handler` | schedules a task cancel (never raises) |
| Shell command (`command_runner.py`) | `_shell_sigint_handler` | kills the shell |

The per-run and per-shell handlers **save and restore** whatever handler preceded them. The bug lives in the *gap between handlers*:

1. Ctrl+C #1 cancels the agent task → `run_with_mcp`'s `finally` **restores the previous handler**, which between turns is Python's **default**.
2. Ctrl+C #2 lands in that brief unwind window → hits the **default** handler → raises a bare `KeyboardInterrupt`.
3. `KeyboardInterrupt` is a `BaseException`, so the interactive loop's `except Exception` doesn't catch it → it bubbles to `main_entry`'s `except KeyboardInterrupt: return 0` → **the whole process exits.**

Slow taps work because by the time the second one arrives, the run/shell handler is back in place. Fast taps slip through the crack.

## Fix

1. **Session-wide baseline SIGINT guard.** `interactive_mode` installs a benign handler for the lifetime of the REPL that *swallows* Ctrl+C in the gaps. Now the saved/restored "original" handler is never the process-killing default, so a stray Ctrl+C in any unwind window is a no-op instead of an exit. The per-run/per-shell handlers still own real cancellation while they're active.
2. **Defense-in-depth `except KeyboardInterrupt`** in the turn body — if one ever sneaks through, it's treated as a turn cancel and the loop continues. Ctrl+D remains the only way out.

## Verification

`tests/test_ctrl_c_guard.py`:
- The guard returns `None` and never raises.
- A **real delivered SIGINT** (`os.kill(getpid(), SIGINT)`) is swallowed with the guard installed.
- **Control test:** the same SIGINT *does* raise `KeyboardInterrupt` under the default handler — proving the guard is what fixes it.

All existing `cli_runner` tests pass (45), `ruff format --check .` clean, `ruff check` clean.

## Scope

- `code_puppy/cli_runner.py` — add `_interactive_sigint_guard`, install it in `interactive_mode`, add the turn-body `KeyboardInterrupt` catch.
- `tests/test_ctrl_c_guard.py` (new).
