### PR TITLE
fix(windows): stop ANSI leak from CRLF shell output

### DIFF
--- a/code_puppy/messaging/rich_renderer.py
+++ b/code_puppy/messaging/rich_renderer.py
@@ -919,15 +919,24 @@ class RichConsoleRenderer:
 
         from rich.text import Text
 
-        # Check if line contains carriage return (progress bar style output)
-        if "\r" in msg.line:
+        # Strip trailing CRLF first. On Windows, subprocess output ends in
+        # CRLF; a lone trailing CR must NOT be mistaken for an interior
+        # progress-bar redraw, or the line is routed through the raw stdout
+        # bypass below and leaks literal ANSI when the console has not
+        # enabled VT processing (the Windows ANSI-leak bug).
+        line = msg.line.rstrip("\r\n")
+
+        # Only an *interior* carriage return signals a progress-bar redraw
+        # (e.g. uv/pip download bars).
+        if "\r" in line:
             # Bypass Rich entirely - write directly to stdout so terminal interprets \r
             # Apply dim styling manually via ANSI codes
-            sys.stdout.write(f"\033[2m{msg.line}\033[0m")
+            sys.stdout.write(f"\r\033[2m{line}\033[0m")
             sys.stdout.flush()
         else:
-            # Normal line: use Rich for nice formatting
-            text = Text.from_ansi(msg.line)
+            # Normal line: let Rich own terminal/VT detection so rendering is
+            # deterministic across platforms and sessions.
+            text = Text.from_ansi(line)
             self._console.print(text, style="dim")
 
     def _render_shell_output(self, msg: ShellOutputMessage) -> None:

