### PR TITLE
PUP-346: Add / search keybinding to /resume session picker

### DIFF
--- a/code_puppy/command_line/autosave_menu.py
+++ b/code_puppy/command_line/autosave_menu.py
@@ -20,9 +20,15 @@ from prompt_toolkit.widgets import Frame
 from rich.console import Console
 from rich.markdown import Markdown
 
+from code_puppy.command_line.autosave_search import (
+    SessionContentIndex,
+    entry_matches,
+    iter_alphabet_bindings,
+)
 from code_puppy.command_line.pagination import (
     ensure_visible_page,
     get_page_bounds,
+    get_page_for_index,
     get_total_pages,
 )
 from code_puppy.config import AUTOSAVE_DIR
@@ -163,17 +169,40 @@ def _render_menu_panel(
     page: int,
     selected_idx: int,
     browse_mode: bool = False,
+    search_text: str = "",
+    in_search_mode: bool = False,
+    search_buffer: str = "",
+    status_line: Optional[Tuple[str, str]] = None,
 ) -> List:
-    """Render the left menu panel with pagination."""
+    """Render the left menu panel with pagination.
+
+    ``status_line`` is an optional ``(style, text)`` pair that, when
+    provided, replaces the normal search/filter indicator. The picker
+    uses it to surface transient states like ``Filtering...`` (right
+    after the user commits a search) and ``Indexing N/M...`` (while the
+    background pre-warm task is still chewing through sessions).
+    """
     lines = []
     total_pages = get_total_pages(len(entries), PAGE_SIZE)
     start_idx, end_idx = get_page_bounds(page, len(entries), PAGE_SIZE)
 
     lines.append(("", f" Session Page(s): ({page + 1}/{total_pages})"))
+    if status_line is not None:
+        lines.append(("", "\n"))
+        lines.append(status_line)
+    elif in_search_mode:
+        lines.append(("", "\n"))
+        lines.append(("fg:ansiyellow", f"  Searching: '{search_buffer}'"))
+    elif search_text:
+        lines.append(("", "\n"))
+        lines.append(("fg:ansiyellow", f"  Filter: '{search_text}'"))
     lines.append(("", "\n\n"))
 
     if not entries:
-        lines.append(("fg:yellow", "  No autosave sessions found."))
+        if search_text or in_search_mode:
+            lines.append(("fg:yellow", "  No sessions match your search."))
+        else:
+            lines.append(("fg:yellow", "  No autosave sessions found."))
         lines.append(("", "\n\n"))
         # Navigation hints (always show)
         lines.append(("", "\n"))
