### PR TITLE
Add quick resume support

### DIFF
--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -133,6 +133,48 @@ def _resume_session_from_path(raw_path: str) -> None:
     )
 
 
+def apply_quick_resume(args) -> bool:
+    """Resolve ``--quick-resume [PATH]`` into ``args.resume`` so the existing
+    resume machinery loads it.
+
+    Looks up the most recent autosave for PATH (defaulting to cwd), scoped to
+    the nearest git worktree root + branch when available, with a no-git
+    fallback. No-op when ``--quick-resume`` was not requested or ``--resume`` is
+    already set (explicit ``--resume`` always wins). Returns True when a target
+    was resolved.
+    """
+    existing_resume = getattr(args, "resume", None)
+    quick_resume_target = getattr(args, "quick_resume", None)
+    if quick_resume_target is None or (
+        existing_resume and str(existing_resume).strip()
+    ):
+        return False
+
+    from code_puppy.config import (
+        format_quick_resume_scope,
+        get_quick_resume_location,
+        resolve_quick_resume_pickle,
+    )
+    from code_puppy.messaging import emit_info
+
+    target_path = str(quick_resume_target).strip() or "."
+
+    # Diagnostic identifies the lookup scope without leaking full local paths.
+    cwd, branch = get_quick_resume_location(target_path)
+    emit_info(
+        "\U0001f50d Quick Resume selected - finding latest session for "
+        f"{format_quick_resume_scope(cwd, branch)}"
+    )
+
+    quick_resume_pickle = resolve_quick_resume_pickle(target_path)
+    if quick_resume_pickle:
+        args.resume = quick_resume_pickle
+        return True
+
+    emit_info("No previous session found for this scope; starting fresh.")
+    return False
+
+
 async def main():
     """Main async entry point for Code Puppy CLI."""
     parser = argparse.ArgumentParser(description="Code Puppy - A code generation agent")
@@ -173,6 +215,18 @@ async def main():
         type=str,
         metavar="PATH",
         help="Resume a saved session from a .pkl file (e.g. ~/.code_puppy/contexts/foo.pkl)",