--- a/code_puppy/tools/command_runner.py
+++ b/code_puppy/tools/command_runner.py
@@ -631,7 +631,7 @@ def run_shell_command_streaming(
                             line = process.stdout.readline()
                             if not line:  # EOF
                                 break
-                            line = line.rstrip("\n")
+                            line = line.rstrip("\r\n")
                             line = _truncate_line(line)
                             stdout_lines.append(line)
                             if not silent:
@@ -645,6 +645,12 @@ def run_shell_command_streaming(
                                     remaining = process.stdout.read()
                                     if remaining:
                                         for line in remaining.split("\n"):
+                                            # Normalize trailing CR/LF to match
+                                            # the main readline path; otherwise
+                                            # Windows CRLF leaves a stray \r that
+                                            # can re-trigger the renderer's redraw
+                                            # bypass.
+                                            line = line.rstrip("\r\n")
                                             line = _truncate_line(line)
                                             stdout_lines.append(line)
                                             if not silent:
@@ -667,7 +673,7 @@ def run_shell_command_streaming(
                         line = process.stdout.readline()
                         if not line:  # EOF
                             break
-                        line = line.rstrip("\n")
+                        line = line.rstrip("\r\n")
                         line = _truncate_line(line)
                         stdout_lines.append(line)
                         if not silent:
@@ -700,7 +706,7 @@ def run_shell_command_streaming(
                             line = process.stderr.readline()
                             if not line:  # EOF
                                 break
-                            line = line.rstrip("\n")
+                            line = line.rstrip("\r\n")
                             line = _truncate_line(line)
                             stderr_lines.append(line)
                             if not silent:
@@ -714,6 +720,12 @@ def run_shell_command_streaming(
                                     remaining = process.stderr.read()
                                     if remaining:
                                         for line in remaining.split("\n"):
+                                            # Normalize trailing CR/LF to match
+                                            # the main readline path; otherwise
+                                            # Windows CRLF leaves a stray \r that
+                                            # can re-trigger the renderer's redraw
+                                            # bypass.
+                                            line = line.rstrip("\r\n")
                                             line = _truncate_line(line)
                                             stderr_lines.append(line)
                                             if not silent:
@@ -735,7 +747,7 @@ def run_shell_command_streaming(
                         line = process.stderr.readline()
                         if not line:  # EOF
                             break
-                        line = line.rstrip("\n")
+                        line = line.rstrip("\r\n")
                         line = _truncate_line(line)
                         stderr_lines.append(line)
                         if not silent:

--- a/tests/test_shell_line_crlf.py
+++ b/tests/test_shell_line_crlf.py
@@ -1,0 +1,93 @@
+"""Regression tests for the Windows shell-output ANSI-leak bug.
+
+Bug: on Windows, subprocess output lines arrive as CRLF. The reader only
+stripped the trailing LF (leaving a lone CR), and ``_render_shell_line`` treated
+*any* CR as a progress-bar redraw -- routing every normal line through a raw
+``sys.stdout.write`` of ANSI codes. When the console had not enabled VT
+processing, those codes printed literally as ``[2m ... [0m``.
+
+Fix: strip trailing CRLF and only treat an *interior* CR as a progress-bar
+redraw; otherwise render through Rich so terminal/VT handling is deterministic.
+"""
+
+import sys
+from io import StringIO
+from unittest.mock import Mock
+
+from rich.console import Console
+from rich.text import Text
+
+from code_puppy.messaging.bus import MessageBus
+from code_puppy.messaging.messages import ShellLineMessage
+from code_puppy.messaging.rich_renderer import RichConsoleRenderer
+
+DIM = "\x1b[2m"
+RESET = "\x1b[0m"
+CR = "\r"
+LF = "\n"
+
+
+def _make_renderer() -> tuple[RichConsoleRenderer, Mock]:
+    bus = MessageBus()
+    console = Mock(spec=Console)
+    return RichConsoleRenderer(bus, console=console), console
+
+
+def test_trailing_crlf_line_renders_through_rich_not_raw_bypass(monkeypatch) -> None:
+    """A normal line that merely ends in CR/LF must go through Rich.
+
+    Core of the fix: the trailing CR from a Windows CRLF line ending must not be
+    mistaken for a progress-bar redraw, which would leak raw ANSI to the console.
+    """
+    renderer, console = _make_renderer()
+    fake_stdout = StringIO()
+    monkeypatch.setattr(sys, "stdout", fake_stdout)
+
+    msg = ShellLineMessage(
+        line=f"{DIM}16 passed in 13.95s{RESET}{CR}{LF}", stream="stdout"
+    )
+    renderer._render_shell_line(msg)
+
+    assert console.print.called, "normal line should render via Rich console"
+    assert fake_stdout.getvalue() == "", "must not raw-write ANSI to stdout"
+
+    printed = console.print.call_args.args[0]
+    assert isinstance(printed, Text)
+    assert "[2m" not in printed.plain and "[0m" not in printed.plain
+    assert console.print.call_args.kwargs.get("style") == "dim"
+
+
+def test_interior_cr_line_still_uses_raw_bypass(monkeypatch) -> None:
+    """A genuine progress-bar line (interior CR) keeps the raw-stdout path."""
+    renderer, console = _make_renderer()
+    fake_stdout = StringIO()
+    monkeypatch.setattr(sys, "stdout", fake_stdout)
+
+    msg = ShellLineMessage(line=f"downloading 50%{CR}downloading 60%", stream="stdout")
+    renderer._render_shell_line(msg)
+
+    assert not console.print.called, "progress-bar line should bypass Rich"
+    assert "downloading 60%" in fake_stdout.getvalue()
+
+
+def test_plain_lf_line_is_unchanged_macos_equivalence(monkeypatch) -> None:
+    """macOS/Linux safety: a normal LF-only line behaves exactly as before.
+
+    On Unix, shell output ends in a bare LF with no CR, so rstrip('\r\n')
+    strips the same trailing newline rstrip('\n') did, and the interior-CR
+    check is False either way -> the line still routes through Rich. The fix is
+    therefore a no-op for non-Windows output; it only changes lines that carry a
+    trailing CR (the Windows CRLF case).
+    """
+    renderer, console = _make_renderer()
+    fake_stdout = StringIO()
+    monkeypatch.setattr(sys, "stdout", fake_stdout)
+
+    msg = ShellLineMessage(line=f"{DIM}hello from macos{RESET}{LF}", stream="stdout")
+    renderer._render_shell_line(msg)
+
+    assert console.print.called, "plain LF line should render via Rich"
+    assert fake_stdout.getvalue() == "", "must not raw-write ANSI to stdout"
+    printed = console.print.call_args.args[0]
+    assert isinstance(printed, Text)
+    assert printed.plain == "hello from macos"


### PR DESCRIPTION
## What

Fix a Windows-only bug where shell command output ending in CRLF leaked
literal ANSI escape codes to the terminal (e.g. `←[2m ... ←[0m` showing up as
visible garbage instead of dim styling).

## Why

On Windows, subprocess output lines end in `\r\n`. The renderer treated *any*
`\r` in a line as a progress-bar redraw and routed the line through a raw
`sys.stdout.write()` bypass. When the console had not enabled VT processing,
that bypass emitted the raw ANSI bytes verbatim — the leak. The trailing `\r`
from a normal CRLF line was being misread as a redraw signal.

## How

- `code_puppy/messaging/rich_renderer.py` — `_render_shell_line` now strips the
  trailing CR/LF **first** (`line = msg.line.rstrip("\r\n")`) and only treats an
  *interior* carriage return as a progress-bar redraw. Normal CRLF lines now go
  through Rich's normal path, which owns terminal/VT detection.
- `code_puppy/tools/command_runner.py` — normalize line endings with
  `rstrip("\r\n")` in both the main readline paths **and** the post-exit
  final-drain loops, for stdout and stderr, so a stray trailing `\r` can't sneak
  back in and re-trigger the renderer's redraw bypass. The drain loops keep
  `split("\n")` (deliberately **not** `splitlines()`) so interior `\r` used by
  progress bars is preserved.

## Testing

- New `tests/test_shell_line_crlf.py` covers the CRLF / ANSI-leak behavior:
  CRLF-terminated lines render via Rich (no raw bypass), while interior-`\r`
  redraw lines still take the raw stdout path.
- `ruff check` + `ruff format --check` clean on the changed files.
- New test green; existing command_runner / rich_renderer suites pass.

## Scope

Focused: 2 source files + 1 new test. No behavior change on macOS/Linux — the
fix is a strict superset of the prior behavior (interior-`\r` redraws are
preserved; only the trailing-CRLF misclassification is corrected).
