### PR TITLE
feat: Implement `/undo` command and hook file modifications to UndoManager

### DIFF
--- a/code_puppy/command_line/core_commands.py
+++ b/code_puppy/command_line/core_commands.py
@@ -654,25 +654,26 @@ def handle_generate_pr_description_command(command: str) -> str:
 
     # Return the prompt to be processed by the main chat system
     return pr_prompt
-+
-+@register_command(
-+    name="undo",
-+    description="Undo the last file modification made by the agent",
-+    usage="/undo",
-+    aliases=["u", "undo_last"],
-+    category="core",
-+)
-+def handle_undo_command(command: str) -> bool:
-+    """Undo the last file operation recorded."""
-+    from code_puppy.undo_manager import UndoManager
-+    from code_puppy.messaging import emit_info, emit_error
-+    
-+    manager = UndoManager()
-+    result = manager.undo_last()
-+    
-+    if "Failed" in result:
-+        emit_error(result)
-+    else:
-+        emit_info(f" {result}")
-+        
-+    return True
+
+
+@register_command(
+    name="undo",
+    description="Undo the last file modification made by the agent",
+    usage="/undo",
+    aliases=["u", "undo_last"],
+    category="core",
+)
+def handle_undo_command(command: str) -> bool:
+    """Undo the last file operation recorded."""
+    from code_puppy.undo_manager import UndoManager
+    from code_puppy.messaging import emit_info, emit_error
+
+    manager = UndoManager()
+    result = manager.undo_last()
+
+    if "Failed" in result:
+        emit_error(result)
+    else:
+        emit_info(f" {result}")
+
+    return True

--- a/code_puppy/command_line/core_commands.py
+++ b/code_puppy/command_line/core_commands.py
@@ -654,3 +654,25 @@ def handle_generate_pr_description_command(command: str) -> str:
 
     # Return the prompt to be processed by the main chat system
     return pr_prompt
++
++@register_command(
++    name="undo",
++    description="Undo the last file modification made by the agent",
++    usage="/undo",
++    aliases=["u", "undo_last"],
++    category="core",
++)
++def handle_undo_command(command: str) -> bool:
++    """Undo the last file operation recorded."""
++    from code_puppy.undo_manager import UndoManager
++    from code_puppy.messaging import emit_info, emit_error
++    
++    manager = UndoManager()
++    result = manager.undo_last()
++    
++    if "Failed" in result:
++        emit_error(result)
++    else:
++        emit_info(f" {result}")
++        
++    return True

--- a/code_puppy/tools/file_modifications.py
+++ b/code_puppy/tools/file_modifications.py
@@ -14,6 +14,7 @@ import difflib
 import json
 import os
 import traceback
+from code_puppy.undo_manager import UndoManager
 import warnings
 from typing import Annotated, Any, Dict, List, Union
 
@@ -218,6 +219,7 @@ def _delete_snippet_from_file(
     snippet: str,
     message_group: str | None = None,
 ) -> Dict[str, Any]:
+    UndoManager().record_change(file_path, 'delete_snippet')
     file_path = os.path.abspath(file_path)
     diff_text = ""
     try:
@@ -267,6 +269,7 @@ def _replace_in_file(
     replacements: List[Dict[str, str]],
     message_group: str | None = None,
 ) -> Dict[str, Any]:
+    UndoManager().record_change(path, 'replace_in_file')
     """Robust replacement engine with explicit edge‑case reporting."""
     file_path = os.path.abspath(path)
     diff_text = ""
@@ -362,6 +365,7 @@ def _write_to_file(
     overwrite: bool = False,
     message_group: str | None = None,
 ) -> Dict[str, Any]:
+    UndoManager().record_change(path, 'write_to_file')
     file_path = os.path.abspath(path)
 
     try:
@@ -504,6 +508,7 @@ def replace_in_file(
 def _edit_file(
     context: RunContext, payload: EditFilePayload, group_id: str | None = None
 ) -> Dict[str, Any]:
+    UndoManager().record_change(payload.file_path, 'edit_file')
     """
     High-level implementation of the *edit_file* behaviour.
 
@@ -595,6 +600,7 @@ def _edit_file(
 def _delete_file(
     context: RunContext, file_path: str, message_group: str | None = None
 ) -> Dict[str, Any]:
+    UndoManager().record_change(file_path, 'delete_file')
     file_path = os.path.abspath(file_path)
 
     # Use the plugin system for permission handling with operation data

--- a/code_puppy/tools/file_modifications.py
+++ b/code_puppy/tools/file_modifications.py
@@ -219,7 +219,7 @@ def _delete_snippet_from_file(
     snippet: str,
     message_group: str | None = None,
 ) -> Dict[str, Any]:
-    UndoManager().record_change(file_path, 'delete_snippet')
+    UndoManager().record_change(file_path, "delete_snippet")
     file_path = os.path.abspath(file_path)
     diff_text = ""
     try:
@@ -269,7 +269,7 @@ def _replace_in_file(
     replacements: List[Dict[str, str]],
     message_group: str | None = None,
 ) -> Dict[str, Any]:
-    UndoManager().record_change(path, 'replace_in_file')
+    UndoManager().record_change(path, "replace_in_file")
     """Robust replacement engine with explicit edge‑case reporting."""
     file_path = os.path.abspath(path)
     diff_text = ""
@@ -365,7 +365,7 @@ def _write_to_file(
     overwrite: bool = False,
     message_group: str | None = None,
 ) -> Dict[str, Any]:
-    UndoManager().record_change(path, 'write_to_file')
+    UndoManager().record_change(path, "write_to_file")
     file_path = os.path.abspath(path)
 
     try:
@@ -508,7 +508,7 @@ def replace_in_file(
 def _edit_file(
     context: RunContext, payload: EditFilePayload, group_id: str | None = None
 ) -> Dict[str, Any]:
-    UndoManager().record_change(payload.file_path, 'edit_file')
+    UndoManager().record_change(payload.file_path, "edit_file")
     """
     High-level implementation of the *edit_file* behaviour.
 
@@ -600,7 +600,7 @@ def _edit_file(
 def _delete_file(
     context: RunContext, file_path: str, message_group: str | None = None
 ) -> Dict[str, Any]:
-    UndoManager().record_change(file_path, 'delete_file')
+    UndoManager().record_change(file_path, "delete_file")
     file_path = os.path.abspath(file_path)
 
     # Use the plugin system for permission handling with operation data

--- a/code_puppy/undo_manager.py
+++ b/code_puppy/undo_manager.py
@@ -1,0 +1,57 @@
+import os
+import shutil
+from typing import Optional, List
+from dataclasses import dataclass
+
+@dataclass
+class FileChange:
+    file_path: str
+    original_content: Optional[str]  # None if the file was created
+    action: str  # e.g., 'replace_in_file', 'create_file', 'delete_file'
+
+class UndoManager:
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(UndoManager, cls).__new__(cls)
+            cls._instance.history = []
+        return cls._instance
+
+    def __init__(self):
+        if not hasattr(self, 'history'):
+            self.history: List[FileChange] = []
+
+    def record_change(self, file_path: str, action: str):
+        original_content = None
+        if os.path.exists(file_path):
+            try:
+                with open(file_path, 'r', encoding='utf-8') as f:
+                    original_content = f.read()
+            except Exception:
+                pass  # Ignore binary files or unreadable files for now
+        self.history.append(FileChange(file_path=file_path, original_content=original_content, action=action))
+
+    def pop_change(self) -> Optional[FileChange]:
+        if self.history:
+            return self.history.pop()
+        return None
+
+    def undo_last(self) -> str:
+        change = self.pop_change()
+        if not change:
+            return "No more actions to undo."
+        
+        try:
+            if change.original_content is None:
+                # File was created, so we delete it
+                if os.path.exists(change.file_path):
+                    os.remove(change.file_path)
+                return f"Undid {change.action}: deleted {change.file_path}"
+            else:
+                # File was modified or deleted, restore original content
+                with open(change.file_path, 'w', encoding='utf-8') as f:
+                    f.write(change.original_content)
+                return f"Undid {change.action}: restored {change.file_path}"
+        except Exception as e:
+            return f"Failed to undo {change.action} on {change.file_path}: {e}"

--- a/code_puppy/undo_manager.py
+++ b/code_puppy/undo_manager.py
@@ -1,13 +1,14 @@
 import os
-import shutil
 from typing import Optional, List
 from dataclasses import dataclass
+
 
 @dataclass
 class FileChange:
     file_path: str
     original_content: Optional[str]  # None if the file was created
     action: str  # e.g., 'replace_in_file', 'create_file', 'delete_file'
+
 
 class UndoManager:
     _instance = None
@@ -19,18 +20,22 @@ class UndoManager:
         return cls._instance
 
     def __init__(self):
-        if not hasattr(self, 'history'):
+        if not hasattr(self, "history"):
             self.history: List[FileChange] = []
 
     def record_change(self, file_path: str, action: str):
         original_content = None
         if os.path.exists(file_path):
             try:
-                with open(file_path, 'r', encoding='utf-8') as f:
+                with open(file_path, "r", encoding="utf-8") as f:
                     original_content = f.read()
             except Exception:
                 pass  # Ignore binary files or unreadable files for now
-        self.history.append(FileChange(file_path=file_path, original_content=original_content, action=action))
+        self.history.append(
+            FileChange(
+                file_path=file_path, original_content=original_content, action=action
+            )
+        )
 
     def pop_change(self) -> Optional[FileChange]:
         if self.history:
@@ -41,7 +46,7 @@ class UndoManager:
         change = self.pop_change()
         if not change:
             return "No more actions to undo."
-        
+
         try:
             if change.original_content is None:
                 # File was created, so we delete it
@@ -50,7 +55,7 @@ class UndoManager:
                 return f"Undid {change.action}: deleted {change.file_path}"
             else:
                 # File was modified or deleted, restore original content
-                with open(change.file_path, 'w', encoding='utf-8') as f:
+                with open(change.file_path, "w", encoding="utf-8") as f:
                     f.write(change.original_content)
                 return f"Undid {change.action}: restored {change.file_path}"
         except Exception as e:

--- a/tests/test_undo_manager.py
+++ b/tests/test_undo_manager.py
@@ -2,21 +2,22 @@ import os
 import tempfile
 from code_puppy.undo_manager import UndoManager
 
+
 def test_undo_manager():
     manager = UndoManager()
     with tempfile.NamedTemporaryFile(delete=False) as f:
         f.write(b"hello world")
         filepath = f.name
-    
+
     manager.record_change(filepath, "replace_in_file")
-    
+
     with open(filepath, "w") as f:
         f.write("new world")
-        
+
     res = manager.undo_last()
     assert "Undid" in res
-    
+
     with open(filepath, "r") as f:
         assert f.read() == "hello world"
-        
+
     os.remove(filepath)

--- a/tests/test_undo_manager.py
+++ b/tests/test_undo_manager.py
@@ -1,0 +1,22 @@
+import os
+import tempfile
+from code_puppy.undo_manager import UndoManager
+
+def test_undo_manager():
+    manager = UndoManager()
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        f.write(b"hello world")
+        filepath = f.name
+    
+    manager.record_change(filepath, "replace_in_file")
+    
+    with open(filepath, "w") as f:
+        f.write("new world")
+        
+    res = manager.undo_last()
+    assert "Undid" in res
+    
+    with open(filepath, "r") as f:
+        assert f.read() == "hello world"
+        
+    os.remove(filepath)


### PR DESCRIPTION
### **Description**
Currently, when the Code Puppy agent modifies, replaces, or deletes a file, there is no quick way to revert the action natively. This PR introduces a global `/undo` slash command that allows users to instantly revert the last file operation performed by the agent. It integrates the `UndoManager` singleton into the core file modification toolset.

### **Key Changes**
* **Added Slash Command (`/undo`)**: 
  * Registered a new core command `/undo` (aliases: `/u`, `/undo_last`) that invokes `UndoManager().undo_last()`.
  * Wires up appropriate console feedback.
* **Injected Undo Hooks**: 
  * Added `UndoManager().record_change()` calls to `_write_to_file`, `_replace_in_file`, `_delete_snippet_from_file`, `_edit_file`, and `_delete_file`.

### **Testing & Verification**
* Verified file state correctly records prior to writing/replacing.
* All extended file modification test suites pass.
* `UndoManager` unit tests pass.