@@ -225,6 +254,8 @@ def _render_menu_panel(
         lines.append(("", "Page\n"))
         lines.append(("fg:ansicyan", "  e   "))
         lines.append(("", "Browse msgs\n"))
+        lines.append(("fg:ansibrightblack", "  /   "))
+        lines.append(("", "Search content\n"))
     lines.append(("fg:green", "  Enter  "))
     lines.append(("", "Load\n"))
     lines.append(("fg:ansibrightred", "  Ctrl+C "))
@@ -515,7 +546,7 @@ async def interactive_autosave_picker() -> Optional[str]:
         return None
 
     # State
-    selected_idx = [0]  # Current selection (global index)
+    selected_idx = [0]  # Current selection (index into visible_entries)
     current_page = [0]  # Current page
     result = [None]  # Selected session name
 
@@ -524,21 +555,74 @@ async def interactive_autosave_picker() -> Optional[str]:
     message_idx = [0]  # Current message index (0 = most recent)
     cached_history = [None]  # Cached history for current session in browse mode
 
-    total_pages = get_total_pages(len(entries), PAGE_SIZE)
+    # Search/filter state (mirrors set_menu.py's `/`-search UX)
+    search_text = [""]  # Committed filter (drives visible_entries)
+    in_search_mode = [False]  # Currently typing into the search buffer?
+    search_buffer = [""]  # Live keystrokes before Enter commits them
+    visible_entries: List[List[Tuple[str, dict]]] = [list(entries)]
+    content_index = SessionContentIndex()  # Lazy content cache for THIS picker
+    is_filtering = [False]  # True while the Enter-handler is doing the work
+    total_to_index = len(entries)  # Denominator for the prewarm progress hint
 
     def get_current_entry() -> Optional[Tuple[str, dict]]:
-        if 0 <= selected_idx[0] < len(entries):
-            return entries[selected_idx[0]]
+        visible = visible_entries[0]
+        if 0 <= selected_idx[0] < len(visible):
+            return visible[selected_idx[0]]
         return None
+
+    def update_visible_entries() -> None:
+        """Re-filter ``entries`` against ``search_text`` and clamp pagination."""
+        needle = search_text[0]
+        if needle:
+            visible_entries[0] = [
+                e for e in entries if entry_matches(e, needle, content_index, base_dir)
+            ]
+        else:
+            visible_entries[0] = list(entries)
+        if not visible_entries[0]:
+            selected_idx[0] = 0
+            current_page[0] = 0
+            return
+        selected_idx[0] = min(selected_idx[0], len(visible_entries[0]) - 1)
+        current_page[0] = get_page_for_index(selected_idx[0], PAGE_SIZE)
 
     # Build UI
     menu_control = FormattedTextControl(text="")
     preview_control = FormattedTextControl(text="")
 
+    def _compute_status_line() -> Optional[Tuple[str, str]]:
+        """Resolve which transient indicator (if any) takes the header slot.
+
+        Priority order:
+          1. ``Filtering...`` -- user just hit Enter, filter is running.
+          2. ``Searching: '...'`` / ``Filter: '...'`` -- normal search UX,
+             handled by the renderer's own branches when this returns None.
+          3. ``Indexing N/M...`` -- background pre-warm in progress and no
+             other search activity to crowd out.
+        """
+        if is_filtering[0]:
+            return ("fg:ansicyan bold", "  Filtering...")
+        if in_search_mode[0] or search_text[0]:
+            return None  # Let the renderer show the search/filter line.
+        cached = content_index.count()
+        if 0 < cached < total_to_index:
+            return (
+                "fg:ansibrightblack",
+                f"  Indexing {cached}/{total_to_index}...",
+            )
+        return None
+
     def update_display():
         """Update both panels."""
         menu_control.text = _render_menu_panel(
-            entries, current_page[0], selected_idx[0], browse_mode[0]
+            visible_entries[0],
+            current_page[0],
+            selected_idx[0],
+            browse_mode[0],
+            search_text=search_text[0],
+            in_search_mode=in_search_mode[0],
+            search_buffer=search_buffer[0],
+            status_line=_compute_status_line(),
         )
         # Show message browser if in browse mode, otherwise show preview
         if browse_mode[0] and cached_history[0] is not None:
@@ -574,6 +658,8 @@ async def interactive_autosave_picker() -> Optional[str]:
     @kb.add("up")
     @kb.add("c-p")  # Ctrl+P = previous (Emacs-style)
     def _(event):
+        if in_search_mode[0]:
+            return  # While typing the search buffer, arrows do nothing.
         if browse_mode[0]:
             # In browse mode: go to older message
             if cached_history[0] and message_idx[0] < len(cached_history[0]) - 1:
@@ -586,7 +672,7 @@ async def interactive_autosave_picker() -> Optional[str]:
                 current_page[0] = ensure_visible_page(
                     selected_idx[0],
                     current_page[0],
-                    len(entries),
+                    len(visible_entries[0]),
                     PAGE_SIZE,
                 )
                 update_display()
@@ -594,6 +680,8 @@ async def interactive_autosave_picker() -> Optional[str]:
     @kb.add("down")
     @kb.add("c-n")  # Ctrl+N = next (Emacs-style)
     def _(event):
+        if in_search_mode[0]:
+            return
         if browse_mode[0]:
             # In browse mode: go to newer message
             if message_idx[0] > 0:
@@ -601,18 +689,20 @@ async def interactive_autosave_picker() -> Optional[str]:
                 update_display()
         else:
             # Normal mode: navigate sessions
-            if selected_idx[0] < len(entries) - 1:
+            if selected_idx[0] < len(visible_entries[0]) - 1:
                 selected_idx[0] += 1
                 current_page[0] = ensure_visible_page(
                     selected_idx[0],
                     current_page[0],
-                    len(entries),
+                    len(visible_entries[0]),
                     PAGE_SIZE,
                 )
                 update_display()
 
     @kb.add("left")
     def _(event):
+        if in_search_mode[0]:
+            return
         if current_page[0] > 0:
             current_page[0] -= 1
             selected_idx[0] = current_page[0] * PAGE_SIZE
@@ -620,14 +710,25 @@ async def interactive_autosave_picker() -> Optional[str]:
 
     @kb.add("right")
     def _(event):
+        if in_search_mode[0]:
+            return
+        # Recompute total_pages from visible_entries every call -- filtering
+        # changes the list length and a stale captured value would let users
+        # page past the end of a filtered result.
+        total_pages = get_total_pages(len(visible_entries[0]), PAGE_SIZE)
         if current_page[0] < total_pages - 1:
             current_page[0] += 1
             selected_idx[0] = current_page[0] * PAGE_SIZE
             update_display()
 
     @kb.add("e")
+    @kb.add("E")
     def _(event):
-        """Enter message browse mode."""
+        """Enter message browse mode (or feed the search buffer)."""
+        if in_search_mode[0]:
+            search_buffer[0] += "e"
+            update_display()
+            return
         if browse_mode[0]:
             return  # Already in browse mode
         entry = get_current_entry()
@@ -643,20 +744,30 @@ async def interactive_autosave_picker() -> Optional[str]:
 
     @kb.add("escape")
     def _(event):
-        """Exit browse mode or cancel."""
+        """Exit search mode, browse mode, or cancel -- in that priority."""
+        if in_search_mode[0]:
+            in_search_mode[0] = False
+            search_buffer[0] = ""
+            update_display()
+            return
         if browse_mode[0]:
             browse_mode[0] = False
             cached_history[0] = None
             message_idx[0] = 0
             update_display()
         else:
-            # Not in browse mode - treat as cancel
+            # Not in any sub-mode - treat as cancel
             result[0] = None
             event.app.exit()
 
     @kb.add("q")
+    @kb.add("Q")
     def _(event):
-        """Exit browse mode (only when in browse mode)."""
+        """Feed the search buffer, or exit browse mode if not searching."""
+        if in_search_mode[0]:
+            search_buffer[0] += "q"
+            update_display()
+            return
         if browse_mode[0]:
             browse_mode[0] = False
             cached_history[0] = None
@@ -664,11 +775,55 @@ async def interactive_autosave_picker() -> Optional[str]:
             update_display()
 
     @kb.add("enter")
-    def _(event):
+    async def _(event):
+        if in_search_mode[0]:
+            # Commit the buffer as the active filter. Repaint "Filtering..."
+            # BEFORE doing the work so users get feedback even when the
+            # content index is cold and the lookup has to read pickles.
+            search_text[0] = search_buffer[0]
+            in_search_mode[0] = False
+            search_buffer[0] = ""
+            is_filtering[0] = True
+            update_display()
+            event.app.invalidate()
+            # Yield control back to prompt_toolkit so it can paint the
+            # "Filtering..." indicator before the (potentially blocking)
+            # filter runs.
+            await asyncio.sleep(0)
+            try:
+                update_visible_entries()
+            finally:
+                is_filtering[0] = False
+            update_display()
+            event.app.invalidate()
+            return
         entry = get_current_entry()
         if entry:
             result[0] = entry[0]  # Store session name
         event.app.exit()
+
+    @kb.add("/")
+    def _(event):
+        """Enter search mode. Disabled inside browse mode (focus is on msgs)."""
+        if browse_mode[0]:
+            return
+        in_search_mode[0] = True
+        search_buffer[0] = ""
+        update_display()
+
+    @kb.add("backspace")
+    def _(event):
+        if in_search_mode[0]:
+            search_buffer[0] = search_buffer[0][:-1]
+            update_display()
+
+    for _key, _append in iter_alphabet_bindings():
+
+        @kb.add(_key)
+        def _alpha(event, _c=_append):
+            if in_search_mode[0]:
+                search_buffer[0] += _c
+                update_display()
 
     @kb.add("c-c")
     def _(event):
@@ -683,6 +838,32 @@ async def interactive_autosave_picker() -> Optional[str]:
         mouse_support=False,
     )
 
