### PR TITLE
feat: add /plan planning-only slash command scaffold

### DIFF
--- a/code_puppy/command_line/core_commands.py
+++ b/code_puppy/command_line/core_commands.py
@@ -614,6 +614,38 @@ def handle_mcp_command(command: str) -> bool:
 
 
 @register_command(
+    name="plan",
+    description="Create a plan-only response without executing tools",
+    usage="/plan <goal>",
+    category="core",
+)
+def handle_plan_command(command: str) -> bool | str:
+    """Build a planning prompt and route it to the main chat pipeline."""
+    parts = command.split(maxsplit=1)
+    goal = parts[1].strip() if len(parts) > 1 else ""
+
+    if not goal:
+        emit_error("Usage: /plan <goal>")
+        return True
+
+    planning_prompt = f"""You are in plan-only mode.
+Do not execute tools, do not modify files, and do not run shell commands.
+
+User goal:
+{goal}
+
+Return only:
+1. A concise objective summary
+2. A numbered implementation plan
+3. Risks/unknowns
+4. Validation checklist
+5. Optional follow-up questions (only if needed)
+"""
+
+    return planning_prompt
+
+
+@register_command(
     name="generate-pr-description",
     description="Generate comprehensive PR description",
     usage="/generate-pr-description [@dir]",

--- a/tests/command_line/test_core_commands_full_coverage.py
+++ b/tests/command_line/test_core_commands_full_coverage.py
@@ -633,6 +633,25 @@ class TestHandleModelSettingsCommand:
             assert handle_model_settings_command("/model_settings") is True
 
 
+class TestHandlePlanCommand:
+    def test_plan_with_goal_returns_prompt(self):
+        from code_puppy.command_line.core_commands import handle_plan_command
+
+        result = handle_plan_command("/plan add retry logic to network client")
+        assert isinstance(result, str)
+        assert "plan-only mode" in result
+        assert "add retry logic" in result
+
+    def test_plan_without_goal_emits_usage(self):
+        from code_puppy.command_line.core_commands import handle_plan_command
+
+        with patch("code_puppy.command_line.core_commands.emit_error") as mock_error:
+            result = handle_plan_command("/plan")
+
+        assert result is True
+        mock_error.assert_called_once_with("Usage: /plan <goal>")
+
+
 class TestHandleGeneratePrDescription:
     def test_basic(self):
         from code_puppy.command_line.core_commands import (

--- a/tests/test_command_handler.py
+++ b/tests/test_command_handler.py
@@ -1113,6 +1113,12 @@ class TestCommandRegistry:
         assert cmd is not None
         assert cmd.category == "core"
 
+    def test_plan_command_registered(self):
+        """Test that /plan command is registered."""
+        cmd = get_command("plan")
+        assert cmd is not None
+        assert cmd.category == "core"
+
     def test_dump_context_command_registered(self):
         """Test that dump_context command is registered."""
         cmd = get_command("dump_context")


### PR DESCRIPTION
## Summary
- adds a new core slash command: `/plan <goal>`
- routes `/plan` into a planning-only prompt (no tools, no file edits, no shell execution)
- shows usage guidance when goal text is missing

## Testing
- `.venv/bin/ruff check code_puppy/command_line/core_commands.py tests/command_line/test_core_commands_full_coverage.py tests/test_command_handler.py`
- `.venv/bin/pytest tests/command_line/test_core_commands_full_coverage.py -k "plan or generate_pr_description" --no-cov`
- `.venv/bin/pytest tests/test_command_handler.py -k "plan_command_registered" --no-cov`

## Notes
- scoped to command scaffolding only (no execution pipeline changes)
