### PR TITLE
feat(plugins): rich /plugins detail panel + POSIX path display conven…

### DIFF
--- a/code_puppy/plugins/agent_skills/config.py
+++ b/code_puppy/plugins/agent_skills/config.py
@@ -14,7 +14,11 @@ def get_skill_directories() -> List[str]:
     """Get configured skill directories.
 
     Returns:
-        List of skill directory paths from configuration.
+        List of skill directory paths from configuration, normalized to
+        POSIX-style forward-slash separators for cross-platform display
+        consistency (see the ``display-paths-as-posix`` convention adopted
+        by ``plugin_list``). Consumers that need a native ``Path`` wrap the
+        string in ``Path(...)``, which accepts either separator on Windows.
         Reads from puppy.cfg [puppy] section under 'skill_directories' key.
         Default: ['~/.code_puppy/skills', './.code_puppy/skills', './skills']
 
@@ -29,14 +33,14 @@ def get_skill_directories() -> List[str]:
             directories = json.loads(config_value)
             # Ensure it's a list
             if isinstance(directories, list):
-                return directories
+                return [Path(d).as_posix() for d in directories]
         except json.JSONDecodeError as e:
             logger.error(f"Failed to parse skill_directories config: {e}")
 
     # Fallback to defaults
-    home_skills = str(Path.home() / ".code_puppy" / "skills")
-    project_config_skills = str(Path.cwd() / ".code_puppy" / "skills")
-    local_skills = str(Path.cwd() / "skills")
+    home_skills = (Path.home() / ".code_puppy" / "skills").as_posix()
+    project_config_skills = (Path.cwd() / ".code_puppy" / "skills").as_posix()
+    local_skills = (Path.cwd() / "skills").as_posix()
     return [
         home_skills,
         project_config_skills,

--- a/code_puppy/plugins/plugin_list/plugin_contributions.py
+++ b/code_puppy/plugins/plugin_list/plugin_contributions.py
@@ -1,0 +1,355 @@
+"""Per-plugin contribution extraction for the ``/plugins`` preview.
+
+For a given plugin name, return the concrete things it contributes per
+category — tools, slash commands, agents, skills, model types/providers,
+MCP catalog servers, browser types, and agent-advertised tool names.
+
+Best-effort and display-only: we invoke only the target plugin's own
+collection callbacks (filtered via ``get_callback_owner``), and every read
+is wrapped in ``try/except`` so a raising callback or registry yields no
+items rather than crashing the preview.
+
+Some plugins register via a direct registry instead of firing the matching
+callback, so two categories need extra attribution:
+
+* commands: ``@register_command`` writes straight into the command registry
+  without firing ``custom_command_help``.
+* tools: ``TOOL_REGISTRY`` is mutable, so a plugin can add a tool without
+  firing ``register_tools``.
+
+For both, we read the registry and attribute each entry to the plugin whose
+module defines the handler / register_func (see ``_plugin_owner_of_module``).
+Core entries never match a real plugin name, so they fall out naturally.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional
+
+from code_puppy.callbacks import get_callback_owner, get_callbacks
+
+# ---------------------------------------------------------------------------
+# Category keys (stable identifiers the preview renderer can key off).
+# ---------------------------------------------------------------------------
+CATEGORY_TOOLS = "tools"
+CATEGORY_COMMANDS = "commands"
+CATEGORY_AGENTS = "agents"
+CATEGORY_SKILLS = "skills"
+CATEGORY_MODEL_TYPES = "model_types"
+CATEGORY_MODEL_PROVIDERS = "model_providers"
+CATEGORY_MCP_SERVERS = "mcp_servers"
+CATEGORY_BROWSER_TYPES = "browser_types"
+CATEGORY_AGENT_TOOLS = "agent_tools"
+
+
+# ---------------------------------------------------------------------------
+# Owner-filtered invocation primitives
+# ---------------------------------------------------------------------------
+def _owned_callbacks(plugin_name: str, phase: str) -> List[Callable[..., Any]]:
+    """Return *phase*'s callbacks attributed to *plugin_name*."""
+    return [
+        cb
+        for cb in get_callbacks(phase, include_disabled=True)
+        if get_callback_owner(cb) == plugin_name
+    ]
+
+
+def _invoke_owned(plugin_name: str, phase: str, *args: Any) -> List[Any]:
+    """Invoke each owned callback for *phase*; a raising callback is skipped."""
+    results: List[Any] = []
+    for cb in _owned_callbacks(plugin_name, phase):
+        try:
+            results.append(cb(*args))
+        except Exception:
+            continue
+    return results
+
+
+def _dedupe(items: List[str]) -> List[str]:
+    """Drop falsy/duplicate entries while preserving first-seen order."""
+    seen: set[str] = set()
+    out: List[str] = []
+    for item in items:
+        if not item or item in seen:
+            continue
+        seen.add(item)
+        out.append(item)
+    return out
+
+
+def _as_list(result: Any) -> List[Any]:
+    """Normalize a callback result into a list (mirrors core's leniency)."""
+    if result is None:
+        return []
+    return result if isinstance(result, list) else [result]
+
+
+def _dict_key(entry: Any, key: str) -> str:
+    """Return ``entry[key]`` as a non-empty str, else ``""``."""
+    if isinstance(entry, dict):
+        value = entry.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Direct-registry attribution (commands / tools that bypass callback hooks)
+# ---------------------------------------------------------------------------
+def _plugin_owner_of_module(module_name: Optional[str]) -> Optional[str]:
+    """Map a callable's ``__module__`` to the plugin name that defines it.
+
+    Mirrors the three plugin module-name layouts:
+
+    * builtin -> ``code_puppy.plugins.<name>.<...>``
+    * project -> ``project_plugins.<name>.<...>``
+    * user    -> ``<name>.<...>``
+
+    Returns ``None`` when the module is empty/unparseable.
+    """
+    if not module_name:
+        return None
+    parts = module_name.split(".")
+    if module_name.startswith("code_puppy.plugins."):
+        return parts[2] if len(parts) >= 3 else None
+    if module_name.startswith("project_plugins."):
+        return parts[1] if len(parts) >= 2 else None
+    return parts[0] if parts and parts[0] else None
+
+
+def _owns_callable(plugin_name: str, func: Any) -> bool:
+    """Whether *func* is defined inside *plugin_name*'s module tree."""
+    module_name = getattr(func, "__module__", None)
+    return _plugin_owner_of_module(module_name) == plugin_name
+
+
+# ---------------------------------------------------------------------------
+# Per-category extraction helpers
+# ---------------------------------------------------------------------------
+def _collect_dict_field(
+    plugin_name: str, phase: str, field: str, *args: Any
+) -> List[str]:
+    """Invoke *phase* (owned by *plugin_name*) and collect ``entry[field]``.
+
+    Each callback returns a dict or list of dicts; ``entry[field]`` from
+    each is appended. ``*args`` is forwarded (e.g. ``register_agent_tools(None)``).
+    """
+    names: List[str] = []
+    for result in _invoke_owned(plugin_name, phase, *args):
+        for entry in _as_list(result):
+            names.append(_dict_key(entry, field))
+    return names
+
+
+def _collect_dict_keys(plugin_name: str, phase: str) -> List[str]:
+    """Invoke *phase* and collect the string keys of each dict result.
+
+    Used for hooks whose contract is ``() -> {name: handler}`` rather than
+    ``() -> [{"name": ...}]``.
+    """
+    keys: List[str] = []
+    for result in _invoke_owned(plugin_name, phase):
+        keys.extend(_dict_keys(result))
+    return keys
+
+
+def get_tools(plugin_name: str) -> List[str]:
+    """Tool names contributed by *plugin_name*, deduped (first-seen order).
+
+    Combines the ``register_tools`` callback with direct ``TOOL_REGISTRY``
+    entries owned by this plugin's module.
+    """
+    names = _collect_dict_field(plugin_name, "register_tools", "name")
+    names.extend(_registry_tools(plugin_name))
+    return _dedupe(names)
+
+
+def _registry_tools(plugin_name: str) -> List[str]:
+    """Tool names from ``TOOL_REGISTRY`` owned by *plugin_name* (read-only)."""
+    names: List[str] = []
+    try:
+        from code_puppy.tools import TOOL_REGISTRY
+
+        items = list(TOOL_REGISTRY.items())
+    except Exception:
+        return names
+    for tool_name, register_func in items:
+        try:
+            if isinstance(tool_name, str) and _owns_callable(
+                plugin_name, register_func
+            ):
+                names.append(tool_name)
+        except Exception:
+            continue
+    return names
+
+
+def get_commands(plugin_name: str) -> List[str]:
+    """Slash commands contributed by *plugin_name*, deduped (first-seen order).
+
+    Combines the ``custom_command_help`` callback (which may return a single
+    ``(name, description)`` tuple, a list of such tuples, or a legacy list of
+    ``"/name - description"`` strings) with direct ``command_registry`` entries
+    whose handler is owned by this plugin. Each command renders as
+    ``"/name — description"`` (description omitted when absent).
+    """
+    commands: List[str] = []
+    for result in _invoke_owned(plugin_name, "custom_command_help"):
+        if not result:
+            continue
+        # Shape 1: a bare (name, description) tuple.
+        if isinstance(result, tuple) and len(result) == 2:
+            commands.append(_format_command(result[0], result[1]))
+            continue
+        if not isinstance(result, list):
+            continue
+        # Shape 2: list of (name, description) tuples.
+        if result and isinstance(result[0], tuple):
+            for item in result:
+                if isinstance(item, tuple) and len(item) == 2:
+                    commands.append(_format_command(item[0], item[1]))
+        # Shape 3: legacy list of "/name - description" strings.
+        elif result and isinstance(result[0], str):
+            for item in result:
+                parsed = _parse_legacy_command(item)
+                if parsed:
+                    commands.append(parsed)
+    commands.extend(_registry_commands(plugin_name))
+    return _dedupe(commands)
+
+
+def _registry_commands(plugin_name: str) -> List[str]:
+    """Slash commands from ``command_registry`` owned by *plugin_name*.
+
+    Uses ``get_unique_commands`` (one entry per primary command, no aliases),
+    attributing each to the plugin that defines its handler.
+    """
+    commands: List[str] = []
+    try:
+        from code_puppy.command_line.command_registry import get_unique_commands
+
+        infos = get_unique_commands()
+    except Exception:
+        return commands
+    for info in infos:
+        try:
+            if not _owns_callable(plugin_name, getattr(info, "handler", None)):
+                continue
+            name = getattr(info, "name", "")
+            description = getattr(info, "description", "")
+            formatted = _format_command(name, description)
+            if formatted:
+                commands.append(formatted)
+        except Exception:
+            continue
+    return commands
+
+
+def _format_command(name: Any, description: Any) -> str:
+    """Render a ``(name, description)`` pair as ``/name — description``."""
+    cmd = str(name).strip().lstrip("/").strip()
+    if not cmd:
+        return ""
+    desc = str(description).strip()
+    return f"/{cmd} — {desc}" if desc else f"/{cmd}"
+
+
+def _parse_legacy_command(line: Any) -> str:
+    """Parse a legacy ``"/name - description"`` string."""
+    if not isinstance(line, str) or not line.startswith("/"):
+        return ""
+    if " - " in line:
+        name, desc = line.split(" - ", 1)
+        return _format_command(name, desc)
+    return _format_command(line, "")
+
+
+def get_agents(plugin_name: str) -> List[str]:
+    """Agent names from ``register_agents`` -> ``[{"name", ...}]``."""
+    return _dedupe(_collect_dict_field(plugin_name, "register_agents", "name"))
+
+
+def get_skills(plugin_name: str) -> List[str]:
+    """Skill names from ``register_skills`` -> ``[{"name", ...}]``."""
+    return _dedupe(_collect_dict_field(plugin_name, "register_skills", "name"))
+
+
+def get_model_types(plugin_name: str) -> List[str]:
+    """Model type names from ``register_model_type`` -> ``[{"type", ...}]``."""
+    return _dedupe(_collect_dict_field(plugin_name, "register_model_type", "type"))
+
+
+def get_model_providers(plugin_name: str) -> List[str]:
+    """Provider keys from ``register_model_providers`` -> ``{name: ModelClass}``."""
+    return _dedupe(_collect_dict_keys(plugin_name, "register_model_providers"))
+
+
+def get_mcp_servers(plugin_name: str) -> List[str]:
+    """Server names from ``register_mcp_catalog_servers`` -> ``[MCPServerTemplate]``.
+
+    Accepts ``MCPServerTemplate``-like objects (``.name`` attribute) as well
+    as plain dicts with a ``"name"`` key, for maximum leniency.
+    """
+    names: List[str] = []
+    for result in _invoke_owned(plugin_name, "register_mcp_catalog_servers"):
+        for entry in _as_list(result):
+            names.append(_server_name(entry))
+    return _dedupe(names)
+
+
+def _server_name(entry: Any) -> str:
+    """Extract a display name from an MCP server template or dict."""
+    name = getattr(entry, "name", None)
+    if isinstance(name, str) and name:
+        return name
+    return _dict_key(entry, "name")
+
+
+def get_browser_types(plugin_name: str) -> List[str]:
+    """Browser type keys from ``register_browser_types`` -> ``{type_name: init}``."""
+    return _dedupe(_collect_dict_keys(plugin_name, "register_browser_types"))
+
+
+def get_agent_tools(plugin_name: str) -> List[str]:
+    """Advertised tool names from ``register_agent_tools(None)`` -> ``[str]``.
+
+    ``None`` means "any agent" per the hook contract.
+    """
+    names: List[str] = []
+    for result in _invoke_owned(plugin_name, "register_agent_tools", None):
+        for item in _as_list(result):
+            if isinstance(item, str):
+                names.append(item)
+    return _dedupe(names)
+
+
+def _dict_keys(result: Any) -> List[str]:
+    """Return the string keys of a dict result (provider/browser shape)."""
+    if not isinstance(result, dict):
+        return []
+    return [k for k in result.keys() if isinstance(k, str) and k]
+
+
+# ---------------------------------------------------------------------------
+# Public aggregate API
+# ---------------------------------------------------------------------------
+_EXTRACTORS: Dict[str, Callable[[str], List[str]]] = {
+    CATEGORY_TOOLS: get_tools,
+    CATEGORY_COMMANDS: get_commands,
+    CATEGORY_AGENTS: get_agents,
+    CATEGORY_SKILLS: get_skills,
+    CATEGORY_MODEL_TYPES: get_model_types,
+    CATEGORY_MODEL_PROVIDERS: get_model_providers,
+    CATEGORY_MCP_SERVERS: get_mcp_servers,
+    CATEGORY_BROWSER_TYPES: get_browser_types,
+    CATEGORY_AGENT_TOOLS: get_agent_tools,
+}
+
+
+def get_contributions(plugin_name: str) -> Dict[str, List[str]]:
+    """Return every contribution category for *plugin_name*.
+
+    Keyed by the ``CATEGORY_*`` constants; each value is a (possibly empty)
+    list of display strings, so the renderer always gets a complete dict.
+    """
+    return {category: extract(plugin_name) for category, extract in _EXTRACTORS.items()}