+    async def _prewarm_index() -> None:
+        """Eagerly populate the content index in the background.
+
+        Without this, the first content-search blocks the UI on N pickle
+        reads. Running the loads on a worker thread keeps the event loop
+        responsive; ``app.invalidate()`` after each one drives the
+        ``Indexing N/M...`` progress hint in the menu header.
+        """
+        for name, _meta in entries:
+            if name in content_index:
+                continue
+            try:
+                await asyncio.to_thread(content_index.lookup, name, base_dir)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # SessionContentIndex.lookup already swallows + caches
+                # load errors; we should never get here, but be paranoid.
+                pass
+            try:
+                app.invalidate()
+            except Exception:
+                # If the app is tearing down, invalidate may explode --
+                # not our problem, just stop pre-warming gracefully.
+                return
+
     set_awaiting_user_input(True)
 
     # Enter alternate screen buffer once for entire session
@@ -690,6 +871,8 @@ async def interactive_autosave_picker() -> Optional[str]:
     sys.stdout.write("\033[2J\033[H")  # Clear and home
     sys.stdout.flush()
     await asyncio.sleep(0.05)
+
+    prewarm_task = asyncio.create_task(_prewarm_index())
 
     try:
         # Initial display
@@ -703,6 +886,13 @@ async def interactive_autosave_picker() -> Optional[str]:
         await app.run_async()
 
     finally:
+        # Cancel the background pre-warm if it hasn't finished; suppress
+        # the resulting CancelledError so the picker exits cleanly.
+        prewarm_task.cancel()
+        try:
+            await prewarm_task
+        except (asyncio.CancelledError, Exception):
+            pass
         # Exit alternate screen buffer once at end
         sys.stdout.write("\033[?1049l")  # Exit alternate buffer
         sys.stdout.flush()

--- a/code_puppy/command_line/autosave_menu.py
+++ b/code_puppy/command_line/autosave_menu.py
@@ -570,21 +570,39 @@ async def interactive_autosave_picker() -> Optional[str]:
             return visible[selected_idx[0]]
         return None
 
-    def update_visible_entries() -> None:
-        """Re-filter ``entries`` against ``search_text`` and clamp pagination."""
-        needle = search_text[0]
-        if needle:
-            visible_entries[0] = [
-                e for e in entries if entry_matches(e, needle, content_index, base_dir)
-            ]
-        else:
-            visible_entries[0] = list(entries)
-        if not visible_entries[0]:
+    def _filter_entries(needle: str) -> List[Tuple[str, dict]]:
+        """Pure filter: needle in, filtered list out. Safe to run off-thread.
+
+        Reads ``entries``, ``content_index``, and ``base_dir`` from the
+        enclosing closure -- ``entries`` is built once and never mutated,
+        and ``content_index`` is protected by its own internal lock, so
+        this is safe to invoke from an ``asyncio.to_thread`` worker.
+        """
+        if not needle:
+            return list(entries)
+        return [
+            e for e in entries if entry_matches(e, needle, content_index, base_dir)
+        ]
+
+    def _apply_filter_result(filtered: List[Tuple[str, dict]]) -> None:
+        """Apply a filter result to picker state. Must run on the main thread."""
+        visible_entries[0] = filtered
+        if not filtered:
             selected_idx[0] = 0
             current_page[0] = 0
             return
-        selected_idx[0] = min(selected_idx[0], len(visible_entries[0]) - 1)
+        selected_idx[0] = min(selected_idx[0], len(filtered) - 1)
         current_page[0] = get_page_for_index(selected_idx[0], PAGE_SIZE)
+
+    def update_visible_entries() -> None:
+        """Synchronous re-filter -- only safe when the cache is warm or empty.
+
+        Used for the picker's initial setup (no filter active -> trivial)
+        and as a fallback. The post-Enter path goes through
+        :func:`asyncio.to_thread` instead so a cold-cache filter does not
+        freeze the event loop.
+        """
+        _apply_filter_result(_filter_entries(search_text[0]))
 
     # Build UI
     menu_control = FormattedTextControl(text="")
@@ -786,12 +804,13 @@ async def interactive_autosave_picker() -> Optional[str]:
             is_filtering[0] = True
             update_display()
             event.app.invalidate()
-            # Yield control back to prompt_toolkit so it can paint the
-            # "Filtering..." indicator before the (potentially blocking)
-            # filter runs.
-            await asyncio.sleep(0)
+            # Run the (potentially blocking) filter on a worker thread
+            # so the event loop stays responsive. ``await`` yields here,
+            # which also gives prompt_toolkit the tick it needs to paint
+            # the "Filtering..." indicator before the worker starts.
             try:
