### PR TITLE
fix: skill search multi-word matching & proactive activation guidance

### DIFF
--- a/code_puppy/plugins/agent_skills/prompt_builder.py
+++ b/code_puppy/plugins/agent_skills/prompt_builder.py
@@ -39,8 +39,11 @@ def build_available_skills_block(skills: List["SkillMetadata"]) -> str:
 
 
 def build_skills_guidance() -> str:
-    """One-liner telling the model how to actually use a skill."""
+    """Tell the model when and how to use a skill."""
     return (
-        "Call `activate_skill(name)` to load a skill's full instructions, "
-        "or `list_or_search_skills(query)` to find one."
+        "When the user's question or task relates to a skill listed above, "
+        "activate it with `activate_skill(name)` **before** answering so its "
+        "full instructions are loaded into context. Use "
+        "`list_or_search_skills(query)` to discover skills by keyword — it "
+        "matches any individual word in the query."
     )

--- a/code_puppy/tools/skills_tools.py
+++ b/code_puppy/tools/skills_tools.py
@@ -16,6 +16,13 @@ from code_puppy.messaging import (
 logger = logging.getLogger(__name__)
 
 
+def _skill_haystack(skill: dict) -> str:
+    """Lowercased blob of a skill's searchable text (name + desc + tags)."""
+    return (
+        skill["name"] + " " + skill["description"] + " " + " ".join(skill["tags"])
+    ).lower()
+
+
 # Output models
 class SkillListOutput(BaseModel):
     """Output for list_or_search_skills tool."""
@@ -180,27 +187,16 @@ def register_list_or_search_skills(agent):
             for m in metadatas
         ]
 
-        # Filter by query if provided
+        # Filter by query — match if ANY term appears in the skill's name,
+        # description, or tags. Avoids the old bug where the entire query was
+        # treated as one substring (so "code puppy architecture" matched nothing).
         if query:
-            query_lower = query.lower()
-            filtered = []
-            for skill in skills_list:
-                # Check name (case-insensitive)
-                if query_lower in skill["name"].lower():
-                    filtered.append(skill)
-                    continue
-
-                # Check description (case-insensitive)
-                if query_lower in skill["description"].lower():
-                    filtered.append(skill)
-                    continue
-
-                # Check tags (case-insensitive)
-                for tag in skill["tags"]:
-                    if query_lower in tag.lower():
-                        filtered.append(skill)
-                        break
-            skills_list = filtered
+            terms = query.lower().replace("-", " ").replace("_", " ").split()
+            skills_list = [
+                s
+                for s in skills_list
+                if any(term in _skill_haystack(s) for term in terms)
+            ]
 
         # Emit message for UI
         skill_entries = [


### PR DESCRIPTION
## Problem

The `code-puppy-agent` skill (and others) failed to load when a user asked a Code Puppy question. The model called `list_or_search_skills("code puppy architecture commands skills loading")` and got **0 results** — so it never activated the skill.

## Root Cause — Two Issues

### 1. Passive guidance prompt (root cause)
The skill was already listed in the system prompt (`- code-puppy-agent: Deep reference on Code Puppy's...`), but the guidance text only described the *mechanism* passively:
> *"Call activate_skill(name) to load a skill's full instructions..."*

It never told the model to **use** skills proactively. So instead of activating the skill it could already see, the model went searching.

### 2. Whole-phrase substring search (secondary bug)
`list_or_search_skills` checked `query.lower() in skill["name"].lower()` — the entire query as one substring. So `"code puppy architecture"` never matched `"code-puppy-agent"` → **0 results**.

## Fix

**`prompt_builder.py`** — Guidance now explicitly says to activate skills *before answering* when the user's question relates to one listed.

**`skills_tools.py`** — Search now splits the query into individual terms (normalizing hyphens/underscores) and matches if **any** term appears in the skill's name, description, or tags. Small `_skill_haystack()` helper keeps the comprehension clean.

## Testing
- All 132 existing skill tests pass (`test_skills_tools.py`, `test_skills_tools_full_coverage.py`, `test_agent_skills.py`, `test_agent_skills_callbacks_coverage.py`)
- 100% coverage maintained on `skills_tools.py`
- `ruff check` + `ruff format` clean