### PR TITLE
feat(session): unified autosave store + headless `-r NAME` save-back

### DIFF
--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -27,7 +27,7 @@ from code_puppy.config import (
     COMMAND_HISTORY_FILE,
     ensure_config_exists,
     finalize_autosave_session,
-    get_current_autosave_session_name,
+    get_current_session_name,
     initialize_command_history_file,
     record_terminal_session,
     save_command_to_history,
@@ -80,57 +80,6 @@ def _render_turn_exception(exc: Exception) -> None:
     from code_puppy.messaging.queue_console import get_queue_console
 
     get_queue_console().print_exception()
-
-
-def _resume_session_from_path(raw_path: str) -> None:
-    """Restore agent message history from a saved .pkl session file.
-
-    Accepts any path (autosaves, contexts, somewhere weird on disk). We don't
-    care where it lives — we just decompose into (parent_dir, stem) and reuse
-    ``session_storage.load_session`` so we stay DRY.
-    """
-    from code_puppy.agents.agent_manager import get_current_agent
-    from code_puppy.messaging import emit_error, emit_success
-    from code_puppy.session_storage import load_session
-
-    session_path = Path(raw_path).expanduser().resolve()
-
-    if not session_path.exists():
-        emit_error(f"--resume: session file not found: {session_path}")
-        sys.exit(1)
-
-    if session_path.suffix != ".pkl":
-        emit_error(
-            f"--resume: expected a .pkl session file, got '{session_path.suffix}': {session_path}"
-        )
-        sys.exit(1)
-
-    try:
-        history = load_session(session_path.stem, session_path.parent)
-    except Exception as exc:
-        emit_error(f"--resume: failed to load session: {exc}")
-        sys.exit(1)
-
-    try:
-        agent = get_current_agent()
-        agent.set_message_history(history)
-    except Exception as exc:
-        emit_error(f"--resume: failed to attach history to agent: {exc}")
-        sys.exit(1)
-
-    # Rotate autosave id so we don't clobber the original file we just resumed.
-    try:
-        from code_puppy.config import rotate_autosave_id
-
-        rotate_autosave_id()
-    except Exception:
-        pass  # autosave rotation is best-effort
-
-    total_tokens = sum(agent.estimate_tokens_for_message(m) for m in history)
-    emit_success(
-        f"✅ Resumed session: {len(history)} messages ({total_tokens} tokens)\n"
-        f"📁 From: {session_path}"
-    )
 
 
 def apply_quick_resume(args) -> bool:
@@ -447,14 +396,98 @@ async def main():
         else:
             default_version_mismatch_behavior(current_version)
 
+    # One-shot sweep of legacy ~/.code_puppy/contexts/ into the unified
+    # autosaves/ store. Idempotent via a sentinel; safe to call every
+    # startup. MUST run before any plugin startup callback can read
+    # AUTOSAVE_DIR (otherwise a plugin could miss freshly-swept files)
+    # and before the resume block below resolves -r NAME.
+    try:
+        from code_puppy.session_migration import sweep_contexts_to_autosaves
+
+        sweep_contexts_to_autosaves()
+    except Exception:
+        # Sweep failure must never block startup -- it logs internally.
+        pass
+
     await callbacks.on_startup()
 
     # Resolve --quick-resume [PATH] into --resume so the resume machinery below
     # loads the most recent session for that canonical (git-root + branch) scope.
     apply_quick_resume(args)
 
+    # Holds the resolved (normalised) session name when -r/--resume is in
+    # effect, so save-back paths can persist into the same file the resolver
+    # opened — not the raw user input (which might be ``foo.pkl`` or an
+    # absolute path that the resolver normalised to a bare slug).
+    resolved_resume_session: str | None = None
+
     if args.resume:
-        _resume_session_from_path(args.resume)
+        from code_puppy.agents.agent_manager import get_current_agent
+        from code_puppy.config import AUTOSAVE_DIR, pin_current_session_name
+        from code_puppy.messaging import emit_error, emit_info, emit_success
+        from code_puppy.session_lifecycle import (
+            ResumeTargetError,
+            resolve_or_create_resume_target,
+        )
+        from code_puppy.session_storage import list_sessions, load_session
+
+        resume_target = args.resume
+        sessions_dir = Path(AUTOSAVE_DIR)
+
+        # Lazy-create is symmetric across modes: both headless and
+        # interactive accept ``-r missing-name`` and materialise an
+        # empty session. The typo-guard concern is preserved by the
+        # visible ``Created new session: NAME`` info line plus the
+        # empty ``message_count: 0`` initial state.
+        try:
+            session_name, session_dir, lazy_created = resolve_or_create_resume_target(
+                resume_target,
+                sessions_dir=sessions_dir,
+                allow_lazy_create=True,
+            )
+        except ResumeTargetError as resolve_exc:
+            emit_error(resolve_exc.message)
+            if resolve_exc.hint:
+                emit_info(resolve_exc.hint)
+            available = list_sessions(sessions_dir)
+            if available:
+                emit_info(f"Available sessions: {', '.join(available[:10])}")
+            sys.exit(1)
+
+        # When lazy-create fired, announce it so scripts and users can
+        # distinguish first-run creation from a normal resume.
+        if lazy_created:
+            emit_info(f"Created new session: {session_name}")
+
+        try:
+            history = load_session(session_name, session_dir)
+            agent = get_current_agent()
+            agent.set_message_history(history)
+            total_tokens = sum(agent.estimate_tokens_for_message(m) for m in history)
+
+            # Pin the singleton so periodic autosave AND headless save-back
+            # both update this named file in place. Replaces the old
+            # rotate_autosave_id() call, which under unification would
+            # actively undo the named-session wiring we want.
+            #
+            # Note: even when the user resumed via an absolute path
+            # (resolver branches 1 or 3), we pin the *stem* and let
+            # subsequent writes land in AUTOSAVE_DIR. That keeps cross-mode
+            # resume by name consistent; users who passed a one-off path
+            # can copy the resulting AUTOSAVE_DIR file back if they care.
+            pin_current_session_name(session_name)
+
+            # Record the resolved name for the headless save-back path below.
+            resolved_resume_session = session_name
+
+            if not lazy_created:
+                emit_success(
+                    f"Resumed: {len(history)} messages "
+                    f"({total_tokens} tokens) from {session_name}"
+                )
+        except Exception as e:
+            emit_error(f"Failed to resume from {resume_target}: {e}")
+            sys.exit(1)
 
     global shutdown_flag
     shutdown_flag = False
@@ -470,7 +503,11 @@ async def main():
             prompt_only_mode = False
 
         if prompt_only_mode:
-            await execute_single_prompt(initial_command, message_renderer)
+            await execute_single_prompt(
+                initial_command,
+                message_renderer,
+                session_name=resolved_resume_session,
+            )
         else:
             # Default to interactive mode (no args = same as -i)
             await interactive_mode(message_renderer, initial_command=initial_command)
@@ -652,55 +689,7 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
 
     # Autosave loading is now manual - use /autosave_load command
 
-    # Track this terminal's active session for /switch-agent auto-resume
-    record_terminal_session(get_current_autosave_session_name(), overwrite=False)
-
-    # Auto-run tutorial on first startup
-    try:
-        from code_puppy.command_line.onboarding_wizard import should_show_onboarding
-
-        if should_show_onboarding():
-            import concurrent.futures
-
-            from code_puppy.command_line.onboarding_wizard import run_onboarding_wizard
-            from code_puppy.config import set_model_name
-            from code_puppy.messaging import emit_info
-
-            from code_puppy.command_line.onboarding_wizard import (
-                require_model_setup_if_needed,
-            )
-
-            with concurrent.futures.ThreadPoolExecutor() as executor:
-                future = executor.submit(lambda: asyncio.run(run_onboarding_wizard()))
-                result = future.result(timeout=300)
-
-            if result == "chatgpt":
-                emit_info("🔐 Starting ChatGPT OAuth flow...")
-                from code_puppy.plugins.chatgpt_oauth.oauth_flow import run_oauth_flow
-
-                run_oauth_flow()
-                set_model_name("chatgpt-gpt-5.4")
-            elif result == "claude":
-                emit_info("🔐 Starting Claude Code OAuth flow...")
-                from code_puppy.plugins.claude_code_oauth.register_callbacks import (
-                    _perform_authentication,
-                )
-
-                _perform_authentication()
-                set_model_name("claude-code-claude-opus-4-7")
-            elif result == "completed":
-                emit_info("🎉 Tutorial complete! Happy coding!")
-            elif result == "skipped":
-                emit_info("⏭️ Tutorial skipped. Run /tutorial anytime!")
-
-            # No bundled default model anymore: if the user skipped OAuth they
-            # must add a model explicitly.
-            require_model_setup_if_needed(result)
-    except Exception as e:
-        from code_puppy.messaging import emit_warning
-
-        emit_warning(f"Tutorial auto-start failed: {e}")
-
+    record_terminal_session(get_current_session_name(), overwrite=False)
     # Track the current agent task for cancellation on quit
     current_agent_task = None
 
@@ -856,7 +845,7 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
                                 interactive_autosave_picker,
                             )
                             from code_puppy.config import (
-                                set_current_autosave_from_session_name,
+                                pin_current_session_name,
                             )
                             from code_puppy.messaging import (
                                 emit_error,
@@ -882,7 +871,7 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
                             agent.set_message_history(history)
 
                             # Set current autosave session
-                            set_current_autosave_from_session_name(chosen_session)
+                            pin_current_session_name(chosen_session)
 
                             total_tokens = sum(
                                 agent.estimate_tokens_for_message(msg)
@@ -1196,8 +1185,28 @@ async def run_prompt_with_attachments(
             return None, agent_task
 
 
-async def execute_single_prompt(prompt: str, message_renderer) -> None:
-    """Execute a single prompt and exit (for -p flag)."""
+async def execute_single_prompt(
+    prompt: str,
+    message_renderer,
+    *,
+    session_name: str | None = None,
+) -> None:
+    """Execute a single prompt and exit (for -p flag).
+
+    When ``session_name`` is supplied (i.e. the user passed ``-r NAME``),
+    history is persisted back to that named session in a ``finally`` block
+    so partial state still lands on cancel / error paths. The runtime
+    prunes interrupted tool calls before returning so the saved history is
+    coherent (see ``agents/_runtime.py`` -- the two ``_message_history``
+    commit/prune sites around lines 446 and 498).
+
+    Edge case worth knowing: when the agent returns ``(None, None)`` for an
+    empty-prompt scenario, the response emit is skipped but the ``finally``
+    still fires, producing a no-op idempotent rewrite of an existing
+    session (and a phantom ``post_autosave`` event for plugin authors who
+    count saves). Acceptable trade-off versus the complexity of a
+    'something-actually-ran' tracking flag.
+    """
     # Shell pass-through: !<cmd> bypasses the agent even in -p mode
     from code_puppy.command_line.shell_passthrough import (
         execute_shell_passthrough,
@@ -1206,9 +1215,26 @@ async def execute_single_prompt(prompt: str, message_renderer) -> None:
 
     if is_shell_passthrough(prompt):
         execute_shell_passthrough(prompt)
+        # Agent never ran — do NOT touch the named session, otherwise
+        # `-r mywork -p '!ls'` would clobber existing history with an empty
+        # save-back. Return before the try/finally so the save path is
+        # genuinely unreachable, not just guarded.
         return
 
-    from code_puppy.messaging import emit_info
+    from code_puppy.messaging import (
+        emit_error,
+        emit_info,
+        emit_warning,
+        get_message_bus,
+    )
+    from code_puppy.messaging.messages import AgentResponseMessage
+
+    # Hoist save-back imports here rather than into the ``finally`` block --
+    # if the user passed ``-r`` we will exercise these on every code path,
+    # and lazy-importing inside ``finally`` just hides the dependency without
+    # buying any actual startup savings (the module is already loaded).
+    from code_puppy.config import AUTOSAVE_DIR
+    from code_puppy.session_lifecycle import persist_named_session
 
     emit_info(f"Executing prompt: {prompt}")
 
@@ -1220,29 +1246,47 @@ async def execute_single_prompt(prompt: str, message_renderer) -> None:
             prompt,
             spinner_console=message_renderer.console,
         )
-        if result is None:
-            return
+        if result is not None:
+            response_msg = AgentResponseMessage(
+                content=result.output,
+                is_markdown=True,
+            )
+            get_message_bus().emit(response_msg)
 
-        agent_response = result.output
-
-        # Emit structured message for proper markdown rendering
-        from code_puppy.messaging import get_message_bus
-        from code_puppy.messaging.messages import AgentResponseMessage
-
-        response_msg = AgentResponseMessage(
-            content=agent_response,
-            is_markdown=True,
-        )
-        get_message_bus().emit(response_msg)
+            # Commit the completed turn (user prompt + assistant response)
+            # into the agent's history BEFORE the finally-block save-back.
+            # Without this, headless -r save-back persists only user prompts
+            # (the normal _do_run path never writes result.all_messages()
+            # back to agent._message_history), so resumed sessions feed the
+            # model a pile of unanswered prompts and it re-answers them all.
+            # Mirrors interactive_mode's post-run set_message_history call.
+            if hasattr(result, "all_messages"):
+                agent.set_message_history(list(result.all_messages()))
 
     except asyncio.CancelledError:
-        from code_puppy.messaging import emit_warning
-
         emit_warning("Execution cancelled by user")
     except Exception as e:
-        from code_puppy.messaging import emit_error
-
         emit_error(f"Error executing prompt: {str(e)}")
+    finally:
+        if session_name:
+            try:
+                persist_named_session(
+                    get_current_agent(),
+                    session_name,
+                    base_dir=Path(AUTOSAVE_DIR),
+                    # Headless -r save-back is automated (user passed a
+                    # flag and walked away) rather than an explicit
+                    # /dump_context-style intent, so it carries the same
+                    # auto_saved=True bit as autosave proper. Plugins
+                    # that filter on `metadata.auto_saved` get the right
+                    # signal.
+                    auto_saved=True,
+                )
+            except Exception as save_exc:
+                # The user's primary deliverable (the agent response) has
+                # already been emitted. Report the save failure but do not
+                # re-raise -- a save bug shouldn't mask a successful turn.
+                emit_error(f"Failed to save session {session_name}: {save_exc}")
 
 
 def _force_utf8_stdio():

--- a/code_puppy/command_line/autosave_menu.py
+++ b/code_puppy/command_line/autosave_menu.py
@@ -48,8 +48,26 @@ def _get_session_metadata(base_dir: Path, session_name: str) -> dict:
         return {}
 
 
+def _is_auto_flavored(session_name: str) -> bool:
+    """Return True for system-generated session names.
+
+    Matches the ``auto_session_`` prefix reserved by
+    ``code_puppy.session_lifecycle.is_valid_session_name``. Pre-unification,
+    all autosaves carried this prefix; the unified-autosave migration introduces user-named
+    entries (from ``-r NAME``, ``/dump_context``, ``/load_context``) into
+    the same store, hence the need to distinguish.
+    """
+    return session_name.startswith("auto_session_")
+
+
 def _get_session_entries(base_dir: Path) -> List[Tuple[str, dict]]:
-    """Get all sessions with their metadata, sorted by timestamp."""
+    """Get all sessions with their metadata.
+
+    Returns entries grouped "named first, auto-flavored second", each group
+    sorted mtime-descending. Section headers (if any) are inserted at
+    render time -- see ``_render_menu_panel`` -- to keep this function's
+    return shape stable and pagination math straightforward.
+    """
     try:
         sessions = list_sessions(base_dir)
     except (FileNotFoundError, PermissionError):
@@ -75,8 +93,11 @@ def _get_session_entries(base_dir: Path) -> List[Tuple[str, dict]]:
                 return datetime.min
         return datetime.min
 
-    entries.sort(key=sort_key, reverse=True)
-    return entries
+    named = [e for e in entries if not _is_auto_flavored(e[0])]
+    auto = [e for e in entries if _is_auto_flavored(e[0])]
+    named.sort(key=sort_key, reverse=True)
+    auto.sort(key=sort_key, reverse=True)
+    return named + auto
 
 
 def _extract_last_user_message(history: list) -> str:
@@ -216,10 +237,24 @@ def _render_menu_panel(
         lines.append(("", "Cancel"))
         return lines
 
-    # Show sessions for current page
+    # Show sessions for current page. We inject visual section headers
+    # at named->auto boundaries within the visible page (and at the very
+    # top if the page starts in either section). Section headers do NOT
+    # consume entry indices -- they're cosmetic only -- so selection and
+    # pagination math stay untouched.
+    prev_section = None
     for i in range(start_idx, end_idx):
         session_name, metadata = entries[i]
         is_selected = i == selected_idx
+        section = "auto" if _is_auto_flavored(session_name) else "named"
+
+        if section != prev_section:
+            header = "Named sessions" if section == "named" else "Auto-saved sessions"
+            # Blank line between sections (skip for the very first one).
+            if prev_section is not None:
+                lines.append(("", "\n"))
+            lines.append(("fg:ansibrightcyan bold", f"  {header}\n"))
+            prev_section = section
 
         # Format timestamp
         timestamp = metadata.get("timestamp", "unknown")
@@ -232,11 +267,19 @@ def _render_menu_panel(
         # Format message count
         msg_count = metadata.get("message_count", "?")
 
+        # For named sessions, include the name so users can tell them
+        # apart at a glance. Auto-flavored sessions keep the existing
+        # timestamp+count summary -- the auto_session_* names are noise.
+        if section == "named":
+            label = f"{time_str} \u2022 {msg_count} msgs ({session_name})"
+        else:
+            label = f"{time_str} \u2022 {msg_count} msgs"
+
         # Highlight selected item
         if is_selected:
-            lines.append(("fg:ansibrightblack", f" > {time_str} • {msg_count} msgs"))
+            lines.append(("fg:ansibrightblack", f" > {label}"))
         else:
-            lines.append(("fg:ansibrightblack", f"   {time_str} • {msg_count} msgs"))
+            lines.append(("fg:ansibrightblack", f"   {label}"))
 
         lines.append(("", "\n"))
 

--- a/code_puppy/command_line/session_commands.py
+++ b/code_puppy/command_line/session_commands.py
@@ -4,13 +4,12 @@ This module contains @register_command decorated handlers that are automatically
 discovered by the command registry system.
 """
 
-from datetime import datetime
 import logging
 from pathlib import Path
 
 from code_puppy.command_line.command_registry import register_command
-from code_puppy.config import CONTEXTS_DIR
-from code_puppy.session_storage import list_sessions, load_session, save_session
+from code_puppy.config import AUTOSAVE_DIR
+from code_puppy.session_storage import list_sessions, load_session
 
 logger = logging.getLogger(__name__)
 
@@ -64,25 +63,23 @@ def get_commands_help():
 def handle_session_command(command: str) -> bool:
     """Handle /session command."""
     from code_puppy.config import (
-        AUTOSAVE_DIR,
-        get_current_autosave_id,
-        get_current_autosave_session_name,
-        rotate_autosave_id,
+        get_current_session_name,
+        rotate_session_name,
     )
     from code_puppy.messaging import emit_info, emit_success, emit_warning
 
     tokens = command.split()
 
     if len(tokens) == 1 or tokens[1] == "id":
-        sid = get_current_autosave_id()
+        session_name = get_current_session_name()
         emit_info(
-            f"[bold magenta]Autosave Session[/bold magenta]: {sid}\n"
-            f"Files prefix: {Path(AUTOSAVE_DIR) / get_current_autosave_session_name()}"
+            f"[bold magenta]Autosave Session[/bold magenta]: {session_name}\n"
+            f"Files prefix: {Path(AUTOSAVE_DIR) / session_name}"
         )
         return True
     if tokens[1] == "new":
-        new_sid = rotate_autosave_id()
-        emit_success(f"New autosave session id: {new_sid}")
+        new_name = rotate_session_name()
+        emit_success(f"New autosave session: {new_name}")
         return True
     emit_warning("Usage: /session [id|new]")
     return True
@@ -350,7 +347,11 @@ def handle_quick_resume_command(command: str) -> bool:
 def handle_dump_context_command(command: str) -> bool:
     """Dump message history to a file."""
     from code_puppy.agents.agent_manager import get_current_agent
-    from code_puppy.messaging import emit_error, emit_success, emit_warning
+    from code_puppy.messaging import emit_error, emit_warning
+    from code_puppy.session_lifecycle import (
+        is_valid_session_name,
+        persist_named_session,
+    )
 
     tokens = command.split()
     if len(tokens) != 2:
@@ -358,24 +359,38 @@ def handle_dump_context_command(command: str) -> bool:
         return True
 
     session_name = tokens[1]
-    agent = get_current_agent()
-    history = agent.get_message_history()
+    # Enforce reserved-prefix + slug rules at every user-input write site
+    # (the resolver enforces them for ``-r NAME``; this is the parallel
+    # gate for ``/dump_context``). Without it, /dump_context bypasses
+    # the validator that ``-r`` runs and lets a user squat the
+    # ``auto_session_`` namespace or smuggle in a path-traversal name.
+    if not is_valid_session_name(session_name, allow_reserved_prefix=False):
+        emit_error(
+            f"Invalid session name: {session_name!r}. "
+            "Session names must be 1-128 chars of [A-Za-z0-9._-] "
+            "and may not start with 'auto_session_' (reserved)."
+        )
+        return True
 
-    if not history:
+    agent = get_current_agent()
+    if not agent.get_message_history():
         emit_warning("No message history to dump!")
         return True
 
     try:
-        metadata = save_session(
-            history=history,
-            session_name=session_name,
-            base_dir=Path(CONTEXTS_DIR),
-            timestamp=datetime.now().isoformat(),
-            token_estimator=agent.estimate_tokens_for_message,
-        )
-        emit_success(
-            f"✅ Context saved: {metadata.message_count} messages ({metadata.total_tokens} tokens)\n"
-            f"📁 Files: {metadata.pickle_path}, {metadata.metadata_path}"
+        # The user-facing success line is preserved verbatim via
+        # ``success_message_template`` so /dump_context UX doesn't
+        # regress. The silent save-back paths (``-r``, periodic
+        # autosave) omit the template and stay quiet.
+        persist_named_session(
+            agent,
+            session_name,
+            base_dir=Path(AUTOSAVE_DIR),
+            success_message_template=(
+                "\u2705 Context saved: {message_count} messages "
+                "({total_tokens} tokens)\n"
+                "\U0001f4c1 Files: {pickle_path}, {metadata_path}"
+            ),
         )
         return True
 
@@ -392,10 +407,8 @@ def handle_dump_context_command(command: str) -> bool:
 )
 def handle_load_context_command(command: str) -> bool:
     """Load message history from a file."""
-    from rich.text import Text
-
     from code_puppy.agents.agent_manager import get_current_agent
-    from code_puppy.config import rotate_autosave_id
+    from code_puppy.config import rotate_session_name
     from code_puppy.messaging import emit_error, emit_info, emit_success, emit_warning
 
     tokens = command.split()
@@ -404,14 +417,14 @@ def handle_load_context_command(command: str) -> bool:
         return True
 
     session_name = tokens[1]
-    contexts_dir = Path(CONTEXTS_DIR)
-    session_path = contexts_dir / f"{session_name}.pkl"
+    sessions_dir = Path(AUTOSAVE_DIR)
+    session_path = sessions_dir / f"{session_name}.pkl"
 
     try:
-        history = load_session(session_name, contexts_dir)
+        history = load_session(session_name, sessions_dir)
     except FileNotFoundError:
         emit_error(f"Context file not found: {session_path}")
-        available = list_sessions(contexts_dir)
+        available = list_sessions(sessions_dir)
         if available:
             emit_info(f"Available contexts: {', '.join(available)}")
         return True
@@ -423,22 +436,41 @@ def handle_load_context_command(command: str) -> bool:
     agent.set_message_history(history)
     total_tokens = sum(agent.estimate_tokens_for_message(m) for m in history)
 
-    # Rotate autosave id to avoid overwriting any existing autosave
-    try:
-        new_id = rotate_autosave_id()
-        autosave_info = Text.from_markup(
-            f"\n[dim]Autosave session rotated to: {new_id}[/dim]"
-        )
-    except Exception:
-        autosave_info = Text("")
+    # Rotate the singleton to a fresh ``auto_session_<TS>`` so subsequent
+    # autosaves do NOT overwrite the loaded snapshot. This asymmetry with
+    # ``-r NAME`` (which pins and saves back in place) is INTENTIONAL --
+    # the two verbs encode two different intents:
+    #
+    #   * ``/dump_context NAME`` + ``/load_context NAME`` are a snapshot
+    #     pair (think ``pg_dump`` / ``pg_restore``, save games, git
+    #     stash). The named file is a stable reference point; loading
+    #     it lets you inspect / branch from it without dirtying the
+    #     original.
+    #   * ``-r NAME`` / ``--resume NAME`` is a continuation verb (pick
+    #     up where you left off). That path pins and saves back.
+    #
+    # Origin: commit ``cc04629b`` (Mike Pfaffenberger, 2025-10-11)
+    # introduced this rotate-on-load behavior as a deliberate design
+    # choice; the commit message explicitly says "Automatically rotate
+    # session ID when loading saved context to prevent overwrites." The
+    # ``-r`` flag was added 4 months later (commit ``92bb0f90``) and
+    # the asymmetry was preserved -- on purpose. Do NOT "unify" these
+    # two paths in the name of symmetry; you'd be deleting the encoded
+    # distinction between snapshot-load and continuation-resume.
+    #
+    # If a user wants to continue working on the loaded snapshot in
+    # place, the explicit move is ``/load_context NAME`` followed by
+    # ``/dump_context NAME`` later -- or relaunch via ``-r NAME``.
+    new_autosave_id = rotate_session_name()
 
-    # Build the success message with proper Text concatenation
-    success_msg = Text(
-        f"✅ Context loaded: {len(history)} messages ({total_tokens} tokens)\n"
-        f"📁 From: {session_path}"
+    emit_success(
+        f"\u2705 Context loaded: {len(history)} messages "
+        f"({total_tokens} tokens)\n"
+        f"\U0001f4c1 From: {session_path}\n"
+        f"\U0001f504 Autosave rotated to: {new_autosave_id} "
+        f"(snapshot at {session_path.name} is preserved; further "
+        f"autosaves land in the new session)"
     )
-    success_msg.append_text(autosave_info)
-    emit_success(success_msg)
 
     # Display recent message history for context
     from code_puppy.command_line.autosave_menu import display_resumed_history

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -1750,40 +1750,166 @@ def reset_all_banner_colors():
         set_banner_color(name, color)
 
 
-def get_current_autosave_id() -> str:
-    """Get or create the current autosave session ID for this process."""
+def get_current_session_name() -> str:
+    """Return the full filename of the session this process is writing to.
+
+    On first call, lazily mints a fresh auto-flavored name
+    (``auto_session_<YYYYMMDD>_<HHMMSS>``). Subsequent calls return the
+    same string until ``rotate_session_name`` or ``pin_current_session_name``
+    is called.
+
+    The ``auto_session_`` prefix is RESERVED for system-generated names;
+    user-input names cannot start with it (enforced by
+    ``session_lifecycle.is_valid_session_name``).
+
+    This replaces the pre-unification dance of ``get_current_autosave_id`` +
+    runtime ``f"auto_session_{id}"`` construction, which silently broke
+    named-session save-back the moment a user-named string was pinned.
+    """
     global _CURRENT_AUTOSAVE_ID
     if not _CURRENT_AUTOSAVE_ID:
-        # Use a full timestamp so tests and UX can predict the name if needed
-        _CURRENT_AUTOSAVE_ID = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        _CURRENT_AUTOSAVE_ID = (
+            f"auto_session_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        )
     return _CURRENT_AUTOSAVE_ID
+
+
+def rotate_session_name() -> str:
+    """Reset the singleton; next read mints a fresh auto-flavored name.
+
+    Used by ``/clear`` and ``/switch-agent`` to start a new session
+    regardless of whether the previous one was auto- or user-named.
+    """
+    global _CURRENT_AUTOSAVE_ID
+    _CURRENT_AUTOSAVE_ID = ""
+    return get_current_session_name()
+
+
+def pin_current_session_name(name: str) -> str:
+    """Pin the session to a specific filename. NO transformation.
+
+    Validates defensively against the stored-name rules so a forgetful
+    caller cannot smuggle a path-traversal name into the singleton and have
+    the next autosave write it to ``AUTOSAVE_DIR / "../../etc/passwd"``.
+    Raises ``ValueError`` on invalid input.
+
+    Callers that already validated (resolver, ``/load_context``) treat the
+    raise as a "shouldn't happen" guard.
+    """
+    from code_puppy.session_lifecycle import is_valid_session_name
+
+    if not is_valid_session_name(name, allow_reserved_prefix=True):
+        raise ValueError(f"invalid session name: {name!r}")
+    global _CURRENT_AUTOSAVE_ID
+    _CURRENT_AUTOSAVE_ID = name
+    return _CURRENT_AUTOSAVE_ID
+
+
+# ----- Deprecated aliases (the unified-autosave migration) ---------------------------------
+#
+# The pre-unification API stored a bare ID in the singleton and synthesized
+# ``auto_session_<id>`` on every read. That scheme broke the moment a
+# user-named string (e.g. ``"mywork"``) was pinned: the next read produced
+# ``"auto_session_mywork"`` and named-session save-back wrote the wrong file.
+#
+# These aliases preserve external plugin compatibility for ONE release. Every
+# internal caller in this PR has been migrated to the new API; the aliases
+# never fire from in-repo code (otherwise ``-W error`` test runs would fail
+# and every startup would spam ``DeprecationWarning`` in user terminals).
+
+
+def get_current_autosave_id() -> str:
+    """DEPRECATED: use ``get_current_session_name()``.
+
+    Returns the current session name with any ``auto_session_`` prefix
+    stripped (matches the pre-unification return shape). For user-named
+    sessions, returns the name verbatim.
+
+    .. note::
+       External callers that wrote
+       ``f"auto_session_{get_current_autosave_id()}"`` to reconstruct a
+       filename USED to be correct (the singleton always held a bare ID);
+       after the unified-autosave migration the singleton can hold a user-named string like
+       ``"mywork"``, in which case the reconstruction produces
+       ``"auto_session_mywork"`` -- a WRONG filename. Switch to
+       ``get_current_session_name()``.
+    """
+    import warnings
+
+    warnings.warn(
+        "get_current_autosave_id is deprecated; use get_current_session_name",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    name = get_current_session_name()
+    prefix = "auto_session_"
+    if name.startswith(prefix):
+        return name[len(prefix) :]
+    return name
 
 
 def rotate_autosave_id() -> str:
-    """Force a new autosave session ID and return it."""
-    global _CURRENT_AUTOSAVE_ID
-    _CURRENT_AUTOSAVE_ID = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-    return _CURRENT_AUTOSAVE_ID
+    """DEPRECATED: use ``rotate_session_name()``.
+
+    Returns the rotated name with any ``auto_session_`` prefix stripped,
+    matching the pre-unification return shape. Internally always returns
+    an auto-flavored name (rotate ALWAYS mints fresh), so the strip is a
+    pure shape-preservation transformation.
+    """
+    import warnings
+
+    warnings.warn(
+        "rotate_autosave_id is deprecated; use rotate_session_name",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    name = rotate_session_name()
+    prefix = "auto_session_"
+    if name.startswith(prefix):
+        return name[len(prefix) :]
+    return name
 
 
 def get_current_autosave_session_name() -> str:
-    """Return the full session name used for autosaves (no file extension)."""
-    return f"auto_session_{get_current_autosave_id()}"
+    """DEPRECATED: use ``get_current_session_name()``.
+
+    Returns the full stored name VERBATIM. NOT re-synthesized from a stripped
+    ID -- doing so would produce ``"auto_session_mywork"`` for a user-named
+    session and break TTY-keyed cross-restart resume.
+    """
+    import warnings
+
+    warnings.warn(
+        "get_current_autosave_session_name is deprecated; use get_current_session_name",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return get_current_session_name()
 
 
 def set_current_autosave_from_session_name(session_name: str) -> str:
-    """Set the current autosave ID based on a full session name.
+    """DEPRECATED: use ``pin_current_session_name(name)``.
 
-    Accepts names like 'auto_session_YYYYMMDD_HHMMSS' and extracts the ID part.
-    Returns the ID that was set.
+    Behavior change vs. pre-unification: the old function stripped an
+    ``auto_session_`` prefix on input. The new contract does NOT strip --
+    the singleton holds the full filename verbatim. Callers that passed
+    ``"auto_session_xyz"`` expecting the singleton to end up as ``"xyz"``
+    (no in-repo callers do this) would now see ``"auto_session_xyz"`` in
+    the singleton.
+
+    Also: because ``pin_current_session_name`` validates input, this alias
+    now raises ``ValueError`` for names that pre-unification it would have
+    silently accepted (control chars, empty string, path-separator chars).
     """
-    global _CURRENT_AUTOSAVE_ID
-    prefix = "auto_session_"
-    if session_name.startswith(prefix):
-        _CURRENT_AUTOSAVE_ID = session_name[len(prefix) :]
-    else:
-        _CURRENT_AUTOSAVE_ID = session_name
-    return _CURRENT_AUTOSAVE_ID
+    import warnings
+
+    warnings.warn(
+        "set_current_autosave_from_session_name is deprecated; "
+        "use pin_current_session_name",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return pin_current_session_name(session_name)
 
 
 def auto_save_session_if_enabled() -> bool:
@@ -1803,7 +1929,7 @@ def auto_save_session_if_enabled() -> bool:
             return False
 
         now = datetime.datetime.now()
-        session_name = get_current_autosave_session_name()
+        session_name = get_current_session_name()
         autosave_dir = pathlib.Path(AUTOSAVE_DIR)
 
         metadata = save_session(
@@ -1835,9 +1961,18 @@ def auto_save_session_if_enabled() -> bool:
             pass
 
         emit_info(
-            f"🐾 Auto-saved session: {metadata.message_count} messages "
+            f"\U0001f43e Auto-saved session: {metadata.message_count} messages "
             f"({metadata.total_tokens} tokens){stats_suffix}"
         )
+
+        # Fire post_autosave so plugins can render follow-up lines
+        # (token quota, etc.) without us knowing about them here.
+        # Delegates to the shared lifecycle helper -- see its docstring for
+        # why an executor wrap is needed and where to add disk-level
+        # forensics if we ever want them across all callers.
+        from code_puppy.session_lifecycle import fire_post_autosave_callback
+
+        fire_post_autosave_callback(metadata)
 
         return True
 
@@ -1879,10 +2014,20 @@ def get_terminal_tty() -> Optional[str]:
 
 
 def _is_valid_autosave_session_name(session_name: str) -> bool:
-    """Return True when a terminal marker names a safe autosave session."""
-    import re
+    """Return True when a terminal marker names a safe stored session.
 
-    return bool(re.fullmatch(r"auto_session_\d{8}_\d{6}", session_name))
+    Accepts both auto-flavored entries (``auto_session_<YYYYMMDD>_<HHMMSS>``)
+    AND user-named entries (any slug matching
+    ``session_lifecycle.is_valid_session_name(..., allow_reserved_prefix=True)``).
+    Without this, TTY-keyed cross-restart resume would silently reject every
+    user-named session.
+
+    The name kept the ``_autosave_`` prefix for backward compatibility with
+    external callers; conceptually it's a stored-name validator now.
+    """
+    from code_puppy.session_lifecycle import is_valid_session_name
+
+    return is_valid_session_name(session_name, allow_reserved_prefix=True)
 
 
 def _tty_session_path(tty: str) -> pathlib.Path:
@@ -2212,9 +2357,9 @@ def resolve_quick_resume_pickle(
 
 def finalize_autosave_session() -> str:
     """Persist the current autosave snapshot and rotate to a fresh session."""
-    record_terminal_session(get_current_autosave_session_name())
+    record_terminal_session(get_current_session_name())
     auto_save_session_if_enabled()
-    return rotate_autosave_id()
+    return rotate_session_name()
 
 
 def get_suppress_thinking_messages() -> bool:

--- a/code_puppy/plugins/switch_agent_resume/register_callbacks.py
+++ b/code_puppy/plugins/switch_agent_resume/register_callbacks.py
@@ -22,10 +22,10 @@ def _do_switch_and_resume(agent_name: str) -> bool:
     from code_puppy.config import (
         AUTOSAVE_DIR,
         finalize_autosave_session,
-        get_current_autosave_session_name,
+        get_current_session_name,
         get_last_terminal_session,
+        pin_current_session_name,
         record_terminal_session,
-        set_current_autosave_from_session_name,
     )
     from code_puppy.messaging import emit_info, emit_success, emit_warning
     from code_puppy.session_storage import (
@@ -55,7 +55,7 @@ def _do_switch_and_resume(agent_name: str) -> bool:
     try:
         history = current_agent.get_message_history()
         if history:  # Only save if there's something to save
-            session_name = get_current_autosave_session_name()
+            session_name = get_current_session_name()
             # Record the terminal session mapping before saving
             record_terminal_session(session_name)
             # Force-save the session to disk
@@ -98,7 +98,7 @@ def _do_switch_and_resume(agent_name: str) -> bool:
                 raise FileNotFoundError(session_pickle)
             history = load_session(last_session_to_resume, autosave_dir)
             new_agent.set_message_history(history)
-            set_current_autosave_from_session_name(last_session_to_resume)
+            pin_current_session_name(last_session_to_resume)
             record_terminal_session(last_session_to_resume)
             total_tokens = sum(
                 new_agent.estimate_tokens_for_message(m) for m in history

--- a/code_puppy/session_lifecycle.py
+++ b/code_puppy/session_lifecycle.py
@@ -1,0 +1,317 @@
+"""Single source of truth for 'persist a named session and fire plugin hooks.'
+
+Sits between the pure-I/O ``session_storage`` module and the callers that
+need session lifecycle orchestration in one place:
+
+- ``cli_runner.execute_single_prompt`` -- headless ``-p -r`` save-back
+- ``cli_runner.main`` -- lazy-create on ``-r missing-name``
+- ``config.auto_save_session_if_enabled`` -- standard autosave hook firing
+- ``command_line.session_commands.handle_dump_context_command`` -- ``/dump_context``
+
+Why a separate module rather than putting this on top of ``session_storage``?
+Storage primitives are pure I/O -- they have no business knowing what
+``post_autosave`` means or that a plugin system exists. Hoisting that
+orchestration into a thin lifecycle module keeps each layer single-purpose and
+gives future session hooks (``on_session_create`` and friends) an obvious home.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+from code_puppy.session_storage import SessionMetadata, save_session
+
+if TYPE_CHECKING:
+    from code_puppy.agents.base_agent import BaseAgent
+
+# Write-side validator. Read-side path resolution stays permissive so users
+# can keep passing absolute paths to existing ``.pkl`` files -- the lazy-create
+# path is the only place we create files from user-supplied strings.
+_SESSION_NAME_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+
+# Reserved prefix for system-generated auto-flavored names. User input matching
+# this is rejected so users can never squat on the auto-generated namespace and
+# confuse the autosave-menu UX or break TTY-keyed resume.
+_RESERVED_PREFIX = "auto_session_"
+
+# Matches the headroom used by ``config.auto_save_session_if_enabled`` so
+# plugin authors only have to honour one budget.
+_POST_AUTOSAVE_TIMEOUT_S = 4.0
+
+
+def is_valid_session_name(name: str, *, allow_reserved_prefix: bool = False) -> bool:
+    """Return True if ``name`` is a safe slug.
+
+    Bare-slug regex + an explicit reject of all-dot names. All-dot names
+    would not actually escape the sessions dir (the ``.pkl`` suffix is
+    appended, so ``.`` becomes ``.pkl`` rather than ``.``), but they still
+    produce cosmetically broken hidden filenames with no recoverable session
+    name and so are rejected on quality-of-life grounds.
+
+    ``allow_reserved_prefix=False`` (default) additionally rejects names
+    starting with ``auto_session_`` so user input cannot collide with the
+    auto-generated namespace. Call sites validating user input pass the
+    default; the stored-name validator (which legitimately sees
+    ``auto_session_*`` filenames on disk) passes ``True``.
+    """
+    if not _SESSION_NAME_RE.match(name):
+        return False
+    if set(name) <= {"."}:
+        return False
+    if not allow_reserved_prefix and name.startswith(_RESERVED_PREFIX):
+        return False
+    return True
+
+
+def persist_named_session(
+    agent: "BaseAgent",
+    session_name: str,
+    *,
+    base_dir: Path,
+    auto_saved: bool = False,
+    success_message_template: Optional[str] = None,
+) -> SessionMetadata:
+    """Save ``agent.get_message_history()`` under ``session_name`` and fire hooks.
+
+    ``auto_saved`` distinguishes the originating intent for plugins that care:
+    pass ``True`` for system-triggered writes (autosave, the headless
+    save-back at end of ``-p``), pass ``False`` for user-intent writes like
+    ``/dump_context``. The bit is preserved in ``SessionMetadata`` so
+    downstream consumers can filter.
+
+    ``success_message_template`` (optional) is a format string with these
+    available substitutions: ``{message_count}``, ``{total_tokens}``,
+    ``{pickle_path}``, ``{metadata_path}``, ``{session_name}``. When provided,
+    the formatted result is emitted via ``emit_success`` so a caller like
+    ``/dump_context`` can keep its existing user-facing line without
+    bifurcating the helper. When omitted, no success line is emitted (the
+    correct behavior for silent save-back paths like ``-r NAME`` and
+    periodic autosave).
+
+    Returns the ``SessionMetadata`` produced by ``save_session`` so callers can
+    surface their own UX as well.
+    """
+    metadata = save_session(
+        history=agent.get_message_history(),
+        session_name=session_name,
+        base_dir=base_dir,
+        timestamp=datetime.now().isoformat(),
+        token_estimator=agent.estimate_tokens_for_message,
+        auto_saved=auto_saved,
+    )
+    if success_message_template is not None:
+        try:
+            from code_puppy.messaging import emit_success
+
+            emit_success(
+                success_message_template.format(
+                    message_count=metadata.message_count,
+                    total_tokens=metadata.total_tokens,
+                    pickle_path=metadata.pickle_path,
+                    metadata_path=metadata.metadata_path,
+                    session_name=session_name,
+                )
+            )
+        except (KeyError, IndexError, ValueError):
+            # KeyError: template references an unknown {field}.
+            # IndexError: positional placeholder out of range.
+            # ValueError: bad format spec like "{x:!}". All three are bugs
+            # in the caller-supplied template, not transient failures --
+            # swallow so the save path keeps running, but DON'T swallow
+            # MemoryError / KeyboardInterrupt / etc.
+            pass
+    # NOTE: deliberately does NOT fire ``fire_post_autosave_callback``.
+    # The ``post_autosave`` hook is reserved for the periodic background
+    # auto-save path (``config.auto_save_session_if_enabled``); firing it
+    # from /dump_context and headless ``-r NAME -p ...`` save-back too
+    # would change plugin-visible behavior for callers that registered
+    # against the hook (e.g. ``a downstream token-quota plugin``
+    # would print the quota line after every explicit /dump_context).
+    # Pre-unification semantics: only periodic auto-save fires the hook.
+    return metadata
+
+
+class ResumeTargetError(Exception):
+    """Raised by :func:`resolve_or_create_resume_target` for unrecoverable inputs.
+
+    ``message`` is suitable for ``emit_error``; ``hint`` (optional) carries
+    a follow-on ``emit_info`` line. The CLI layer is responsible for
+    rendering and exiting; this module raises rather than calling
+    ``sys.exit`` so the resolver is testable without spawning subprocesses.
+    """
+
+    def __init__(self, message: str, hint: str | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.hint = hint
+
+
+def resolve_or_create_resume_target(
+    resume_target: str,
+    *,
+    sessions_dir: Path,
+    allow_lazy_create: bool,
+) -> tuple[str, Path, bool]:
+    """Resolve the ``-r`` argument to ``(session_name, session_dir, lazy_created)``.
+
+    Resolution order:
+
+    1. ``<resume_target>`` is a path ending in ``.pkl`` that exists --
+       load directly from that file. ``lazy_created=False``.
+    2. ``<sessions_dir>/<resume_target>.pkl`` exists -- load that named
+       session. ``lazy_created=False``.
+    3. ``<resume_target>`` is a path (any extension) that exists -- load it.
+       ``lazy_created=False``.
+    4. ``<resume_target>`` is a bare slug ending in ``.pkl`` with no path
+       separator -- strip the ``.pkl`` suffix and fall through to lazy-create
+       under the bare name. Prevents accidental ``foo.pkl.pkl`` creation
+       when users instinctively append the extension. Case-sensitive
+       match against ``.pkl`` exactly (``Path.suffix`` semantics); ``foo.PKL``
+       does NOT normalize -- ``.pkl`` is the documented spelling.
+    5. Nothing matched. If ``allow_lazy_create`` is True AND the target is a
+       safe slug, lazy-create an empty session under that name in
+       ``sessions_dir`` and return ``lazy_created=True``. Otherwise raise
+       :class:`ResumeTargetError`.
+
+    Every returning branch validates the returned ``session_name`` against
+    ``is_valid_session_name(..., allow_reserved_prefix=True)`` so callers
+    (notably ``pin_current_session_name``) can rely on the resolver never
+    handing back a pathological name. Pre-existing on-disk files with
+    non-slug stems (e.g. legacy ``My Project.pkl`` from old unguarded
+    ``/dump_context``) raise :class:`ResumeTargetError` with a hint to
+    rename, rather than crashing later inside the pin.
+
+    Branches 1-3 are read-only and intentionally permissive about path shape.
+    Branches 4-5 are the only write-side paths, so the bare-slug reserved-
+    prefix rule is applied via ``is_valid_session_name`` (default
+    ``allow_reserved_prefix=False``) ONLY there -- swapping the order would
+    either break legitimate absolute-path resume or weaken the traversal
+    guard.
+    """
+    resume_path = Path(resume_target)
+    if resume_path.suffix == ".pkl" and resume_path.exists():
+        return _validated_branch_result(
+            resume_path.stem, resume_path.parent, False, sessions_dir
+        )
+
+    named = sessions_dir / f"{resume_target}.pkl"
+    if named.exists():
+        return _validated_branch_result(
+            resume_target, sessions_dir, False, sessions_dir
+        )
+
+    if resume_path.exists():
+        return _validated_branch_result(
+            resume_path.stem, resume_path.parent, False, sessions_dir
+        )
+
+    # Branch 4: bare-name normalization. "foo.pkl" with no path separator
+    # and a valid bare-name slug after suffix strip --> treat as "foo".
+    # Avoids the historical ``foo.pkl.pkl`` lazy-create bug.
+    normalized_target = resume_target
+    if (
+        resume_path.suffix == ".pkl"
+        and "/" not in resume_target
+        and "\\" not in resume_target
+        and is_valid_session_name(resume_path.stem, allow_reserved_prefix=False)
+    ):
+        normalized_target = resume_path.stem
+
+    if not allow_lazy_create:
+        raise ResumeTargetError(
+            f"Resume target not found: {resume_target}",
+        )
+
+    # Lazy-create gate: user-input reserved-prefix protection. The
+    # post-creation validation below uses allow_reserved_prefix=True
+    # (stored-name semantics) so the same name we just allowed in passes
+    # the resolver's output guard.
+    if not is_valid_session_name(normalized_target, allow_reserved_prefix=False):
+        raise ResumeTargetError(
+            f"Invalid session name for lazy-create: {normalized_target!r}",
+            hint=(
+                "Session names must be 1-128 chars of [A-Za-z0-9._-] "
+                "and may not start with 'auto_session_' (reserved)."
+            ),
+        )
+
+    create_empty_session(normalized_target, base_dir=sessions_dir)
+    return _validated_branch_result(normalized_target, sessions_dir, True, sessions_dir)
+
+
+def _validated_branch_result(
+    name: str,
+    session_dir: Path,
+    lazy_created: bool,
+    sessions_dir: Path,
+) -> tuple[str, Path, bool]:
+    """Validate a resolver-output tuple before returning it.
+
+    Closes the contract gap where the resolver was permissive about read
+    paths but the singleton ``pin_current_session_name`` is strict --
+    without this, a pre-existing legacy file like ``My Project.pkl`` would
+    pass the resolver and then crash startup inside the pin. We raise here
+    instead so ``cli_runner``'s existing try/except can exit 1 cleanly
+    with a useful hint.
+    """
+    if not is_valid_session_name(name, allow_reserved_prefix=True):
+        raise ResumeTargetError(
+            f"Session name {name!r} is not a valid slug.",
+            hint=(
+                f"Rename the file under {sessions_dir} to match "
+                f"[A-Za-z0-9._-]{{1,128}} and try again."
+            ),
+        )
+    return name, session_dir, lazy_created
+
+
+def create_empty_session(session_name: str, *, base_dir: Path) -> SessionMetadata:
+    """Materialise an empty named session (used for ``-r missing-name``).
+
+    Goes through ``save_session`` (not a hand-rolled ``write_bytes``) so the
+    new file lands with the same atomic-write + metadata-JSON guarantees as
+    any other session — which means ``/autosave_load`` and friends won't
+    crash on a half-formed lazy-created entry.
+    """
+    return save_session(
+        history=[],
+        session_name=session_name,
+        base_dir=base_dir,
+        timestamp=datetime.now().isoformat(),
+        token_estimator=lambda _msg: 0,
+        auto_saved=False,
+    )
+
+
+def fire_post_autosave_callback(metadata: SessionMetadata) -> None:
+    """Best-effort fire of the ``post_autosave`` callback. Never raises.
+
+    Wrapped in a ``ThreadPoolExecutor`` because ``_trigger_callbacks_sync``
+    silently skips async callbacks when invoked from inside a running event
+    loop (see ``callbacks.py`` -- the sync trigger only calls ``asyncio.run``
+    when no loop is active). The worker thread has no loop, so async plugin
+    hooks fire correctly from both sync command handlers and async CLI paths.
+
+    Hook failures are swallowed silently -- post_autosave is a decorative
+    plugin surface (quota lines, dashboards) and a misbehaving plugin must
+    never poison the save path or surface a user-visible error after a
+    successful write. If you want disk-level forensics on plugin failures,
+    add them here (and they will apply to every caller -- autosave,
+    headless save-back, /dump_context, etc.) rather than at any single
+    call site.
+    """
+    try:
+        from code_puppy import callbacks
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(
+                callbacks._trigger_callbacks_sync, "post_autosave", metadata
+            )
+            future.result(timeout=_POST_AUTOSAVE_TIMEOUT_S)
+    except Exception:
+        # Hook is decorative; never block the save path on it.
+        pass

--- a/code_puppy/session_migration.py
+++ b/code_puppy/session_migration.py
@@ -1,0 +1,222 @@
+"""One-shot sweep of legacy ``contexts/`` into the unified ``autosaves/`` store.
+
+History: in earlier versions, named sessions lived in
+``~/.code_puppy/contexts/`` (populated only by the obscure ``/dump_context``
+slash command) and auto-saved sessions lived in ``~/.code_puppy/autosaves/``
+(populated automatically by the interactive autosave loop). Under the
+unified store, ``-r NAME``, ``/dump_context NAME``, and ``/load_context NAME``
+all read and write ``autosaves/``. This module moves any files a power user
+had ``/dump_context``'d into the legacy location so they remain visible.
+
+The sweep is deliberately small: no flock, no quarantine, no slugification.
+``contexts/`` was nearly empty for almost all users pre-Phase-1 (the
+``/dump_context`` command is manual and obscure), so the typical sweep
+moves zero files. When it does move files, name conflicts are genuinely
+rare because autosave names follow ``auto_session_<ts>`` and user-named
+entries are anything else. A skip-with-warning policy handles the rare
+collision without needing a collision subsystem.
+
+The sweep is **idempotent** via a sentinel file. Two simultaneous startups
+racing the sweep are benign -- ``os.replace`` is atomic per file, the loser
+of any per-file race sees the destination already exists and skips, and the
+sentinel is touched atomically.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import tempfile
+from typing import Optional
+
+_SENTINEL_FILENAME = ".contexts_sweep_done"
+
+
+def _autosave_dir() -> pathlib.Path:
+    """Return AUTOSAVE_DIR as a Path. Lazy import dodges a config cycle."""
+    from code_puppy.config import AUTOSAVE_DIR
+
+    return pathlib.Path(AUTOSAVE_DIR)
+
+
+def _legacy_contexts_dir() -> pathlib.Path:
+    """Return the pre-unification contexts dir as a Path."""
+    from code_puppy.config import CONTEXTS_DIR
+
+    return pathlib.Path(CONTEXTS_DIR)
+
+
+def _sidecar_for(pickle_path: pathlib.Path) -> pathlib.Path:
+    """Return the metadata-sidecar path adjacent to a session pickle.
+
+    Matches the layout produced by ``session_storage.save_session``:
+    ``<stem>.pkl`` and ``<stem>_meta.json`` live side-by-side.
+    """
+    return pickle_path.with_name(f"{pickle_path.stem}_meta.json")
+
+
+def _atomic_touch(path: pathlib.Path) -> None:
+    """Create an empty file at ``path`` via tempfile + ``os.replace``.
+
+    Survives concurrent attempts -- the loser overwrites the winner with
+    an identically-empty file, which is functionally a no-op.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=".sentinel_", dir=str(path.parent))
+    try:
+        os.close(fd)
+        os.replace(tmp_name, path)
+    except Exception:
+        # Best-effort cleanup of the tempfile if replace failed.
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _log_orphan_sidecar(old_sidecar: pathlib.Path, error: Exception) -> None:
+    """Log a sidecar-orphan event to the project's forensic error log.
+
+    Called when the pickle move succeeded but the sidecar move failed
+    (disk full, permission flip mid-sweep). The pickle is loadable from
+    its new home; the orphan sidecar sits in ``contexts/`` and the user
+    can clean it up from the log. This matches the project's "per-file
+    error doesn't abort" policy and keeps the load-bearing pickle data.
+    """
+    try:
+        from code_puppy.error_logging import log_error_message
+
+        log_error_message(
+            f"Sidecar orphan during contexts sweep: {old_sidecar} "
+            f"(reason: {error!r}). The matching pickle was moved "
+            f"successfully; this sidecar is safe to delete manually.",
+            context="session_migration.sweep_contexts_to_autosaves",
+        )
+    except Exception:
+        # Forensic logging is decorative; never crash the sweep over it.
+        pass
+
+
+def _move_pair(
+    pickle_src: pathlib.Path, dest_dir: pathlib.Path
+) -> tuple[bool, Optional[str]]:
+    """Move pickle + sidecar from source to ``dest_dir``. Returns (moved, skip_reason).
+
+    ``skip_reason`` is non-None when we deliberately did NOT move (e.g.
+    name collision in dest). Pickle moves first; if the sidecar move fails
+    afterwards we log the orphan but still count the pickle as moved.
+    """
+    dest_pickle = dest_dir / pickle_src.name
+    sidecar_src = _sidecar_for(pickle_src)
+    dest_sidecar = _sidecar_for(dest_pickle)
+    # Asymmetric-collision guard: a prior interrupted sweep could have
+    # moved only the sidecar OR only the pickle. Either kind of dest
+    # entity blocks the move so we never silently overwrite half a pair.
+    if dest_pickle.exists() or dest_sidecar.exists():
+        return False, (
+            f"Skipped sweep of {pickle_src} -- name already exists in "
+            f"{dest_dir}. Leave the legacy copy in place or rename and "
+            f"move it manually."
+        )
+
+    try:
+        os.replace(str(pickle_src), str(dest_pickle))
+    except OSError as exc:
+        return False, f"Failed to move {pickle_src}: {exc}"
+
+    if sidecar_src.exists():
+        try:
+            os.replace(str(sidecar_src), str(dest_sidecar))
+        except OSError as exc:
+            # Pickle already at dest; sidecar stuck at source. Log the
+            # orphan path so the user can clean it up.
+            _log_orphan_sidecar(sidecar_src, exc)
+    return True, None
+
+
+def sweep_contexts_to_autosaves() -> None:
+    """Move any legacy ``contexts/`` session files into ``autosaves/``.
+
+    Idempotent via a sentinel. Safe to call on every startup; the second
+    call is an O(1) sentinel check. Failure modes are best-effort logged
+    and never abort the caller.
+
+    This is the ONLY caller-facing function in this module.
+    """
+    try:
+        autosave_dir = _autosave_dir()
+        contexts_dir = _legacy_contexts_dir()
+        sentinel = autosave_dir / _SENTINEL_FILENAME
+
+        if sentinel.exists():
+            return
+
+        autosave_dir.mkdir(parents=True, exist_ok=True)
+
+        if not contexts_dir.exists():
+            # Nothing to sweep. Drop the sentinel so we never re-check.
+            _atomic_touch(sentinel)
+            return
+
+        moved = 0
+        skipped = 0
+        failures = 0
+        for entry in sorted(contexts_dir.glob("*.pkl")):
+            try:
+                ok, reason = _move_pair(entry, autosave_dir)
+            except Exception as exc:
+                failures += 1
+                _log_orphan_sidecar(entry, exc)
+                continue
+
+            if ok:
+                moved += 1
+            elif reason is not None:
+                skipped += 1
+                _emit_warning_safely(reason)
+            else:
+                failures += 1
+
+        _atomic_touch(sentinel)
+
+        if moved or skipped or failures:
+            _emit_info_safely(
+                f"Swept {moved} files from {contexts_dir} to "
+                f"{autosave_dir} ({skipped} skipped -- name conflicts, "
+                f"{failures} failed)."
+            )
+
+    except Exception as exc:  # pragma: no cover - defensive
+        # Sweep MUST NOT crash the app. Worst case: legacy files stay
+        # put, user sees them missing from the picker, and the sentinel
+        # may or may not be touched. Next launch retries.
+        try:
+            from code_puppy.error_logging import log_error_message
+
+            log_error_message(
+                f"Contexts sweep aborted: {exc!r}",
+                context="session_migration.sweep_contexts_to_autosaves",
+            )
+        except Exception:
+            pass
+
+
+def _emit_info_safely(message: str) -> None:
+    """Best-effort ``emit_info`` -- never crash the sweep over UX wiring."""
+    try:
+        from code_puppy.messaging import emit_info
+
+        emit_info(message)
+    except Exception:
+        pass
+
+
+def _emit_warning_safely(message: str) -> None:
+    """Best-effort ``emit_warning`` -- never crash the sweep."""
+    try:
+        from code_puppy.messaging import emit_warning
+
+        emit_warning(message)
+    except Exception:
+        pass

--- a/code_puppy/session_storage.py
+++ b/code_puppy/session_storage.py
@@ -315,9 +315,9 @@ async def restore_autosave_interactively(base_dir: Path) -> None:
 
     # Set current autosave session id so subsequent autosaves overwrite this session
     try:
-        from code_puppy.config import set_current_autosave_from_session_name
+        from code_puppy.config import pin_current_session_name
 
-        set_current_autosave_from_session_name(chosen_name)
+        pin_current_session_name(chosen_name)
     except Exception:
         pass
 

--- a/tests/command_line/test_autosave_menu.py
+++ b/tests/command_line/test_autosave_menu.py
@@ -1284,3 +1284,77 @@ class TestDisplayResumedHistory:
         assert "Hello from assistant" in captured.out
         # Tool output shown
         assert "Tool result" in captured.out or "test_tool" in captured.out
+
+
+class TestNamedAutoSplit:
+    """the unified-autosave migration: menu separates user-named from auto-flavored entries.
+
+    Mixing them in one timestamp-sorted list was the round-1 UX complaint:
+    user-named sessions (which the user picks deliberately) got buried
+    under the auto-flavored ones (which are time-decaying anyway). The new
+    contract returns named first, then auto, each sorted mtime-desc.
+    """
+
+    @patch("code_puppy.command_line.autosave_menu.list_sessions")
+    @patch("code_puppy.command_line.autosave_menu._get_session_metadata")
+    def test_named_sessions_sort_before_auto(self, mock_metadata, mock_list):
+        from code_puppy.command_line.autosave_menu import _get_session_entries
+
+        # Mixed: 2 named + 2 auto, with auto having NEWER timestamps to
+        # prove section ordering wins over timestamp ordering.
+        mock_list.return_value = [
+            "auto_session_20260101_120000",  # newest auto
+            "mywork",  # older named
+            "auto_session_20251201_120000",  # older auto
+            "vacation_planning",  # newer named
+        ]
+        mock_metadata.side_effect = [
+            {"timestamp": "2026-01-01T12:00:00"},
+            {"timestamp": "2025-06-01T12:00:00"},
+            {"timestamp": "2025-12-01T12:00:00"},
+            {"timestamp": "2025-12-15T12:00:00"},
+        ]
+
+        result = _get_session_entries(Path("/fake/dir"))
+
+        names = [entry[0] for entry in result]
+        # Named entries come first, sorted newest-first within their group.
+        assert names[0] == "vacation_planning"
+        assert names[1] == "mywork"
+        # Auto entries come second, sorted newest-first within their group.
+        assert names[2] == "auto_session_20260101_120000"
+        assert names[3] == "auto_session_20251201_120000"
+
+    @patch("code_puppy.command_line.autosave_menu.list_sessions")
+    @patch("code_puppy.command_line.autosave_menu._get_session_metadata")
+    def test_only_named_sessions(self, mock_metadata, mock_list):
+        from code_puppy.command_line.autosave_menu import _get_session_entries
+
+        mock_list.return_value = ["mywork", "vacation"]
+        mock_metadata.side_effect = [
+            {"timestamp": "2025-06-01T12:00:00"},
+            {"timestamp": "2025-12-01T12:00:00"},
+        ]
+
+        result = _get_session_entries(Path("/fake/dir"))
+        assert [e[0] for e in result] == ["vacation", "mywork"]
+
+    @patch("code_puppy.command_line.autosave_menu.list_sessions")
+    @patch("code_puppy.command_line.autosave_menu._get_session_metadata")
+    def test_only_auto_sessions(self, mock_metadata, mock_list):
+        from code_puppy.command_line.autosave_menu import _get_session_entries
+
+        mock_list.return_value = [
+            "auto_session_20260101_120000",
+            "auto_session_20251201_120000",
+        ]
+        mock_metadata.side_effect = [
+            {"timestamp": "2026-01-01T12:00:00"},
+            {"timestamp": "2025-12-01T12:00:00"},
+        ]
+
+        result = _get_session_entries(Path("/fake/dir"))
+        assert [e[0] for e in result] == [
+            "auto_session_20260101_120000",
+            "auto_session_20251201_120000",
+        ]

--- a/tests/command_line/test_session_commands.py
+++ b/tests/command_line/test_session_commands.py
@@ -23,35 +23,55 @@ class TestHandleSessionCommand:
 
     def test_session_show_id(self):
         with (
-            patch("code_puppy.config.get_current_autosave_id", return_value="abc123"),
             patch(
-                "code_puppy.config.get_current_autosave_session_name",
-                return_value="session_abc123",
+                "code_puppy.config.get_current_session_name",
+                return_value="auto_session_abc123",
             ),
             patch("code_puppy.messaging.emit_info") as mock_info,
         ):
             result = self._run("/session")
             assert result is True
             mock_info.assert_called_once()
+            # Both the session-line and the prefix-path show the full name
+            # verbatim (no id/name duality post-unification).
+            assert "auto_session_abc123" in mock_info.call_args[0][0]
 
     def test_session_id_subcommand(self):
         with (
-            patch("code_puppy.config.get_current_autosave_id", return_value="xyz"),
             patch(
-                "code_puppy.config.get_current_autosave_session_name",
-                return_value="s",
+                "code_puppy.config.get_current_session_name",
+                return_value="auto_session_xyz",
             ),
             patch("code_puppy.messaging.emit_info"),
         ):
             assert self._run("/session id") is True
 
+    def test_session_show_user_named(self):
+        """User-named session displays the full name verbatim, no auto_ prefix."""
+        with (
+            patch(
+                "code_puppy.config.get_current_session_name",
+                return_value="mywork",
+            ),
+            patch("code_puppy.messaging.emit_info") as mock_info,
+        ):
+            assert self._run("/session") is True
+            rendered = mock_info.call_args[0][0]
+            assert "mywork" in rendered
+            # Regression guard: must NOT re-synthesize auto_session_mywork
+            assert "auto_session_mywork" not in rendered
+
     def test_session_new(self):
         with (
-            patch("code_puppy.config.rotate_autosave_id", return_value="new123"),
+            patch(
+                "code_puppy.config.rotate_session_name",
+                return_value="auto_session_new123",
+            ),
             patch("code_puppy.messaging.emit_success") as mock_s,
         ):
             assert self._run("/session new") is True
-            assert "new123" in mock_s.call_args[0][0]
+            # Post-LEAN-Phase-2 emits the full name (not the bare id).
+            assert "auto_session_new123" in mock_s.call_args[0][0]
 
     def test_session_invalid(self):
         with patch("code_puppy.messaging.emit_warning") as mock_w:
@@ -298,7 +318,7 @@ class TestHandleDumpContextCommand:
                 return_value=agent,
             ),
             patch(
-                "code_puppy.command_line.session_commands.save_session",
+                "code_puppy.session_lifecycle.persist_named_session",
                 return_value=meta,
             ),
             patch("code_puppy.messaging.emit_success"),
@@ -314,13 +334,33 @@ class TestHandleDumpContextCommand:
                 return_value=agent,
             ),
             patch(
-                "code_puppy.command_line.session_commands.save_session",
+                "code_puppy.session_lifecycle.persist_named_session",
                 side_effect=Exception("disk full"),
             ),
             patch("code_puppy.messaging.emit_error") as me,
         ):
             assert self._run("/dump_context mysession") is True
             assert "disk full" in me.call_args[0][0]
+
+    def test_reserved_prefix_rejected(self):
+        """User cannot squat on the auto_session_ namespace via /dump_context.
+
+        Pre-unification, /dump_context bypassed every validator and would
+        happily write ``contexts/auto_session_anything.pkl``, polluting the
+        autosave namespace. The new contract routes through
+        persist_named_session and validates input first.
+        """
+        agent = MagicMock()
+        agent.get_message_history.return_value = ["m1"]
+        with (
+            patch(
+                "code_puppy.agents.agent_manager.get_current_agent",
+                return_value=agent,
+            ),
+            patch("code_puppy.messaging.emit_error") as me,
+        ):
+            assert self._run("/dump_context auto_session_squat") is True
+            assert "reserved" in me.call_args[0][0].lower()
 
 
 class TestHandleLoadContextCommand:
@@ -379,6 +419,19 @@ class TestHandleLoadContextCommand:
             assert "corrupt" in me.call_args[0][0]
 
     def test_success(self):
+        """/load_context NAME rotates the singleton (does NOT pin).
+
+        This is the deliberate, original ``/load_context`` semantic from
+        commit ``cc04629b`` (Mike Pfaffenberger, 2025-10-11):
+        ``/dump_context`` + ``/load_context`` are a snapshot pair (like
+        ``pg_dump`` / ``pg_restore``, save games, git stash). Loading a
+        named snapshot must NOT cause subsequent autosaves to overwrite
+        that snapshot -- the rotate forks future writes to a fresh
+        ``auto_session_<TS>`` file so the loaded reference point stays
+        frozen on disk. The ``-r NAME`` continuation path pins (and saves
+        back in place); the asymmetry between the two verbs is
+        intentional and load-bearing. Do NOT "unify" them.
+        """
         agent = MagicMock()
         agent.estimate_tokens_for_message.return_value = 50
         with (
@@ -390,32 +443,19 @@ class TestHandleLoadContextCommand:
                 "code_puppy.agents.agent_manager.get_current_agent",
                 return_value=agent,
             ),
-            patch("code_puppy.config.rotate_autosave_id", return_value="new_id"),
-            patch("code_puppy.messaging.emit_success"),
+            patch(
+                "code_puppy.config.rotate_session_name",
+                return_value="auto_session_20260101_120000",
+            ) as mock_rotate,
+            patch("code_puppy.messaging.emit_success") as mock_success,
             patch("code_puppy.command_line.autosave_menu.display_resumed_history"),
         ):
             assert self._run("/load_context mysession") is True
-
-    def test_success_rotate_fails(self):
-        agent = MagicMock()
-        agent.estimate_tokens_for_message.return_value = 50
-        with (
-            patch(
-                "code_puppy.command_line.session_commands.load_session",
-                return_value=["m1"],
-            ),
-            patch(
-                "code_puppy.agents.agent_manager.get_current_agent",
-                return_value=agent,
-            ),
-            patch(
-                "code_puppy.config.rotate_autosave_id",
-                side_effect=Exception("fail"),
-            ),
-            patch("code_puppy.messaging.emit_success"),
-            patch("code_puppy.command_line.autosave_menu.display_resumed_history"),
-        ):
-            assert self._run("/load_context mysession") is True
+            mock_rotate.assert_called_once_with()
+            # Success line surfaces the new autosave id so the user is
+            # never surprised about where their next saves are landing.
+            success_text = mock_success.call_args[0][0]
+            assert "auto_session_20260101_120000" in success_text
 
 
 class TestHandleClearCommand:

--- a/tests/plugins/test_switch_agent_resume.py
+++ b/tests/plugins/test_switch_agent_resume.py
@@ -276,12 +276,21 @@ class TestGetLastTerminalSession:
         assert result is None
 
     def test_returns_none_for_malformed_marker(self, tmp_path):
-        """Rejects non-autosave marker names instead of trusting arbitrary pickle names."""
+        """Rejects names that fail the stored-name validator.
+
+        Post-unified-autosave migration the validator accepts BOTH auto-flavored names
+        (``auto_session_<TS>``) and user-named slugs matching the bare-name
+        regex with ``allow_reserved_prefix=True``. This regression guard
+        therefore uses a name that fails the slug regex (contains a
+        path-separator character) rather than the pre-unification
+        ``manual_session`` which the new contract correctly accepts.
+        """
         from code_puppy.config import get_last_terminal_session
 
         tty_sessions_dir = tmp_path / "tty_sessions"
         tty_sessions_dir.mkdir()
-        (tty_sessions_dir / "dev_ttys001.txt").write_text("manual_session")
+        # Spaces and slashes are not in [A-Za-z0-9._-] -- always rejected.
+        (tty_sessions_dir / "dev_ttys001.txt").write_text("bad name with spaces")
 
         with (
             patch.object(_config_mod, "get_terminal_tty", return_value="/dev/ttys001"),
@@ -290,6 +299,27 @@ class TestGetLastTerminalSession:
             result = get_last_terminal_session()
 
         assert result is None
+
+    def test_returns_user_named_session(self, tmp_path):
+        """Regression guard: user-named markers MUST be accepted (was a B2 bug).
+
+        Pre-unification the validator required ``auto_session_\\d{8}_\\d{6}``
+        and would silently reject every user-named entry, breaking TTY-keyed
+        cross-restart resume for ``-r NAME`` users.
+        """
+        from code_puppy.config import get_last_terminal_session
+
+        tty_sessions_dir = tmp_path / "tty_sessions"
+        tty_sessions_dir.mkdir()
+        (tty_sessions_dir / "dev_ttys001.txt").write_text("mywork")
+
+        with (
+            patch.object(_config_mod, "get_terminal_tty", return_value="/dev/ttys001"),
+            patch.object(_config_mod, "CACHE_DIR", str(tmp_path)),
+        ):
+            result = get_last_terminal_session()
+
+        assert result == "mywork"
 
 
 # ---------------------------------------------------------------------------
@@ -319,7 +349,7 @@ class TestFinalizeAutosaveSession:
         with (
             patch.object(
                 _config_mod,
-                "get_current_autosave_session_name",
+                "get_current_session_name",
                 return_value="current-session",
             ),
             patch.object(
@@ -330,7 +360,7 @@ class TestFinalizeAutosaveSession:
                 "auto_save_session_if_enabled",
                 side_effect=fake_autosave,
             ),
-            patch.object(_config_mod, "rotate_autosave_id", side_effect=fake_rotate),
+            patch.object(_config_mod, "rotate_session_name", side_effect=fake_rotate),
         ):
             new_id = finalize_autosave_session()
 
@@ -341,17 +371,15 @@ class TestFinalizeAutosaveSession:
         assert "rotate" in call_order
 
     def test_returns_new_session_id(self):
-        """finalize_autosave_session returns whatever rotate_autosave_id returns."""
+        """finalize_autosave_session returns whatever rotate_session_name returns."""
         from code_puppy.config import finalize_autosave_session
 
         with (
-            patch.object(
-                _config_mod, "get_current_autosave_session_name", return_value="s"
-            ),
+            patch.object(_config_mod, "get_current_session_name", return_value="s"),
             patch.object(_config_mod, "record_terminal_session"),
             patch.object(_config_mod, "auto_save_session_if_enabled"),
             patch.object(
-                _config_mod, "rotate_autosave_id", return_value="brand-new-id"
+                _config_mod, "rotate_session_name", return_value="brand-new-id"
             ),
         ):
             result = finalize_autosave_session()
@@ -592,9 +620,7 @@ class TestDoSwitchAndResume:
             patch.object(
                 _session_storage_mod, "load_session", return_value=fake_history
             ) as mock_load,
-            patch.object(
-                _config_mod, "set_current_autosave_from_session_name"
-            ) as mock_set_name,
+            patch.object(_config_mod, "pin_current_session_name") as mock_set_name,
             patch.object(_config_mod, "AUTOSAVE_DIR", "/tmp/autosaves"),
             patch.object(_messaging_mod, "emit_info"),
             patch.object(_messaging_mod, "emit_success"),
@@ -724,9 +750,7 @@ class TestDoSwitchAndResume:
             patch.object(
                 _session_storage_mod, "load_session", return_value=fake_history
             ) as mock_load,
-            patch.object(
-                _config_mod, "set_current_autosave_from_session_name"
-            ) as mock_set_name,
+            patch.object(_config_mod, "pin_current_session_name") as mock_set_name,
             patch.object(_config_mod, "record_terminal_session") as mock_record,
             patch.object(_config_mod, "AUTOSAVE_DIR", "/tmp/autosaves"),
             patch.object(_messaging_mod, "emit_info"),

--- a/tests/test_auto_save_session.py
+++ b/tests/test_auto_save_session.py
@@ -135,7 +135,7 @@ class TestAutoSaveSessionFunctionality:
 
     @patch("code_puppy.messaging.emit_info")
     @patch("code_puppy.config.save_session")
-    @patch("code_puppy.config.get_current_autosave_session_name")
+    @patch("code_puppy.config.get_current_session_name")
     @patch("code_puppy.config.datetime.datetime")
     @patch("code_puppy.config.get_auto_save_session")
     @patch("code_puppy.agents.agent_manager.get_current_agent")
@@ -203,22 +203,22 @@ class TestAutoSaveSessionFunctionality:
 
 
 class TestFinalizeAutoSaveSession:
-    @patch("code_puppy.config.rotate_autosave_id", return_value="fresh_id")
+    @patch("code_puppy.config.rotate_session_name", return_value="auto_session_fresh")
     @patch("code_puppy.config.auto_save_session_if_enabled", return_value=True)
     def test_finalize_autosave_session_saves_and_rotates(
         self, mock_auto_save, mock_rotate
     ):
         result = cp_config.finalize_autosave_session()
-        assert result == "fresh_id"
+        assert result == "auto_session_fresh"
         mock_auto_save.assert_called_once_with()
         mock_rotate.assert_called_once_with()
 
-    @patch("code_puppy.config.rotate_autosave_id", return_value="fresh_id")
+    @patch("code_puppy.config.rotate_session_name", return_value="auto_session_fresh")
     @patch("code_puppy.config.auto_save_session_if_enabled", return_value=False)
     def test_finalize_autosave_session_rotates_even_without_save(
         self, mock_auto_save, mock_rotate
     ):
         result = cp_config.finalize_autosave_session()
-        assert result == "fresh_id"
+        assert result == "auto_session_fresh"
         mock_auto_save.assert_called_once_with()
         mock_rotate.assert_called_once_with()

--- a/tests/test_cli_runner.py
+++ b/tests/test_cli_runner.py
@@ -12,6 +12,7 @@ Main focus areas:
 - Entry point behavior
 """
 
+import asyncio
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -367,3 +368,214 @@ class TestAgentRunning:
         agent = get_current_agent()
         assert agent is not None
         assert agent.name == "test-agent"
+
+
+class TestResumeFlag:
+    """Test --resume flag functionality."""
+
+    def test_resume_session_loading_logic(self, tmp_path):
+        """Test that resume can load from a pickle file path."""
+
+        from code_puppy.session_storage import load_session, save_session
+
+        # Create a fake session
+        fake_history = [{"role": "user", "content": "Hello"}]
+        session_name = "test-resume-session"
+
+        # Save session using the standard save_session function
+        metadata = save_session(
+            history=fake_history,
+            session_name=session_name,
+            base_dir=tmp_path,
+            timestamp="2025-01-01T00:00:00",
+            token_estimator=lambda x: 10,
+        )
+
+        # Verify the session was saved
+        assert metadata.pickle_path.exists()
+
+        # Load session using the standard load_session function
+        loaded_history = load_session(session_name, tmp_path)
+
+        # Verify history was loaded correctly
+        assert len(loaded_history) == 1
+        assert loaded_history[0]["role"] == "user"
+        assert loaded_history[0]["content"] == "Hello"
+
+    def test_resume_path_resolution_full_pkl_path(self, tmp_path):
+        """Test that a full .pkl path is properly resolved."""
+        from pathlib import Path
+
+        # Create a fake pickle file
+        session_file = tmp_path / "my-session.pkl"
+        session_file.write_bytes(b"dummy")
+
+        resume_path = Path(str(session_file))
+        assert resume_path.suffix == ".pkl"
+        assert resume_path.exists()
+        assert resume_path.stem == "my-session"
+        assert resume_path.parent == tmp_path
+
+    def test_resume_path_resolution_session_name(self, tmp_path):
+        """Test that a session name is resolved to the contexts directory."""
+
+        # Simulate a contexts directory with a session file
+        contexts_dir = tmp_path
+        session_name = "saved-session"
+        session_file = contexts_dir / f"{session_name}.pkl"
+        session_file.write_bytes(b"dummy")
+
+        # Check resolution logic
+        assert (contexts_dir / f"{session_name}.pkl").exists()
+
+
+class TestHeadlessSessionPersistence:
+    """-r in headless -p mode lazy-creates the session and saves back.
+
+    These tests pin the wiring between ``cli_runner.execute_single_prompt``
+    and ``session_lifecycle.persist_named_session`` -- specifically that the
+    save happens in a ``finally`` block (so cancel/error paths still persist),
+    that shell-passthrough never clobbers a named session, and that the
+    no-``-r`` default stays disk-silent.
+    """
+
+    @staticmethod
+    def _agent_with_history(history):
+        agent = MagicMock()
+        agent.get_message_history.return_value = history
+        agent.estimate_tokens_for_message.side_effect = lambda _m: 1
+        return agent
+
+    @staticmethod
+    def _renderer():
+        renderer = MagicMock()
+        renderer.console = MagicMock()
+        return renderer
+
+    @pytest.mark.asyncio
+    async def test_save_back_on_success_path(self, tmp_path):
+        from code_puppy.cli_runner import execute_single_prompt
+
+        history = [{"role": "user", "content": "step 1"}]
+        agent = self._agent_with_history(history)
+        run_result = MagicMock()
+        run_result.output = "ok"
+
+        with (
+            patch("code_puppy.cli_runner.get_current_agent", return_value=agent),
+            patch(
+                "code_puppy.cli_runner.run_prompt_with_attachments",
+                new=AsyncMock(return_value=(run_result, MagicMock())),
+            ),
+            patch("code_puppy.config.AUTOSAVE_DIR", str(tmp_path)),
+            patch(
+                "code_puppy.session_lifecycle.fire_post_autosave_callback"
+            ) as fire_cb,
+        ):
+            await execute_single_prompt(
+                "hi",
+                self._renderer(),
+                session_name="mywork",
+            )
+
+        assert (tmp_path / "mywork.pkl").exists()
+        # post_autosave hook is reserved for the periodic background save
+        # path (``config.auto_save_session_if_enabled``). The headless
+        # ``-r NAME -p ...`` save-back deliberately does NOT fire it, so
+        # plugins that decorate the auto-save line (e.g. the walmart
+        # token-quota plugin) don't double-print.
+        assert fire_cb.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_save_back_on_cancelled_error(self, tmp_path):
+        """Partial state still persists when the run is cancelled."""
+        from code_puppy.cli_runner import execute_single_prompt
+
+        agent = self._agent_with_history([{"role": "user", "content": "partial"}])
+
+        async def _raise_cancelled(*_args, **_kwargs):
+            raise asyncio.CancelledError()
+
+        with (
+            patch("code_puppy.cli_runner.get_current_agent", return_value=agent),
+            patch(
+                "code_puppy.cli_runner.run_prompt_with_attachments",
+                new=_raise_cancelled,
+            ),
+            patch("code_puppy.config.AUTOSAVE_DIR", str(tmp_path)),
+            patch("code_puppy.session_lifecycle.fire_post_autosave_callback"),
+        ):
+            await execute_single_prompt("hi", self._renderer(), session_name="mywork")
+
+        assert (tmp_path / "mywork.pkl").exists()
+
+    @pytest.mark.asyncio
+    async def test_save_back_on_generic_exception(self, tmp_path):
+        """Save still fires when the agent raises a non-cancel exception."""
+        from code_puppy.cli_runner import execute_single_prompt
+
+        agent = self._agent_with_history([{"role": "user", "content": "partial"}])
+
+        async def _raise(*_args, **_kwargs):
+            raise RuntimeError("model exploded")
+
+        with (
+            patch("code_puppy.cli_runner.get_current_agent", return_value=agent),
+            patch("code_puppy.cli_runner.run_prompt_with_attachments", new=_raise),
+            patch("code_puppy.config.AUTOSAVE_DIR", str(tmp_path)),
+            patch("code_puppy.session_lifecycle.fire_post_autosave_callback"),
+        ):
+            await execute_single_prompt("hi", self._renderer(), session_name="mywork")
+
+        assert (tmp_path / "mywork.pkl").exists()
+
+    @pytest.mark.asyncio
+    async def test_no_save_when_session_name_is_none(self, tmp_path):
+        """Default headless -p must remain disk-silent (no -r passed)."""
+        from code_puppy.cli_runner import execute_single_prompt
+
+        agent = self._agent_with_history([{"role": "user", "content": "ephemeral"}])
+        run_result = MagicMock()
+        run_result.output = "ok"
+
+        with (
+            patch("code_puppy.cli_runner.get_current_agent", return_value=agent),
+            patch(
+                "code_puppy.cli_runner.run_prompt_with_attachments",
+                new=AsyncMock(return_value=(run_result, MagicMock())),
+            ),
+            patch("code_puppy.config.AUTOSAVE_DIR", str(tmp_path)),
+            patch("code_puppy.session_lifecycle.persist_named_session") as mock_persist,
+        ):
+            await execute_single_prompt("hi", self._renderer(), session_name=None)
+
+        mock_persist.assert_not_called()
+        # And nothing landed on disk under the (empty) contexts dir.
+        assert list(tmp_path.iterdir()) == []
+
+    @pytest.mark.asyncio
+    async def test_shell_passthrough_does_not_clobber_session(self, tmp_path):
+        """`-r mywork -p '!ls'` must not zero out an existing named session."""
+        from code_puppy.cli_runner import execute_single_prompt
+
+        # Seed an existing session file with real content.
+        seeded = b"non-empty existing session bytes"
+        (tmp_path / "mywork.pkl").write_bytes(seeded)
+
+        with (
+            patch(
+                "code_puppy.command_line.shell_passthrough.is_shell_passthrough",
+                return_value=True,
+            ),
+            patch(
+                "code_puppy.command_line.shell_passthrough.execute_shell_passthrough"
+            ) as mock_shell,
+            patch("code_puppy.config.AUTOSAVE_DIR", str(tmp_path)),
+            patch("code_puppy.session_lifecycle.persist_named_session") as mock_persist,
+        ):
+            await execute_single_prompt("!ls", self._renderer(), session_name="mywork")
+
+        mock_shell.assert_called_once_with("!ls")
+        mock_persist.assert_not_called()
+        # Pre-existing session bytes must be byte-identical.
+        assert (tmp_path / "mywork.pkl").read_bytes() == seeded

--- a/tests/test_command_handler.py
+++ b/tests/test_command_handler.py
@@ -607,11 +607,10 @@ class TestSessionCommand:
     """Tests for /session command."""
 
     def test_session_show_current_id(self):
-        """Test /session shows current session ID."""
+        """Test /session shows current session name."""
         with (
-            patch("code_puppy.config.get_current_autosave_id", return_value="test-id"),
             patch(
-                "code_puppy.config.get_current_autosave_session_name",
+                "code_puppy.config.get_current_session_name",
                 return_value="test-session",
             ),
             patch("code_puppy.config.AUTOSAVE_DIR", "/tmp/autosave"),
@@ -621,14 +620,13 @@ class TestSessionCommand:
             assert result is True
             mock_emit.assert_called_once()
             call_str = str(mock_emit.call_args)
-            assert "test-id" in call_str
+            assert "test-session" in call_str
 
     def test_session_id_subcommand(self):
-        """Test /session id shows current session ID."""
+        """Test /session id shows current session name."""
         with (
-            patch("code_puppy.config.get_current_autosave_id", return_value="test-id"),
             patch(
-                "code_puppy.config.get_current_autosave_session_name",
+                "code_puppy.config.get_current_session_name",
                 return_value="test-session",
             ),
             patch("code_puppy.config.AUTOSAVE_DIR", "/tmp/autosave"),
@@ -642,7 +640,8 @@ class TestSessionCommand:
         """Test /session new creates new session."""
         with (
             patch(
-                "code_puppy.config.rotate_autosave_id", return_value="new-id"
+                "code_puppy.config.rotate_session_name",
+                return_value="auto_session_new",
             ) as mock_rotate,
             patch("code_puppy.messaging.emit_success") as mock_success,
         ):
@@ -651,7 +650,7 @@ class TestSessionCommand:
             mock_rotate.assert_called_once()
             mock_success.assert_called_once()
             call_str = str(mock_success.call_args)
-            assert "new-id" in call_str
+            assert "auto_session_new" in call_str
 
     def test_session_invalid_subcommand(self):
         """Test /session with invalid subcommand shows usage."""
@@ -665,9 +664,8 @@ class TestSessionCommand:
     def test_session_alias_works(self):
         """Test /s alias works for /session."""
         with (
-            patch("code_puppy.config.get_current_autosave_id", return_value="test-id"),
             patch(
-                "code_puppy.config.get_current_autosave_session_name",
+                "code_puppy.config.get_current_session_name",
                 return_value="test",
             ),
             patch("code_puppy.config.AUTOSAVE_DIR", "/tmp"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -881,3 +881,145 @@ class TestModelSupportsSetting:
             "claude-sonnet-4": {"type": "anthropic", "name": "claude-sonnet-4"}
         }
         assert cp_config.model_supports_setting("claude-sonnet-4", "effort") is False
+
+
+class TestSessionSingletonAndAliases:
+    """the unified-autosave migration: new singleton helpers + deprecated alias compat.
+
+    Pre-unification the singleton held a bare ID and synthesized
+    ``auto_session_<id>`` on every read. That scheme broke for user-named
+    sessions. The new contract stores the full filename verbatim; the old
+    helpers become thin deprecation-warning shims that internal code
+    must NOT call (verified separately by absence of warnings in CI).
+    """
+
+    def _reset_singleton(self):
+        """Reset the module-level singleton between tests for isolation."""
+        cp_config._CURRENT_AUTOSAVE_ID = ""
+
+    def test_get_current_session_name_lazy_mints_auto_flavored(self):
+        self._reset_singleton()
+        name = cp_config.get_current_session_name()
+        assert name.startswith("auto_session_")
+        # Idempotent until rotation/pin.
+        assert cp_config.get_current_session_name() == name
+
+    def test_rotate_session_name_always_returns_auto_flavored(self):
+        self._reset_singleton()
+        cp_config.pin_current_session_name("mywork")
+        # Rotate replaces a user-named singleton with a fresh auto one.
+        rotated = cp_config.rotate_session_name()
+        assert rotated.startswith("auto_session_")
+        assert cp_config.get_current_session_name() == rotated
+
+    def test_pin_stores_name_verbatim(self):
+        self._reset_singleton()
+        cp_config.pin_current_session_name("mywork")
+        assert cp_config.get_current_session_name() == "mywork"
+
+    def test_pin_rejects_invalid_name(self):
+        self._reset_singleton()
+        with pytest.raises(ValueError):
+            cp_config.pin_current_session_name("../../etc/passwd")
+        with pytest.raises(ValueError):
+            cp_config.pin_current_session_name("name with spaces")
+        with pytest.raises(ValueError):
+            cp_config.pin_current_session_name("")
+
+    def test_pin_accepts_auto_flavored_name(self):
+        """Stored-name semantics: ``auto_session_*`` is legitimate.
+
+        Regression guard for the round-1 B1 issue: the singleton must
+        accept the very names ``rotate_session_name`` mints, otherwise
+        the rotate -> pin round-trip would fail.
+        \n"""
+        self._reset_singleton()
+        cp_config.pin_current_session_name("auto_session_20260101_120000")
+        assert cp_config.get_current_session_name() == "auto_session_20260101_120000"
+
+    def test_get_current_autosave_session_name_alias_returns_verbatim(self):
+        """Alias semantics: full name, NOT re-synthesized.
+
+        Regression guard for B2 of round-1 (where the alias would have
+        wrapped a user-named singleton in ``auto_session_`` and broken
+        TTY-keyed resume).
+        """
+        import warnings
+
+        self._reset_singleton()
+        cp_config.pin_current_session_name("mywork")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            assert cp_config.get_current_autosave_session_name() == "mywork"
+
+    def test_deprecated_aliases_emit_warning(self):
+        """All four legacy entry points emit DeprecationWarning."""
+        import warnings
+
+        self._reset_singleton()
+        cp_config.pin_current_session_name("aliastest")
+
+        for fn_name in (
+            "get_current_autosave_id",
+            "get_current_autosave_session_name",
+            "rotate_autosave_id",
+        ):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                getattr(cp_config, fn_name)()
+                assert any(
+                    issubclass(w.category, DeprecationWarning) for w in caught
+                ), f"{fn_name} did not emit DeprecationWarning"
+
+        # set_current_autosave_from_session_name takes an arg.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            cp_config.set_current_autosave_from_session_name("aliastest2")
+            assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+    def test_deprecated_get_current_autosave_id_strips_prefix(self):
+        """The alias preserves the pre-unification return shape (bare id)."""
+        import warnings
+
+        self._reset_singleton()
+        cp_config.pin_current_session_name("auto_session_20260101_120000")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            assert cp_config.get_current_autosave_id() == "20260101_120000"
+
+    def test_deprecated_get_current_autosave_id_returns_user_named_verbatim(self):
+        """Without the ``auto_session_`` prefix, alias returns name as-is."""
+        import warnings
+
+        self._reset_singleton()
+        cp_config.pin_current_session_name("mywork")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            assert cp_config.get_current_autosave_id() == "mywork"
+
+
+class TestStoredNameValidator:
+    """``_is_valid_autosave_session_name`` is now a stored-name validator.
+
+    Pre-unification it gated TTY-keyed resume on ``auto_session_\\d{8}_\\d{6}``
+    exactly. Post-LEAN-Phase-2 it accepts both auto-flavored AND user-named
+    entries so the cross-restart resume path works for ``-r NAME`` users.
+    """
+
+    def test_accepts_auto_flavored(self):
+        assert (
+            cp_config._is_valid_autosave_session_name("auto_session_20260101_120000")
+            is True
+        )
+
+    def test_accepts_user_named(self):
+        # Round-1 B2 regression guard: must NOT reject user-named entries.
+        assert cp_config._is_valid_autosave_session_name("mywork") is True
+        assert cp_config._is_valid_autosave_session_name("my-work_2026") is True
+
+    def test_rejects_path_traversal(self):
+        assert cp_config._is_valid_autosave_session_name("../etc") is False
+
+    def test_rejects_whitespace_and_control(self):
+        assert cp_config._is_valid_autosave_session_name("bad name") is False
+        assert cp_config._is_valid_autosave_session_name("") is False

--- a/tests/test_config_full_coverage.py
+++ b/tests/test_config_full_coverage.py
@@ -873,12 +873,17 @@ class TestAutosaveSession:
         assert name.startswith("auto_session_")
 
     def test_set_from_session_name_with_prefix(self):
+        # Post-unification: the deprecation shim stores the full name verbatim
+        # rather than stripping the `auto_session_` prefix. Documented behavior
+        # change so the singleton always holds a loadable session filename.
         result = cp_config.set_current_autosave_from_session_name(
             "auto_session_20250101_120000"
         )
-        assert result == "20250101_120000"
+        assert result == "auto_session_20250101_120000"
 
     def test_set_from_session_name_without_prefix(self):
+        # Post-unification: non-prefixed names are stored verbatim too
+        # (a user-named session like 'mywork' must round-trip unchanged).
         result = cp_config.set_current_autosave_from_session_name("custom_id")
         assert result == "custom_id"
 

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -1,0 +1,519 @@
+"""Tests for ``code_puppy.session_lifecycle``.
+
+The lifecycle module is the seam between pure-I/O session_storage and the
+plugin-callback world. We pin three contracts here:
+
+1. Bare-slug validation accepts safe names and rejects traversal/absolute paths.
+2. ``create_empty_session`` lands BOTH a valid pickle AND its metadata JSON
+   (the bug class we're guarding against is silent half-creation).
+3. ``persist_named_session`` saves the agent's history AND fires
+   ``post_autosave`` even from inside a running asyncio loop -- this is the
+   correctness fix that motivated the executor wrap.
+"""
+
+import asyncio
+import json
+import pickle
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from code_puppy.session_lifecycle import (
+    ResumeTargetError,
+    create_empty_session,
+    is_valid_session_name,
+    persist_named_session,
+    resolve_or_create_resume_target,
+)
+
+
+class TestSessionNameValidator:
+    """``is_valid_session_name`` is the write-side guard against path traversal."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "mywork",
+            "my-work",
+            "my_work",
+            "my.work",
+            "MyWork-2026.01.02",
+            "a",
+            "A" * 128,
+            "release-prep_v2.1",
+        ],
+    )
+    def test_accepts_safe_slugs(self, name):
+        assert is_valid_session_name(name) is True
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "",  # empty
+            "A" * 129,  # too long
+            "../../etc/passwd",  # classic traversal
+            "/tmp/owned",  # absolute path
+            "../foo",  # relative traversal
+            "foo/bar",  # nested path
+            "foo\\bar",  # windows path
+            "foo bar",  # whitespace
+            "foo\tbar",  # tab
+            "foo\nbar",  # newline
+            "foo:bar",  # colon (drive letter on windows)
+            "foo*bar",  # glob
+            ".",  # current dir
+            "..",  # parent dir
+            "name with emoji",
+        ],
+    )
+    def test_rejects_unsafe_inputs(self, name):
+        assert is_valid_session_name(name) is False
+
+
+class TestCreateEmptySession:
+    """Lazy-create must land both .pkl and metadata JSON atomically."""
+
+    def test_writes_both_pickle_and_metadata(self, tmp_path):
+        metadata = create_empty_session("brand-new", base_dir=tmp_path)
+
+        assert metadata.pickle_path.exists()
+        assert metadata.metadata_path.exists()
+        assert metadata.pickle_path == tmp_path / "brand-new.pkl"
+
+    def test_pickle_contains_empty_history(self, tmp_path):
+        create_empty_session("brand-new", base_dir=tmp_path)
+        loaded = pickle.loads((tmp_path / "brand-new.pkl").read_bytes())
+        assert loaded == []
+
+    def test_metadata_reflects_empty_session(self, tmp_path):
+        create_empty_session("brand-new", base_dir=tmp_path)
+        meta = json.loads((tmp_path / "brand-new_meta.json").read_text())
+        assert meta["message_count"] == 0
+        assert meta["total_tokens"] == 0
+        assert meta["session_name"] == "brand-new"
+        assert meta["auto_saved"] is False
+
+    def test_creates_parent_dir_if_missing(self, tmp_path):
+        nested = tmp_path / "does" / "not" / "exist"
+        create_empty_session("first", base_dir=nested)
+        assert (nested / "first.pkl").exists()
+
+
+def _make_fake_agent(history=None):
+    """Tiny test double matching the BaseAgent surface lifecycle.py touches."""
+    agent = MagicMock()
+    agent.get_message_history.return_value = history or []
+    agent.estimate_tokens_for_message.side_effect = lambda _msg: 1
+    return agent
+
+
+class TestPersistNamedSession:
+    """End-to-end: history lands on disk AND post_autosave fires."""
+
+    def test_persists_agent_history(self, tmp_path):
+        history = [{"role": "user", "content": "hi"}]
+        agent = _make_fake_agent(history)
+
+        metadata = persist_named_session(agent, "mywork", base_dir=tmp_path)
+
+        assert metadata.message_count == 1
+        loaded = pickle.loads((tmp_path / "mywork.pkl").read_bytes())
+        assert loaded == history
+
+    def test_does_not_fire_post_autosave_callback(self, tmp_path):
+        """``persist_named_session`` must NOT fire ``post_autosave``.
+
+        That hook is reserved for the periodic background auto-save path
+        (``config.auto_save_session_if_enabled``). Firing it from
+        ``/dump_context`` and headless ``-r NAME -p ...`` save-back too
+        would print plugin-decorated lines (e.g. the walmart token-quota
+        line) after every explicit user-initiated save -- a visible UX
+        regression. Pre-unification semantics: only periodic auto-save
+        fires the hook.
+        """
+        agent = _make_fake_agent([{"role": "user", "content": "x"}])
+
+        with patch("code_puppy.callbacks._trigger_callbacks_sync") as mock_trigger:
+            persist_named_session(agent, "mywork", base_dir=tmp_path)
+
+        # Zero plugin callbacks fire from this path.
+        assert mock_trigger.call_count == 0
+        # The save itself still landed on disk -- the assertion above is
+        # not vacuous because the save succeeded.
+        assert (tmp_path / "mywork.pkl").exists()
+
+    def test_async_callback_fires_from_inside_running_loop(self, tmp_path):
+        """The whole reason the executor wrap exists.
+
+        ``_trigger_callbacks_sync`` only invokes async callbacks via
+        ``asyncio.run``, which raises if a loop is already running. The
+        executor wrap moves the trigger into a worker thread that has no
+        loop, so async hooks can fire. We prove the wrap is doing its job
+        by observing loop state from inside the patched callable -- if the
+        wrap were removed the side_effect would see a running loop, which
+        is exactly what would break real async callbacks.
+
+        Exercises ``fire_post_autosave_callback`` directly: ``persist_named_session``
+        deliberately no longer fires the hook (it's reserved for the periodic
+        auto-save path), but the wrap-correctness invariant still has to hold
+        for the path that DOES call ``fire_post_autosave_callback``
+        (``config.auto_save_session_if_enabled``) -- and that path is always
+        invoked from inside an async CLI loop in production.
+        """
+        from code_puppy.session_lifecycle import (
+            SessionMetadata,
+            fire_post_autosave_callback,
+        )
+
+        loop_state = []
+
+        def _capture_loop_state(*_args, **_kwargs):
+            try:
+                asyncio.get_running_loop()
+                loop_state.append("has_loop")
+            except RuntimeError:
+                loop_state.append("no_loop")
+            return []
+
+        metadata = SessionMetadata(
+            session_name="mywork",
+            timestamp="2026-01-01T00:00:00",
+            message_count=1,
+            total_tokens=1,
+            pickle_path=tmp_path / "mywork.pkl",
+            metadata_path=tmp_path / "mywork_meta.json",
+            auto_saved=True,
+        )
+
+        with patch(
+            "code_puppy.callbacks._trigger_callbacks_sync",
+            side_effect=_capture_loop_state,
+        ):
+
+            async def _runner():
+                fire_post_autosave_callback(metadata)
+
+            asyncio.run(_runner())
+
+        # This is the property the executor wrap exists to guarantee. If a
+        # future refactor removes the wrap the trigger would see a running
+        # loop here and async callbacks would silently no-op.
+        assert loop_state == ["no_loop"], (
+            "executor wrap regressed: trigger ran inside the asyncio.run "
+            "loop, which is exactly the bug the wrap exists to prevent"
+        )
+
+
+class TestResolveOrCreateResumeTarget:
+    """Pin every branch of the ``-r`` resolver in one place.
+
+    The resolver is the single production code path that maps ``args.resume``
+    onto a session file (existing or freshly lazy-created). Tests must drive
+    the real function -- mirroring the gate inside the test body would not
+    catch a future re-ordering regression.
+    """
+
+    def test_existing_pkl_path_resolves_directly(self, tmp_path):
+        target = tmp_path / "my-session.pkl"
+        target.write_bytes(b"dummy")
+
+        name, dir_, lazy = resolve_or_create_resume_target(
+            str(target),
+            sessions_dir=tmp_path / "contexts_unused",
+            allow_lazy_create=True,
+        )
+        assert (name, dir_, lazy) == ("my-session", tmp_path, False)
+
+    def test_existing_named_session_resolves_under_contexts_dir(self, tmp_path):
+        contexts_dir = tmp_path / "ctx"
+        contexts_dir.mkdir()
+        (contexts_dir / "mywork.pkl").write_bytes(b"dummy")
+
+        name, dir_, lazy = resolve_or_create_resume_target(
+            "mywork",
+            sessions_dir=contexts_dir,
+            allow_lazy_create=True,
+        )
+        assert (name, dir_, lazy) == ("mywork", contexts_dir, False)
+
+    def test_existing_path_without_pkl_suffix_resolves(self, tmp_path):
+        target = tmp_path / "weird-name"
+        target.write_bytes(b"dummy")
+
+        name, dir_, lazy = resolve_or_create_resume_target(
+            str(target),
+            sessions_dir=tmp_path / "ctx_unused",
+            allow_lazy_create=True,
+        )
+        assert (name, dir_, lazy) == ("weird-name", tmp_path, False)
+
+    def test_missing_target_raises_when_lazy_create_disabled(self, tmp_path):
+        with pytest.raises(ResumeTargetError) as excinfo:
+            resolve_or_create_resume_target(
+                "nope",
+                sessions_dir=tmp_path,
+                allow_lazy_create=False,
+            )
+        assert "Resume target not found" in excinfo.value.message
+        # Pre-existing contents must be untouched.
+        assert list(tmp_path.iterdir()) == []
+
+    def test_missing_target_lazy_creates_when_enabled(self, tmp_path):
+        name, dir_, lazy = resolve_or_create_resume_target(
+            "fresh-session",
+            sessions_dir=tmp_path,
+            allow_lazy_create=True,
+        )
+        assert (name, dir_, lazy) == ("fresh-session", tmp_path, True)
+        assert (tmp_path / "fresh-session.pkl").exists()
+        # Metadata JSON must land too -- otherwise restore_autosave_interactively
+        # would render the lazy-created session as "(unknown time)".
+        assert (tmp_path / "fresh-session_meta.json").exists()
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        [
+            # Names that do NOT resolve to an existing read path AND are
+            # unsafe slugs -- the only combination that actually exercises
+            # the lazy-create validator. Names like "/etc/passwd" or ".."
+            # that DO resolve to real paths are intentionally accepted by
+            # the read branches above and never reach validation; their
+            # safety is enforced downstream when `load_session` fails to
+            # unpickle them, not here.
+            "../../tmp/traversal-sentinel-does-not-exist",
+            "foo/bar/baz",
+            "foo bar",
+            "foo\tbar",
+            "foo\nbar",
+        ],
+    )
+    def test_invalid_lazy_create_name_raises_and_writes_nothing(
+        self, tmp_path, bad_name
+    ):
+        with pytest.raises(ResumeTargetError) as excinfo:
+            resolve_or_create_resume_target(
+                bad_name,
+                sessions_dir=tmp_path,
+                allow_lazy_create=True,
+            )
+        assert "Invalid session name" in excinfo.value.message
+        assert excinfo.value.hint is not None
+        # The whole point of validate-before-create: nothing on disk under
+        # the contexts dir, no escaped artefact at the traversed location.
+        assert list(tmp_path.iterdir()) == []
+        assert not (
+            tmp_path.parent / "tmp" / "traversal-sentinel-does-not-exist.pkl"
+        ).exists()
+
+
+class TestReservedPrefix:
+    """``allow_reserved_prefix`` kwarg: user input rejected, stored names allowed.
+
+    The ``auto_session_`` prefix is reserved for system-generated names so
+    users can never squat on the auto-generated namespace and confuse the
+    autosave-menu UX or break TTY-keyed resume.
+    """
+
+    def test_user_input_rejects_reserved_prefix_by_default(self):
+        assert is_valid_session_name("auto_session_squat") is False
+        assert is_valid_session_name("auto_session_") is False
+
+    def test_stored_name_validator_accepts_reserved_prefix(self):
+        # The on-disk filename ``auto_session_20260101_120000.pkl`` is
+        # entirely legitimate -- the stored-name validator MUST accept it.
+        assert (
+            is_valid_session_name(
+                "auto_session_20260101_120000", allow_reserved_prefix=True
+            )
+            is True
+        )
+
+    def test_reserved_prefix_check_runs_after_regex_check(self):
+        # A name that fails the regex (control char) is rejected regardless
+        # of the prefix flag -- regex check is the floor, not the ceiling.
+        assert (
+            is_valid_session_name("auto_session_bad name", allow_reserved_prefix=True)
+            is False
+        )
+
+    def test_lazy_create_blocks_reserved_prefix(self, tmp_path):
+        from code_puppy.session_lifecycle import (
+            ResumeTargetError,
+            resolve_or_create_resume_target,
+        )
+
+        with pytest.raises(ResumeTargetError) as excinfo:
+            resolve_or_create_resume_target(
+                "auto_session_squat",
+                sessions_dir=tmp_path,
+                allow_lazy_create=True,
+            )
+        assert "Invalid session name" in excinfo.value.message
+        assert "reserved" in excinfo.value.hint.lower()
+        assert list(tmp_path.iterdir()) == []
+
+
+class TestPklSuffixNormalization:
+    """Resolver normalizes ``-r foo.pkl`` to ``-r foo`` when bare-name slug is valid."""
+
+    def test_bare_name_with_pkl_suffix_lazy_creates_without_double_suffix(
+        self, tmp_path
+    ):
+        from code_puppy.session_lifecycle import resolve_or_create_resume_target
+
+        name, dir_, lazy = resolve_or_create_resume_target(
+            "foo.pkl",
+            sessions_dir=tmp_path,
+            allow_lazy_create=True,
+        )
+        assert name == "foo"
+        assert lazy is True
+        # The lazy-created file is foo.pkl, NOT foo.pkl.pkl.
+        assert (tmp_path / "foo.pkl").exists()
+        assert not (tmp_path / "foo.pkl.pkl").exists()
+
+    def test_path_with_separator_is_not_normalized(self, tmp_path):
+        from code_puppy.session_lifecycle import (
+            ResumeTargetError,
+            resolve_or_create_resume_target,
+        )
+
+        # An input that LOOKS like a path (has separator) is not normalized
+        # -- absolute/relative paths to existing files keep their direct-load
+        # semantics, and a non-existent path-with-separator falls through
+        # to the lazy-create gate and is rejected for traversal.
+        with pytest.raises(ResumeTargetError):
+            resolve_or_create_resume_target(
+                "sub/dir/foo.pkl",
+                sessions_dir=tmp_path,
+                allow_lazy_create=True,
+            )
+
+    def test_uppercase_pkl_is_not_normalized(self, tmp_path):
+        """Case-sensitive on Linux/Mac; ``.PKL`` lazy-creates as-is.
+
+        Documented behavior: ``.pkl`` is the canonical spelling and we
+        deliberately don't accept variants (no permissive case folding,
+        no surprise truncation of names that happen to end in .PKL).
+        """
+        from code_puppy.session_lifecycle import resolve_or_create_resume_target
+
+        name, _, lazy = resolve_or_create_resume_target(
+            "FOO.PKL",
+            sessions_dir=tmp_path,
+            allow_lazy_create=True,
+        )
+        assert name == "FOO.PKL"
+        assert lazy is True
+        assert (tmp_path / "FOO.PKL.pkl").exists()
+
+
+class TestResolverSelfValidation:
+    """Resolver validates its own output to keep ``pin_current_session_name`` safe.
+
+    Without this, a pre-existing on-disk file with a non-slug stem (e.g.
+    ``My Project.pkl`` from old unguarded ``/dump_context``) would pass
+    the permissive read-side resolution branches and then crash startup
+    inside ``pin_current_session_name`` -- which validates strictly.
+    """
+
+    def test_resolver_rejects_pre_existing_non_slug_named_file(self, tmp_path):
+        from code_puppy.session_lifecycle import (
+            ResumeTargetError,
+            resolve_or_create_resume_target,
+        )
+
+        # Pre-place a non-slug file as a direct .pkl path (branch 1).
+        bad = tmp_path / "My Project.pkl"
+        bad.write_bytes(b"x")
+
+        with pytest.raises(ResumeTargetError) as excinfo:
+            resolve_or_create_resume_target(
+                str(bad),
+                sessions_dir=tmp_path,
+                allow_lazy_create=True,
+            )
+        assert "not a valid slug" in excinfo.value.message
+        # Hint points at the sessions dir so the user knows where to rename.
+        assert str(tmp_path) in excinfo.value.hint
+
+    def test_resolver_accepts_pre_existing_auto_flavored_named_file(self, tmp_path):
+        """Branch 2 (named-session in sessions_dir) accepts auto_session_*."""
+        from code_puppy.session_lifecycle import resolve_or_create_resume_target
+
+        auto_name = "auto_session_20260101_120000"
+        (tmp_path / f"{auto_name}.pkl").write_bytes(b"x")
+
+        name, dir_, lazy = resolve_or_create_resume_target(
+            auto_name,
+            sessions_dir=tmp_path,
+            allow_lazy_create=False,
+        )
+        assert name == auto_name
+        assert dir_ == tmp_path
+        assert lazy is False
+
+
+class TestPersistNamedSessionTemplate:
+    """``success_message_template`` is the /dump_context-vs-silent split."""
+
+    def test_template_omitted_emits_no_success_line(self, tmp_path):
+        """Periodic autosave / -r save-back path: no user-facing success."""
+        from unittest.mock import MagicMock, patch
+
+        from code_puppy.session_lifecycle import persist_named_session
+
+        agent = MagicMock()
+        agent.get_message_history.return_value = []
+        agent.estimate_tokens_for_message.return_value = 0
+
+        with patch("code_puppy.messaging.emit_success") as mock_success:
+            persist_named_session(agent, "silent_session", base_dir=tmp_path)
+
+        mock_success.assert_not_called()
+
+    def test_template_present_formats_and_emits(self, tmp_path):
+        """/dump_context path: explicit success line via template."""
+        from unittest.mock import MagicMock, patch
+
+        from code_puppy.session_lifecycle import persist_named_session
+
+        agent = MagicMock()
+        agent.get_message_history.return_value = []
+        agent.estimate_tokens_for_message.return_value = 0
+
+        with patch("code_puppy.messaging.emit_success") as mock_success:
+            persist_named_session(
+                agent,
+                "loud_session",
+                base_dir=tmp_path,
+                success_message_template=(
+                    "saved {message_count} msgs for {session_name}"
+                ),
+            )
+
+        mock_success.assert_called_once()
+        rendered = mock_success.call_args[0][0]
+        assert "loud_session" in rendered
+        assert "0 msgs" in rendered
+
+    def test_template_format_failure_does_not_crash(self, tmp_path):
+        """A bad template must not poison the save path."""
+        from unittest.mock import MagicMock, patch
+
+        from code_puppy.session_lifecycle import persist_named_session
+
+        agent = MagicMock()
+        agent.get_message_history.return_value = []
+        agent.estimate_tokens_for_message.return_value = 0
+
+        with patch("code_puppy.messaging.emit_success"):
+            # Template references a nonexistent substitution key; format()
+            # will raise KeyError, but the helper must swallow it.
+            persist_named_session(
+                agent,
+                "session_x",
+                base_dir=tmp_path,
+                success_message_template="bad {does_not_exist} field",
+            )
+        # If we got here without raising, the contract holds.

--- a/tests/test_session_migration.py
+++ b/tests/test_session_migration.py
@@ -1,0 +1,186 @@
+"""Tests for the one-shot ``contexts/`` -> ``autosaves/`` sweep.
+
+Under the unified-store model, the legacy CONTEXTS_DIR is no longer the
+canonical named-session store; everything lives under AUTOSAVE_DIR. Any
+sessions a user had ``/dump_context``'d into the legacy location are moved
+on first launch via
+:func:`code_puppy.session_migration.sweep_contexts_to_autosaves`,
+which is what we exercise here.
+
+Why a separate test module vs. tucking it into ``test_session_storage``:
+the sweep cuts across two directories, several failure modes, and a
+sentinel file -- giving it its own file keeps each test small and the
+shared fixtures readable.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def sweep_dirs(tmp_path: Path, monkeypatch):
+    """Wire AUTOSAVE_DIR + CONTEXTS_DIR to a clean tmp_path layout."""
+    contexts = tmp_path / "contexts"
+    autosaves = tmp_path / "autosaves"
+    monkeypatch.setattr("code_puppy.config.CONTEXTS_DIR", str(contexts))
+    monkeypatch.setattr("code_puppy.config.AUTOSAVE_DIR", str(autosaves))
+    return contexts, autosaves
+
+
+def _write_pair(
+    directory: Path, stem: str, *, contents: str = "x"
+) -> tuple[Path, Path]:
+    """Write a fake (pickle, sidecar) pair under ``directory`` and return them."""
+    directory.mkdir(parents=True, exist_ok=True)
+    pkl = directory / f"{stem}.pkl"
+    meta = directory / f"{stem}_meta.json"
+    pkl.write_text(contents)
+    meta.write_text(json.dumps({"session_name": stem}))
+    return pkl, meta
+
+
+class TestSweepContextsToAutosaves:
+    def test_noop_when_contexts_missing(self, sweep_dirs):
+        from code_puppy.session_migration import sweep_contexts_to_autosaves
+
+        contexts, autosaves = sweep_dirs
+        # contexts/ never created
+        sweep_contexts_to_autosaves()
+        # Sentinel touched even with nothing to do, so subsequent runs
+        # skip the recheck.
+        assert (autosaves / ".contexts_sweep_done").exists()
+        # No spurious files in either dir.
+        assert list(autosaves.iterdir()) == [autosaves / ".contexts_sweep_done"]
+
+    def test_clean_run_moves_pickle_and_sidecar(self, sweep_dirs):
+        from code_puppy.session_migration import sweep_contexts_to_autosaves
+
+        contexts, autosaves = sweep_dirs
+        pkl_src, meta_src = _write_pair(contexts, "mywork", contents="payload")
+
+        sweep_contexts_to_autosaves()
+
+        # Pickle + sidecar moved.
+        assert not pkl_src.exists()
+        assert not meta_src.exists()
+        moved_pkl = autosaves / "mywork.pkl"
+        moved_meta = autosaves / "mywork_meta.json"
+        assert moved_pkl.read_text() == "payload"
+        assert json.loads(moved_meta.read_text())["session_name"] == "mywork"
+        # Sentinel present.
+        assert (autosaves / ".contexts_sweep_done").exists()
+
+    def test_idempotent_via_sentinel(self, sweep_dirs):
+        from code_puppy.session_migration import sweep_contexts_to_autosaves
+
+        contexts, autosaves = sweep_dirs
+        _write_pair(contexts, "mywork")
+
+        sweep_contexts_to_autosaves()
+        # Drop a sentinel-only fixture: a new file in contexts/ after the
+        # first sweep must NOT be moved on the second run.
+        _write_pair(contexts, "second_run_file")
+
+        sweep_contexts_to_autosaves()
+
+        assert (contexts / "second_run_file.pkl").exists()
+        assert not (autosaves / "second_run_file.pkl").exists()
+
+    def test_name_conflict_skips_and_warns(self, sweep_dirs):
+        from code_puppy.session_migration import sweep_contexts_to_autosaves
+
+        contexts, autosaves = sweep_dirs
+        _write_pair(contexts, "mywork", contents="from-contexts")
+        _write_pair(autosaves, "mywork", contents="from-autosaves")
+
+        with patch("code_puppy.messaging.emit_warning") as mock_warn:
+            sweep_contexts_to_autosaves()
+
+        # Conflicting source stays put.
+        assert (contexts / "mywork.pkl").read_text() == "from-contexts"
+        # Dest unchanged.
+        assert (autosaves / "mywork.pkl").read_text() == "from-autosaves"
+        # Warning emitted, mentions the path.
+        assert mock_warn.called
+        warning_text = mock_warn.call_args[0][0]
+        assert "mywork" in warning_text
+        assert "already exists" in warning_text
+
+    def test_per_file_error_does_not_abort(self, sweep_dirs):
+        """A single move failure must not stop the sweep for siblings."""
+        from code_puppy.session_migration import sweep_contexts_to_autosaves
+
+        contexts, autosaves = sweep_dirs
+        _write_pair(contexts, "good_one", contents="ok")
+        _write_pair(contexts, "bad_one", contents="will-fail")
+
+        real_replace = __import__("os").replace
+
+        def selective_failure(src, dst):
+            if "bad_one.pkl" in str(src):
+                raise OSError("simulated disk full")
+            return real_replace(src, dst)
+
+        with patch("os.replace", side_effect=selective_failure):
+            sweep_contexts_to_autosaves()
+
+        # Good one made it.
+        assert (autosaves / "good_one.pkl").read_text() == "ok"
+        # Bad one stayed put. (Sidecar too -- pickle never moved.)
+        assert (contexts / "bad_one.pkl").exists()
+        # Sentinel still touched.
+        assert (autosaves / ".contexts_sweep_done").exists()
+
+    def test_sidecar_failure_leaves_pickle_loadable(self, sweep_dirs):
+        """Pickle-first + log-on-sidecar-orphan: load-bearing data survives.
+
+        Regression guard for B3 of the LEAN-plan review. Without this, a
+        sidecar-move failure between pickle-move and sidecar-move would
+        either roll back the pickle (losing data) or silently strand the
+        orphan with no audit trail.
+        """
+        from code_puppy.session_migration import sweep_contexts_to_autosaves
+
+        contexts, autosaves = sweep_dirs
+        _write_pair(contexts, "session_a", contents="payload")
+
+        real_replace = __import__("os").replace
+
+        def fail_only_sidecar(src, dst):
+            if str(src).endswith("_meta.json"):
+                raise OSError("simulated sidecar failure")
+            return real_replace(src, dst)
+
+        with (
+            patch("os.replace", side_effect=fail_only_sidecar),
+            patch("code_puppy.error_logging.log_error_message") as mock_log,
+        ):
+            sweep_contexts_to_autosaves()
+
+        # Pickle moved successfully -- the load-bearing data is at its
+        # new home and reads fine.
+        assert (autosaves / "session_a.pkl").read_text() == "payload"
+        # Orphan sidecar stuck at source.
+        assert (contexts / "session_a_meta.json").exists()
+        # Orphan path logged for SRE follow-up.
+        assert mock_log.called
+        log_text = mock_log.call_args[0][0]
+        assert "session_a_meta.json" in log_text
+
+    def test_sweep_never_raises(self, sweep_dirs):
+        """Even an internal explosion must not crash the caller."""
+        from code_puppy.session_migration import sweep_contexts_to_autosaves
+
+        contexts, autosaves = sweep_dirs
+        _write_pair(contexts, "victim")
+
+        # Force a failure somewhere in the iteration by mocking list_dir
+        # in a way that explodes after entering the try-block.
+        with patch("pathlib.Path.glob", side_effect=RuntimeError("unexpected")):
+            # Must not raise.
+            sweep_contexts_to_autosaves()

--- a/tests/test_session_storage_coverage.py
+++ b/tests/test_session_storage_coverage.py
@@ -74,7 +74,7 @@ def mock_interactive_imports(
                 return_value=agent,
             ),
             patch(
-                "code_puppy.config.set_current_autosave_from_session_name",
+                "code_puppy.config.pin_current_session_name",
                 MagicMock(),
             ),
         ]
@@ -526,8 +526,15 @@ class TestRestoreAutosaveErrorHandling:
         assert any("Failed to load" in w for w in warnings)
 
     @pytest.mark.asyncio
-    async def test_set_autosave_id_failure_ignored(self, tmp_path):
-        """Failure to set autosave ID should be silently ignored."""
+    async def test_pin_session_name_failure_ignored(self, tmp_path):
+        """Failure to pin the session name post-load should be silently ignored.
+
+        Post-LEAN-Phase-2 the config-mutation step in
+        ``restore_autosave_interactively`` is ``pin_current_session_name``
+        (it replaced the pre-Phase-2 ``set_current_autosave_from_session_name``).
+        The restore path wraps that call in ``try/except`` so a bad name
+        won't tank an otherwise-successful pickle load.
+        """
         import pickle
 
         history = [{"role": "user", "content": "test"}]
@@ -543,9 +550,9 @@ class TestRestoreAutosaveErrorHandling:
         mock_agent = MagicMock()
         mock_agent.estimate_tokens_for_message.return_value = 5
 
-        # Patch set_current_autosave_from_session_name to raise an exception
+        # Patch pin_current_session_name to raise an exception
         with patch(
-            "code_puppy.config.set_current_autosave_from_session_name",
+            "code_puppy.config.pin_current_session_name",
             side_effect=Exception("Config error"),
         ):
             async with mock_interactive_imports(

--- a/tests/test_shell_passthrough.py
+++ b/tests/test_shell_passthrough.py
@@ -420,3 +420,68 @@ class TestInitialCommandPassthrough:
 
             # Shell passthrough should NOT have been called
             mock_run.assert_not_called()
+
+
+class TestInteractiveBootstrapMarker:
+    """Regression guard for the unified-autosave migration code-review B1 finding.
+
+    The TTY-keyed resume marker (``record_terminal_session(...)``) is
+    written exactly once at the top of every ``interactive_mode`` boot,
+    so a later ``-r`` invocation from the SAME TTY can find the right
+    session pickle even after process restart.
+
+    The original unified-autosave migration implementation had an 8-space indent on
+    this line, parking it inside the prompt_toolkit ``except ImportError``
+    block -- the call only fired when the import FAILED. Tests passed
+    because nothing asserted the call fires on the happy boot path.
+    This guard locks the behavior down.
+    """
+
+    @patch("code_puppy.command_line.shell_passthrough._get_console")
+    def test_record_terminal_session_fires_on_normal_boot(self, mock_get_console):
+        from code_puppy.cli_runner import interactive_mode
+
+        mock_get_console.return_value = MagicMock()
+        mock_renderer = MagicMock()
+        mock_renderer.console = MagicMock()
+
+        mock_agent = MagicMock()
+        mock_agent.get_user_prompt.return_value = "Enter task:"
+
+        with (
+            patch("code_puppy.cli_runner.print_truecolor_warning"),
+            patch(
+                "code_puppy.cli_runner.get_cancel_agent_display_name",
+                return_value="Ctrl+C",
+            ),
+            patch("code_puppy.messaging.emit_system_message"),
+            patch("code_puppy.messaging.emit_info"),
+            patch("code_puppy.messaging.emit_success"),
+            patch("code_puppy.messaging.emit_warning"),
+            patch("code_puppy.cli_runner.get_current_agent", return_value=mock_agent),
+            patch(
+                "code_puppy.agents.agent_manager.get_current_agent",
+                return_value=mock_agent,
+            ),
+            patch(
+                "code_puppy.cli_runner.run_prompt_with_attachments",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "code_puppy.command_line.prompt_toolkit_completion."
+                "get_input_with_combined_completion",
+                side_effect=EOFError,
+            ),
+            patch(
+                "code_puppy.cli_runner.get_current_session_name",
+                return_value="auto_session_20260101_120000",
+            ),
+            patch("code_puppy.cli_runner.record_terminal_session") as mock_record,
+        ):
+            asyncio.run(interactive_mode(mock_renderer))
+
+            # The whole point: marker writes on EVERY boot, not only on
+            # the failed-import branch.
+            mock_record.assert_called_once_with(
+                "auto_session_20260101_120000", overwrite=False
+            )


### PR DESCRIPTION
## Summary

Consolidates session storage into a single canonical store, adds headless `-r NAME -p ...` save-back, and migrates any legacy `contexts/` directory in one shot.

This was originally developed against an internal fork; opening here because it's pure-core functionality with zero internal dependencies.

## What changes

### Unified autosave store
Replaces the previous `contexts/` (manual `/dump_context`) + `autosaves/` (periodic) split with a single canonical store at `AUTOSAVE_DIR` (`~/.code_puppy/autosaves/`). All of `-r NAME`, `/dump_context`, `/load_context`, `/autosave_load`, and periodic autosave now read/write the same directory. Pre-existing `contexts/*.pkl` are swept into `autosaves/` once per install (sentinel-gated, atomic moves via `os.replace`, asymmetric-collision guard).

### New `session_lifecycle` module
Thin orchestration layer between pure-I/O `session_storage` and callers. Exposes:
- `is_valid_session_name(name, *, allow_reserved_prefix=False)` — slug validator (`^[A-Za-z0-9._-]{1,128}$`, rejects all-dot names and reserved `auto_session_` prefix unless the caller is the singleton itself)
- `persist_named_session(...)` — wraps `save_session` with the right `auto_saved` flag + success message; deliberately does NOT fire `post_autosave` (reserved for periodic background autosave)
- `resolve_or_create_resume_target(...)` — five-branch resume target resolution: existing `.pkl` path, existing `<sessions_dir>/<name>.pkl`, any path that exists, bare slug normalisation (strips `.pkl` suffix), lazy-create when allowed
- `create_empty_session(...)` — materialises an empty named session through the same write path
- `fire_post_autosave_callback(...)` — `ThreadPoolExecutor` wrap so the sync hook trigger can reach async plugin callbacks even when called from inside a running event loop

### Headless `-r NAME -p ...` save-back
`execute_single_prompt` now persists the completed turn back to the named session in a `finally` block, so cancellation and exceptions still save partial state. Shell-passthrough (`!cmd`) is explicitly guarded — `-r mywork -p '!ls'` will not clobber the existing session bytes. `agent.set_message_history(list(result.all_messages()))` is called before save so the assistant reply lands in the pickle (not just the user prompt).

### Singleton rename + backwards-compatible deprecation
The autosave singleton is renamed from `_CURRENT_AUTOSAVE_ID` to a full-filename store. New API:
- `get_current_session_name()` / `rotate_session_name()` / `pin_current_session_name(name)`

Old API kept as deprecated shims with `DeprecationWarning` for one release:
- `get_current_autosave_id()` (strips `auto_session_` prefix to preserve return shape)
- `rotate_autosave_id()`
- `get_current_autosave_session_name()`
- `set_current_autosave_from_session_name(name)` — now raises `ValueError` for previously-silent-accepted invalid input (control chars, empty string, path separators). Worth a CHANGELOG note if external plugins use it.

All internal call sites have migrated to the new names.

### Autosave menu UX split
Named sessions appear in their own labelled section above auto-flavored entries; both groups sorted mtime-desc. Section headers are cosmetic and do NOT consume entry indices, so existing pagination arithmetic is untouched.

### Intentional asymmetry, documented
`/load_context <name>` and `-r NAME` behave differently *by design*:
- `/load_context` is a **snapshot verb** (think `pg_restore`): rotates the active autosave so the loaded snapshot stays frozen on disk
- `-r NAME` is a **continuation verb**: pins the session so subsequent saves land back in `<NAME>.pkl`

The asymmetry is explained inline at `handle_load_context_command` with the git archaeology to back it up (commit `cc04629b`).

## Test coverage

Adds ~1,250 lines across:

- `tests/test_session_lifecycle.py` — slug validator (positive + traversal/whitespace/reserved-prefix rejection), `create_empty_session` writes both pickle + metadata, `resolve_or_create_resume_target` branch coverage, `fire_post_autosave_callback` async-from-sync paths
- `tests/test_session_migration.py` — sweep moves both pickle + sidecar, idempotent via sentinel, asymmetric-collision skip, error logging for sidecar orphans
- `tests/test_cli_runner.py::TestHeadlessSessionPersistence` — save on success, save on cancel, save on generic exception, no save when `session_name is None`, shell-passthrough does NOT clobber existing session (byte-identical)
- `tests/test_session_commands.py` — `/dump_context` slug validation (traversal/reserved-prefix rejection)
- `tests/test_autosave_menu.py` — section header ordering + index arithmetic

## Validation

Headless end-to-end validation matrix (offline harness driving the real `execute_single_prompt` + `main()` resume block with only the agent + `run_prompt_with_attachments` stubbed):

| Scenario | Result |
|---|---|
| `-p '...'` (no `-r`) is disk-silent | PASS |
| `-r brand-new -p '...'` lazy-creates + writes turn | PASS |
| `-r mywork -p '...'` on existing appends turn | PASS |
| `-r foo.pkl -p '...'` normalises (no `.pkl.pkl`) | PASS (after fix) |
| `-r /abs/path/foo.pkl -p '...'` doesn't escape AUTOSAVE_DIR | PASS (after fix) |
| `-r mywork -p '!ls'` shell-passthrough guard works | PASS |
| Cancel mid-`-r NAME -p '...'` persists partial history | PASS |
| `-r auto_session_*` lazy-create rejected | PASS |
| `-r auto_session_existing` resume still works | PASS |
| `-r ../../etc/passwd` rejected | PASS |
| Legacy contexts/ sweep on startup | PASS |
| Sweep skips on name collision | PASS |
| Sweep idempotent via sentinel | PASS |
| Save-back failure emits error, doesn't propagate | PASS |
| Successive `-r foo -p '...'` calls compound history | PASS |

## Files

```
 README.md (skipped — public README structure differs; deferred to a docs PR)
 code_puppy/cli_runner.py
 code_puppy/command_line/autosave_menu.py
 code_puppy/command_line/session_commands.py
 code_puppy/config.py
 code_puppy/plugins/switch_agent_resume/register_callbacks.py
 code_puppy/session_lifecycle.py             (new)
 code_puppy/session_migration.py             (new)
 code_puppy/session_storage.py
 tests/command_line/test_autosave_menu.py
 tests/command_line/test_session_commands.py
 tests/plugins/test_switch_agent_resume.py
 tests/test_auto_save_session.py
 tests/test_cli_runner.py
 tests/test_config.py
 tests/test_session_lifecycle.py             (new)
 tests/test_session_migration.py             (new)
 tests/test_session_storage_coverage.py
 tests/test_shell_passthrough.py
```

18 files, +2403 / −263.