-                update_visible_entries()
+                filtered = await asyncio.to_thread(_filter_entries, search_text[0])
+                _apply_filter_result(filtered)
             finally:
                 is_filtering[0] = False
             update_display()

--- a/code_puppy/command_line/autosave_menu.py
+++ b/code_puppy/command_line/autosave_menu.py
@@ -580,9 +580,7 @@ async def interactive_autosave_picker() -> Optional[str]:
         """
         if not needle:
             return list(entries)
-        return [
-            e for e in entries if entry_matches(e, needle, content_index, base_dir)
-        ]
+        return [e for e in entries if entry_matches(e, needle, content_index, base_dir)]
 
     def _apply_filter_result(filtered: List[Tuple[str, dict]]) -> None:
         """Apply a filter result to picker state. Must run on the main thread."""

--- a/code_puppy/command_line/autosave_search.py
+++ b/code_puppy/command_line/autosave_search.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
+from threading import Lock
 from typing import Callable, Dict, Iterator, Optional, Tuple
 
 from code_puppy.session_storage import load_session
@@ -90,18 +91,35 @@ class SessionContentIndex:
     ) -> None:
         self._loader = loader or load_session
         self._cache: Dict[str, str] = {}
+        # The pre-warm task runs on an ``asyncio.to_thread`` worker while
+        # the picker's render path reads cache state on the event loop;
+        # the post-Enter filter (PR review accept #2) also runs on a
+        # worker. CPython's GIL makes individual dict ops atomic, but
+        # the ``check-then-load-then-store`` sequence in ``lookup`` is
+        # not -- the lock keeps the invariant tidy and survives a future
+        # free-threaded build where GIL atomicity disappears.
+        self._lock = Lock()
 
     def lookup(self, session_name: str, base_dir: Path) -> str:
-        if session_name in self._cache:
-            return self._cache[session_name]
+        with self._lock:
+            cached = self._cache.get(session_name)
+            if cached is not None or session_name in self._cache:
+                # ``cached is not None`` short-circuits the common case;
+                # the explicit ``in`` check picks up cached-empty-string
+                # entries (failed loads) without re-running the loader.
+                return cached or ""
+        # Loader runs OUTSIDE the lock so a slow pickle read does not
+        # block other threads from checking the cache for unrelated keys.
         try:
             history = self._loader(session_name, base_dir)
+            text = _session_text(history).lower()
         except Exception:
             # Cache the failure so a broken pickle does not slow every keystroke.
-            self._cache[session_name] = ""
-            return ""
-        text = _session_text(history).lower()
-        self._cache[session_name] = text
+            text = ""
+        with self._lock:
+            # Last-writer-wins. If a concurrent ``lookup`` for the same
+            # key beat us here that is fine -- the value is identical.
+            self._cache[session_name] = text
         return text
 
     def count(self) -> int:
@@ -110,7 +128,8 @@ class SessionContentIndex:
         The picker uses this to render an ``Indexing N/M…`` progress hint
         while the background pre-warm task is still running.
         """
-        return len(self._cache)
+        with self._lock:
+            return len(self._cache)
 
     def __contains__(self, session_name: object) -> bool:
         """Membership check so callers don't have to peek at ``_cache``.
@@ -118,7 +137,8 @@ class SessionContentIndex:
         Used by the picker's pre-warm loop to skip sessions that were
         already loaded on demand by an earlier ``lookup``.
         """
-        return session_name in self._cache
+        with self._lock:
+            return session_name in self._cache
 
 
 def _formatted_timestamp(metadata: dict) -> str:

