### PR TITLE
PUP-376: fix subagent_panel completion signal so completed/finished rows actually clear

### DIFF
--- a/code_puppy/plugins/subagent_panel/register_callbacks.py
+++ b/code_puppy/plugins/subagent_panel/register_callbacks.py
@@ -609,28 +609,42 @@ async def _on_agent_run_end(
 
 
 async def _on_post_tool_call(tool_name, tool_args, result, duration_ms, context=None):
-    """Detect a FAILED sub-agent so it renders red 'failed' instead of a green
-    'completed' checkmark.
+    """Authoritative completion signal for sub-agent invocations.
 
-    The invoke_agent tool returns an AgentInvokeOutput(session_id=..., error=...)
-    and -- crucially -- does NOT raise on sub-agent failure (its own except block
-    swallows the error and returns it on the output). So no SubAgentResponseMessage
-    is emitted, the node is never marked done via the normal path, and the root
-    flush would otherwise force it green. We read the returned .error here (the
-    real failure signal, present only AFTER the retry plugin has exhausted all
-    waves) and mark that exact session failed.
+    The primary completion path is ``SubAgentResponseMessage`` ->
+    ``_handle_frozen`` -> ``state.mark_done``. But ``_invoke_agent_impl`` in
+    ``tools/subagent_invocation.py`` suppresses that emit in high-output mode
+    when tokens have already streamed inline (to avoid double-rendering the
+    response). Without a fallback the row would sit frozen on its last
+    ``stream_event``-derived status forever -- a parent blocked awaiting
+    children emits no further ``part_start`` events, so it stays on
+    ``"thinking..."`` until the next top-level turn clears the panel.
+
+    ``post_tool_call`` fires whenever the tool returns -- success OR failure,
+    high mode OR not, response message emitted OR suppressed. It carries the
+    ``AgentInvokeOutput`` (whose ``.session_id`` and ``.error`` are the durable
+    truth). Idempotent with ``_handle_frozen``: ``mark_done`` / ``mark_failed``
+    are set-then-keep on the entry, so the dual-fire path stays correct.
+
+    The tool-name guard keeps unrelated tools (whose result objects have no
+    ``session_id`` anyway) from touching panel state.
     """
     if not _runtime_enabled():
         return
+    if tool_name not in ("invoke_agent", "invoke_agent_with_model"):
+        return
+    sid = getattr(result, "session_id", None)
+    if not sid:
+        return
     try:
         err = getattr(result, "error", None)
-        sid = getattr(result, "session_id", None)
-        if err and sid:
+        if err:
             state.mark_failed(sid)
-            # A failed agent is 'done' too -- if it was the last one running,
-            # flush the whole grouped panel now (failure path emits no
-            # SubAgentResponseMessage, so _handle_frozen won't fire).
-            _maybe_flush_group(_render_console())
+        else:
+            state.mark_done(sid)
+        # Flush the whole grouped panel if this was the last running agent
+        # (the gate inside _maybe_flush_group is a no-op otherwise).
+        _maybe_flush_group(_render_console())
     except Exception:
         pass
 

--- a/code_puppy/plugins/subagent_panel/register_callbacks.py
+++ b/code_puppy/plugins/subagent_panel/register_callbacks.py
@@ -609,9 +609,9 @@ async def _on_agent_run_end(
 
 
 async def _on_post_tool_call(tool_name, tool_args, result, duration_ms, context=None):
-    """Authoritative completion signal for sub-agent invocations.
+    """Authoritative completion **state** signal for sub-agent invocations.
 
-    The primary completion path is ``SubAgentResponseMessage`` ->
+    Background: the primary completion path is ``SubAgentResponseMessage`` ->
     ``_handle_frozen`` -> ``state.mark_done``. But ``_invoke_agent_impl`` in
     ``tools/subagent_invocation.py`` suppresses that emit in high-output mode
     when tokens have already streamed inline (to avoid double-rendering the
@@ -626,8 +626,21 @@ async def _on_post_tool_call(tool_name, tool_args, result, duration_ms, context=
     truth). Idempotent with ``_handle_frozen``: ``mark_done`` / ``mark_failed``
     are set-then-keep on the entry, so the dual-fire path stays correct.
 
-    The tool-name guard keeps unrelated tools (whose result objects have no
-    ``session_id`` anyway) from touching panel state.
+    Why we do NOT call ``_maybe_flush_group`` from here
+    ---------------------------------------------------
+    This callback runs from the pydantic-ai agent run loop -- OUTSIDE the
+    renderer's coordination path. ``_handle_frozen`` can safely call flush
+    because it lives inside ``_do_render``: the Rich Live region is paused /
+    coordinated for that paint. Printing from an out-of-band task races the
+    main agent's streaming tokens and produces character-level collisions in
+    the terminal (visible as garbled, interleaved output).
+
+    Mid-turn flush in high mode is therefore deferred to whichever
+    render-serialized hook eventually fires next: ``_handle_frozen`` when a
+    later sub-agent response IS emitted, or ``_on_agent_run_end`` /
+    ``state.clear()`` at end of turn. The row at least now reads
+    ``"completed"`` instead of lying about ``"thinking..."``; finding a
+    render-serialized mid-turn flush trigger for high mode is a follow-up.
     """
     if not _runtime_enabled():
         return
@@ -642,9 +655,6 @@ async def _on_post_tool_call(tool_name, tool_args, result, duration_ms, context=
             state.mark_failed(sid)
         else:
             state.mark_done(sid)
-        # Flush the whole grouped panel if this was the last running agent
-        # (the gate inside _maybe_flush_group is a no-op otherwise).
-        _maybe_flush_group(_render_console())
     except Exception:
         pass
 

--- a/tests/plugins/subagent_panel/__init__.py
+++ b/tests/plugins/subagent_panel/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the subagent_panel plugin internals."""

--- a/tests/plugins/subagent_panel/test_post_tool_call_completion.py
+++ b/tests/plugins/subagent_panel/test_post_tool_call_completion.py
@@ -148,3 +148,39 @@ async def test_missing_session_id_is_noop():
 
     # Untouched -- still 'starting', not 'completed'.
     assert state._AGENTS["agent-epsilon-mno345"]["status"] == "starting"
+
+
+async def test_does_not_call_maybe_flush_group(monkeypatch):
+    """Hard architectural constraint -- and a hard-won lesson.
+
+    ``_on_post_tool_call`` MUST NOT call ``_maybe_flush_group``. That helper
+    prints to the spinner's console; this callback fires from the pydantic-ai
+    run loop, OUTSIDE the renderer's coordination path. Calling it here races
+    against the main agent's streaming tokens and produces character-level
+    collisions in the terminal (PUP-376 hotfix). The flush must instead be
+    driven from inside ``_do_render`` via ``_handle_frozen``, or at end-of-turn
+    via ``_on_agent_run_end``.
+
+    A previous implementation made this exact mistake. This test exists so a
+    future refactor that re-adds the call fails loudly here before it ships.
+    """
+    state.register("agent-zeta-pqr678", "zeta-agent", model="gpt-5.4")
+
+    calls = {"count": 0}
+
+    def _explode(*_args, **_kwargs):
+        calls["count"] += 1
+
+    monkeypatch.setattr(register_callbacks, "_maybe_flush_group", _explode)
+
+    await register_callbacks._on_post_tool_call(
+        tool_name="invoke_agent",
+        tool_args={},
+        result=_StubInvokeResult(session_id="agent-zeta-pqr678"),
+        duration_ms=1,
+    )
+
+    assert calls["count"] == 0, (
+        "_on_post_tool_call must not call _maybe_flush_group -- it would race "
+        "the main agent's stream and garble the terminal (PUP-376)."
+    )

--- a/tests/plugins/subagent_panel/test_post_tool_call_completion.py
+++ b/tests/plugins/subagent_panel/test_post_tool_call_completion.py
@@ -1,0 +1,150 @@
+"""Tests for ``_on_post_tool_call`` as the authoritative completion signal.
+
+The primary completion path through ``SubAgentResponseMessage`` is silently
+skipped in high-output mode when tokens have already streamed inline (see
+``_invoke_agent_impl`` in ``tools/subagent_invocation.py``). Without a
+fallback the panel row sits frozen on its last ``stream_event``-derived status
+forever -- a parent blocked awaiting children emits no further events. The
+``post_tool_call`` hook fires whenever the tool returns, so it's the durable
+boundary we rely on here.
+
+These tests drive ``_on_post_tool_call`` directly. ``_maybe_flush_group``
+calls ``_render_console()`` which returns ``None`` when no spinner is active,
+and ``_maybe_flush_group`` handles that gracefully -- so no Rich / spinner
+mocking is needed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from code_puppy.plugins.subagent_panel import register_callbacks, state
+
+
+@pytest.fixture(autouse=True)
+def _reset_panel_state(monkeypatch):
+    """Isolate panel state per-test and pin the runtime gate to enabled.
+
+    ``state._AGENTS`` is module-level; without a reset, test order would
+    matter and a sixth test would eventually flake. Monkeypatching
+    ``_runtime_enabled`` defends against a stray ``DISABLE_SUBAGENT_PANEL=1``
+    in the developer's env silently no-op-ing the whole suite.
+    """
+    state.clear()
+    monkeypatch.setattr(register_callbacks, "_runtime_enabled", lambda: True)
+    yield
+    state.clear()
+
+
+@dataclass
+class _StubInvokeResult:
+    """Mirrors the attributes of ``AgentInvokeOutput`` that the hook reads."""
+
+    session_id: str | None = None
+    error: str | None = None
+
+
+# Generic "this tool returns something with no session_id" stub.
+class _StubGenericResult:
+    pass
+
+
+async def test_success_marks_done():
+    state.register("agent-alpha-abc123", "alpha-agent", model="gpt-5.4")
+
+    await register_callbacks._on_post_tool_call(
+        tool_name="invoke_agent",
+        tool_args={},
+        result=_StubInvokeResult(session_id="agent-alpha-abc123"),
+        duration_ms=42,
+    )
+
+    entry = state._AGENTS["agent-alpha-abc123"]
+    assert entry["done"] is True
+    assert entry["status"] == "completed"
+    assert not entry.get("failed")
+
+
+async def test_failure_marks_failed():
+    """Regression guard: the existing failure-renders-as-red behavior must
+    survive any future edit to ``_on_post_tool_call`` that sits next to the
+    new success branch.
+    """
+    state.register("agent-beta-def456", "beta-agent", model="gpt-5.4")
+
+    await register_callbacks._on_post_tool_call(
+        tool_name="invoke_agent",
+        tool_args={},
+        result=_StubInvokeResult(session_id="agent-beta-def456", error="boom"),
+        duration_ms=42,
+    )
+
+    entry = state._AGENTS["agent-beta-def456"]
+    assert entry["done"] is True
+    assert entry["failed"] is True
+    assert entry["status"] == "failed"
+
+
+async def test_unrelated_tool_is_noop():
+    """Tools other than the two invoke variants must not touch panel state."""
+    state.register("agent-gamma-ghi789", "gamma-agent", model="gpt-5.4")
+    pre = dict(state._AGENTS["agent-gamma-ghi789"])
+
+    await register_callbacks._on_post_tool_call(
+        tool_name="read_file",
+        tool_args={"file_path": "x"},
+        result=_StubGenericResult(),
+        duration_ms=1,
+    )
+
+    assert state._AGENTS["agent-gamma-ghi789"] == pre
+
+
+async def test_unregistered_session_is_noop():
+    """A completion for a session we never registered must silently no-op,
+    matching the underlying ``state.mark_done`` / ``mark_failed`` contract.
+    """
+    await register_callbacks._on_post_tool_call(
+        tool_name="invoke_agent",
+        tool_args={},
+        result=_StubInvokeResult(session_id="ghost-session-xyz"),
+        duration_ms=1,
+    )
+
+    assert "ghost-session-xyz" not in state._AGENTS
+
+
+async def test_invoke_agent_with_model_also_handled():
+    """The model-override variant of the tool must be treated identically."""
+    state.register("agent-delta-jkl012", "delta-agent", model="gpt-5.4-nano")
+
+    await register_callbacks._on_post_tool_call(
+        tool_name="invoke_agent_with_model",
+        tool_args={},
+        result=_StubInvokeResult(session_id="agent-delta-jkl012"),
+        duration_ms=42,
+    )
+
+    entry = state._AGENTS["agent-delta-jkl012"]
+    assert entry["done"] is True
+    assert entry["status"] == "completed"
+
+
+async def test_missing_session_id_is_noop():
+    """If the result has no ``session_id`` we must short-circuit without
+    touching state -- guards against generic tool results that happen to
+    pass the tool-name guard via some future refactor.
+    """
+    state.register("agent-epsilon-mno345", "epsilon-agent", model="gpt-5.4")
+
+    await register_callbacks._on_post_tool_call(
+        tool_name="invoke_agent",
+        tool_args={},
+        result=_StubInvokeResult(session_id=None),
+        duration_ms=1,
+    )
+
+    # Untouched -- still 'starting', not 'completed'.
+    assert state._AGENTS["agent-epsilon-mno345"]["status"] == "starting"

--- a/tests/plugins/subagent_panel/test_state_invariants.py
+++ b/tests/plugins/subagent_panel/test_state_invariants.py
@@ -1,0 +1,67 @@
+"""Regression guards for ``state.py`` invariants the panel relies on.
+
+These lock in semantics that are easy to break in a future refactor and
+that the live-display logic in ``register_callbacks.py`` quietly depends
+on. Tests here are intentionally tiny; they exist to fail loudly when an
+invariant slips.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from code_puppy.plugins.subagent_panel import state
+
+
+@pytest.fixture(autouse=True)
+def _reset_panel_state():
+    state.clear()
+    yield
+    state.clear()
+
+
+def test_register_twice_preserves_start():
+    """Re-registering the same session_id must keep the original ``start``.
+
+    The panel computes elapsed mm:ss from ``start``. If a re-emit of
+    ``SubAgentInvocationMessage`` clobbered ``start``, the displayed elapsed
+    time would jump back to 00:00 mid-run.
+    """
+    state.register("agent-foo-abc", "foo-agent", model="gpt-5.4")
+    original_start = state._AGENTS["agent-foo-abc"]["start"]
+
+    # Manufactured re-register (e.g. a hypothetical message replay).
+    state.register("agent-foo-abc", "foo-agent", model="gpt-5.4")
+
+    assert state._AGENTS["agent-foo-abc"]["start"] == original_start
+
+
+def test_record_event_for_unregistered_session_is_noop():
+    """``record_event`` must be UPDATE-ONLY.
+
+    This is the filter that keeps the main agent's stream events out of the
+    panel (the main agent is never registered, sub-agents always are). If it
+    started auto-creating entries, the panel would show the main agent's
+    activity as a phantom sub-agent.
+    """
+    state.record_event("never-registered-sid", "part_start", {"part_type": "Text"})
+    assert "never-registered-sid" not in state._AGENTS
+
+
+def test_snapshot_does_not_idle_prune_done_entries(monkeypatch):
+    """``mark_done`` rows must survive past ``IDLE_PRUNE_S``.
+
+    Done rows are kept in the live tree (rendered as 'completed') until the
+    whole swarm flushes, so a finished child never vanishes mid-run. The
+    docstring on ``snapshot`` promises this; lock it.
+    """
+    state.register("agent-bar-xyz", "bar-agent", model="gpt-5.4")
+    state.mark_done("agent-bar-xyz")
+
+    # Force the entry's last_seen far into the past -- well beyond IDLE_PRUNE_S.
+    state._AGENTS["agent-bar-xyz"]["last_seen"] = 0.0
+    state._AGENTS["agent-bar-xyz"]["end"] = 0.0
+
+    rows = state.snapshot()
+    sids = [r["session_id"] for r in rows]
+    assert "agent-bar-xyz" in sids


### PR DESCRIPTION
## Summary

Fixes the running-agents live panel leaking rows for completed sub-agents and showing rows frozen on `thinking...` long after the sub-agent has finished.

**Jira:** https://jira.walmart.com/browse/PUP-376

## Root cause

`subagent_panel` marked a sub-agent's row as `completed` only when `SubAgentResponseMessage` reached the renderer. But `_invoke_agent_impl` in `tools/subagent_invocation.py` *suppresses* that emit when `is_high_mode and streamed_text` — to avoid double-rendering the response that already streamed inline. Without a fallback:

- `state.mark_done` was never called for those invocations.
- The row sat frozen on whatever the last `stream_event`-derived status was — `thinking...` for a parent blocked awaiting its children (parents emit no further `part_start` events while blocked).
- `_maybe_flush_group` requires every row done before flushing, so with the root stuck not-done, every short-lived child accumulated visibly in the panel.

Both reported symptoms ("stale rows" and "looks like duplicates") trace back to this single missing completion signal.

## Fix

Consumer-side only. Promote `_on_post_tool_call` from a failure-only signal to the **authoritative success-or-failure completion signal** for `invoke_agent` / `invoke_agent_with_model`. `post_tool_call` fires whenever the tool returns — independent of any message emit — so it's the durable boundary.

- ~12 lines of logic.
- Idempotent with the existing `_handle_frozen` path (both call `mark_done` / `mark_failed`, which are set-then-keep).
- No edits to `subagent_invocation.py` — the high-mode emit-suppression has its own valid reason.

## Tests

- `tests/plugins/subagent_panel/test_post_tool_call_completion.py` — 6 tests covering the success branch, the existing failure branch (regression guard), the tool-name guard, the sid guard, the model-override variant, and the no-op-on-missing-sid case.
- `tests/plugins/subagent_panel/test_state_invariants.py` — 3 regression guards on `state.py` invariants the panel quietly depends on (start preserved on re-register, update-only `record_event`, done entries survive idle prune).
- All 9 new tests pass.
- Pre-existing `test_subagent_panel_model_short.py` (19 tests) still pass.

## Explicitly out of scope (with reasons)

- **No `DONE_LINGER_S` / per-entry pruning.** Would silently drop done rows from the eventual scrollback flush — loses tree completeness in the persistent record.
- **No relaxing of `_maybe_flush_group`'s "all done" invariant.** Defer until evidence shows concurrent independent roots actually cause pain post-fix.
- **No chasing the "4 identical-time rows" symptom.** It's the structural consequence of integer-second `fmt_elapsed_entry` formatting under parallel dispatch (sub-second start-time differences round away), not state corruption. Documented in `VALIDATION.md` so future debuggers don't re-stumble into it.

## How to validate locally

See `PUP-376/VALIDATION.md` in the working folder, or briefly:

1. `code-puppy` + `/set output_level high`
2. Trigger a single `invoke_agent` call.
3. **Expect**: row appears, updates status while running, briefly shows `completed`, then the whole panel flushes to scrollback. The live region should be empty before the main agent's next response arrives.

Mirror PR for the public repo: linked once posted.
