### PR TITLE
fix: drain stdin on turn cancel so the next prompt isn't truncated

### DIFF
--- a/code_puppy/agents/_key_listeners.py
+++ b/code_puppy/agents/_key_listeners.py
@@ -415,6 +415,56 @@ def _listen_posix(
 
 
 # =============================================================================
+# Stdin drain (cancel cleanup)
+# =============================================================================
+#
+# When a turn is cancelled (Ctrl+C), the listener thread is still sitting in
+# cbreak mode doing ``stdin.read(1)`` right up until it observes the stop
+# event. Any follow-up instruction the user starts typing in that unwind
+# window gets eaten one byte at a time and silently discarded, leaving a
+# *truncated* tail that prompt_toolkit then submits as a corrupt prompt.
+# After the listener is fully stopped (thread joined, termios restored), we
+# drain whatever is left in the tty input queue so the next prompt starts
+# from a clean slate instead of a half-typed mess. Best-effort and TTY-only.
+
+
+def flush_stdin_input() -> None:
+    """Discard any pending bytes in the terminal's input queue.
+
+    Safe to call unconditionally: no-ops when stdin isn't a TTY or the
+    platform primitives are unavailable. Intended for the cancel path,
+    where leftover keystrokes are guaranteed-corrupt rather than useful.
+    """
+    import sys
+
+    stdin = getattr(sys, "stdin", None)
+    if stdin is None or not hasattr(stdin, "isatty"):
+        return
+    try:
+        if not stdin.isatty():
+            return
+    except Exception:
+        return
+
+    if sys.platform.startswith("win"):
+        try:
+            import msvcrt
+
+            while msvcrt.kbhit():
+                msvcrt.getwch()
+        except Exception:
+            pass
+        return
+
+    try:
+        import termios
+
+        termios.tcflush(stdin.fileno(), termios.TCIFLUSH)
+    except Exception:
+        pass
+
+
+# =============================================================================
 # Reentrant suspend context manager
 # =============================================================================
 #
@@ -474,4 +524,5 @@ __all__ = [
     "set_escape_handler",
     "spawn_key_listener",
     "suspended_key_listener",
+    "flush_stdin_input",
 ]

--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -622,7 +622,7 @@ async def run_with_mcp(
     run_success = False
     run_error: Optional[BaseException] = None
     run_response_text = ""
-
+    run_cancelled = False
     try:
         if cancel_agent_uses_signal():
             original_handler = signal.signal(signal.SIGINT, keyboard_interrupt_handler)
@@ -652,10 +652,12 @@ async def run_with_mcp(
         return result
     except asyncio.CancelledError:
         run_response_text = ""
+        run_cancelled = True
         agent_task.cancel()
         drain_pause_state_on_cancel()
     except KeyboardInterrupt:
         run_response_text = ""
+        run_cancelled = True
         if not agent_task.done():
             agent_task.cancel()
         drain_pause_state_on_cancel()
@@ -690,5 +692,14 @@ async def run_with_mcp(
             # Handle is None (no TTY); just flip the stop event so any
             # half-spawned bits unwind cleanly.
             key_listener_stop_event.set()
+        # On cancel the listener was reading stdin in cbreak mode right up
+        # until it saw the stop event, so it ate the leading bytes of any
+        # follow-up the user started typing -- leaving a truncated tail that
+        # the next prompt would submit as a corrupt instruction. Now that the
+        # listener is fully stopped (thread joined, termios restored), drain
+        # the tty input queue so the next prompt starts clean. Cancel-only:
+        # the happy path has nothing to flush and we won't nuke real input.
+        if run_cancelled:
+            _key_listeners.flush_stdin_input()
         if original_handler is not None:  # SIG_DFL is 0/falsy — explicit check!
             signal.signal(signal.SIGINT, original_handler)

--- a/tests/test_cancel_stdin_flush.py
+++ b/tests/test_cancel_stdin_flush.py
@@ -1,0 +1,106 @@
+"""Tests for the cancel-path stdin drain.
+
+Background: while an agent turn runs, a key-listener thread holds the
+terminal in cbreak mode and reads stdin one byte at a time. On Ctrl+C the
+listener keeps eating bytes until it sees the stop event, so the leading
+characters of any follow-up the user types get swallowed and the truncated
+tail would be submitted as a corrupt prompt. ``flush_stdin_input`` drains
+the tty input queue on cancel so the next prompt starts from a clean slate.
+
+These tests use a real pseudo-terminal so ``termios.tcflush`` actually
+runs -- no mocking the very primitive whose behavior we care about.
+"""
+
+import os
+import select
+import sys
+import time
+
+import pytest
+
+from code_puppy.agents._key_listeners import flush_stdin_input
+
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="pty/termios drain test is POSIX-only",
+)
+
+
+class _FakeStdin:
+    """Minimal stdin stand-in backed by a real terminal fd."""
+
+    def __init__(self, fd: int, *, isatty: bool = True) -> None:
+        self._fd = fd
+        self._isatty = isatty
+
+    def fileno(self) -> int:
+        return self._fd
+
+    def isatty(self) -> bool:
+        return self._isatty
+
+
+def _has_pending(fd: int) -> bool:
+    """True if there are unread bytes waiting on ``fd`` (non-blocking)."""
+    read_ready, _, _ = select.select([fd], [], [], 0.2)
+    return bool(read_ready)
+
+
+def test_flush_drains_pending_input(monkeypatch):
+    """Bytes typed-ahead during cancel are discarded by the flush."""
+    import pty
+
+    master, slave = pty.openpty()
+    try:
+        # Simulate the user mashing a follow-up instruction while the turn
+        # is still unwinding -- it lands in the slave's input queue.
+        os.write(master, b"this is my real follow up instruction\n")
+        # Give the kernel a beat to move the bytes into the input queue.
+        time.sleep(0.05)
+        assert _has_pending(slave), "precondition: bytes should be queued"
+
+        monkeypatch.setattr(sys, "stdin", _FakeStdin(slave))
+        flush_stdin_input()
+
+        assert not _has_pending(slave), "flush should have drained the queue"
+    finally:
+        os.close(master)
+        os.close(slave)
+
+
+def test_without_flush_input_survives(monkeypatch):
+    """Control: without flushing, the queued bytes remain readable.
+
+    Proves the test harness genuinely buffers input, so the assertion in
+    the flush test isn't passing for some unrelated reason.
+    """
+    import pty
+
+    master, slave = pty.openpty()
+    try:
+        os.write(master, b"leftover\n")
+        time.sleep(0.05)
+        assert _has_pending(slave), "bytes should be queued without a flush"
+    finally:
+        os.close(master)
+        os.close(slave)
+
+
+def test_flush_noops_on_non_tty(monkeypatch):
+    """A non-TTY stdin must not raise (and must not flush anything)."""
+    r, w = os.pipe()
+    try:
+        os.write(w, b"pipe data\n")
+        monkeypatch.setattr(sys, "stdin", _FakeStdin(r, isatty=False))
+        # Should be a clean no-op -- no exception, data untouched.
+        flush_stdin_input()
+        assert _has_pending(r), "non-tty input must be left alone"
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+def test_flush_survives_missing_stdin(monkeypatch):
+    """If stdin is None / weird, flush degrades to a silent no-op."""
+    monkeypatch.setattr(sys, "stdin", None)
+    flush_stdin_input()  # must not raise


### PR DESCRIPTION
## The bug

Cancel a turn with **Ctrl+C**, immediately start typing your next instruction, and the agent receives a **truncated, corrupted prompt** — the leading characters of what you typed silently vanish.

### Why it happens

Every agent turn, `run_with_mcp` spawns a POSIX key-listener thread (`agents/_key_listeners.py`) that:

1. Puts the terminal into **cbreak mode** (`tty.setcbreak`)
2. Sits in a `select` loop reading stdin **one byte at a time** (`stdin.read(1)`), watching for Ctrl+X (shell cancel) and Ctrl+T (pause/steer).

cbreak leaves `ISIG` on, so Ctrl+C still fires SIGINT → cancels the agent. The problem is the **gap between your Ctrl+C and that thread actually dying**:

1. Ctrl+C → SIGINT → schedules cancel → `CancelledError` → `finally` runs `handle.stop()` (just *sets an event*) then `thread.join(timeout=1.0)`.
2. The listener only checks the stop event at the top of its `select(..., 0.05)` loop — it doesn't notice instantly.
3. **In that window you're already typing your follow-up** (that's the whole cancel-and-retype workflow). The still-alive listener keeps doing `stdin.read(1)`, **swallowing your leading characters one by one** and discarding them (they don't match Ctrl+X/Ctrl+T).
4. The thread finally exits and restores termios. Only the characters typed *after* that moment survive in the tty buffer.
5. `prompt_async` reads the **surviving tail**, you hit Enter → a **truncated instruction is submitted to the agent.**

This lines up with the observed symptoms:
- The number of dropped chars is *time*-based (how long the async cancel takes to unwind × how fast you type), so it *feels* like a hidden, prompt-length-shaped limit.
- A throwaway empty Enter "fixes" it — by the second prompt the listener thread is long dead and termios is restored.
- It only ever happens on cancel-mid-turn, the only time the cbreak listener is alive *while you're typing fresh input*.

The genuinely nasty part: it's not just cosmetic — a **partial, corrupted instruction actually reaches the agent**, which then confidently acts on half a sentence. Silent data corruption.

## The fix

Drain the terminal's input queue on the cancel path, **after** the listener thread is fully stopped (joined) and termios is restored, so the next prompt starts from a clean slate instead of a half-eaten one.

- New `agents/_key_listeners.flush_stdin_input()` — POSIX `termios.tcflush(TCIFLUSH)` / Windows `msvcrt` drain. TTY-guarded, best-effort, no-ops when stdin isn't a TTY or is unavailable.
- `run_with_mcp` tracks a `run_cancelled` flag and calls the flush in its `finally` **only on cancel**. The happy path is completely untouched — no risk of nuking legitimate input.

### Why discard rather than preserve?

Bytes the listener already `read(1)`'d are gone — they can't be un-read, so true type-ahead preservation isn't possible here. And type-ahead during a turn was already non-functional anyway. So flushing is a pure win: it converts a **silent partial-submit** into a **predictable clean prompt**, which matches the mental model you already have when you hit Ctrl+C ("stop, let me rethink").

## What we added

| File | Change |
|---|---|
| `code_puppy/agents/_key_listeners.py` | New `flush_stdin_input()` helper (+ `__all__` export) |
| `code_puppy/agents/_runtime.py` | Track `run_cancelled`; call the flush in `run_with_mcp`'s `finally`, cancel-path only, after the listener join |
| `tests/test_cancel_stdin_flush.py` | New tests |

### Tests

Uses a **real pseudo-terminal** so `termios.tcflush` genuinely runs — no mocking the primitive under test:

- `test_flush_drains_pending_input` — queued bytes are gone after the flush
- `test_without_flush_input_survives` — control proving the harness really buffers input
- `test_flush_noops_on_non_tty` — pipe/non-TTY stdin is left untouched, no raise
- `test_flush_survives_missing_stdin` — `stdin = None` degrades to a silent no-op

All green locally, plus the existing ctrl-c/cancel suites (`9 passed, 6 skipped`). `ruff check .` and `ruff format --check .` clean repo-wide.