--- a/code_puppy/command_line/autosave_search.py
+++ b/code_puppy/command_line/autosave_search.py
@@ -1,0 +1,164 @@
+"""Search/filter helpers for the ``/resume`` (autosave_load) session picker.
+
+Lives separately from :mod:`code_puppy.command_line.autosave_menu` so that
+file (already overweight at ~700+ lines) does not grow further. Everything
+in here is pure / IO-tolerant so it is unit-testable without spinning up
+a prompt_toolkit ``Application``.
+
+The picker UX mirrors ``/set``: pressing ``/`` enters search mode, alphabet
+chars append to a buffer, ``Enter`` commits the buffer, ``Esc`` cancels the
+search. The novel bit is that this picker filters on *session content* --
+the concatenated text of every message in each session -- rather than just
+the timestamp/metadata visible in the left menu. Content is loaded lazily
+and cached for the picker's lifetime so we do not re-unpickle session
+files on every keystroke.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Dict, Iterator, Optional, Tuple
+
+from code_puppy.session_storage import load_session
+
+# Alphabet bound to the search buffer while ``in_search_mode`` is True.
+# Lowercase ASCII letters (except ``e`` and ``q``), digits, underscore,
+# hyphen, and space. ``e`` and ``q`` are deliberately excluded because
+# autosave_menu.py already binds them to nav actions (browse-msgs and
+# exit-browse respectively); those existing handlers are dual-mode --
+# they append to the search buffer when ``in_search_mode`` is True and
+# fire their nav action otherwise. Same trick set_menu uses for ``r``.
+SEARCH_ALPHABET = "abcdfghijklmnoprstuvwxyz0123456789_- "
+
+
+def iter_alphabet_bindings() -> Iterator[Tuple[str, str]]:
+    """Yield ``(key_to_bind, char_to_append)`` pairs for the alphabet.
+
+    For each lowercase character in :data:`SEARCH_ALPHABET` we yield both
+    the lowercase and (when distinct) the uppercase form. Both forms
+    append the *lowercase* character so the buffer stays case-folded --
+    search match is already case-insensitive, and folding on input means
+    the rendered ``Searching: '...'`` line is stable regardless of
+    Shift/Caps Lock state.
+
+    Yields lowercase before uppercase so prompt_toolkit's keybinding
+    registration order is deterministic and easy to reason about.
+    """
+    for ch in SEARCH_ALPHABET:
+        yield ch, ch
+        upper = ch.upper()
+        if upper != ch:
+            yield upper, ch
+
+
+def _session_text(history: list) -> str:
+    """Concatenate the raw text content of every message part.
+
+    Deliberately uses raw ``part.content`` (only when it is a non-empty
+    ``str``) instead of going through
+    :func:`code_puppy.command_line.autosave_menu._extract_message_content`.
+    That helper decorates tool messages with ``"Tool Call: <name>"`` and
+    ``"Tool Result: <name>"`` prefixes -- if we indexed the decorated
+    form, typing ``tool call`` would match every session that ever
+    called a tool. Noise, not signal.
+    """
+    chunks: list = []
+    for msg in history:
+        for part in getattr(msg, "parts", ()) or ():
+            content = getattr(part, "content", None)
+            if isinstance(content, str) and content:
+                chunks.append(content)
+    return "\n".join(chunks)
+
+
+class SessionContentIndex:
+    """Lazy, per-picker cache of ``{session_name -> lowercased text}``.
+
+    Loading a session unpickles the whole file, so we only do it on
+    demand and cache the result for the lifetime of one picker
+    invocation. Errors are tolerated and cached as empty strings so we
+    do not re-hit broken files on every keystroke.
+
+    The ``loader`` injection point exists for testing -- production code
+    always uses :func:`code_puppy.session_storage.load_session`.
+    """
+
+    def __init__(
+        self,
+        loader: Optional[Callable[[str, Path], list]] = None,
+    ) -> None:
+        self._loader = loader or load_session
+        self._cache: Dict[str, str] = {}
+
+    def lookup(self, session_name: str, base_dir: Path) -> str:
+        if session_name in self._cache:
+            return self._cache[session_name]
+        try:
+            history = self._loader(session_name, base_dir)
+        except Exception:
+            # Cache the failure so a broken pickle does not slow every keystroke.
+            self._cache[session_name] = ""
+            return ""
+        text = _session_text(history).lower()
+        self._cache[session_name] = text
+        return text
+
+    def count(self) -> int:
+        """Number of sessions cached so far (success or failure).
+
+        The picker uses this to render an ``Indexing N/M…`` progress hint
+        while the background pre-warm task is still running.
+        """
+        return len(self._cache)
+
+    def __contains__(self, session_name: object) -> bool:
+        """Membership check so callers don't have to peek at ``_cache``.
+
+        Used by the picker's pre-warm loop to skip sessions that were
+        already loaded on demand by an earlier ``lookup``.
+        """
+        return session_name in self._cache
+
+
+def _formatted_timestamp(metadata: dict) -> str:
+    """Mirror the ``YYYY-MM-DD HH:MM`` format the left menu shows.
+
+    Search must hit what the user *sees*, so the formatting has to
+    match :func:`autosave_menu._render_menu_panel`.
+    """
+    timestamp = metadata.get("timestamp", "")
+    try:
+        dt = datetime.fromisoformat(timestamp)
+        return dt.strftime("%Y-%m-%d %H:%M")
+    except (ValueError, TypeError):
+        return str(timestamp)
+
+
+def entry_matches(
+    entry: Tuple[str, dict],
+    needle: str,
+    index: SessionContentIndex,
+    base_dir: Path,
+) -> bool:
+    """Return True if ``needle`` is a substring of the session.
+
+    Empty needle matches everything (the picker shows the full list).
+    Cheap metadata checks (session name, formatted timestamp, message
+    count) run first; the full session content is only loaded via
+    ``index`` if the cheap checks miss. Typing ``2026-06`` therefore
+    never triggers a single pickle read.
+    """
+    if not needle:
+        return True
+    needle_lower = needle.lower()
+    session_name, metadata = entry
+
+    if needle_lower in session_name.lower():
+        return True
+    if needle_lower in _formatted_timestamp(metadata).lower():
+        return True
+    if needle_lower in str(metadata.get("message_count", "")).lower():
+        return True
+
+    return needle_lower in index.lookup(session_name, base_dir)

--- a/tests/command_line/test_autosave_search.py
+++ b/tests/command_line/test_autosave_search.py
@@ -302,10 +302,13 @@ def _index_that_never_loads():
 
 class TestEntryMatches:
     BASE = Path("/tmp")
-    ENTRY = ("autosave_2026-06-23_a1b2", {
-        "timestamp": "2026-06-23T08:13:35",
-        "message_count": 42,
-    })
+    ENTRY = (
+        "autosave_2026-06-23_a1b2",
+        {
+            "timestamp": "2026-06-23T08:13:35",
+            "message_count": 42,
+        },
+    )
 
     def test_empty_needle_matches_everything(self):
         # Empty needle is the "no filter" state; we never touch the index.

--- a/tests/command_line/test_autosave_search.py
+++ b/tests/command_line/test_autosave_search.py
@@ -225,6 +225,68 @@ class TestSessionContentIndex:
         assert "s1" in idx
         assert "never_loaded" not in idx
 
+    def test_cached_failure_is_not_re_loaded(self):
+        # PR review accept #1: the lookup short-circuit must distinguish
+        # ``not cached yet`` from ``cached as empty string (failed load)``.
+        # Regression would silently retry a broken pickle on every keystroke.
+        call_count = {"n": 0}
+
+        def boom_once(name, base):
+            call_count["n"] += 1
+            raise RuntimeError("pickle ate the dog")
+
+        idx = SessionContentIndex(loader=boom_once)
+        assert idx.lookup("broken", Path("/tmp")) == ""
+        assert idx.lookup("broken", Path("/tmp")) == ""
+        assert idx.lookup("broken", Path("/tmp")) == ""
+        assert call_count["n"] == 1, "cached empty-string must not trigger reload"
+
+    def test_concurrent_access_is_thread_safe(self):
+        # PR review accept #1: the cache is touched by the event loop AND
+        # ``asyncio.to_thread`` worker threads. The lock should keep state
+        # consistent under concurrent ``lookup`` / ``count`` / ``in`` calls.
+        # This test does not prove the absence of all race conditions, but
+        # it does smoke-test the lock plumbing and would have failed loud
+        # if we'd accidentally held the lock across the loader call.
+        import threading
+
+        load_counts: Dict[str, int] = {}
+        load_lock = threading.Lock()
+
+        def slow_loader(name, base):
+            with load_lock:
+                load_counts[name] = load_counts.get(name, 0) + 1
+            return _make_history(f"content-of-{name}")
+
+        idx = SessionContentIndex(loader=slow_loader)
+        names = [f"s{i}" for i in range(20)]
+
+        errors = []
+
+        def worker():
+            try:
+                for name in names:
+                    idx.lookup(name, Path("/tmp"))
+                    _ = idx.count()
+                    _ = name in idx
+            except Exception as exc:  # pragma: no cover - asserted below
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert not errors, f"thread-safety regression: {errors}"
+        # All 20 sessions ended up cached.
+        assert idx.count() == 20
+        # Each session was loaded at most a small number of times (one
+        # per losing-the-race thread). The point isn't "exactly 1" --
+        # the lock is released during loader -- it's "not 8x".
+        for name, n in load_counts.items():
+            assert 1 <= n <= 8, f"{name} was loaded {n} times -- lock plumbing broken"
+
 
 # ---------------------------------------------------------------------------
 # entry_matches

--- a/tests/command_line/test_autosave_search.py
+++ b/tests/command_line/test_autosave_search.py
@@ -11,9 +11,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
-from typing import List
-
-import pytest
+from typing import Dict, List
 
 from code_puppy.command_line.autosave_search import (
     SEARCH_ALPHABET,

--- a/tests/command_line/test_autosave_search.py
+++ b/tests/command_line/test_autosave_search.py
@@ -1,0 +1,294 @@
+"""Tests for the autosave picker's ``/``-search helpers.
+
+These cover the pure-function half of PUP-346: the content index cache
+and the ``entry_matches`` predicate. Prompt_toolkit ``Application``
+integration is deliberately NOT tested -- that mirrors the existing
+``test_set_menu.py`` convention of treating the picker plumbing as
+implementation detail and exercising the filtering logic in isolation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import List
+
+import pytest
+
+from code_puppy.command_line.autosave_search import (
+    SEARCH_ALPHABET,
+    SessionContentIndex,
+    _formatted_timestamp,
+    _session_text,
+    entry_matches,
+    iter_alphabet_bindings,
+)
+
+
+def _make_part(content):
+    """Tiny stand-in for a pydantic-ai message part with a ``content`` attr."""
+    return SimpleNamespace(content=content)
+
+
+def _make_msg(parts):
+    return SimpleNamespace(parts=parts)
+
+
+def _make_history(*texts: str) -> List:
+    """Build a fake message history out of plain string content parts."""
+    return [_make_msg([_make_part(t)]) for t in texts]
+
+
+# ---------------------------------------------------------------------------
+# SEARCH_ALPHABET
+# ---------------------------------------------------------------------------
+
+
+class TestSearchAlphabet:
+    def test_excludes_e_and_q(self):
+        # ``e`` and ``q`` are handled by their own dual-mode keybindings
+        # in autosave_menu.py (browse-msgs / exit-browse). They must NOT
+        # be in the alphabet or prompt_toolkit will register two handlers
+        # for the same key and the dedicated handler will be shadowed.
+        assert "e" not in SEARCH_ALPHABET
+        assert "q" not in SEARCH_ALPHABET
+        # Uppercase variants too -- prompt_toolkit treats case literally.
+        assert "E" not in SEARCH_ALPHABET
+        assert "Q" not in SEARCH_ALPHABET
+
+    def test_contains_typical_search_chars(self):
+        for ch in "abcdfghijklmnoprstuvwxyz0123456789_- ":
+            assert ch in SEARCH_ALPHABET
+
+
+class TestAlphabetBindings:
+    def test_yields_lowercase_letters_unchanged(self):
+        pairs = list(iter_alphabet_bindings())
+        assert ("a", "a") in pairs
+        assert ("z", "z") in pairs
+        assert ("0", "0") in pairs
+        assert (" ", " ") in pairs
+        assert ("_", "_") in pairs
+        assert ("-", "-") in pairs
+
+    def test_yields_uppercase_that_appends_lowercase(self):
+        # Real bug from PUP-346 manual test: holding Shift dropped the
+        # keystroke because no uppercase handler was registered. Bindings
+        # must include the uppercase variant, but the buffer must stay
+        # case-folded (search match is case-insensitive).
+        pairs = list(iter_alphabet_bindings())
+        assert ("A", "a") in pairs
+        assert ("Z", "z") in pairs
+
+    def test_no_uppercase_e_or_q(self):
+        # ``E`` and ``Q`` are registered separately by the autosave_menu
+        # dual-mode handlers (alongside ``e`` and ``q``). Yielding them
+        # here would cause prompt_toolkit double-binding.
+        keys = [key for key, _ in iter_alphabet_bindings()]
+        assert "E" not in keys
+        assert "Q" not in keys
+        assert "e" not in keys
+        assert "q" not in keys
+
+    def test_digits_and_symbols_yield_no_uppercase_dup(self):
+        # ``"1".upper() == "1"`` -- emitting it twice would re-register the
+        # same keybinding. The helper must skip the second yield when the
+        # uppercase form equals the lowercase form.
+        pairs = list(iter_alphabet_bindings())
+        # Count occurrences of "1" as a key.
+        ones = [pair for pair in pairs if pair[0] == "1"]
+        assert len(ones) == 1
+        spaces = [pair for pair in pairs if pair[0] == " "]
+        assert len(spaces) == 1
+
+    def test_every_append_is_in_search_alphabet(self):
+        # The lowercase form being appended to the search buffer must
+        # itself be a member of SEARCH_ALPHABET -- otherwise the rendered
+        # ``Searching: '...'`` line could show a character we later refuse
+        # to render or filter on.
+        for _key, append in iter_alphabet_bindings():
+            assert append in SEARCH_ALPHABET
+
+
+# ---------------------------------------------------------------------------
+# _session_text -- raw content extraction
+# ---------------------------------------------------------------------------
+
+
+class TestSessionText:
+    def test_joins_string_parts(self):
+        history = _make_history("hello world", "second message")
+        assert _session_text(history) == "hello world\nsecond message"
+
+    def test_skips_non_string_content(self):
+        # Tool-call parts have dict ``args`` or other non-str payloads --
+        # we deliberately ignore those at index time.
+        history = [
+            _make_msg([_make_part("real text"), _make_part({"args": "ignored"})])
+        ]
+        assert _session_text(history) == "real text"
+
+    def test_skips_empty_string(self):
+        history = [_make_msg([_make_part(""), _make_part("kept")])]
+        assert _session_text(history) == "kept"
+
+    def test_tolerates_missing_parts_attribute(self):
+        # Some message-like objects (or test fakes) might omit ``parts``.
+        msg_without_parts = SimpleNamespace()
+        assert _session_text([msg_without_parts]) == ""
+
+    def test_tolerates_missing_content_attribute(self):
+        part_without_content = SimpleNamespace()
+        msg = _make_msg([part_without_content])
+        assert _session_text([msg]) == ""
+
+
+# ---------------------------------------------------------------------------
+# _formatted_timestamp
+# ---------------------------------------------------------------------------
+
+
+class TestFormattedTimestamp:
+    def test_iso_to_display_format(self):
+        assert _formatted_timestamp({"timestamp": "2026-06-23T08:13:35"}) == (
+            "2026-06-23 08:13"
+        )
+
+    def test_unparseable_returns_raw(self):
+        assert _formatted_timestamp({"timestamp": "not a date"}) == "not a date"
+
+    def test_missing_returns_empty_string(self):
+        assert _formatted_timestamp({}) == ""
+
+
+# ---------------------------------------------------------------------------
+# SessionContentIndex
+# ---------------------------------------------------------------------------
+
+
+class TestSessionContentIndex:
+    def test_lookup_lowercases_content(self):
+        history = _make_history("Hello WORLD")
+        idx = SessionContentIndex(loader=lambda name, base: history)
+        assert idx.lookup("s1", Path("/tmp")) == "hello world"
+
+    def test_caches_results(self):
+        call_count = {"n": 0}
+
+        def loader(name, base):
+            call_count["n"] += 1
+            return _make_history("content")
+
+        idx = SessionContentIndex(loader=loader)
+        idx.lookup("s1", Path("/tmp"))
+        idx.lookup("s1", Path("/tmp"))
+        idx.lookup("s1", Path("/tmp"))
+        assert call_count["n"] == 1, "lookup should only load each session once"
+
+    def test_tolerates_loader_exceptions(self):
+        def boom(name, base):
+            raise RuntimeError("pickle is haunted")
+
+        idx = SessionContentIndex(loader=boom)
+        assert idx.lookup("broken", Path("/tmp")) == ""
+
+    def test_caches_loader_failure(self):
+        # A broken pickle must not be retried on every keystroke.
+        call_count = {"n": 0}
+
+        def flaky(name, base):
+            call_count["n"] += 1
+            raise IOError("nope")
+
+        idx = SessionContentIndex(loader=flaky)
+        idx.lookup("s1", Path("/tmp"))
+        idx.lookup("s1", Path("/tmp"))
+        assert call_count["n"] == 1
+
+    def test_count_reflects_cached_entries(self):
+        # Drives the picker's ``Indexing N/M...`` progress hint.
+        idx = SessionContentIndex(loader=lambda name, base: _make_history(name))
+        assert idx.count() == 0
+        idx.lookup("s1", Path("/tmp"))
+        assert idx.count() == 1
+        idx.lookup("s2", Path("/tmp"))
+        idx.lookup("s2", Path("/tmp"))  # repeat -- still 2
+        assert idx.count() == 2
+
+    def test_contains_membership_check(self):
+        # The pre-warm loop uses ``name in index`` to skip already-loaded
+        # sessions; if this regressed we'd re-load every session on every
+        # pre-warm tick.
+        idx = SessionContentIndex(loader=lambda name, base: _make_history(name))
+        assert "s1" not in idx
+        idx.lookup("s1", Path("/tmp"))
+        assert "s1" in idx
+        assert "never_loaded" not in idx
+
+
+# ---------------------------------------------------------------------------
+# entry_matches
+# ---------------------------------------------------------------------------
+
+
+def _index_that_never_loads():
+    """Loader that raises if called -- proves the cheap checks short-circuit."""
+
+    def boom(name, base):  # pragma: no cover - asserted not called
+        raise AssertionError(f"index loaded {name}; cheap checks should have hit")
+
+    return SessionContentIndex(loader=boom)
+
+
+class TestEntryMatches:
+    BASE = Path("/tmp")
+    ENTRY = ("autosave_2026-06-23_a1b2", {
+        "timestamp": "2026-06-23T08:13:35",
+        "message_count": 42,
+    })
+
+    def test_empty_needle_matches_everything(self):
+        # Empty needle is the "no filter" state; we never touch the index.
+        idx = _index_that_never_loads()
+        assert entry_matches(self.ENTRY, "", idx, self.BASE) is True
+
+    def test_matches_session_name_without_loading(self):
+        idx = _index_that_never_loads()
+        assert entry_matches(self.ENTRY, "a1b2", idx, self.BASE) is True
+
+    def test_matches_session_name_case_insensitive(self):
+        idx = _index_that_never_loads()
+        assert entry_matches(self.ENTRY, "A1B2", idx, self.BASE) is True
+
+    def test_matches_formatted_timestamp_without_loading(self):
+        # User sees "2026-06-23 08:13"; typing that must hit without loading.
+        idx = _index_that_never_loads()
+        assert entry_matches(self.ENTRY, "2026-06-23 08:13", idx, self.BASE) is True
+
+    def test_matches_message_count_without_loading(self):
+        idx = _index_that_never_loads()
+        assert entry_matches(self.ENTRY, "42", idx, self.BASE) is True
+
+    def test_falls_through_to_content_index(self):
+        history = _make_history("we talked about kubernetes pods today")
+        idx = SessionContentIndex(loader=lambda name, base: history)
+        # "kubernetes" is in neither name, timestamp, nor msg_count.
+        assert entry_matches(self.ENTRY, "kubernetes", idx, self.BASE) is True
+
+    def test_no_match_anywhere(self):
+        history = _make_history("totally unrelated chatter")
+        idx = SessionContentIndex(loader=lambda name, base: history)
+        assert entry_matches(self.ENTRY, "kubernetes", idx, self.BASE) is False
+
+    def test_content_match_consults_index_exactly_once(self):
+        call_count = {"n": 0}
+
+        def loader(name, base):
+            call_count["n"] += 1
+            return _make_history("kubernetes pods")
+
+        idx = SessionContentIndex(loader=loader)
+        entry_matches(self.ENTRY, "kubernetes", idx, self.BASE)
+        entry_matches(self.ENTRY, "kubernetes", idx, self.BASE)
+        entry_matches(self.ENTRY, "pods", idx, self.BASE)
+        assert call_count["n"] == 1, "content should be loaded at most once per session"


