### PR TITLE
fix(mcp): coerce stringified tool args against each tool's JSON Schema

### DIFF
--- a/code_puppy/mcp_/managed_server.py
+++ b/code_puppy/mcp_/managed_server.py
@@ -24,6 +24,7 @@ from pydantic_ai.mcp import (
 
 from code_puppy.http_utils import create_async_client
 from code_puppy.mcp_.blocking_startup import BlockingMCPServerStdio
+from code_puppy.mcp_.tool_arg_coercion import coerce_tool_args
 
 
 def _expand_env_vars(value: Any) -> Any:
@@ -81,13 +82,45 @@ class ServerConfig:
     config: Dict = field(default_factory=dict)  # Raw config from JSON
 
 
+async def _input_schema_for_tool(
+    call_tool: CallToolFunc, name: str
+) -> Optional[Dict[str, Any]]:
+    """Best-effort lookup of an MCP tool's JSON inputSchema.
+
+    ``call_tool`` is pydantic-ai's bound ``direct_call_tool`` method, so its
+    ``__self__`` is the underlying MCP server, which exposes a (cached)
+    ``list_tools()``. The ``name`` here is already prefix-stripped, matching the
+    raw tool names returned by ``list_tools()``.
+
+    Returns ``None`` if the schema cannot be resolved for any reason -- callers
+    must treat that as "don't coerce".
+    """
+    server = getattr(call_tool, "__self__", None)
+    list_tools = getattr(server, "list_tools", None)
+    if list_tools is None:
+        return None
+    try:
+        tools = await list_tools()
+    except Exception:
+        return None
+    for tool in tools:
+        if getattr(tool, "name", None) == name:
+            return getattr(tool, "inputSchema", None)
+    return None
+
+
 async def process_tool_call(
     ctx: RunContext[Any],
     call_tool: CallToolFunc,
     name: str,
     tool_args: dict[str, Any],
 ) -> ToolResult:
-    """A tool call processor that passes along the deps."""
+    """A tool call processor that coerces args and passes along the deps.
+
+    pydantic-ai forwards MCP tool args without coercing them against each tool's
+    real JSON Schema, so models that emit stringified arrays/bools/numbers cause
+    downstream validation failures. We coerce here before forwarding.
+    """
     from rich.console import Console
 
     from code_puppy.config import get_banner_color
@@ -96,6 +129,10 @@ async def process_tool_call(
     color = get_banner_color("mcp_tool_call")
     banner = f"[bold white on {color}] MCP TOOL CALL [/bold white on {color}]"
     console.print(f"\n{banner} 🔧 [bold cyan]{name}[/bold cyan]")
+
+    input_schema = await _input_schema_for_tool(call_tool, name)
+    tool_args = coerce_tool_args(tool_args, input_schema)
+
     return await call_tool(name, tool_args, {"deps": ctx.deps})
 
 

--- a/code_puppy/mcp_/tool_arg_coercion.py
+++ b/code_puppy/mcp_/tool_arg_coercion.py
@@ -1,0 +1,180 @@
+"""Coercion of MCP tool-call arguments against their JSON Schema.
+
+Why this exists
+---------------
+code-puppy delegates MCP tool calls to pydantic-ai. pydantic-ai's MCP toolset
+validates incoming tool-call args with a *passthrough* validator
+(``SchemaValidator(schema=core_schema.any_schema())``) that performs **zero**
+coercion against each tool's real JSON ``inputSchema``. Whatever the model /
+gateway emits is forwarded raw to the MCP server.
+
+In practice some model layers emit arrays / booleans / numbers **encoded as
+JSON strings** (e.g. ``"[\\"public\\"]"``, ``"false"``, ``"100"``). Because
+nothing coerces them back to their schema types, the downstream MCP server's
+strict validation rejects them with errors like ``"string found, array
+expected"`` or Zod's ``"expected boolean, received string"``.
+
+This module coerces such stringified scalars/containers back to the types
+declared by the tool's own JSON Schema *before* the call is forwarded. It is
+deliberately defensive: anything it cannot confidently coerce is passed through
+unchanged. It never raises and never drops data.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+__all__ = ["coerce_tool_args"]
+
+# JSON Schema "type" keywords we know how to coerce a string *into*.
+_COERCIBLE_TYPES = frozenset({"array", "object", "number", "integer", "boolean"})
+
+
+def coerce_tool_args(
+    tool_args: Dict[str, Any],
+    input_schema: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Coerce ``tool_args`` against an MCP tool's JSON ``input_schema``.
+
+    For every argument whose value is a ``str`` but whose schema declares a
+    non-string type (array/object/number/integer/boolean), attempt to parse the
+    string into that type. If the parse fails or yields the wrong type, the
+    original value is kept untouched.
+
+    Args:
+        tool_args: The raw arguments emitted for the tool call.
+        input_schema: The tool's JSON Schema (typically
+            ``ToolDefinition.parameters_json_schema`` / ``mcp_tool.inputSchema``).
+            May be ``None`` or malformed; in that case args are returned as-is.
+
+    Returns:
+        A new dict with coerced values where possible. The input is never mutated.
+    """
+    if not isinstance(tool_args, dict):
+        return tool_args
+    if not isinstance(input_schema, dict):
+        return tool_args
+
+    properties = input_schema.get("properties")
+    if not isinstance(properties, dict):
+        return tool_args
+
+    coerced: Dict[str, Any] = dict(tool_args)
+    for key, value in tool_args.items():
+        if not isinstance(value, str):
+            # Only stringified values are ever ambiguous; leave the rest alone.
+            continue
+        prop_schema = properties.get(key)
+        if not isinstance(prop_schema, dict):
+            continue
+        coerced[key] = _coerce_value(value, prop_schema)
+    return coerced
+
+
+def _schema_types(prop_schema: Dict[str, Any]) -> List[str]:
+    """Extract the candidate JSON Schema types for a property.
+
+    Handles ``{"type": "array"}``, ``{"type": ["array", "null"]}`` and the
+    ``anyOf`` / ``oneOf`` union shapes. Returns an ordered, de-duplicated list of
+    coercion-relevant type names.
+    """
+    found: List[str] = []
+
+    def _add(raw_type: Any) -> None:
+        if isinstance(raw_type, str) and raw_type in _COERCIBLE_TYPES:
+            if raw_type not in found:
+                found.append(raw_type)
+
+    raw = prop_schema.get("type")
+    if isinstance(raw, str):
+        _add(raw)
+    elif isinstance(raw, list):
+        for entry in raw:
+            _add(entry)
+
+    for union_key in ("anyOf", "oneOf"):
+        union = prop_schema.get(union_key)
+        if isinstance(union, list):
+            for sub in union:
+                if isinstance(sub, dict):
+                    for t in _schema_types(sub):
+                        if t not in found:
+                            found.append(t)
+
+    return found
+
+
+def _coerce_value(value: str, prop_schema: Dict[str, Any]) -> Any:
+    """Coerce a single stringified ``value`` toward one of its schema types.
+
+    Tries each candidate type in declaration order and returns the first
+    successful coercion. Falls back to the original string if none apply.
+    """
+    for schema_type in _schema_types(prop_schema):
+        coerced, ok = _coerce_to_type(value, schema_type)
+        if ok:
+            return coerced
+    return value
+
+
+def _coerce_to_type(value: str, schema_type: str) -> tuple[Any, bool]:
+    """Attempt to coerce ``value`` to ``schema_type``.
+
+    Returns a ``(coerced_value, success)`` tuple. On failure the second element
+    is ``False`` and the first should be ignored.
+    """
+    if schema_type == "boolean":
+        return _coerce_boolean(value)
+    if schema_type == "integer":
+        return _coerce_integer(value)
+    if schema_type == "number":
+        return _coerce_number(value)
+    if schema_type == "array":
+        return _coerce_json_container(value, list)
+    if schema_type == "object":
+        return _coerce_json_container(value, dict)
+    return value, False
+
+
+def _coerce_boolean(value: str) -> tuple[Any, bool]:
+    lowered = value.strip().lower()
+    if lowered == "true":
+        return True, True
+    if lowered == "false":
+        return False, True
+    return value, False
+
+
+def _coerce_integer(value: str) -> tuple[Any, bool]:
+    text = value.strip()
+    try:
+        return int(text), True
+    except (TypeError, ValueError):
+        # Allow integral floats like "100.0" -> 100.
+        try:
+            parsed = float(text)
+        except (TypeError, ValueError):
+            return value, False
+        if parsed.is_integer():
+            return int(parsed), True
+        return value, False
+
+
+def _coerce_number(value: str) -> tuple[Any, bool]:
+    text = value.strip()
+    try:
+        return float(text), True
+    except (TypeError, ValueError):
+        return value, False
+
+
+def _coerce_json_container(value: str, expected: type) -> tuple[Any, bool]:
+    """Parse ``value`` as JSON and accept it only if it is an ``expected`` type."""
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return value, False
+    if isinstance(parsed, expected):
+        return parsed, True
+    return value, False

--- a/tests/mcp/test_tool_arg_coercion.py
+++ b/tests/mcp/test_tool_arg_coercion.py
@@ -1,0 +1,198 @@
+"""Tests for MCP tool-argument coercion.
+
+These cover the bug where models emit arrays/booleans/numbers encoded as JSON
+strings, which pydantic-ai forwards raw (it uses an ``any_schema`` passthrough
+validator), causing downstream MCP servers to reject them. Confirmed in the
+wild against both the SonarQube and Supabase MCP servers.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from code_puppy.mcp_.managed_server import (
+    _input_schema_for_tool,
+    process_tool_call,
+)
+from code_puppy.mcp_.tool_arg_coercion import coerce_tool_args
+
+
+def _schema(properties: dict) -> dict:
+    return {"type": "object", "properties": properties}
+
+
+def test_stringified_array_becomes_array():
+    schema = _schema({"schemas": {"type": "array", "items": {"type": "string"}}})
+    args = {"schemas": '["public"]'}
+    assert coerce_tool_args(args, schema) == {"schemas": ["public"]}
+
+
+def test_stringified_object_becomes_object():
+    schema = _schema({"filters": {"type": "object"}})
+    args = {"filters": '{"status": "open"}'}
+    assert coerce_tool_args(args, schema) == {"filters": {"status": "open"}}
+
+
+def test_false_string_becomes_bool():
+    schema = _schema({"verbose": {"type": "boolean"}})
+    assert coerce_tool_args({"verbose": "false"}, schema) == {"verbose": False}
+
+
+def test_true_string_case_insensitive_becomes_bool():
+    schema = _schema({"verbose": {"type": "boolean"}})
+    assert coerce_tool_args({"verbose": "TRUE"}, schema) == {"verbose": True}
+
+
+def test_numeric_string_becomes_int():
+    schema = _schema({"limit": {"type": "integer"}})
+    assert coerce_tool_args({"limit": "100"}, schema) == {"limit": 100}
+
+
+def test_numeric_string_becomes_float():
+    schema = _schema({"ratio": {"type": "number"}})
+    assert coerce_tool_args({"ratio": "1.5"}, schema) == {"ratio": 1.5}
+
+
+def test_integral_float_string_for_integer():
+    schema = _schema({"limit": {"type": "integer"}})
+    assert coerce_tool_args({"limit": "100.0"}, schema) == {"limit": 100}
+
+
+def test_already_correct_values_pass_through_untouched():
+    schema = _schema(
+        {
+            "schemas": {"type": "array"},
+            "verbose": {"type": "boolean"},
+            "limit": {"type": "integer"},
+        }
+    )
+    args = {"schemas": ["public"], "verbose": True, "limit": 100}
+    assert coerce_tool_args(args, schema) == args
+
+
+def test_string_arg_with_string_schema_is_left_alone():
+    schema = _schema({"name": {"type": "string"}})
+    # A genuine JSON-looking string for a string field must NOT be parsed.
+    args = {"name": "[1, 2, 3]"}
+    assert coerce_tool_args(args, schema) == {"name": "[1, 2, 3]"}
+
+
+def test_uncoercible_junk_passes_through_without_crashing():
+    schema = _schema(
+        {
+            "schemas": {"type": "array"},
+            "limit": {"type": "integer"},
+            "verbose": {"type": "boolean"},
+        }
+    )
+    args = {"schemas": "not json at all", "limit": "abc", "verbose": "maybe"}
+    # Nothing coercible -> everything passes through verbatim, no exception.
+    assert coerce_tool_args(args, schema) == args
+
+
+def test_json_parses_but_wrong_type_passes_through():
+    # Value parses as an int but schema wants an array -> keep the original.
+    schema = _schema({"schemas": {"type": "array"}})
+    assert coerce_tool_args({"schemas": "5"}, schema) == {"schemas": "5"}
+
+
+def test_nullable_union_type_list_is_coerced():
+    schema = _schema({"schemas": {"type": ["array", "null"]}})
+    assert coerce_tool_args({"schemas": '["a","b"]'}, schema) == {"schemas": ["a", "b"]}
+
+
+def test_anyof_union_is_coerced():
+    schema = _schema({"limit": {"anyOf": [{"type": "integer"}, {"type": "null"}]}})
+    assert coerce_tool_args({"limit": "42"}, schema) == {"limit": 42}
+
+
+def test_missing_schema_returns_args_unchanged():
+    args = {"schemas": '["public"]'}
+    assert coerce_tool_args(args, None) == args
+    assert coerce_tool_args(args, {}) == args
+    assert coerce_tool_args(args, {"type": "object"}) == args
+
+
+def test_unknown_property_left_alone():
+    schema = _schema({"known": {"type": "array"}})
+    args = {"unknown": '["x"]'}
+    assert coerce_tool_args(args, schema) == {"unknown": '["x"]'}
+
+
+def test_input_is_not_mutated():
+    schema = _schema({"limit": {"type": "integer"}})
+    args = {"limit": "100"}
+    coerce_tool_args(args, schema)
+    assert args == {"limit": "100"}
+
+
+def test_non_dict_args_returned_as_is():
+    assert coerce_tool_args("nope", _schema({})) == "nope"  # type: ignore[arg-type]
+
+
+# --- Integration: the process_tool_call wiring -----------------------------
+
+
+class _FakeServer:
+    """Stands in for a pydantic-ai MCP server exposing list_tools()."""
+
+    def __init__(self, tools):
+        self._tools = tools
+        self.list_tools_calls = 0
+
+    async def list_tools(self):
+        self.list_tools_calls += 1
+        return self._tools
+
+    async def direct_call_tool(self, name, args, metadata=None):
+        return {"name": name, "args": args, "metadata": metadata}
+
+
+def _tool(name: str, input_schema: dict) -> SimpleNamespace:
+    return SimpleNamespace(name=name, inputSchema=input_schema)
+
+
+@pytest.mark.asyncio
+async def test_input_schema_for_tool_resolves_via_bound_server():
+    server = _FakeServer([_tool("search", _schema({"q": {"type": "string"}}))])
+    schema = await _input_schema_for_tool(server.direct_call_tool, "search")
+    assert schema == _schema({"q": {"type": "string"}})
+
+
+@pytest.mark.asyncio
+async def test_input_schema_for_tool_missing_returns_none():
+    server = _FakeServer([_tool("search", _schema({}))])
+    assert await _input_schema_for_tool(server.direct_call_tool, "nope") is None
+
+
+@pytest.mark.asyncio
+async def test_input_schema_for_tool_handles_non_server_callable():
+    async def plain_callable(name, args, metadata=None):
+        return None
+
+    assert await _input_schema_for_tool(plain_callable, "whatever") is None
+
+
+@pytest.mark.asyncio
+async def test_process_tool_call_coerces_before_forwarding():
+    schema = _schema(
+        {
+            "schemas": {"type": "array"},
+            "verbose": {"type": "boolean"},
+            "limit": {"type": "integer"},
+        }
+    )
+    server = _FakeServer([_tool("list_tables", schema)])
+    ctx = SimpleNamespace(deps="DEPS")
+    raw_args = {"schemas": '["public"]', "verbose": "false", "limit": "100"}
+
+    result = await process_tool_call(
+        ctx, server.direct_call_tool, "list_tables", raw_args
+    )
+
+    assert result["args"] == {
+        "schemas": ["public"],
+        "verbose": False,
+        "limit": 100,
+    }
+    assert result["metadata"] == {"deps": "DEPS"}


### PR DESCRIPTION
## Symptom

Every MCP tool that takes a **non-string** argument (array, number, boolean) fails, while tools that take only string args work perfectly. Errors look like:

- `string found, array expected`
- Zod: `expected array, received string` / `expected boolean, received string`

This reproduces across **multiple** MCP servers — confirmed against both the **SonarQube** and **Supabase** MCP servers — so it is **not** server-specific. It's in code-puppy's MCP argument-passing path.

## Root cause

code-puppy delegates MCP tool calls to pydantic-ai. pydantic-ai's MCP toolset validates incoming tool-call args with a **passthrough validator** that does **zero** coercion against each tool's real JSON `inputSchema`:

```python
# pydantic_ai/toolsets/external.py
TOOL_SCHEMA_VALIDATOR = SchemaValidator(schema=core_schema.any_schema())
# pydantic_ai/mcp.py
args_validator=TOOL_SCHEMA_VALIDATOR  # "just parses JSON without additional validation"
```

So whatever the model/gateway emits is forwarded **raw** to the MCP server. The model layer emits arrays/bools/numbers **encoded as JSON strings** (e.g. `"[\"public\"]"`, `"false"`, `"100"`), and because nothing coerces them back to their schema types, the downstream server's strict validation rejects them.

`code_puppy/mcp_/` previously did **not** touch tool args — it delegated entirely to pydantic-ai.

## The fix

Coerce incoming `tool_args` against the tool's own JSON Schema **before** the call is forwarded, using the `process_tool_call` hook code-puppy already wires into every MCP server (`MCPServerSSE`, `BlockingMCPServerStdio`, `MCPServerStreamableHTTP`). No `site-packages/pydantic_ai` patching (that gets wiped on reinstall), and it applies **uniformly to all MCP servers**.

New module **`code_puppy/mcp_/tool_arg_coercion.py`** with a single well-typed entry point `coerce_tool_args(tool_args, input_schema)`:

- For each arg whose value is a `str` but whose schema type is `array`/`object`/`number`/`integer`/`boolean`, attempt to parse it into that type.
- **Arrays / objects** → `json.loads`, accepted only if the parsed value is the right container type.
- **Booleans** → `"true"`/`"false"` (case-insensitive) → `bool`.
- **Integers / numbers** → numeric strings → `int`/`float` (integral floats like `"100.0"` accepted for `integer`).
- Handles `type: ["array", "null"]` unions and `anyOf`/`oneOf`.
- **Defensive by design:** if coercion fails or the schema is ambiguous, the original value passes through **unchanged**. Never crashes, never loses data, never mutates input.

Wiring (`code_puppy/mcp_/managed_server.py`): `process_tool_call` now resolves the tool's `inputSchema` from the bound server's cached `list_tools()` (via `_input_schema_for_tool`) and runs `coerce_tool_args` before forwarding. Schema resolution is best-effort — if it can't be found, args are forwarded as-is.

## Test coverage

New `tests/mcp/test_tool_arg_coercion.py`:

- stringified array → array, stringified object → object
- `"false"`/`"TRUE"` → `bool`
- `"100"` → `int`, `"1.5"` → `float`, `"100.0"` → `int`
- already-correct values pass through untouched
- un-coercible junk (`"not json"`, `"abc"`, `"maybe"`) passes through without crashing
- value that JSON-parses but to the wrong type is left alone
- string field with JSON-looking string is **not** parsed
- `["array","null"]` and `anyOf` union schemas
- input dict is not mutated
- end-to-end `process_tool_call` wiring: stringified array/bool/int all coerced and `deps` forwarded

All MCP tests green (`898 passed, 6 skipped`), and the full suite passes apart from two pre-existing browser-coverage failures unrelated to this change (they fail identically on a clean `main`).