--- a/code_puppy/plugins/plugin_list/plugin_meta.py
+++ b/code_puppy/plugins/plugin_list/plugin_meta.py
@@ -1,0 +1,67 @@
+"""Metadata resolution for loaded plugins.
+
+Surfaces metadata the plugin system tracks but never displayed: the plugin's
+module docstring (as a description), its on-disk path, and the lifecycle hook
+phases it registers callbacks for. Kept separate from ``plugins_menu`` so the
+TUI stays focused on rendering.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import List, Optional, get_args
+
+# Module-name templates per tier, mirroring how the plugin loader registers
+# each tier in ``sys.modules`` (see code_puppy/plugins/__init__.py).
+_MODULE_TEMPLATES = {
+    "builtin": "code_puppy.plugins.{name}.register_callbacks",
+    "user": "{name}.register_callbacks",
+    "project": "project_plugins.{name}.register_callbacks",
+}
+
+
+def _resolve_module(name: str, tier: str):
+    """Return the loaded ``register_callbacks`` module for *name*/*tier*.
+
+    Returns ``None`` if the module can't be found in ``sys.modules`` (e.g. a
+    plugin that loaded via a bare ``__init__.py`` fallback).
+    """
+    template = _MODULE_TEMPLATES.get(tier)
+    if not template:
+        return None
+    return sys.modules.get(template.format(name=name))
+
+
+def get_description(name: str, tier: str) -> Optional[str]:
+    """Return the first paragraph of the plugin's module docstring, or ``None``."""
+    module = _resolve_module(name, tier)
+    doc = getattr(module, "__doc__", None) if module else None
+    if not doc:
+        return None
+    first_para = doc.strip().split("\n\n", 1)[0]
+    return " ".join(line.strip() for line in first_para.splitlines()).strip() or None
+
+
+def get_file_path(name: str, tier: str) -> Optional[str]:
+    """Return the on-disk path of the plugin's ``register_callbacks`` module."""
+    module = _resolve_module(name, tier)
+    return getattr(module, "__file__", None) if module else None
+
+
+def get_hooks(name: str) -> List[str]:
+    """Return the sorted lifecycle phases *name* registered callbacks for.
+
+    Disabled plugins still appear (``include_disabled=True``), so the preview
+    shows what a plugin would hook into once re-enabled.
+    """
+    from code_puppy.callbacks import PhaseType, get_callback_owner, get_callbacks
+
+    phases = [
+        phase
+        for phase in get_args(PhaseType)
+        if any(
+            get_callback_owner(func) == name
+            for func in get_callbacks(phase, include_disabled=True)
+        )
+    ]
+    return sorted(phases)

--- a/code_puppy/plugins/plugin_list/plugin_text_utils.py
+++ b/code_puppy/plugins/plugin_list/plugin_text_utils.py
@@ -1,0 +1,177 @@
+"""Pure text-fragment helpers for the /plugins menu detail pane.
+
+Extracted from ``plugins_menu.py`` to keep that file under the 600-line cap and
+because these helpers are pure (no class state, no I/O) and independently
+unit-testable. They all operate on prompt_toolkit's ``(style, text)`` fragment
+tuples or raw strings.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from prompt_toolkit.utils import get_cwidth
+
+Fragments = List[Tuple[str, str]]
+
+
+def count_lines(fragments: Fragments) -> int:
+    """Number of logical (newline-delimited) lines in *fragments*."""
+    return sum(text.count("\n") for _, text in fragments)
+
+
+def drop_leading_lines(fragments: Fragments, n: int) -> Fragments:
+    """Return *fragments* with the first *n* logical lines removed."""
+    if n <= 0:
+        return list(fragments)
+    out: Fragments = []
+    seen = 0
+    for style, text in fragments:
+        if seen >= n:
+            out.append((style, text))
+            continue
+        pos = 0
+        while seen < n:
+            nl = text.find("\n", pos)
+            if nl == -1:
+                pos = len(text)
+                break
+            seen += 1
+            pos = nl + 1
+        remainder = text[pos:]
+        if seen >= n and remainder:
+            out.append((style, remainder))
+    return out
+
+
+# prompt_toolkit's ``get_cwidth`` uses older Unicode East Asian Width data, so
+# it reports 1 for emoji codepoints (e.g. U+1F6E0 hammer-and-wrench) that modern
+# terminals actually render at 2 cells. Without compensating for this, padded
+# lines end up 1 cell short per emoji and the overflow bleeds into the divider
+# column on the next render. The ranges below cover the main emoji blocks where
+# this happens — anything in them is forced to width 2.
+_EMOJI_RANGES: tuple[tuple[int, int], ...] = (
+    (0x2600, 0x27BF),  # Misc Symbols + Dingbats
+    (
+        0x1F000,
+        0x1FFFF,
+    ),  # Emoji blocks (Misc Symbols & Pictographs through Symbols & Pictographs Ext-A)
+)
+
+
+def _is_emoji(cp: int) -> bool:
+    return any(lo <= cp <= hi for lo, hi in _EMOJI_RANGES)
+
+
+# Codepoints stripped along with emojis: variation selectors (VS1-VS16) and
+# the zero-width joiner. These are meaningless without the emoji they modify.
+_EMOJI_MODIFIERS = frozenset(range(0xFE00, 0xFE10)) | {0x200D}
+
+
+def strip_emojis(text: str) -> str:
+    """Remove emoji codepoints (and their variation selectors / ZWJ) from *text*.
+
+    Emojis are a known headache in prompt_toolkit TUIs: ``get_cwidth`` under-
+    reports many of them, terminal renderers disagree about cell width, and
+    variation selectors complicate cell math. Rather than play whack-a-mole
+    with each new glyph, display content goes through this strip so the menu
+    renders plain text only — the emoji-range override in ``cell_width`` stays
+    in place as a defensive backstop for any stragglers.
+    """
+    return "".join(
+        ch for ch in text if not _is_emoji(ord(ch)) and ord(ch) not in _EMOJI_MODIFIERS
+    )
+
+
+def strip_emojis_from_fragments(fragments: Fragments) -> Fragments:
+    """Apply :func:`strip_emojis` to every fragment's text payload."""
+    return [(style, strip_emojis(text)) for style, text in fragments]
+
+
+def cell_width(text: str) -> int:
+    """Sum of terminal cell widths for *text* (emojis count as 2, ASCII as 1).
+
+    Overrides ``get_cwidth`` for emoji codepoints it under-reports as width 1.
+    Variation selectors (VS16 U+FE0F, etc.) and zero-width joiners stay at 0.
+    """
+    total = 0
+    for ch in text:
+        w = get_cwidth(ch)
+        if w == 1 and _is_emoji(ord(ch)):
+            w = 2
+        total += w
+    return total
+
+
+def pad_lines_to_cells(fragments: Fragments, width: int) -> Fragments:
+    """Pad each logical line in *fragments* to *width* terminal cells.
+
+    Prompt_toolkit's cell-diff renderer mishandles wide characters (emojis):
+    a line containing an emoji occupies one more cell than its Python length,
+    and when content shifts the diff can leave the emoji's "second half" cell
+    frozen with stale glyphs. By measuring width in real terminal cells and
+    explicitly writing trailing spaces to every column, we sidestep the
+    renderer's wide-char tracking entirely.
+    """
+    if width <= 0:
+        return list(fragments)
+    out: Fragments = []
+    cells = 0
+    for style, text in fragments:
+        i = 0
+        while True:
+            nl = text.find("\n", i)
+            if nl == -1:
+                segment = text[i:]
+                if segment:
+                    out.append((style, segment))
+                    cells += cell_width(segment)
+                break
+            segment = text[i:nl]
+            if segment:
+                out.append((style, segment))
+                cells += cell_width(segment)
+            if cells < width:
+                out.append(("", " " * (width - cells)))
+            out.append(("", "\n"))
+            cells = 0
+            i = nl + 1
+    if 0 < cells < width:
+        out.append(("", " " * (width - cells)))
+    return out
+
+
+def wrap_text(body: str, width: int) -> List[str]:
+    """Wrap a single string to ``width`` columns without dropping characters.
+
+    Mirrors inspect_history's ``_wrap_one_line``: prefer breaking after the
+    last space in each window so words stay whole, hard-break when there is no
+    usable space (long paths, etc.). ``"".join(result) == body`` always holds.
+    """
+    if width <= 0 or len(body) <= width:
+        return [body]
+    pieces: List[str] = []
+    remaining = body
+    while len(remaining) > width:
+        window = remaining[:width]
+        cut = window.rfind(" ")
+        if cut <= 0:
+            cut = width
+        else:
+            cut += 1
+        pieces.append(remaining[:cut])
+        remaining = remaining[cut:]
+    pieces.append(remaining)
+    return pieces
+
+
+__all__ = [
+    "Fragments",
+    "cell_width",
+    "count_lines",
+    "drop_leading_lines",
+    "pad_lines_to_cells",
+    "strip_emojis",
+    "strip_emojis_from_fragments",
+    "wrap_text",
+]

--- a/code_puppy/plugins/plugin_list/plugins_menu.py
+++ b/code_puppy/plugins/plugin_list/plugins_menu.py
@@ -2,10 +2,16 @@
 
 Launch with ``/plugins`` to browse and toggle plugins on/off.
 Built with prompt_toolkit, following the same pattern as the skills menu.
+
+This module is the *controller*: terminal sizing, key bindings, app lifecycle,
+and plugin state mutation. All rendering (fragment construction, padding,
+emoji stripping) lives in :mod:`plugins_menu_render` so each module has one
+reason to change.
 """
 
 from __future__ import annotations
 
+import shutil
 import sys
 import time
 from typing import List, Optional, Tuple
@@ -18,8 +24,17 @@ from prompt_toolkit.widgets import Frame
 
 from code_puppy.command_line.pagination import (
     ensure_visible_page,
-    get_page_bounds,
     get_total_pages,
+)
+from code_puppy.plugins.plugin_list.plugin_text_utils import (
+    Fragments,
+    count_lines,
+    drop_leading_lines,
+)
+from code_puppy.plugins.plugin_list.plugins_menu_render import (
+    fill_pane,
+    render_detail,
+    render_list,
 )
 from code_puppy.tools.command_runner import set_awaiting_user_input
 
@@ -37,7 +52,16 @@ class _PluginEntry:
 
 
 class PluginsMenu:
-    """Interactive TUI for enabling/disabling plugins."""
+    """Interactive TUI for enabling/disabling plugins.
+
+    The view (``plugins_menu_render``) reads the following attributes on this
+    object — keep them stable to avoid breaking the render contract:
+
+    * ``plugins``, ``disabled``, ``selected_idx``, ``current_page``, ``page_size``
+    * ``_detail_cols``, ``_pane_rows``
+    * ``_changed``
+    * ``_current()``
+    """
 
     def __init__(self) -> None:
         self.plugins: List[_PluginEntry] = []
@@ -45,11 +69,25 @@ class PluginsMenu:
 
         self.selected_idx = 0
         self.current_page = 0
+        # Mirrors PAGE_SIZE so the renderer's pagination math and the
+        # keybindings (which use the module constant) can't drift apart.
+        self.page_size = PAGE_SIZE
         self.result: Optional[str] = None
         self._changed = False
 
+        self.detail_scroll = 0
+
+        # Pane height is tracked so we can pad short content with blank rows —
+        # prompt_toolkit's cell-diff leaves "empty" area below content alone,
+        # which strands stale glyphs from previous renders.
+        self._menu_cols = 30
+        self._detail_cols = 60
+        self._pane_rows = 20
+        self._last_size: Tuple[int, int] = (0, 0)
+
         self.menu_control: Optional[FormattedTextControl] = None
         self.detail_control: Optional[FormattedTextControl] = None
+        self.detail_window: Optional[Window] = None
 
         self._refresh_data()
 
@@ -82,183 +120,174 @@ class PluginsMenu:
         is_disabled = entry.name in self.disabled
         set_plugin_disabled(entry.name, not is_disabled)
         self._changed = True
+        self.detail_scroll = 0
         self._refresh_data()
         self.update_display()
-
-    # -- rendering ---------------------------------------------------------
-
-    def _render_list(self) -> List[Tuple[str, str]]:
-        lines: List[Tuple[str, str]] = []
-
-        lines.append(("bold", " Plugins"))
-        lines.append(("", "\n\n"))
-
-        if not self.plugins:
-            lines.append(("fg:ansiyellow", "  No plugins loaded."))
-            lines.append(("", "\n"))
-            self._render_hints(lines)
-            return lines
-
-        total_pages = get_total_pages(len(self.plugins), PAGE_SIZE)
-        start_idx, end_idx = get_page_bounds(
-            self.current_page, len(self.plugins), PAGE_SIZE
-        )
-
-        for i in range(start_idx, end_idx):
-            entry = self.plugins[i]
-            is_selected = i == self.selected_idx
-            is_disabled = entry.name in self.disabled
-
-            icon = "x" if is_disabled else "+"
-            icon_style = "fg:ansired" if is_disabled else "fg:ansigreen"
-            prefix = " > " if is_selected else "   "
-
-            if is_selected:
-                lines.append(("bold", prefix))
-                lines.append((icon_style + " bold", icon))
-                lines.append(("bold", f" {entry.name}"))
-            else:
-                lines.append(("", prefix))
-                lines.append((icon_style, icon))
-                lines.append(("fg:ansibrightblack", f" {entry.name}"))
-
-            lines.append(("", "\n"))
-
-        lines.append(("", "\n"))
-        lines.append(
-            ("fg:ansibrightblack", f" Page {self.current_page + 1}/{total_pages}")
-        )
-        lines.append(("", "\n"))
-
-        self._render_hints(lines)
-        return lines
-
-    def _render_hints(self, lines: List[Tuple[str, str]]) -> None:
-        lines.append(("", "\n"))
-        lines.append(("fg:ansibrightblack", "  up/down or j/k "))
-        lines.append(("", "Navigate\n"))
-        lines.append(("fg:ansibrightblack", "  left/right     "))
-        lines.append(("", "Page\n"))
-        lines.append(("fg:ansigreen", "  Enter          "))
-        lines.append(("", "Toggle\n"))
-        lines.append(("fg:ansired", "  q / Esc        "))
-        lines.append(("", "Exit"))
-
-    def _render_detail(self) -> List[Tuple[str, str]]:
-        lines: List[Tuple[str, str]] = []
-
-        lines.append(("dim cyan", " PLUGIN DETAILS"))
-        lines.append(("", "\n\n"))
-
-        entry = self._current()
-        if not entry:
-            lines.append(("fg:ansiyellow", "  No plugin selected."))
-            return lines
-
-        is_disabled = entry.name in self.disabled
-
-        # Name
-        lines.append(("bold", f"  {entry.name}"))
-        lines.append(("", "\n\n"))
-
-        # Tier
-        lines.append(("bold", "  Tier: "))
-        lines.append(("", entry.tier))
-        lines.append(("", "\n\n"))
-
-        # Status
-        lines.append(("bold", "  Status: "))
-        if is_disabled:
-            lines.append(("fg:ansired bold", "Disabled"))
-            lines.append(("", "\n"))
-            lines.append(
-                ("fg:ansibrightblack", "  Callbacks are skipped at dispatch time.")
-            )
-        else:
-            lines.append(("fg:ansigreen bold", "Enabled"))
-            lines.append(("", "\n"))
-            lines.append(("fg:ansibrightblack", "  All callbacks are active."))
-        lines.append(("", "\n\n"))
-
-        lines.append(("fg:ansibrightblack", "  Press Enter to toggle."))
-
-        if self._changed:
-            lines.append(("", "\n\n"))
-            lines.append(("fg:ansiyellow bold", "  Restart Code Puppy for"))
-            lines.append(("", "\n"))
-            lines.append(("fg:ansiyellow bold", "  changes to take effect."))
-
-        return lines
 
     # -- display update ----------------------------------------------------
 
     def update_display(self) -> None:
+        # fill_pane writes every cell of every row — see its docstring for
+        # the stale-glyph rationale.
         if self.menu_control:
-            self.menu_control.text = self._render_list()
+            self.menu_control.text = fill_pane(
+                render_list(self), self._menu_cols, self._pane_rows
+            )
         if self.detail_control:
-            self.detail_control.text = self._render_detail()
+            sliced = drop_leading_lines(render_detail(self), self.detail_scroll)
+            self.detail_control.text = fill_pane(
+                sliced, self._detail_cols, self._pane_rows
+            )
+
+    def _max_detail_scroll(self) -> int:
+        """Topmost line we may scroll to, keeping a screenful visible."""
+        total = count_lines(render_detail(self))
+        visible = 1
+        if self.detail_window is not None and self.detail_window.render_info:
+            visible = max(1, self.detail_window.render_info.window_height)
+        return max(0, total - visible)
+
+    def _scroll_detail(self, delta: int) -> None:
+        new = max(0, min(self.detail_scroll + delta, self._max_detail_scroll()))
+        if new != self.detail_scroll:
+            self.detail_scroll = new
+            self.update_display()
 
     # -- application -------------------------------------------------------
 
-    def run(self) -> Optional[str]:
-        self.menu_control = FormattedTextControl(text="")
-        self.detail_control = FormattedTextControl(text="")
+    def _measure_terminal(self) -> Tuple[int, int]:
+        """Return (cols, rows) of the current terminal, with sane fallbacks."""
+        try:
+            size = shutil.get_terminal_size(fallback=(120, 40))
+            return max(60, size.columns), max(15, size.lines)
+        except Exception:
+            return 120, 40
 
-        menu_window = Window(
-            content=self.menu_control, wrap_lines=True, width=Dimension(weight=40)
+    def _recompute_dimensions(self) -> bool:
+        """Re-measure the terminal and recompute pane widths.
+
+        Returns True when the size actually changed. The width-callable
+        closures in ``run`` read ``self._menu_cols`` / ``self._detail_cols``
+        on every render, so updating these here automatically reflows the
+        layout on terminal resize.
+        """
+        cols, rows = self._measure_terminal()
+        if self._last_size == (cols, rows):
+            return False
+        self._last_size = (cols, rows)
+        # Two side-by-side Frames cost 4 columns of border (1 per side, per
+        # frame). Anything more leaves dead space on the right edge.
+        usable_cols = max(40, cols - 4)
+        # 35% / 65% split, with a minimum so the menu pane is always usable.
+        self._menu_cols = max(20, min(40, int(usable_cols * 0.35)))
+        self._detail_cols = max(20, usable_cols - self._menu_cols)
+        # Reserve 2 rows for the Frame's top + bottom borders.
+        self._pane_rows = max(5, rows - 2)
+        return True
+
+    def _set_selection(self, new_idx: int) -> None:
+        """Move selection to *new_idx* (clamped), resetting detail scroll.
+
+        Single chokepoint for every selection mutation -- ``_move_selection``,
+        the jump-to-first/last actions, and the page jumps all funnel through
+        here so the "reset detail scroll + keep selection's page visible"
+        contract can't drift between callers.
+        """
+        if not self.plugins:
+            return
+        new_idx = max(0, min(new_idx, len(self.plugins) - 1))
+        if new_idx == self.selected_idx:
+            return
+        self.selected_idx = new_idx
+        self.detail_scroll = 0
+        self.current_page = ensure_visible_page(
+            self.selected_idx,
+            self.current_page,
+            len(self.plugins),
+            PAGE_SIZE,
         )
-        detail_window = Window(
-            content=self.detail_control, wrap_lines=True, width=Dimension(weight=60)
-        )
 
-        menu_frame = Frame(menu_window, width=Dimension(weight=40), title="Plugins")
-        detail_frame = Frame(detail_window, width=Dimension(weight=60), title="Details")
+    def _move_selection(self, delta: int) -> None:
+        """Shift the selection by *delta*, clamped, and keep the page in view."""
+        self._set_selection(self.selected_idx + delta)
 
-        root_container = VSplit([menu_frame, detail_frame])
+    def _change_page(self, delta: int) -> None:
+        """Move the page by *delta* (clamped) and jump selection to its head."""
+        total_pages = get_total_pages(len(self.plugins), PAGE_SIZE)
+        new_page = max(0, min(self.current_page + delta, total_pages - 1))
+        if new_page == self.current_page:
+            return
+        self.current_page = new_page
+        self._set_selection(self.current_page * PAGE_SIZE)
 
+    def _build_key_bindings(self) -> KeyBindings:
+        """Wire keys to match the ``inspect_history`` plugin's mental model.
+
+        Both plugins share the same split-pane shape (list + scrollable
+        detail). Keeping the bindings aligned means muscle memory carries
+        over. The mental model (lifted from inspect_history):
+
+        * Left-hand keys (``h``, ``j``) move things UP.
+        * Right-hand keys (``k``, ``l``) move things DOWN.
+        * ``h``/``l`` (and ``left``/``right``) scroll the *detail* pane.
+        * ``j``/``k`` (and ``up``/``down``, ``c-p``/``c-n``) move the
+          *selection* in the list.
+        * ``pageup``/``pagedown`` page through the list.
+        * ``g``/``home`` and ``G``/``end`` jump to first/last.
+        """
         kb = KeyBindings()
 
+        # -- Selection (j = up, k = down -- inspect_history convention) ---
         @kb.add("up")
-        @kb.add("k")
+        @kb.add("c-p")
+        @kb.add("j")
         def _(event):
-            if self.selected_idx > 0:
-                self.selected_idx -= 1
-                self.current_page = ensure_visible_page(
-                    self.selected_idx,
-                    self.current_page,
-                    len(self.plugins),
-                    PAGE_SIZE,
-                )
+            self._move_selection(-1)
             self.update_display()
 
         @kb.add("down")
-        @kb.add("j")
+        @kb.add("c-n")
+        @kb.add("k")
         def _(event):
-            if self.selected_idx < len(self.plugins) - 1:
-                self.selected_idx += 1
-                self.current_page = ensure_visible_page(
-                    self.selected_idx,
-                    self.current_page,
-                    len(self.plugins),
-                    PAGE_SIZE,
-                )
+            self._move_selection(+1)
             self.update_display()
 
+        # -- Page through the list -----------------------------------------
+        @kb.add("pageup")
+        def _(event):
+            self._change_page(-1)
+            self.update_display()
+
+        @kb.add("pagedown")
+        def _(event):
+            self._change_page(+1)
+            self.update_display()
+
+        # -- Jump to first / last ------------------------------------------
+        @kb.add("home")
+        @kb.add("g")
+        def _(event):
+            self._set_selection(0)
+            self.update_display()
+
+        @kb.add("end")
+        @kb.add("G")
+        def _(event):
+            self._set_selection(len(self.plugins) - 1)
+            self.update_display()
+
+        # -- Detail pane scroll (h/left = up, l/right = down) --------------
+        @kb.add("h")
         @kb.add("left")
         def _(event):
-            if self.current_page > 0:
-                self.current_page -= 1
-                self.selected_idx = self.current_page * PAGE_SIZE
-                self.update_display()
+            self._scroll_detail(-1)
 
+        @kb.add("l")
         @kb.add("right")
         def _(event):
-            total_pages = get_total_pages(len(self.plugins), PAGE_SIZE)
-            if self.current_page < total_pages - 1:
-                self.current_page += 1
-                self.selected_idx = self.current_page * PAGE_SIZE
-                self.update_display()
+            self._scroll_detail(+1)
 
+        # -- Actions / exit ------------------------------------------------
         @kb.add("enter")
         def _(event):
             self._toggle_current()
@@ -266,22 +295,80 @@ class PluginsMenu:
 
         @kb.add("q")
         @kb.add("escape")
-        def _(event):
-            self.result = "quit"
-            event.app.exit()
-
         @kb.add("c-c")
         def _(event):
             self.result = "quit"
             event.app.exit()
 
-        layout = Layout(root_container)
+        return kb
+
+    def _build_layout(self) -> Layout:
+        """Build the side-by-side Plugins / Details layout.
+
+        Pane widths are *callables* so they track the live terminal: when the
+        window is resized, ``_recompute_dimensions`` updates the cached cols
+        and these closures hand prompt_toolkit the fresh numbers on the very
+        next render. ``wrap_lines=False`` is critical: auto-wrap bleeds
+        characters into the divider/border column and leaves stale glyphs on
+        redraw. Long lines (description, path) are pre-wrapped by the renderer.
+        """
+
+        def menu_width() -> Dimension:
+            return Dimension(min=20, max=self._menu_cols, preferred=self._menu_cols)
+
+        def detail_width() -> Dimension:
+            return Dimension(min=20, max=self._detail_cols, preferred=self._detail_cols)
+
+        def pane_height() -> Dimension:
+            return Dimension(min=5, max=self._pane_rows, preferred=self._pane_rows)
+
+        menu_window = Window(
+            content=self.menu_control,
+            wrap_lines=False,
+            width=menu_width,
+            height=pane_height,
+        )
+        detail_window = Window(
+            content=self.detail_control,
+            wrap_lines=False,
+            width=detail_width,
+            height=pane_height,
+        )
+        self.detail_window = detail_window
+
+        menu_frame = Frame(menu_window, title="Plugins")
+        detail_frame = Frame(detail_window, title="Details")
+
+        return Layout(VSplit([menu_frame, detail_frame]))
+
+    def run(self) -> Optional[str]:
+        self.menu_control = FormattedTextControl(text="")
+        self.detail_control = FormattedTextControl(text="")
+
+        self._recompute_dimensions()
+
+        layout = self._build_layout()
+        kb = self._build_key_bindings()
+
         app = Application(
             layout=layout,
             key_bindings=kb,
             full_screen=False,
             mouse_support=False,
         )
+
+        # Live resize: prompt_toolkit re-renders on SIGWINCH automatically, but
+        # our pre-wrapped detail text is laid out to a fixed width and won't
+        # reflow on its own. ``before_render`` fires ahead of layout sizing, so
+        # recomputing dimensions here lets the width callables AND the next
+        # render's pre-wrap both see the fresh geometry in the same frame.
+        # ``_recompute_dimensions`` is a no-op when the size hasn't changed, so
+        # there's no per-frame waste.
+        def _on_before_render(_app: Application) -> None:
+            if self._recompute_dimensions():
+                self.update_display()
+
+        app.before_render += _on_before_render
 
         set_awaiting_user_input(True)
 
@@ -326,3 +413,7 @@ def run_plugins_menu() -> Optional[str]:
         emit_warning("Restart Code Puppy for plugin changes to take effect.")
 
     return result
+
+
+# Re-export for callers that don't want to know about the render split.
+__all__ = ["PluginsMenu", "Fragments", "run_plugins_menu"]

--- a/code_puppy/plugins/plugin_list/plugins_menu_render.py
+++ b/code_puppy/plugins/plugin_list/plugins_menu_render.py
@@ -1,0 +1,297 @@
+"""Rendering for the /plugins TUI — split off so ``plugins_menu`` stays small.
+
+These are pure-ish view functions: they take a :class:`PluginsMenu` (or a
+plain plugin entry) and return ``(style, text)`` fragment tuples for
+prompt_toolkit. No I/O, no key handling, no app state mutation. Keeping
+them out of the menu class also makes the file split sustainable as more
+detail sections get added.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Tuple
+
+from code_puppy.command_line.pagination import get_page_bounds, get_total_pages
+from code_puppy.plugins.plugin_list.plugin_text_utils import (
+    Fragments,
+    count_lines,
+    pad_lines_to_cells,
+    strip_emojis_from_fragments,
+    wrap_text,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - import-cycle guard
+    from code_puppy.plugins.plugin_list.plugins_menu import PluginsMenu, _PluginEntry
+
+# Display order + labels for the "Contributes" section, keyed by the
+# ``CATEGORY_*`` constants from ``plugin_contributions``.
+_CONTRIB_LABELS: List[Tuple[str, str]] = [
+    ("tools", "Tools"),
+    ("commands", "Slash Commands"),
+    ("agents", "Agents"),
+    ("skills", "Skills"),
+    ("model_types", "Model Types"),
+    ("model_providers", "Model Providers"),
+    ("mcp_servers", "MCP Servers"),
+    ("browser_types", "Browser Types"),
+    ("agent_tools", "Agent Tools"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _registers_command_handler(name: str) -> bool:
+    """Whether *name* registered a ``custom_command`` hook.
+
+    Such a plugin has a command handler but may lack ``custom_command_help``,
+    so we know one exists without its name (hence the placeholder we surface).
+    """
+    from code_puppy.plugins.plugin_list import plugin_meta
+
+    try:
+        return "custom_command" in plugin_meta.get_hooks(name)
+    except Exception:
+        return False
+
+
+def _append_wrapped(
+    lines: Fragments, style: str, prefix: str, body: str, inner_width: int
+) -> None:
+    """Append *body* (wrapped to *inner_width*) under *prefix* with *style*."""
+    for piece in wrap_text(body, inner_width):
+        lines.append((style, f"{prefix}{piece}"))
+        lines.append(("", "\n"))
+
+
+# ---------------------------------------------------------------------------
+# List pane (left)
+# ---------------------------------------------------------------------------
+def render_list(menu: "PluginsMenu") -> Fragments:
+    lines: Fragments = []
+
+    lines.append(("bold", " Plugins"))
+    lines.append(("", "\n\n"))
+
+    if not menu.plugins:
+        lines.append(("fg:ansiyellow", "  No plugins loaded."))
+        lines.append(("", "\n"))
+        _render_hints(lines)
+        return lines
+
+    total_pages = get_total_pages(len(menu.plugins), menu.page_size)
+    start_idx, end_idx = get_page_bounds(
+        menu.current_page, len(menu.plugins), menu.page_size
+    )
+
+    for i in range(start_idx, end_idx):
+        entry = menu.plugins[i]
+        is_selected = i == menu.selected_idx
+        is_disabled = entry.name in menu.disabled
+
+        icon = "x" if is_disabled else "+"
+        icon_style = "fg:ansired" if is_disabled else "fg:ansigreen"
+        prefix = " > " if is_selected else "   "
+
+        if is_selected:
+            lines.append(("bold", prefix))
+            lines.append((icon_style + " bold", icon))
+            lines.append(("bold", f" {entry.name}"))
+        else:
+            lines.append(("", prefix))
+            lines.append((icon_style, icon))
+            lines.append(("fg:ansibrightblack", f" {entry.name}"))
+
+        lines.append(("", "\n"))
+
+    lines.append(("", "\n"))
+    lines.append(("fg:ansibrightblack", f" Page {menu.current_page + 1}/{total_pages}"))
+    lines.append(("", "\n"))
+
+    _render_hints(lines)
+    return lines
+
+
+def _render_hints(lines: Fragments) -> None:
+    # Keys mirror the inspect_history plugin so muscle memory carries over
+    # across both split-pane inspectors. See _build_key_bindings docstring
+    # for the full mental model.
+    hints: List[Tuple[str, str, str]] = [
+        ("fg:ansibrightblack", "  up/down or j/k ", "Navigate"),
+        ("fg:ansibrightblack", "  PgUp/PgDn      ", "Page"),
+        ("fg:ansibrightblack", "  g / G          ", "First / Last"),
+        ("fg:ansibrightblack", "  h/l or \u2190/\u2192    ", "Scroll details"),
+        ("fg:ansigreen", "  Enter          ", "Toggle"),
+        ("fg:ansired", "  q / Esc        ", "Exit"),
+    ]
+    lines.append(("", "\n"))
+    for i, (style, key_text, label) in enumerate(hints):
+        lines.append((style, key_text))
+        lines.append(("", label if i == len(hints) - 1 else f"{label}\n"))
+
+
+# ---------------------------------------------------------------------------
+# Detail pane (right)
+# ---------------------------------------------------------------------------
+def render_detail(menu: "PluginsMenu") -> Fragments:
+    lines: Fragments = []
+
+    lines.append(("dim cyan", " PLUGIN DETAILS"))
+    lines.append(("", "\n\n"))
+
+    entry = menu._current()
+    if not entry:
+        lines.append(("fg:ansiyellow", "  No plugin selected."))
+        return lines
+
+    from code_puppy.plugins.plugin_list import plugin_meta
+
+    is_disabled = entry.name in menu.disabled
+
+    lines.append(("bold", f"  {entry.name}"))
+    lines.append(("", "\n\n"))
+
+    # Pre-wrap to pane width: the Window runs wrap_lines=False (auto-wrap
+    # bled chars into the divider column).
+    description = plugin_meta.get_description(entry.name, entry.tier)
+    if description:
+        inner = max(20, menu._detail_cols - 4)  # -2 indent, -2 frame border
+        _append_wrapped(lines, "", "  ", description, inner)
+        lines.append(("", "\n"))
+
+    lines.append(("bold", "  Tier: "))
+    lines.append(("", entry.tier))
+    lines.append(("", "\n\n"))
+
+    lines.append(("bold", "  Status: "))
+    if is_disabled:
+        lines.append(("fg:ansired bold", "Disabled"))
+        lines.append(("", "\n"))
+        lines.append(
+            ("fg:ansibrightblack", "  Callbacks are skipped at dispatch time.")
+        )
+    else:
+        lines.append(("fg:ansigreen bold", "Enabled"))
+        lines.append(("", "\n"))
+        lines.append(("fg:ansibrightblack", "  All callbacks are active."))
+    lines.append(("", "\n\n"))
+
+    _render_contributions(lines, menu, entry)
+
+    hooks = plugin_meta.get_hooks(entry.name)
+    lines.append(("bold", f"  Lifecycle hooks used ({len(hooks)}):"))
+    lines.append(("", "\n"))
+    if hooks:
+        for hook in hooks:
+            lines.append(("fg:ansicyan", f"    • {hook}"))
+            lines.append(("", "\n"))
+    else:
+        lines.append(("fg:ansibrightblack", "    (none registered)"))
+        lines.append(("", "\n"))
+    lines.append(("", "\n"))
+
+    # Pre-wrap: paths can be very long.
+    path = plugin_meta.get_file_path(entry.name, entry.tier)
+    if path:
+        lines.append(("bold", "  Path:"))
+        lines.append(("", "\n"))
+        inner = max(20, menu._detail_cols - 6)  # -4 indent, -2 frame border
+        _append_wrapped(lines, "fg:ansibrightblack", "    ", path, inner)
+        lines.append(("", "\n"))
+
+    if menu._changed:
+        lines.append(("", "\n\n"))
+        # Let the shared wrapper decide whether this fits on one line --
+        # hard-coding a two-line split made the warning look broken on
+        # any pane wider than ~50 cols (which is the common case).
+        inner = max(20, menu._detail_cols - 4)  # -2 indent, -2 frame border
+        _append_wrapped(
+            lines,
+            "fg:ansiyellow bold",
+            "  ",
+            "Restart Code Puppy for changes to take effect.",
+            inner,
+        )
+
+    return lines
+
+
+def _render_contributions(
+    lines: Fragments, menu: "PluginsMenu", entry: "_PluginEntry"
+) -> None:
+    """Render the 'Contributes' section, grouped by non-empty category.
+
+    Best-effort and display-only: extraction failures degrade to showing
+    nothing extra rather than crashing the preview. Empty categories are
+    skipped, and a command handler with no ``custom_command_help`` is
+    surfaced as 'command handler (name unknown)'.
+    """
+    from code_puppy.plugins.plugin_list import plugin_contributions
+
+    try:
+        contributions = plugin_contributions.get_contributions(entry.name)
+    except Exception:
+        contributions = {}
+
+    # Synthesize a placeholder only when custom_command_help gave us nothing
+    # but a command handler exists.
+    if not contributions.get(plugin_contributions.CATEGORY_COMMANDS):
+        if _registers_command_handler(entry.name):
+            contributions[plugin_contributions.CATEGORY_COMMANDS] = [
+                "command handler (name unknown)"
+            ]
+
+    if not any(contributions.get(key) for key, _ in _CONTRIB_LABELS):
+        return
+
+    lines.append(("bold", "  Contributes:"))
+    lines.append(("", "\n"))
+    # Pre-wrap contribution items to the pane's inner width. Without this,
+    # long entries (e.g. agent_skills /<skill-name> entries with trimmed
+    # 80-char descriptions) extend past our padding cap and leave stale
+    # tail glyphs (a literal "...") when the user switches to a plugin
+    # whose detail content doesn't reach those columns.
+    bullet_prefix = "      • "
+    cont_prefix = "        "  # aligns continuation lines under the text
+    inner = max(20, menu._detail_cols - 2 - len(bullet_prefix))
+    for key, label in _CONTRIB_LABELS:
+        items = contributions.get(key)
+        if not items:
+            continue
+        lines.append(("fg:ansimagenta", f"    {label}:"))
+        lines.append(("", "\n"))
+        for item in items:
+            pieces = wrap_text(str(item), inner)
+            for idx, piece in enumerate(pieces):
+                prefix = bullet_prefix if idx == 0 else cont_prefix
+                lines.append(("fg:ansicyan", f"{prefix}{piece}"))
+                lines.append(("", "\n"))
+    lines.append(("", "\n"))
+
+
+# ---------------------------------------------------------------------------
+# Pane post-processing (cell padding + blank-row fill)
+# ---------------------------------------------------------------------------
+def fill_pane(fragments: Fragments, pane_cols: int, pane_rows: int) -> Fragments:
+    """Strip emojis, pad to pane width, fill to *pane_rows* rows.
+
+    Emojis are stripped first (cell-width accounting in TUIs is fragile —
+    cleaner to just not draw them), then each line is cell-padded to the
+    pane's inner width and blank rows fill any unused height. The combo
+    guarantees every visible cell is explicitly written every render.
+
+    Takes scalar dimensions instead of the whole menu so this stays a pure
+    function over its inputs (Law of Demeter — the renderer doesn't need to
+    know about ``PluginsMenu``'s shape).
+    """
+    fragments = strip_emojis_from_fragments(fragments)
+    current_lines = count_lines(fragments)
+    out = list(fragments)
+    # Ensure the final line ends with a newline so blank padding lines up.
+    if out and not out[-1][1].endswith("\n"):
+        out.append(("", "\n"))
+        current_lines += 1
+    blanks_needed = max(0, pane_rows - current_lines)
+    if blanks_needed:
+        out.append(("", "\n" * blanks_needed))
+    return pad_lines_to_cells(out, max(0, pane_cols - 2))

--- a/code_puppy/plugins/plugin_list/register_callbacks.py
+++ b/code_puppy/plugins/plugin_list/register_callbacks.py
@@ -46,11 +46,13 @@ def _build_output() -> str:
     loaded = get_loaded_plugins()
     disabled = get_disabled_plugins()
 
-    builtin_path = str(Path(__file__).parent.parent) + "/"
+    # Display paths with forward slashes regardless of OS so the output is
+    # consistent across Windows / POSIX (and easier to copy-paste).
+    builtin_path = Path(__file__).parent.parent.as_posix() + "/"
     user_path = "~/.code_puppy/plugins/"
     project_dir = get_project_plugins_directory()
     project_path = (
-        str(project_dir) + "/" if project_dir else "<CWD>/.code_puppy/plugins/"
+        project_dir.as_posix() + "/" if project_dir else "<CWD>/.code_puppy/plugins/"
     )
 
     lines = [
@@ -89,45 +91,29 @@ def _all_loaded_plugin_names() -> set[str]:
     return names
 
 
-def _handle_disable(plugin_name: str) -> bool:
-    """Disable a plugin by name."""
+def _handle_toggle(plugin_name: str, *, disabled: bool) -> bool:
+    """Flip *plugin_name*'s disabled state to *disabled*.
+
+    One implementation handles both ``enable`` and ``disable`` — the only
+    difference is the target state and the success-message verb.
+    """
     from code_puppy.messaging import emit_error, emit_info, emit_success, emit_warning
     from code_puppy.plugins.config import set_plugin_disabled
 
-    all_names = _all_loaded_plugin_names()
-    if plugin_name not in all_names:
+    if plugin_name not in _all_loaded_plugin_names():
         emit_error(
             f"Plugin '{plugin_name}' is not loaded. "
             f"Use /plugins to see available plugins."
         )
         return True
 
-    if set_plugin_disabled(plugin_name, disabled=True):
-        emit_success(f"Plugin '{plugin_name}' disabled.")
+    verb = "disabled" if disabled else "re-enabled"
+    state = "disabled" if disabled else "enabled"
+    if set_plugin_disabled(plugin_name, disabled):
+        emit_success(f"Plugin '{plugin_name}' {verb}.")
         emit_warning("Restart Code Puppy for this change to take effect.")
     else:
-        emit_info(f"Plugin '{plugin_name}' is already disabled.")
-    return True
-
-
-def _handle_enable(plugin_name: str) -> bool:
-    """Enable a previously disabled plugin."""
-    from code_puppy.messaging import emit_error, emit_info, emit_success, emit_warning
-    from code_puppy.plugins.config import set_plugin_disabled
-
-    all_names = _all_loaded_plugin_names()
-    if plugin_name not in all_names:
-        emit_error(
-            f"Plugin '{plugin_name}' is not loaded. "
-            f"Use /plugins to see available plugins."
-        )
-        return True
-
-    if set_plugin_disabled(plugin_name, disabled=False):
-        emit_success(f"Plugin '{plugin_name}' re-enabled.")
-        emit_warning("Restart Code Puppy for this change to take effect.")
-    else:
-        emit_info(f"Plugin '{plugin_name}' is already enabled.")
+        emit_info(f"Plugin '{plugin_name}' is already {state}.")
     return True
 
 
@@ -138,48 +124,71 @@ def _custom_help() -> list[tuple[str, str]]:
     return [("plugins", "List, enable, or disable plugins")]
 
 
+def _run_interactive_menu() -> None:
+    """Open the TUI; fall back to a plain-text list if it blows up."""
+    from code_puppy.messaging import emit_info
+
+    try:
+        from code_puppy.plugins.plugin_list.plugins_menu import run_plugins_menu
+
+        run_plugins_menu()
+    except Exception as exc:
+        logger.warning(f"Plugins TUI failed, falling back to list: {exc}")
+        emit_info(_build_output())
+
+
+def _sub_list(_tokens: list[str]) -> bool:
+    from code_puppy.messaging import emit_info
+
+    emit_info(_build_output())
+    return True
+
+
+def _sub_disable(tokens: list[str]) -> bool:
+    return _sub_toggle(tokens, disabled=True)
+
+
+def _sub_enable(tokens: list[str]) -> bool:
+    return _sub_toggle(tokens, disabled=False)
+
+
+def _sub_toggle(tokens: list[str], *, disabled: bool) -> bool:
+    from code_puppy.messaging import emit_error
+
+    action = "disable" if disabled else "enable"
+    if len(tokens) < 3:
+        emit_error(f"Usage: /plugins {action} <plugin-name>")
+        return True
+    return _handle_toggle(tokens[2], disabled=disabled)
+
+
+_SUBCOMMANDS = {
+    "list": _sub_list,
+    "disable": _sub_disable,
+    "enable": _sub_enable,
+}
+
+
 def _handle_custom_command(command: str, name: str) -> Optional[bool]:
     if name != "plugins":
-        return None  # Not our command.
-
-    from code_puppy.messaging import emit_error, emit_info
+        return None
 
     tokens = command.strip().split()
 
-    # Bare /plugins -> interactive TUI
     if len(tokens) <= 1:
-        try:
-            from code_puppy.plugins.plugin_list.plugins_menu import run_plugins_menu
-
-            run_plugins_menu()
-        except Exception as exc:
-            logger.warning(f"Plugins TUI failed, falling back to list: {exc}")
-            emit_info(_build_output())
+        _run_interactive_menu()
         return True
 
-    subcommand = tokens[1].lower()
+    handler = _SUBCOMMANDS.get(tokens[1].lower())
+    if handler is None:
+        from code_puppy.messaging import emit_error
 
-    if subcommand == "list":
-        emit_info(_build_output())
+        emit_error(
+            f"Unknown subcommand: '{tokens[1]}'. "
+            "Usage: /plugins [list | enable <name> | disable <name>]"
+        )
         return True
-
-    if subcommand == "disable":
-        if len(tokens) < 3:
-            emit_error("Usage: /plugins disable <plugin-name>")
-            return True
-        return _handle_disable(tokens[2])
-
-    if subcommand == "enable":
-        if len(tokens) < 3:
-            emit_error("Usage: /plugins enable <plugin-name>")
-            return True
-        return _handle_enable(tokens[2])
-
-    emit_error(
-        f"Unknown subcommand: '{subcommand}'. "
-        "Usage: /plugins [list | enable <name> | disable <name>]"
-    )
-    return True
+    return handler(tokens)
 
 
 register_callback("custom_command_help", _custom_help)

--- a/tests/plugins/test_plugin_contributions.py
+++ b/tests/plugins/test_plugin_contributions.py
@@ -1,0 +1,479 @@
+"""Tests for per-plugin contribution extraction.
+
+Covers ``plugin_list.plugin_contributions`` — that, for a given plugin, it
+invokes *only* that plugin's owned collection callbacks (owner-filtered via
+``_callback_owners``), parses each documented return shape into display
+strings, and never raises when a callback blows up.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from code_puppy import callbacks
+from code_puppy.plugins.plugin_list import plugin_contributions as pc
+
+
+@pytest.fixture
+def clean_callbacks():
+    """Snapshot and restore the global callback registries."""
+    saved_callbacks = {
+        phase: list(funcs) for phase, funcs in callbacks._callbacks.items()
+    }
+    saved_owners = dict(callbacks._callback_owners)
+    saved_loading = callbacks._current_loading_plugin
+    try:
+        yield
+    finally:
+        for phase in callbacks._callbacks:
+            callbacks._callbacks[phase] = saved_callbacks.get(phase, [])
+        callbacks._callback_owners.clear()
+        callbacks._callback_owners.update(saved_owners)
+        callbacks._current_loading_plugin = saved_loading
+
+
+def _register(owner: str, phase: str, fn):
+    """Register *fn* for *phase* owned by *owner*."""
+    callbacks.set_loading_context(owner)
+    try:
+        callbacks.register_callback(phase, fn)
+    finally:
+        callbacks.clear_loading_context()
+    return fn
+
+
+# ── tools ──────────────────────────────────────────────────────────────────
+
+
+def test_get_tools_parses_name(clean_callbacks):
+    _register(
+        "plugA",
+        "register_tools",
+        lambda: [{"name": "do_thing", "register_func": lambda a: None}],
+    )
+    assert pc.get_tools("plugA") == ["do_thing"]
+
+
+def test_get_tools_single_dict_not_list(clean_callbacks):
+    _register(
+        "plugA",
+        "register_tools",
+        lambda: {"name": "solo", "register_func": lambda a: None},
+    )
+    assert pc.get_tools("plugA") == ["solo"]
+
+
+# ── commands (all three shapes) ─────────────────────────────────────────────
+
+
+def test_get_commands_list_of_tuples(clean_callbacks):
+    _register(
+        "plugA",
+        "custom_command_help",
+        lambda: [("foo", "Do foo"), ("bar", "Do bar")],
+    )
+    assert pc.get_commands("plugA") == ["/foo — Do foo", "/bar — Do bar"]
+
+
+def test_get_commands_single_tuple(clean_callbacks):
+    _register("plugA", "custom_command_help", lambda: ("baz", "Do baz"))
+    assert pc.get_commands("plugA") == ["/baz — Do baz"]
+
+
+def test_get_commands_legacy_string(clean_callbacks):
+    _register(
+        "plugA",
+        "custom_command_help",
+        lambda: ["/legacy - The legacy way"],
+    )
+    assert pc.get_commands("plugA") == ["/legacy — The legacy way"]
+
+
+def test_get_commands_strips_leading_slash_in_name(clean_callbacks):
+    _register("plugA", "custom_command_help", lambda: [("/slashed", "desc")])
+    assert pc.get_commands("plugA") == ["/slashed — desc"]
+
+
+# ── agents / skills / model types ───────────────────────────────────────────
+
+
+def test_get_agents(clean_callbacks):
+    _register("plugA", "register_agents", lambda: [{"name": "my-agent"}])
+    assert pc.get_agents("plugA") == ["my-agent"]
+
+
+def test_get_skills(clean_callbacks):
+    _register(
+        "plugA",
+        "register_skills",
+        lambda: [{"name": "my-skill", "skill_md": "# hi"}],
+    )
+    assert pc.get_skills("plugA") == ["my-skill"]
+
+
+def test_get_model_types(clean_callbacks):
+    _register(
+        "plugA",
+        "register_model_type",
+        lambda: [{"type": "my_type", "handler": lambda *a: None}],
+    )
+    assert pc.get_model_types("plugA") == ["my_type"]
+
+
+# ── providers / browser types (dict-keyed) ──────────────────────────────────
+
+
+def test_get_model_providers_dict_keys(clean_callbacks):
+    _register(
+        "plugA",
+        "register_model_providers",
+        lambda: {"walmart_gemini": object},
+    )
+    assert pc.get_model_providers("plugA") == ["walmart_gemini"]
+
+
+def test_get_browser_types_dict_keys(clean_callbacks):
+    _register(
+        "plugA",
+        "register_browser_types",
+        lambda: {"camoufox": lambda *a, **k: None},
+    )
+    assert pc.get_browser_types("plugA") == ["camoufox"]
+
+
+# ── mcp servers (object .name or dict) ──────────────────────────────────────
+
+
+def test_get_mcp_servers_object_name(clean_callbacks):
+    class _Tmpl:
+        name = "my-server"
+
+    _register("plugA", "register_mcp_catalog_servers", lambda: [_Tmpl()])
+    assert pc.get_mcp_servers("plugA") == ["my-server"]
+
+
+def test_get_mcp_servers_dict_name(clean_callbacks):
+    _register(
+        "plugA",
+        "register_mcp_catalog_servers",
+        lambda: [{"name": "dict-server"}],
+    )
+    assert pc.get_mcp_servers("plugA") == ["dict-server"]
+
+
+# ── advertised agent tools ──────────────────────────────────────────────────
+
+
+def test_get_agent_tools_passes_none(clean_callbacks):
+    seen = {}
+
+    def _cb(agent_name=None):
+        seen["arg"] = agent_name
+        return ["tool_a", "tool_b"]
+
+    _register("plugA", "register_agent_tools", _cb)
+    assert pc.get_agent_tools("plugA") == ["tool_a", "tool_b"]
+    assert seen["arg"] is None
+
+
+# ── ownership filtering ─────────────────────────────────────────────────────
+
+
+def test_only_owned_callbacks_invoked(clean_callbacks):
+    _register(
+        "plugA", "register_tools", lambda: [{"name": "a_tool", "register_func": id}]
+    )
+    _register(
+        "plugB", "register_tools", lambda: [{"name": "b_tool", "register_func": id}]
+    )
+    assert pc.get_tools("plugA") == ["a_tool"]
+    assert pc.get_tools("plugB") == ["b_tool"]
+
+
+# ── safety: raising callbacks yield nothing, never crash ─────────────────────
+
+
+def test_raising_callback_yields_no_items(clean_callbacks):
+    def _boom():
+        raise RuntimeError("kaboom")
+
+    _register("plugA", "register_tools", _boom)
+    # The raising callback contributes nothing...
+    assert pc.get_tools("plugA") == []
+
+
+def test_raising_callback_does_not_block_sibling(clean_callbacks):
+    def _boom():
+        raise RuntimeError("kaboom")
+
+    _register("plugA", "register_tools", _boom)
+    _register(
+        "plugA", "register_tools", lambda: [{"name": "good", "register_func": id}]
+    )
+    assert pc.get_tools("plugA") == ["good"]
+
+
+# ── dedupe / empties ────────────────────────────────────────────────────────
+
+
+def test_dedupe_preserves_order(clean_callbacks):
+    _register(
+        "plugA",
+        "register_tools",
+        lambda: [
+            {"name": "dup", "register_func": id},
+            {"name": "dup", "register_func": id},
+            {"name": "uniq", "register_func": id},
+        ],
+    )
+    assert pc.get_tools("plugA") == ["dup", "uniq"]
+
+
+def test_malformed_entries_skipped(clean_callbacks):
+    _register(
+        "plugA",
+        "register_tools",
+        lambda: [{"no_name": True}, "not_a_dict", {"name": "ok", "register_func": id}],
+    )
+    assert pc.get_tools("plugA") == ["ok"]
+
+
+# ── aggregate API ───────────────────────────────────────────────────────────
+
+
+def test_get_contributions_unknown_plugin_returns_empty_structure(clean_callbacks):
+    result = pc.get_contributions("never_loaded_plugin")
+    assert set(result.keys()) == set(pc._EXTRACTORS.keys())
+    assert all(v == [] for v in result.values())
+
+
+def test_get_contributions_aggregates_categories(clean_callbacks):
+    _register("plugA", "register_tools", lambda: [{"name": "t", "register_func": id}])
+    _register("plugA", "register_agents", lambda: [{"name": "ag"}])
+    _register("plugA", "custom_command_help", lambda: [("cmd", "desc")])
+
+    result = pc.get_contributions("plugA")
+    assert result[pc.CATEGORY_TOOLS] == ["t"]
+    assert result[pc.CATEGORY_AGENTS] == ["ag"]
+    assert result[pc.CATEGORY_COMMANDS] == ["/cmd — desc"]
+    assert result[pc.CATEGORY_SKILLS] == []
+
+
+def test_get_contributions_only_target_plugin_across_categories(clean_callbacks):
+    """Aggregate extraction never leaks a sibling plugin's contributions.
+
+    ``plugB`` registers in *every* category; asking for ``plugA`` (which
+    registered nothing) must come back fully empty, and asking for ``plugB``
+    must return only ``plugB``'s items — proving owner filtering holds at the
+    aggregate level, not just per-extractor.
+    """
+    _register(
+        "plugB", "register_tools", lambda: [{"name": "b_tool", "register_func": id}]
+    )
+    _register("plugB", "register_agents", lambda: [{"name": "b_agent"}])
+    _register("plugB", "register_skills", lambda: [{"name": "b_skill"}])
+    _register("plugB", "custom_command_help", lambda: [("bcmd", "B command")])
+
+    # plugA owns nothing -> every category empty.
+    plug_a = pc.get_contributions("plugA")
+    assert all(v == [] for v in plug_a.values())
+
+    # plugB sees only its own items.
+    plug_b = pc.get_contributions("plugB")
+    assert plug_b[pc.CATEGORY_TOOLS] == ["b_tool"]
+    assert plug_b[pc.CATEGORY_AGENTS] == ["b_agent"]
+    assert plug_b[pc.CATEGORY_SKILLS] == ["b_skill"]
+    assert plug_b[pc.CATEGORY_COMMANDS] == ["/bcmd — B command"]
+
+
+# ── empty / None callback returns ───────────────────────────────────────────
+
+
+def test_callback_returning_none_yields_empty(clean_callbacks):
+    _register("plugA", "register_tools", lambda: None)
+    assert pc.get_tools("plugA") == []
+
+
+def test_callback_returning_empty_list_yields_empty(clean_callbacks):
+    _register("plugA", "register_agents", lambda: [])
+    assert pc.get_agents("plugA") == []
+
+
+def test_command_callback_returning_none_yields_empty(clean_callbacks):
+    _register("plugA", "custom_command_help", lambda: None)
+    assert pc.get_commands("plugA") == []
+
+
+def test_command_without_description_omits_dash(clean_callbacks):
+    _register("plugA", "custom_command_help", lambda: [("bare", "")])
+    assert pc.get_commands("plugA") == ["/bare"]
+
+
+def test_get_contributions_empty_string_plugin_name(clean_callbacks):
+    # An empty/None-ish plugin name matches no owner -> empty structure.
+    result = pc.get_contributions("")
+    assert set(result.keys()) == set(pc._EXTRACTORS.keys())
+    assert all(v == [] for v in result.values())
+
+
+# ── direct-registry attribution ─────────────────────────────────────────────
+
+
+class _FakeCommandInfo:
+    """Minimal stand-in for command_registry.CommandInfo."""
+
+    def __init__(self, name, description, handler):
+        self.name = name
+        self.description = description
+        self.handler = handler
+
+
+def _handler_in(module_name):
+    """Return a callable whose ``__module__`` is *module_name*."""
+
+    def _h(command):  # pragma: no cover - never invoked, only inspected
+        return True
+
+    _h.__module__ = module_name
+    return _h
+
+
+def test_plugin_owner_of_module_builtin():
+    assert (
+        pc._plugin_owner_of_module("code_puppy.plugins.wiggum.register_callbacks")
+        == "wiggum"
+    )
+
+
+def test_plugin_owner_of_module_project():
+    assert (
+        pc._plugin_owner_of_module("project_plugins.my_plug.register_callbacks")
+        == "my_plug"
+    )
+
+
+def test_plugin_owner_of_module_user():
+    assert pc._plugin_owner_of_module("user_plug.register_callbacks") == "user_plug"
+
+
+def test_plugin_owner_of_module_core_does_not_match_plugin():
+    # Core modules resolve to a prefix that is not a real plugin name.
+    assert (
+        pc._plugin_owner_of_module("code_puppy.command_line.command_handler")
+        == "code_puppy"
+    )
+
+
+def test_plugin_owner_of_module_none():
+    assert pc._plugin_owner_of_module(None) is None
+    assert pc._plugin_owner_of_module("") is None
+
+
+def test_registry_commands_attributed_by_handler_module(monkeypatch):
+    from code_puppy.command_line import command_registry
+
+    infos = [
+        _FakeCommandInfo(
+            "wiggum",
+            "Loop mode",
+            _handler_in("code_puppy.plugins.wiggum.register_callbacks"),
+        ),
+        _FakeCommandInfo(
+            "other",
+            "Other plugin command",
+            _handler_in("code_puppy.plugins.elsewhere.register_callbacks"),
+        ),
+        _FakeCommandInfo(
+            "core_cmd",
+            "A core command",
+            _handler_in("code_puppy.command_line.command_handler"),
+        ),
+    ]
+    monkeypatch.setattr(command_registry, "get_unique_commands", lambda: infos)
+
+    assert pc._registry_commands("wiggum") == ["/wiggum — Loop mode"]
+    # Sibling plugin's command never leaks into wiggum's list.
+    assert pc._registry_commands("elsewhere") == ["/other — Other plugin command"]
+    # Core commands aren't attributed to any plugin.
+    assert pc._registry_commands("code_puppy") == ["/core_cmd — A core command"]
+
+
+def test_registry_commands_lookup_failure_yields_empty(monkeypatch):
+    from code_puppy.command_line import command_registry
+
+    def _boom():
+        raise RuntimeError("registry exploded")
+
+    monkeypatch.setattr(command_registry, "get_unique_commands", _boom)
+    assert pc._registry_commands("wiggum") == []
+
+
+def test_get_commands_merges_callback_and_registry(clean_callbacks, monkeypatch):
+    from code_puppy.command_line import command_registry
+
+    _register("plugA", "custom_command_help", lambda: [("hooked", "From the hook")])
+    monkeypatch.setattr(
+        command_registry,
+        "get_unique_commands",
+        lambda: [
+            _FakeCommandInfo(
+                "decorated",
+                "From the decorator",
+                _handler_in("code_puppy.plugins.plugA.register_callbacks"),
+            )
+        ],
+    )
+    assert pc.get_commands("plugA") == [
+        "/hooked — From the hook",
+        "/decorated — From the decorator",
+    ]
+
+
+def test_get_commands_dedupes_across_callback_and_registry(
+    clean_callbacks, monkeypatch
+):
+    from code_puppy.command_line import command_registry
+
+    _register("plugA", "custom_command_help", lambda: [("dup", "Same command")])
+    monkeypatch.setattr(
+        command_registry,
+        "get_unique_commands",
+        lambda: [
+            _FakeCommandInfo(
+                "dup",
+                "Same command",
+                _handler_in("code_puppy.plugins.plugA.register_callbacks"),
+            )
+        ],
+    )
+    assert pc.get_commands("plugA") == ["/dup — Same command"]
+
+
+def test_registry_tools_attributed_by_register_func_module(monkeypatch):
+    import code_puppy.tools as tools_pkg
+
+    fake_registry = {
+        "plugA_tool": _handler_in("code_puppy.plugins.plugA.register_callbacks"),
+        "core_tool": _handler_in("code_puppy.tools.file_operations"),
+    }
+    monkeypatch.setattr(tools_pkg, "TOOL_REGISTRY", fake_registry, raising=False)
+
+    assert pc._registry_tools("plugA") == ["plugA_tool"]
+    assert pc._registry_tools("code_puppy") == ["core_tool"]
+
+
+def test_get_tools_merges_callback_and_registry(clean_callbacks, monkeypatch):
+    import code_puppy.tools as tools_pkg
+
+    _register(
+        "plugA",
+        "register_tools",
+        lambda: [{"name": "hooked_tool", "register_func": id}],
+    )
+    monkeypatch.setattr(
+        tools_pkg,
+        "TOOL_REGISTRY",
+        {"direct_tool": _handler_in("code_puppy.plugins.plugA.register_callbacks")},
+        raising=False,
+    )
+    assert pc.get_tools("plugA") == ["hooked_tool", "direct_tool"]

--- a/tests/plugins/test_plugin_meta.py
+++ b/tests/plugins/test_plugin_meta.py
@@ -1,0 +1,663 @@
+"""Tests for the plugin metadata surface.
+
+Covers three collaborating pieces added on the plugin-enhancements branch:
+
+* ``plugin_list.plugin_meta`` — description / file-path / hook resolution
+  across the builtin/user/project tiers and the unresolved-module path.
+  ``get_hooks`` ownership lookup is covered here too, including the
+  disabled-but-still-registered case and the empty case.
+* ``plugins_menu`` preview rendering of the Description / Lifecycle hooks / Path
+  sections.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import patch
+
+import pytest
+
+from code_puppy import callbacks
+from code_puppy.plugins.plugin_list import plugin_meta
+from code_puppy.plugins.plugin_list.plugins_menu_render import fill_pane, render_detail
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def clean_callbacks():
+    """Snapshot and restore the global callback registries.
+
+    Tests register fake-owner callbacks via the loading-context machinery;
+    this keeps that pollution from leaking into other tests.
+    """
+    saved_callbacks = {
+        phase: list(funcs) for phase, funcs in callbacks._callbacks.items()
+    }
+    saved_owners = dict(callbacks._callback_owners)
+    saved_loading = callbacks._current_loading_plugin
+    try:
+        yield
+    finally:
+        for phase in callbacks._callbacks:
+            callbacks._callbacks[phase] = saved_callbacks.get(phase, [])
+        callbacks._callback_owners.clear()
+        callbacks._callback_owners.update(saved_owners)
+        callbacks._current_loading_plugin = saved_loading
+
+
+def _register_owned(owner: str, phase: str):
+    """Register a fresh callback for *phase* owned by *owner*; return it."""
+
+    def _cb(*args, **kwargs):  # pragma: no cover - never dispatched
+        return None
+
+    callbacks.set_loading_context(owner)
+    try:
+        callbacks.register_callback(phase, _cb)
+    finally:
+        callbacks.clear_loading_context()
+    return _cb
+
+
+def _fake_module(doc=None, file=None):
+    """Build a stand-in module object with __doc__/__file__ attributes."""
+    mod = types.ModuleType("fake_plugin_module")
+    mod.__doc__ = doc
+    if file is not None:
+        mod.__file__ = file
+    return mod
+
+
+# ── plugin_meta._resolve_module / tier templates ──────────────────────────
+
+
+class TestResolveModule:
+    def test_unknown_tier_returns_none(self):
+        assert plugin_meta._resolve_module("anything", "bogus_tier") is None
+
+    @pytest.mark.parametrize(
+        "tier,template",
+        [
+            ("builtin", "code_puppy.plugins.{name}.register_callbacks"),
+            ("user", "{name}.register_callbacks"),
+            ("project", "project_plugins.{name}.register_callbacks"),
+        ],
+    )
+    def test_resolves_each_tier(self, tier, template, monkeypatch):
+        mod = _fake_module(doc="x")
+        modname = template.format(name="fakeplug")
+        monkeypatch.setitem(__import__("sys").modules, modname, mod)
+        assert plugin_meta._resolve_module("fakeplug", tier) is mod
+
+    def test_missing_module_returns_none(self):
+        # Nothing registered under this name → None.
+        assert plugin_meta._resolve_module("definitely_not_loaded", "builtin") is None
+
+
+# ── plugin_meta.get_description ───────────────────────────────────────────
+
+
+class TestGetDescription:
+    def _install(self, monkeypatch, doc):
+        mod = _fake_module(doc=doc, file="/x/register_callbacks.py")
+        monkeypatch.setitem(
+            __import__("sys").modules,
+            "code_puppy.plugins.descplug.register_callbacks",
+            mod,
+        )
+
+    def test_first_paragraph_only(self, monkeypatch):
+        self._install(
+            monkeypatch,
+            "Short summary line.\n\nA second paragraph with extra detail "
+            "that should be dropped.",
+        )
+        assert (
+            plugin_meta.get_description("descplug", "builtin") == "Short summary line."
+        )
+
+    def test_newline_collapsing(self, monkeypatch):
+        self._install(
+            monkeypatch,
+            "First wrapped\nsummary line\nspanning three rows.\n\nrest",
+        )
+        assert (
+            plugin_meta.get_description("descplug", "builtin")
+            == "First wrapped summary line spanning three rows."
+        )
+
+    def test_none_when_module_missing(self):
+        assert plugin_meta.get_description("nope_missing", "builtin") is None
+
+    def test_none_when_docstring_missing(self, monkeypatch):
+        self._install(monkeypatch, None)
+        assert plugin_meta.get_description("descplug", "builtin") is None
+
+    def test_none_when_docstring_only_whitespace(self, monkeypatch):
+        self._install(monkeypatch, "   \n\n   ")
+        assert plugin_meta.get_description("descplug", "builtin") is None
+
+    def test_none_for_unknown_tier(self, monkeypatch):
+        self._install(monkeypatch, "Has a docstring.")
+        assert plugin_meta.get_description("descplug", "bogus_tier") is None
+
+
+# ── plugin_meta.get_file_path ─────────────────────────────────────────────
+
+
+class TestGetFilePath:
+    def test_returns_file_when_resolvable(self, monkeypatch):
+        mod = _fake_module(doc="d", file="/plugins/pathplug/register_callbacks.py")
+        monkeypatch.setitem(
+            __import__("sys").modules,
+            "user_pathplug.register_callbacks",
+            mod,
+        )
+        # user tier template is "{name}.register_callbacks"
+        assert (
+            plugin_meta.get_file_path("user_pathplug", "user")
+            == "/plugins/pathplug/register_callbacks.py"
+        )
+
+    def test_none_when_module_missing(self):
+        assert plugin_meta.get_file_path("nope_missing", "builtin") is None
+
+    def test_none_when_file_attr_missing(self, monkeypatch):
+        mod = _fake_module(doc="d")  # no __file__ set
+        # ensure no __file__ leaks from ModuleType defaults
+        if hasattr(mod, "__file__"):
+            del mod.__file__
+        monkeypatch.setitem(
+            __import__("sys").modules,
+            "code_puppy.plugins.nofile.register_callbacks",
+            mod,
+        )
+        assert plugin_meta.get_file_path("nofile", "builtin") is None
+
+    def test_none_for_unknown_tier(self):
+        assert plugin_meta.get_file_path("anything", "bogus_tier") is None
+
+
+# ── plugin_meta.get_hooks ─────────────────────────────────────────────────
+
+
+class TestGetHooks:
+    def test_returns_sorted_phases(self, clean_callbacks):
+        _register_owned("hookplug", "shutdown")
+        _register_owned("hookplug", "startup")
+        _register_owned("hookplug", "load_prompt")
+        assert plugin_meta.get_hooks("hookplug") == [
+            "load_prompt",
+            "shutdown",
+            "startup",
+        ]
+
+    def test_empty_when_none(self, clean_callbacks):
+        assert plugin_meta.get_hooks("plugin_with_no_hooks") == []
+
+    def test_ignores_other_owners(self, clean_callbacks):
+        _register_owned("ownerA", "startup")
+        _register_owned("ownerB", "shutdown")
+        assert plugin_meta.get_hooks("ownerA") == ["startup"]
+        assert plugin_meta.get_hooks("ownerB") == ["shutdown"]
+
+    def test_disabled_plugin_still_registered(self, clean_callbacks):
+        """Disabled plugins keep their callbacks registered — only dispatch
+        skips them — so the preview must still surface their hooks.
+
+        ``get_hooks`` relies on ``get_callbacks(include_disabled=True)`` to
+        bypass the dispatch-time disabled filter.
+        """
+        _register_owned("disabledplug", "startup")
+        _register_owned("disabledplug", "stream_event")
+        with patch(
+            "code_puppy.plugins.config.get_disabled_plugins",
+            return_value={"disabledplug"},
+        ):
+            assert plugin_meta.get_hooks("disabledplug") == [
+                "startup",
+                "stream_event",
+            ]
+
+    def test_empty_for_unknown_plugin(self, clean_callbacks):
+        assert plugin_meta.get_hooks("never_seen_plugin") == []
+
+
+# ── plugins_menu preview rendering ────────────────────────────────────────
+
+
+def _make_menu(name="previewplug", tier="builtin"):
+    """Construct a PluginsMenu with one entry, bypassing real discovery."""
+    from code_puppy.plugins.plugin_list.plugins_menu import PluginsMenu, _PluginEntry
+
+    with (
+        patch(
+            "code_puppy.plugins.get_loaded_plugins",
+            return_value={"builtin": [], "user": [], "project": []},
+        ),
+        patch(
+            "code_puppy.plugins.config.get_disabled_plugins",
+            return_value=set(),
+        ),
+    ):
+        menu = PluginsMenu()
+    menu.plugins = [_PluginEntry(name, tier)]
+    menu.selected_idx = 0
+    return menu
+
+
+def _flatten(fragments) -> str:
+    return "".join(text for _style, text in fragments)
+
+
+class TestMenuPreview:
+    def test_renders_description_hooks_and_path(self):
+        menu = _make_menu()
+        with (
+            patch.object(
+                plugin_meta, "get_description", return_value="A tidy summary."
+            ),
+            patch.object(
+                plugin_meta,
+                "get_hooks",
+                return_value=["startup", "shutdown"],
+            ),
+            patch.object(
+                plugin_meta,
+                "get_file_path",
+                return_value="/abs/path/register_callbacks.py",
+            ),
+        ):
+            text = _flatten(render_detail(menu))
+
+        assert "previewplug" in text
+        # Description section
+        assert "A tidy summary." in text
+        # Lifecycle-hooks section: header carries the count, bullets list each hook
+        assert "Lifecycle hooks used (2):" in text
+        assert "• startup" in text
+        assert "• shutdown" in text
+        assert "(none registered)" not in text
+        # Path section
+        assert "Path:" in text
+        assert "/abs/path/register_callbacks.py" in text
+
+    def test_renders_none_registered_when_no_hooks(self):
+        menu = _make_menu()
+        with (
+            patch.object(plugin_meta, "get_description", return_value=None),
+            patch.object(plugin_meta, "get_hooks", return_value=[]),
+            patch.object(plugin_meta, "get_file_path", return_value=None),
+        ):
+            text = _flatten(render_detail(menu))
+
+        assert "Lifecycle hooks used (0):" in text
+        assert "(none registered)" in text
+        # No path section when path is unresolved.
+        assert "Path:" not in text
+
+    def test_no_description_section_when_missing(self):
+        menu = _make_menu()
+        with (
+            patch.object(plugin_meta, "get_description", return_value=None),
+            patch.object(plugin_meta, "get_hooks", return_value=["startup"]),
+            patch.object(plugin_meta, "get_file_path", return_value="/x.py"),
+        ):
+            fragments = render_detail(menu)
+            text = _flatten(fragments)
+
+        # Lifecycle hooks still render, description simply omitted.
+        assert "Lifecycle hooks used (1):" in text
+        assert "• startup" in text
+
+    def test_no_plugin_selected(self):
+        menu = _make_menu()
+        menu.plugins = []
+        text = _flatten(render_detail(menu))
+        assert "No plugin selected." in text
+
+
+# ── plugins_menu "Contributes" rendering ───────────────────────────────────
+
+from code_puppy.plugins.plugin_list import plugin_contributions as pc  # noqa: E402
+
+_EMPTY_CONTRIB = {key: [] for key in pc._EXTRACTORS}
+
+
+def _contrib(**overrides):
+    """Build a full contributions dict, overriding only the named categories."""
+    data = dict(_EMPTY_CONTRIB)
+    data.update(overrides)
+    return data
+
+
+class TestMenuContributes:
+    def _render(self, contributions, hooks=None):
+        """Render the detail pane with patched extraction + hooks."""
+        menu = _make_menu()
+        with (
+            patch.object(plugin_meta, "get_description", return_value=None),
+            patch.object(plugin_meta, "get_hooks", return_value=hooks or []),
+            patch.object(plugin_meta, "get_file_path", return_value=None),
+            patch.object(pc, "get_contributions", return_value=contributions),
+        ):
+            return _flatten(render_detail(menu))
+
+    def test_groups_categories_with_names_and_descriptions(self):
+        text = self._render(
+            _contrib(
+                tools=["do_thing"],
+                commands=["/foo — Do foo"],
+                agents=["my-agent"],
+                skills=["my-skill"],
+            )
+        )
+        assert "Contributes:" in text
+        assert "Tools:" in text
+        assert "• do_thing" in text
+        assert "Slash Commands:" in text
+        assert "• /foo — Do foo" in text
+        assert "Agents:" in text
+        assert "• my-agent" in text
+        assert "Skills:" in text
+        assert "• my-skill" in text
+
+    def test_skips_empty_categories(self):
+        text = self._render(_contrib(tools=["only_tool"]))
+        assert "Tools:" in text
+        assert "• only_tool" in text
+        # Categories with nothing in them are not rendered at all.
+        assert "Slash Commands:" not in text
+        assert "Agents:" not in text
+        assert "Skills:" not in text
+        assert "Model Types:" not in text
+
+    def test_renders_nothing_when_no_contributions(self):
+        text = self._render(_contrib())
+        assert "Contributes:" not in text
+        # The other sections still render so the preview isn't blank.
+        assert "Lifecycle hooks used (0):" in text
+
+    def test_command_handler_without_help_shows_placeholder(self):
+        # No custom_command_help entries, but a custom_command hook exists.
+        text = self._render(_contrib(), hooks=["custom_command"])
+        assert "Contributes:" in text
+        assert "Slash Commands:" in text
+        assert "• command handler (name unknown)" in text
+
+    def test_real_commands_win_over_placeholder(self):
+        # When help entries exist we never fall back to the placeholder, even
+        # if a custom_command hook is also registered.
+        text = self._render(
+            _contrib(commands=["/named — A real command"]),
+            hooks=["custom_command"],
+        )
+        assert "• /named — A real command" in text
+        assert "command handler (name unknown)" not in text
+
+    def test_all_categories_render(self):
+        text = self._render(
+            _contrib(
+                tools=["t"],
+                commands=["/c"],
+                agents=["a"],
+                skills=["s"],
+                model_types=["mt"],
+                model_providers=["mp"],
+                mcp_servers=["srv"],
+                browser_types=["bt"],
+                agent_tools=["at"],
+            )
+        )
+        for label in (
+            "Tools:",
+            "Slash Commands:",
+            "Agents:",
+            "Skills:",
+            "Model Types:",
+            "Model Providers:",
+            "MCP Servers:",
+            "Browser Types:",
+            "Agent Tools:",
+        ):
+            assert label in text
+
+    def test_long_contributions_get_wrapped(self):
+        """Long entries (e.g. agent_skills /<skill>) must wrap to pane width.
+
+        Without wrapping, the long tail extends past our padding cap and leaves
+        stale glyphs (a literal "...") when the user navigates to a plugin
+        whose detail content doesn't reach those columns.
+        """
+        menu = _make_menu()
+        # Force a narrow detail pane so wrapping is unambiguous.
+        menu._detail_cols = 40
+        long_cmd = "/x — " + ("long " * 20).strip()
+        with (
+            patch.object(plugin_meta, "get_description", return_value=None),
+            patch.object(plugin_meta, "get_hooks", return_value=[]),
+            patch.object(plugin_meta, "get_file_path", return_value=None),
+            patch.object(
+                pc, "get_contributions", return_value=_contrib(commands=[long_cmd])
+            ),
+        ):
+            fragments = render_detail(menu)
+
+        # Every (style, text) fragment whose payload is real content (not just
+        # whitespace/newlines) must fit within the pane's inner width.
+        inner = menu._detail_cols - 2
+        for _style, text in fragments:
+            for line in text.split("\n"):
+                assert len(line) <= inner, f"Line exceeds inner width {inner}: {line!r}"
+
+    def test_extraction_failure_degrades_gracefully(self):
+        """A raising ``get_contributions`` renders nothing extra, not a crash."""
+        menu = _make_menu()
+        with (
+            patch.object(plugin_meta, "get_description", return_value=None),
+            patch.object(plugin_meta, "get_hooks", return_value=[]),
+            patch.object(plugin_meta, "get_file_path", return_value=None),
+            patch.object(pc, "get_contributions", side_effect=RuntimeError("boom")),
+        ):
+            text = _flatten(render_detail(menu))
+        assert "Contributes:" not in text
+        assert "Lifecycle hooks used (0):" in text
+
+
+# ── detail pane scrolling ──────────────────────────────────────────────────
+
+from code_puppy.plugins.plugin_list import plugin_text_utils as ptu  # noqa: E402
+
+
+class TestLineSlicing:
+    def test_count_lines(self):
+        assert ptu.count_lines([("", "a\nb\n"), ("", "c\n")]) == 3
+        assert ptu.count_lines([("", "no newline")]) == 0
+
+    def test_drop_zero_returns_all(self):
+        frags = [("s", "a\n"), ("s", "b\n")]
+        assert ptu.drop_leading_lines(frags, 0) == frags
+
+    def test_drop_leading_lines(self):
+        frags = [("x", "l0\n"), ("y", "l1\n"), ("z", "l2\n")]
+        assert _flatten(ptu.drop_leading_lines(frags, 2)) == "l2\n"
+
+    def test_drop_across_fragment_boundary(self):
+        # One logical line spread across two fragments, then the next line.
+        frags = [("a", "line0 "), ("b", "rest\n"), ("c", "line1\n")]
+        assert _flatten(ptu.drop_leading_lines(frags, 1)) == "line1\n"
+
+    def test_drop_more_than_available(self):
+        assert ptu.drop_leading_lines([("a", "only\n")], 5) == []
+
+    def test_wrap_text_short_returns_single_piece(self):
+        assert ptu.wrap_text("hi there", 20) == ["hi there"]
+
+    def test_wrap_text_breaks_after_last_space(self):
+        # Width 10 -> first window "the quick " (10 chars, break after space).
+        pieces = ptu.wrap_text("the quick brown fox", 10)
+        assert "".join(pieces) == "the quick brown fox"
+        assert all(len(p) <= 10 for p in pieces)
+
+    def test_wrap_text_hard_breaks_long_unbroken_token(self):
+        # A path-like string with no spaces should hard-break, losing nothing.
+        path = "C:\\Users\\weege\\code\\thing.py"
+        pieces = ptu.wrap_text(path, 8)
+        assert "".join(pieces) == path
+        assert all(len(p) <= 8 for p in pieces)
+
+    def test_wrap_text_zero_width_is_noop(self):
+        assert ptu.wrap_text("anything", 0) == ["anything"]
+
+    def test_cell_width_ascii_matches_len(self):
+        assert ptu.cell_width("hello") == 5
+
+    def test_cell_width_emoji_is_two(self):
+        # \U0001F436 is the dog-face emoji (1 Python char, 2 terminal cells).
+        assert ptu.cell_width("\U0001f436") == 2
+
+    def test_cell_width_hammer_wrench_with_vs16_is_two(self):
+        # U+1F6E0 + U+FE0F (variation selector). prompt_toolkit's get_cwidth
+        # under-reports the hammer-wrench at 1 cell; our emoji-range override
+        # forces it to 2. VS16 stays at 0. This is the exact bug that surfaces
+        # in agent_skills contributions, where every /skill is labelled with
+        # this glyph and the undercount bled into the divider.
+        assert ptu.cell_width("\U0001f6e0\ufe0f") == 2
+
+    def test_cell_width_dingbat_is_two(self):
+        # U+2705 (white heavy check mark) sits in the Dingbats range our
+        # override covers; terminals render it at 2 cells.
+        assert ptu.cell_width("\u2705") == 2
+
+    def test_strip_emojis_removes_emoji_and_vs16(self):
+        # Hammer-wrench + VS16, dog face, check mark — all gone. ASCII stays.
+        assert (
+            ptu.strip_emojis("foo \U0001f6e0\ufe0f bar \U0001f436 baz \u2705")
+            == "foo  bar  baz "
+        )
+
+    def test_strip_emojis_removes_zwj(self):
+        # ZWJ sequences (e.g. family emoji) leave no residue.
+        assert ptu.strip_emojis("a\u200db") == "ab"
+
+    def test_strip_emojis_preserves_ascii_and_newlines(self):
+        assert ptu.strip_emojis("hello\nworld\t!") == "hello\nworld\t!"
+
+    def test_strip_emojis_from_fragments_walks_every_fragment(self):
+        frags = [("bold", "a\U0001f436b"), ("", "c\u2705d")]
+        assert ptu.strip_emojis_from_fragments(frags) == [
+            ("bold", "ab"),
+            ("", "cd"),
+        ]
+
+    def test_pad_lines_to_cells_pads_short_lines(self):
+        frags = [("", "hi\n")]
+        out = ptu.pad_lines_to_cells(frags, 5)
+        assert _flatten(out) == "hi   \n"
+
+    def test_pad_lines_to_cells_accounts_for_emoji_width(self):
+        # Emoji is 2 cells, so " X" (where X is the emoji) is 3 cells total
+        # and needs 2 trailing spaces to reach width 5.
+        frags = [("", " \U0001f436\n")]
+        out = ptu.pad_lines_to_cells(frags, 5)
+        assert _flatten(out) == " \U0001f436  \n"
+
+    def test_pad_lines_to_cells_zero_width_noop(self):
+        frags = [("", "x\n")]
+        assert ptu.pad_lines_to_cells(frags, 0) == frags
+
+
+class TestRecomputeDimensions:
+    def test_first_call_returns_true_and_sets_widths(self):
+        menu = _make_menu()
+        with patch.object(menu, "_measure_terminal", return_value=(120, 40)):
+            changed = menu._recompute_dimensions()
+        assert changed is True
+        assert menu._menu_cols > 0
+        assert menu._detail_cols > 0
+        assert menu._last_size == (120, 40)
+
+    def test_unchanged_size_is_noop(self):
+        menu = _make_menu()
+        with patch.object(menu, "_measure_terminal", return_value=(120, 40)):
+            menu._recompute_dimensions()
+            assert menu._recompute_dimensions() is False
+
+    def test_resize_triggers_recompute(self):
+        menu = _make_menu()
+        with patch.object(menu, "_measure_terminal", return_value=(120, 40)):
+            menu._recompute_dimensions()
+            first_detail = menu._detail_cols
+        with patch.object(menu, "_measure_terminal", return_value=(200, 50)):
+            assert menu._recompute_dimensions() is True
+        assert menu._detail_cols != first_detail
+        assert menu._last_size == (200, 50)
+
+
+class TestDetailScroll:
+    def test_scroll_clamps_at_top(self):
+        menu = _make_menu()
+        menu._scroll_detail(-1)
+        assert menu.detail_scroll == 0
+
+    def test_scroll_down_then_up(self):
+        menu = _make_menu()
+        with patch.object(menu, "_max_detail_scroll", return_value=5):
+            menu._scroll_detail(3)
+            assert menu.detail_scroll == 3
+            menu._scroll_detail(-1)
+            assert menu.detail_scroll == 2
+
+    def test_scroll_clamped_to_max(self):
+        menu = _make_menu()
+        with patch.object(menu, "_max_detail_scroll", return_value=2):
+            menu._scroll_detail(10)
+            assert menu.detail_scroll == 2
+
+    def test_update_display_applies_scroll(self):
+        from prompt_toolkit.layout.controls import FormattedTextControl
+
+        menu = _make_menu()
+        # Disable cell-padding and blank-row filling so this test stays focused
+        # on slice behaviour.
+        menu._menu_cols = 0
+        menu._detail_cols = 0
+        menu._pane_rows = 0
+        menu.menu_control = FormattedTextControl(text="")
+        menu.detail_control = FormattedTextControl(text="")
+        # Patch the name as it's bound inside plugins_menu (which imported
+        # ``render_detail`` at module-load time) so update_display() picks
+        # up the stub.
+        with patch(
+            "code_puppy.plugins.plugin_list.plugins_menu.render_detail",
+            return_value=[("", "l0\n"), ("", "l1\n"), ("", "l2\n")],
+        ):
+            menu.detail_scroll = 1
+            menu.update_display()
+        assert _flatten(menu.detail_control.text) == "l1\nl2\n"
+
+
+class TestFillPane:
+    def test_short_content_padded_to_pane_rows(self):
+        # pane_cols=10 -> inner width = 8 (cols - 2 for frame border).
+        out = fill_pane([("", "hi\n")], pane_cols=10, pane_rows=5)
+        text = _flatten(out)
+        # 5 rows total: 1 real (padded to 8 cells) + 4 blank (each 8 spaces).
+        assert text.count("\n") == 5
+        assert text.startswith("hi      \n")
+        # Every blank row is 8 spaces.
+        for line in text.split("\n")[1:-1]:
+            assert line == " " * 8
+
+    def test_content_already_full_height_not_extra_padded(self):
+        out = fill_pane(
+            [("", "a\n"), ("", "b\n"), ("", "c\n")], pane_cols=5, pane_rows=3
+        )
+        # 3 rows of content, 3 rows requested -> no extra blanks.
+        assert _flatten(out).count("\n") == 3
+
+    def test_content_without_trailing_newline_gets_one(self):
+        out = fill_pane([("", "no-newline")], pane_cols=15, pane_rows=3)
+        # Trailing \n added, then padded to 3 rows total.
+        assert _flatten(out).count("\n") == 3


### PR DESCRIPTION
…tion

- New plugin detail panel rendering in /plugins menu

- Wire plugins_menu to the previously-orphaned render module

- DRY/SOLID pass and WHY-only comment cleanup on plugin_list

- Normalize agent_skills dirs to POSIX for cross-platform display parity

## Before & After
https://github.com/user-attachments/assets/f8cb3edb-0b3e-49ba-8abf-8cc45b9c270f