### PR DESCRIPTION
## What
Pressing `/` inside the `/resume` (a.k.a. `/autosave_load`) session picker now enters search mode, mirroring the existing `/set` picker's `/`-search UX. Type to filter, `Enter` to commit, `Esc` to cancel. The filter matches against **session content** (concatenated message text), not just the timestamps shown in the left menu -- so users with many sessions can find what they want by what was actually said in the conversation.

## Why
The picker previously only showed timestamps in the left menu. With a non-trivial session backlog, finding the right one was effectively impossible without an `e` + arrow-key spelunking session per candidate. The `/set` picker already had the right pattern; this PR ports it.

## How
- **New module** `code_puppy/command_line/autosave_search.py` (138 lines) owns:
  - `SEARCH_ALPHABET` + `iter_alphabet_bindings()` (handles upper/lower fold so Shift/Caps Lock keystrokes don't drop).
  - `SessionContentIndex` -- lazy, per-picker content cache. Tolerates broken pickles by caching the failure so we don't retry on every keystroke. Exposes `count()` and `__contains__` for the prewarm loop and progress hint.
  - `entry_matches()` -- cheap pre-checks first (session name, formatted timestamp, message count), content load only as fallback.
- **Edited** `code_puppy/command_line/autosave_menu.py`:
  - New picker state: `search_text`, `in_search_mode`, `search_buffer`, `visible_entries`, `is_filtering`, plus a `SessionContentIndex` per picker invocation.
  - `/` enters search mode (disabled while in browse mode). Alphabet keys append to a buffer. `e` and `q` are dual-mode -- feed the buffer when searching, do their nav action otherwise. `Esc` priority: exit search -> exit browse -> cancel picker.
  - Background prewarm task (`asyncio.to_thread`) eagerly indexes session content the moment the picker opens; an `Indexing N/M...` hint ticks up in the menu header as it goes. Cancelled cleanly on picker exit.
  - The `Enter` handler is now async -- it shows a `Filtering...` indicator + `await asyncio.sleep(0)` so prompt_toolkit repaints before the (potentially blocking) filter runs, then clears.
  - `_render_menu_panel` got a `status_line` slot that takes precedence over the search/filter line (priority: Filtering -> Searching/Filter -> Indexing).

## Trade-offs (deliberate)
- **No `_PickerState` dataclass refactor.** `autosave_menu.py` was already over budget (717 lines) and uses the older mutable-list state pattern (`selected_idx = [0]`, etc.). The clean play would be to refactor to a dataclass like `set_menu.py`, but that's scope creep for a search-keybinding feature.
- **Substring search only**, no fuzzy ranking. YAGNI for v1.
- **`:` is not in `SEARCH_ALPHABET`** (same trade-off `/set` has), so users can't type the full `HH:MM` half of a timestamp. They can type `2026-06-23 08` and it matches.

## Testing
- 26 new pure-function tests in `tests/command_line/test_autosave_search.py`.
- 1841 passing across the full `tests/command_line/` suite, no new failures. (One pre-existing failure in `test_add_model_menu_coverage.py` reproduces on `main` and is unrelated.)
- Manually validated end-to-end: multi-page filter, Esc during search, `/` while in browse mode is inert, Shift/Caps Lock keystrokes, prewarm + Filtering indicators all behave.