+    )
+    parser.add_argument(
+        "--quick-resume",
+        "-qr",
+        nargs="?",
+        const=".",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Resume the most recent session for PATH (defaults to the current "
+            "directory; scopes to git root + branch when available)"
+        ),
     )
     parser.add_argument(
         "command", nargs="*", help="Run a single command (deprecated, use -p instead)"
@@ -394,6 +448,10 @@ async def main():
             default_version_mismatch_behavior(current_version)
 
     await callbacks.on_startup()
+
+    # Resolve --quick-resume [PATH] into --resume so the resume machinery below
+    # loads the most recent session for that canonical (git-root + branch) scope.
+    apply_quick_resume(args)
 
     if args.resume:
         _resume_session_from_path(args.resume)

--- a/code_puppy/command_line/command_registry.py
+++ b/code_puppy/command_line/command_registry.py
@@ -17,6 +17,7 @@ class CommandInfo:
     handler: Callable[[str], bool]
     usage: str = ""
     aliases: List[str] = field(default_factory=list)
+    hidden_aliases: List[str] = field(default_factory=list)
     category: str = "core"
     detailed_help: Optional[str] = None
 
@@ -57,6 +58,7 @@ def register_command(
     description: str,
     usage: str = "",
     aliases: Optional[List[str]] = None,
+    hidden_aliases: Optional[List[str]] = None,
     category: str = "core",
     detailed_help: Optional[str] = None,
 ):
@@ -72,7 +74,10 @@ def register_command(
         name: Primary command name (without leading /)
         description: Short one-line description for help text
         usage: Full usage string (e.g., "/cd <dir>"). Defaults to "/{name}"
-        aliases: List of alternative names (without leading /)
+        aliases: List of visible alternative names (without leading /).
+            These are executable and shown in completions/help.
+        hidden_aliases: List of hidden alternative names (without leading /).
+            These are executable but omitted from completions/help.
         category: Grouping category ("core", "session", "config", etc.)
         detailed_help: Optional detailed help text for /help <command>
 
@@ -99,6 +104,7 @@ def register_command(
             handler=func,
             usage=usage,
             aliases=aliases or [],
+            hidden_aliases=hidden_aliases or [],
             category=category,
             detailed_help=detailed_help,
         )
@@ -106,8 +112,12 @@ def register_command(
         # Register primary name
         _COMMAND_REGISTRY[name] = cmd_info
 
-        # Register all aliases pointing to the same CommandInfo
+        # Register all aliases pointing to the same CommandInfo.
+        # Visible aliases are advertised by completions/help; hidden ones are
+        # executable but omitted from both (see prompt_toolkit_completion).
         for alias in aliases or []:
+            _COMMAND_REGISTRY[alias] = cmd_info
+        for alias in hidden_aliases or []:
             _COMMAND_REGISTRY[alias] = cmd_info
 
         return func

--- a/code_puppy/command_line/session_commands.py
+++ b/code_puppy/command_line/session_commands.py
@@ -5,11 +5,34 @@ discovered by the command registry system.
 """
 
 from datetime import datetime
+import logging
 from pathlib import Path
 
 from code_puppy.command_line.command_registry import register_command
 from code_puppy.config import CONTEXTS_DIR
 from code_puppy.session_storage import list_sessions, load_session, save_session
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_quick_resume_target(command: str) -> str:
+    """Extract the optional PATH arg from a ``/quick-resume`` command string.
+
+    OS-agnostic: splits off only the command word and keeps the remainder
+    verbatim so Windows paths (``C:\\Users\\...``) retain their backslashes --
+    ``shlex`` POSIX mode would silently strip them. A single pair of matching
+    outer quotes (used for paths containing spaces) is removed on every OS.
+    Returns ``"."`` (current directory) when no path was given.
+    """
+    parts = command.split(maxsplit=1)
+    target_path = parts[1].strip() if len(parts) > 1 else "."
+    if (
+        len(target_path) >= 2
+        and target_path[0] in ("'", '"')
+        and target_path[-1] == target_path[0]
+    ):
+        target_path = target_path[1:-1]
+    return target_path or "."
 
 
 # Import get_commands_help from command_handler to avoid circular imports
@@ -236,6 +259,86 @@ def handle_autosave_load_command(command: str) -> bool:
     """Load an autosave session."""
     # Return a special marker to indicate we need to run async autosave loading
     return "__AUTOSAVE_LOAD__"
+
+
+@register_command(
+    name="quick-resume",
+    description="Load the latest autosave for a directory/path and git branch",
+    usage="/quick-resume [path]",
+    hidden_aliases=["qr"],
+    category="session",
+    detailed_help="""
+    Resume the latest autosaved session for a path (defaults to the current
+    directory), scoped to the nearest git worktree root and branch when
+    available.
+
+    If the path is not inside a git repository (or git is unavailable), this
+    gracefully falls back to the relevant directory/workspace scope.
+    """,
+)
+def handle_quick_resume_command(command: str) -> bool:
+    """Load the latest autosave for this directory/path + branch into the agent."""
+    from code_puppy.agents.agent_manager import get_current_agent
+    from code_puppy.config import (
+        format_quick_resume_scope,
+        get_quick_resume_location,
+        resolve_quick_resume_pickle,
+        set_current_autosave_from_session_name,
+    )
+    from code_puppy.messaging import emit_error, emit_info, emit_success
+
+    # Parse an optional path argument (OS-agnostic; preserves Windows
+    # backslashes -- see _parse_quick_resume_target).
+    target_path = _parse_quick_resume_target(command)
+
+    # Diagnostic identifies the scope without leaking full local paths.
+    cwd, branch = get_quick_resume_location(target_path)
+    emit_info(
+        "Quick Resume selected - finding latest session for "
+        f"{format_quick_resume_scope(cwd, branch)}"
+    )
+
+    quick_resume_pickle = resolve_quick_resume_pickle(target_path)
+    if not quick_resume_pickle:
+        emit_info(
+            "No previous session found for this scope; staying in current session."
+        )
+        return True
+
+    session_path = Path(quick_resume_pickle)
+    session_name = session_path.stem
+
+    try:
+        history = load_session(session_name, session_path.parent)
+    except FileNotFoundError:
+        logger.warning("Quick-resume session file not found: %s", session_path)
+        emit_error(
+            "Quick-resume session file was not found; staying in current session."
+        )
+        return True
+    except Exception:
+        logger.exception("Failed to quick-resume from %s", session_path)
+        emit_error("Quick-resume failed; staying in current session.")
+        return True
+
+    agent = get_current_agent()
+    agent.set_message_history(history)
+    set_current_autosave_from_session_name(session_name)
+    total_tokens = sum(agent.estimate_tokens_for_message(m) for m in history)
+
+    emit_success(
+        f"Quick resume loaded: {len(history)} messages ({total_tokens} tokens)"
+    )
+
+    # Best-effort history preview; failure must not abort a successful resume.
+    try:
+        from code_puppy.command_line.autosave_menu import display_resumed_history
+
+        display_resumed_history(history)
+    except Exception:
+        logger.debug("Unable to display quick-resume history preview", exc_info=True)
+
+    return True
 
 
 @register_command(

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -1,11 +1,15 @@
 import configparser
 import datetime
+import hashlib
 import json
+import logging
 import os
 import pathlib
 from typing import Optional
 
 from code_puppy.session_storage import save_session
+
+logger = logging.getLogger(__name__)
 
 
 def _get_xdg_dir(env_var: str, fallback: str) -> str:
@@ -1811,6 +1815,12 @@ def auto_save_session_if_enabled() -> bool:
             auto_saved=True,
         )
 
+        # Point quick-resume at this just-saved session. Every turn, exit, and
+        # finalize routes through this single autosave chokepoint, so cwd and
+        # any tool-observed child workspaces always map to a loadable pickle.
+        # Best-effort: never let pointer bookkeeping block the autosave.
+        record_quick_resume_sessions(session_name)
+
         # Append conversation-wide TTFT + TG averages if we have any data.
         stats_suffix = ""
         try:
@@ -1918,6 +1928,285 @@ def get_last_terminal_session() -> Optional[str]:
             return None
         return session_name
     except Exception:
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Quick-resume: resume the latest autosave for a directory + git branch.
+#
+# Unlike terminal sessions (keyed by TTY, which is POSIX-only), quick-resume is
+# keyed by canonical workspace + branch, so it works identically on Windows and
+# macOS/Linux. All filesystem access goes through ``os.path``/``pathlib`` and
+# git is probed via subprocess with failures swallowed, so a missing git or a
+# non-repo directory degrades gracefully rather than raising.
+# --------------------------------------------------------------------------- #
+
+# Child workspaces touched by tools this run; flushed to pointers on next save.
+_OBSERVED_QUICK_RESUME_KEYS: set[str] = set()
+
+
+def format_quick_resume_scope(cwd: str, branch: Optional[str]) -> str:
+    """Return a non-sensitive scope label for diagnostics (no raw paths)."""
+    scope_id = hashlib.sha1(
+        f"{cwd}\x00{branch or ''}".encode("utf-8"), usedforsecurity=False
+    ).hexdigest()[:12]
+    branch_label = "detected" if branch else "null"
+    return f"scope: {scope_id} | branch: {branch_label}"
+
+
+def _quick_resume_key(cwd: str, branch: Optional[str]) -> str:
+    """Return the stable pointer key for a workspace + branch (NUL-separated)."""
+    return f"{cwd}\x00{branch or ''}"
+
+
+def _absolute_quick_resume_path(target_path: Optional[str]) -> str:
+    """Normalize a target into an absolute, user-expanded path (cwd if None)."""
+    raw_path = os.getcwd() if target_path is None else str(target_path).strip()
+    if not raw_path:
+        raw_path = os.getcwd()
+    expanded = os.path.expanduser(raw_path)
+    if not os.path.isabs(expanded):
+        expanded = os.path.join(os.getcwd(), expanded)
+    return os.path.abspath(expanded)
+
+
+def _candidate_scope_dir(target_path: Optional[str], path_kind: str) -> str:
+    """Return the directory to probe for scope.
+
+    ``path_kind='file'`` probes the path's parent dir; ``'directory'`` uses it
+    as-is; ``'auto'`` checks the filesystem so ``-qr some_file.py`` still works.
+    """
+    candidate = _absolute_quick_resume_path(target_path)
+    if path_kind == "file":
+        return os.path.dirname(candidate) or candidate
+    if path_kind == "directory":
+        return candidate
+    if os.path.isfile(candidate):
+        return os.path.dirname(candidate) or candidate
+    return candidate
+
+
+def _nearest_existing_directory(path: str) -> Optional[str]:
+    """Walk up from ``path`` to the first directory that exists, or None."""
+    current = pathlib.Path(path)
+    while True:
+        try:
+            if current.is_dir():
+                return str(current)
+        except OSError:
+            return None
+        if current.parent == current:  # reached filesystem root
+            return None
+        current = current.parent
+
+
+def _detect_git_toplevel(path: str) -> Optional[str]:
+    """Return the git worktree root for ``path``, or None outside git.
+
+    Uses ``git rev-parse --show-toplevel`` (handles nested repos, submodules,
+    and worktrees). Cross-platform; returns None if git is missing or fails.
+    """
+    probe_dir = _nearest_existing_directory(path)
+    if not probe_dir:
+        return None
+    try:
+        import subprocess
+
+        out = subprocess.run(
+            ["git", "-C", probe_dir, "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=0.5,
+        )
+        if out.returncode == 0:
+            root = out.stdout.strip()
+            return os.path.realpath(root) if root else None
+    except Exception:
+        return None
+    return None
+
+
+def _first_child_under_cwd(path: str) -> Optional[str]:
+    """Return the first path component of ``path`` under cwd, else None.
+
+    Lets a no-git ``-qr ./ticket/src/foo`` collapse to the ``ticket`` workspace
+    instead of scattering pointers across deep subdirectories.
+    """
+    base = os.path.realpath(os.getcwd())
+    target = os.path.realpath(path)
+    if target == base:
+        return None
+    try:
+        rel = os.path.relpath(target, base)
+    except ValueError:  # different drive on Windows -> not under cwd
+        return None
+    parts = pathlib.Path(rel).parts
+    if not parts or parts[0] in (".", ".."):
+        return None
+    return os.path.realpath(os.path.join(base, parts[0]))
+
+
+def _fallback_scope_dir(candidate_dir: str, target_path: Optional[str]) -> str:
+    """Return the non-git scope: cwd itself, or the first child for explicit paths."""
+    if target_path is None:
+        return os.path.realpath(candidate_dir)
+    return _first_child_under_cwd(candidate_dir) or os.path.realpath(candidate_dir)
+
+
+def get_quick_resume_location(
+    target_path: Optional[str] = None, *, path_kind: str = "auto"
+) -> tuple[str, Optional[str]]:
+    """Return ``(canonical_workspace, branch_or_None)`` for a quick-resume scope.
+
+    The canonical workspace is the nearest git worktree root when available,
+    else a directory-only fallback. This is the single source of truth shared by
+    the pointer key and the diagnostic label, so they can never drift.
+    """
+    candidate_dir = _candidate_scope_dir(target_path, path_kind)
+    git_root = _detect_git_toplevel(candidate_dir)
+    cwd = git_root or _fallback_scope_dir(candidate_dir, target_path)
+    branch: Optional[str] = None
+    if git_root:
+        try:
+            from code_puppy.plugins.statusline.payload import detect_git_branch
+
+            branch = detect_git_branch(cwd)
+        except Exception:
+            branch = None
+    return os.path.realpath(cwd), branch
+
+
+def _dir_branch_key_for_path(
+    target_path: Optional[str] = None, *, path_kind: str = "auto"
+) -> str:
+    """Return the pointer key for a target's canonical workspace + branch."""
+    cwd, branch = get_quick_resume_location(target_path, path_kind=path_kind)
+    return _quick_resume_key(cwd, branch)
+
+
+def _dir_session_path(key: str) -> pathlib.Path:
+    """Return the pointer file path for a workspace+branch key.
+
+    The key is hashed so the filename is a short, filesystem-safe hex string on
+    every OS (sidesteps Windows path-length/charset rules regardless of how long
+    or exotic the directory or branch name is). SHA-1 truncated to 16 hex chars
+    is a cache-pointer key, never a security signature -- ``usedforsecurity``
+    flags that intent for scanners.
+    """
+    digest = hashlib.sha1(key.encode("utf-8"), usedforsecurity=False).hexdigest()[:16]
+    return pathlib.Path(CACHE_DIR) / "dir_sessions" / f"{digest}.txt"
+
+
+def _record_directory_session_key(session_name: str, key: str) -> None:
+    """Atomically write ``session_name`` into the pointer file for ``key``."""
+    session_file = _dir_session_path(key)
+    session_file.parent.mkdir(parents=True, exist_ok=True)
+    tmp = session_file.with_suffix(".tmp")
+    tmp.write_text(session_name, encoding="utf-8")
+    tmp.replace(session_file)  # atomic + overwrites on Windows (unlike os.rename)
+
+
+def record_directory_session(
+    session_name: str, target_path: Optional[str] = None, *, path_kind: str = "auto"
+) -> None:
+    """Persist ``session_name`` as the latest autosave for a quick-resume scope.
+
+    Best-effort, mirroring ``record_terminal_session``. ``target_path`` lets
+    ``-qr ./child`` and observed workspaces reuse the same pointer machinery.
+    """
+    if not _is_valid_autosave_session_name(session_name):
+        logger.debug("Ignoring invalid quick-resume autosave pointer name")
+        return
+    try:
+        _record_directory_session_key(
+            session_name, _dir_branch_key_for_path(target_path, path_kind=path_kind)
+        )
+    except Exception:
+        logger.debug("Unable to record quick-resume autosave pointer", exc_info=True)
+
+
+def observe_quick_resume_path(target_path: str, *, path_kind: str = "auto") -> bool:
+    """Remember a child workspace touched by a tool for the next autosave.
+
+    Only a hashed pointer key is stored (never the raw path). The next autosave
+    writes its session name to every observed key so ``-qr ./child`` resolves
+    even when Code Puppy was launched from the parent directory.
+    """
+    if not target_path or not str(target_path).strip():
+        return False
+    try:
+        _OBSERVED_QUICK_RESUME_KEYS.add(
+            _dir_branch_key_for_path(str(target_path), path_kind=path_kind)
+        )
+        return True
+    except Exception:
+        logger.debug("Unable to observe quick-resume path", exc_info=True)
+        return False
+
+
+def clear_observed_quick_resume_paths() -> None:
+    """Clear the observed-workspace set (used by tests)."""
+    _OBSERVED_QUICK_RESUME_KEYS.clear()
+
+
+def record_quick_resume_sessions(session_name: str) -> None:
+    """Record cwd plus every observed child workspace for ``session_name``."""
+    record_directory_session(session_name)
+    if not _is_valid_autosave_session_name(session_name):
+        return
+    for key in tuple(_OBSERVED_QUICK_RESUME_KEYS):
+        try:
+            _record_directory_session_key(session_name, key)
+        except Exception:
+            logger.debug(
+                "Unable to record observed quick-resume pointer", exc_info=True
+            )
+
+
+def get_last_directory_session(
+    target_path: Optional[str] = None, *, path_kind: str = "auto"
+) -> Optional[str]:
+    """Return the last autosave session name for a scope, or None.
+
+    None when there is no pointer, it is empty, or the recorded name fails
+    autosave-name validation. Never raises.
+    """
+    try:
+        session_name = (
+            _dir_session_path(
+                _dir_branch_key_for_path(target_path, path_kind=path_kind)
+            )
+            .read_text(encoding="utf-8")
+            .strip()
+        )
+        if not session_name or not _is_valid_autosave_session_name(session_name):
+            return None
+        return session_name
+    except Exception:
+        logger.debug("Unable to read quick-resume autosave pointer", exc_info=True)
+        return None
+
+
+def resolve_quick_resume_pickle(
+    target_path: Optional[str] = None, *, path_kind: str = "auto"
+) -> Optional[str]:
+    """Return the absolute ``.pkl`` path for a scope's latest session, or None.
+
+    The single source of truth the CLI ``--quick-resume`` flag consults. Resolves
+    strictly inside ``AUTOSAVE_DIR`` (rejecting any path-traversal) and only
+    returns a path that is an existing file.
+    """
+    session_name = get_last_directory_session(target_path, path_kind=path_kind)
+    if not session_name:
+        return None
+    try:
+        autosave_dir = pathlib.Path(AUTOSAVE_DIR).resolve()
+        candidate = (autosave_dir / f"{session_name}.pkl").resolve(strict=False)
+        if candidate.parent != autosave_dir or not candidate.is_file():
+            return None
+        return str(candidate)
+    except OSError:
+        logger.debug("Unable to resolve quick-resume autosave path", exc_info=True)
         return None
 
 

--- a/code_puppy/plugins/quick_resume/register_callbacks.py
+++ b/code_puppy/plugins/quick_resume/register_callbacks.py
@@ -1,0 +1,79 @@
+"""Quick-resume workspace observation hooks.
+
+The autosave layer records a quick-resume pointer for cwd. This plugin teaches
+Code Puppy about *child* workspaces touched through tools, so a later
+``code-puppy -qr ./child`` (or ``/quick-resume ./child``) resolves the session
+even when the process was launched from the parent directory the whole time.
+
+Observation is a pure convenience: it only registers hashed pointer keys and
+never blocks or alters tool output.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from code_puppy.callbacks import register_callback
+
+# Map tool name -> ((arg_name, path_kind), ...) for tools whose args are plain
+# local paths. path_kind tells the scope resolver whether the arg is a file
+# (probe its parent) or a directory. Tools with non-string/nested path payloads
+# (e.g. edit_file) are intentionally omitted.
+_LOCAL_PATH_TOOL_ARGS: dict[str, tuple[tuple[str, str], ...]] = {
+    "agent_run_shell_command": (("cwd", "directory"),),
+    "create_file": (("file_path", "file"),),
+    "delete_file": (("file_path", "file"),),
+    "delete_snippet": (("file_path", "file"),),
+    "grep": (("directory", "directory"),),
+    "list_files": (("directory", "directory"),),
+    "read_file": (("file_path", "file"),),
+    "replace_in_file": (("file_path", "file"),),
+}
+
+
+def _result_failed(result: Any) -> bool:
+    """Return True when a tool result clearly represents a failure.
+
+    Handles both dict results and objects exposing ``error``/``success``.
+    """
+    if isinstance(result, dict):
+        if result.get("error"):
+            return True
+        if result.get("success") is False:
+            return True
+    error = getattr(result, "error", None)
+    if error:
+        return True
+    success = getattr(result, "success", None)
+    return success is False
+
+
+def _observe_tool_paths(
+    tool_name: str,
+    tool_args: dict[str, Any],
+    result: Any,
+    duration_ms: float,
+    context: Any = None,
+) -> None:
+    """Record local workspace paths from successful tool calls (best-effort)."""
+    _ = duration_ms, context  # unused; kept for the post_tool_call signature
+    if _result_failed(result):
+        return
+
+    path_specs = _LOCAL_PATH_TOOL_ARGS.get(tool_name)
+    if not path_specs:
+        return
+
+    try:
+        from code_puppy.config import observe_quick_resume_path
+
+        for arg_name, path_kind in path_specs:
+            raw_path = tool_args.get(arg_name)
+            if isinstance(raw_path, str) and raw_path.strip():
+                observe_quick_resume_path(raw_path, path_kind=path_kind)
+    except Exception:
+        # Observation is a convenience pointer, never worth breaking tool output.
+        return
+
+
+register_callback("post_tool_call", _observe_tool_paths)

--- a/code_puppy/plugins/statusline/payload.py
+++ b/code_puppy/plugins/statusline/payload.py
@@ -40,7 +40,8 @@ def _agent_block() -> Optional[Dict[str, Any]]:
     return {"name": name} if name else None
 
 
-def _git_branch(cwd: str) -> Optional[str]:
+def detect_git_branch(cwd: str) -> Optional[str]:
+    """Return the active git branch for cwd, or None outside a branch/repo."""
     try:
         out = subprocess.run(
             ["git", "rev-parse", "--abbrev-ref", "HEAD"],
@@ -55,6 +56,10 @@ def _git_branch(cwd: str) -> Optional[str]:
     except Exception:
         return None
     return None
+
+
+# Back-compat alias: quick-resume (config.py) reuses this public helper.
+_git_branch = detect_git_branch
 
 
 def _context_block() -> Dict[str, Any]:
@@ -101,7 +106,7 @@ def build_payload() -> Dict[str, Any]:
     if agent:
         payload["agent"] = agent
 
-    branch = _git_branch(cwd)
+    branch = detect_git_branch(cwd)
     if branch:
         payload["workspace"]["git_branch"] = branch
 

--- a/tests/test_quick_resume.py
+++ b/tests/test_quick_resume.py
@@ -1,0 +1,87 @@
+"""Focused tests for /quick-resume argument parsing and CLI wiring.
+
+These cover the OS-agnostic path handling -- the key regression being that
+Windows backslash paths must NOT be mangled (the old shlex POSIX parse turned
+``C:\\Users\\Wes\\proj`` into ``C:UsersWesproj``).
+"""
+
+import argparse
+
+import pytest
+
+from code_puppy.cli_runner import apply_quick_resume
+from code_puppy.command_line.session_commands import _parse_quick_resume_target
+
+
+@pytest.mark.parametrize(
+    "command, expected",
+    [
+        # Windows: backslashes must survive intact (the original bug).
+        (r"/quick-resume C:\Users\Wes\proj", r"C:\Users\Wes\proj"),
+        (r"/qr D:\repos\a b\c", r"D:\repos\a b\c"),
+        (r'/qr "C:\Program Files\My App"', r"C:\Program Files\My App"),
+        # macOS / Linux: absolute, quoted-with-spaces, and relative.
+        ("/quick-resume /Users/me/proj", "/Users/me/proj"),
+        ('/qr "/Users/me/My Project"', "/Users/me/My Project"),
+        ("/quick-resume ./child/src", "./child/src"),
+        ("/quick-resume '/tmp/quoted single'", "/tmp/quoted single"),
+        # No path -> current directory; whitespace-only is treated as none.
+        ("/quick-resume", "."),
+        ("/qr", "."),
+        ("/quick-resume   ", "."),
+    ],
+)
+def test_parse_quick_resume_target(command, expected):
+    assert _parse_quick_resume_target(command) == expected
+
+
+def _args(**kwargs):
+    """Build an argparse.Namespace with quick-resume-relevant defaults."""
+    ns = argparse.Namespace(resume=None, quick_resume=None)
+    for key, value in kwargs.items():
+        setattr(ns, key, value)
+    return ns
+
+
+def test_apply_quick_resume_noop_when_unset():
+    """No --quick-resume flag -> nothing happens, resume stays None."""
+    args = _args()
+    assert apply_quick_resume(args) is False
+    assert args.resume is None
+
+
+def test_apply_quick_resume_explicit_resume_wins():
+    """An explicit --resume always takes precedence over --quick-resume."""
+    args = _args(resume="/path/to/session.pkl", quick_resume=".")
+    assert apply_quick_resume(args) is False
+    assert args.resume == "/path/to/session.pkl"
+
+
+def test_apply_quick_resume_sets_resume_on_hit(monkeypatch):
+    """A resolvable scope populates args.resume with the pickle path."""
+    monkeypatch.setattr(
+        "code_puppy.config.get_quick_resume_location",
+        lambda target: ("/repo", "main"),
+    )
+    monkeypatch.setattr(
+        "code_puppy.config.resolve_quick_resume_pickle",
+        lambda target: "/auto/auto_session_X.pkl",
+    )
+    args = _args(quick_resume=".")
+    assert apply_quick_resume(args) is True
+    assert args.resume == "/auto/auto_session_X.pkl"
+
+
+def test_apply_quick_resume_graceful_miss(monkeypatch):
+    """No matching session -> returns False and leaves resume unset."""
+    monkeypatch.setattr(
+        "code_puppy.config.get_quick_resume_location",
+        lambda target: ("/repo", None),
+    )
+    monkeypatch.setattr(
+        "code_puppy.config.resolve_quick_resume_pickle",
+        lambda target: None,
+    )
+    args = _args(quick_resume="/some/where")
+    assert apply_quick_resume(args) is False
+    assert args.resume is None


### PR DESCRIPTION
## What

Add quick-resume support so Code Puppy can resume the latest autosaved session for the current workspace or an explicit path via `--quick-resume` / `-qr`.

## Why

Terminal-session resume is tied to the running terminal. Quick resume gives users a workspace-scoped way to pick up the latest session, including child workspaces touched through tool calls.

## How

- Add CLI handling for `--quick-resume [PATH]` and `/quick-resume [PATH]`.
- Store workspace + branch scoped autosave pointers using hashed keys under the cache directory.
- Reuse git-root/branch detection when available, with a no-git directory fallback.
- Add a plugin hook that observes successful local-path tool calls and records those workspaces on autosave.
- Expose statusline branch detection as a reusable helper.

## Testing

- `uv run --no-sync ruff check .`
- `uv run --no-sync ruff format --check .`
- `CI=1 CODE_PUPPY_TEST_FAST=1 uv run --no-sync pytest tests/test_quick_resume.py -q`

## Scope

Focused on quick-resume behavior only. No `.venv`, `uv.lock`, `pyproject.toml`, dependency-index URL, or Walmart Artifactory URL changes are included.
