### PR TITLE
feat(callbacks): add register_cli_args/handle_cli_args plugin hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,8 @@ and skills (`<CWD>/.code_puppy/skills/`).
 | `register_agents` | Agent catalogue | `() -> list[dict]` with `{"name": str, "class": type}` |
 | `register_model_type` | Custom model type | `() -> list[dict]` with `{"type": str, "handler": callable}` |
 | `register_skills` | Skill catalogue | `() -> list[dict]` with `{"name": str, "skill_md" \| "skill_md_path" \| "frontmatter"+"body"}` |
+| `register_cli_args` | Before CLI `parse_args()` | `(parser) -> list` — plugins call `parser.add_argument(...)`; namespace flags (e.g. `--myplugin-foo`) to avoid argparse collisions |
+| `handle_cli_args` | After CLI `parse_args()` | `(args) -> dict \| None` — return `{"handled": True, "exit_code": int}` to terminate the CLI cleanly; return `None` to let startup proceed |
 | `load_model_config` | Patch model config | `(*args, **kwargs) -> Any` |
 | `load_models_config` | Inject models | `() -> dict` |
 | `load_model_descriptions` | Inject description overlays | `() -> dict[str, str]` |

--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -31,6 +31,8 @@ PhaseType = Literal[
     "register_agents",
     "register_model_type",
     "register_skills",
+    "register_cli_args",
+    "handle_cli_args",
     "get_model_system_prompt",
     "prepare_model_prompt",
     "agent_run_start",
@@ -85,6 +87,8 @@ _callbacks: Dict[PhaseType, List[CallbackFunc]] = {
     "register_agents": [],
     "register_model_type": [],
     "register_skills": [],
+    "register_cli_args": [],
+    "handle_cli_args": [],
     "get_model_system_prompt": [],
     "prepare_model_prompt": [],
     "agent_run_start": [],
@@ -232,7 +236,18 @@ def count_callbacks(phase: Optional[PhaseType] = None) -> int:
     return len(_callbacks.get(phase, []))
 
 
-def _trigger_callbacks_sync(phase: PhaseType, *args, **kwargs) -> List[Any]:
+def _trigger_callbacks_sync(
+    phase: PhaseType, *args, raise_on_error: bool = False, **kwargs
+) -> List[Any]:
+    """Run all sync callbacks for ``phase`` and collect their results.
+
+    By default each callback is wrapped in its own try/except so a single
+    misbehaving plugin can't take down the app (error isolation). For phases
+    where a callback failure is a *fatal* developer error that must surface
+    immediately (e.g. ``register_cli_args`` adding a duplicate/conflicting
+    option string), pass ``raise_on_error=True`` to disable the isolation and
+    let the exception propagate (fail-fast).
+    """
     callbacks = get_callbacks(phase)
     if not callbacks:
         logger.debug(f"No callbacks registered for phase '{phase}'")
@@ -265,6 +280,8 @@ def _trigger_callbacks_sync(phase: PhaseType, *args, **kwargs) -> List[Any]:
                 f"Callback {callback.__name__} failed in phase '{phase}': {e}\n"
                 f"{traceback.format_exc()}"
             )
+            if raise_on_error:
+                raise
             results.append(None)
 
     return results
@@ -575,6 +592,51 @@ def on_register_agents() -> List[Dict[str, Any]]:
     Example return: [{"name": "my-agent", "class": MyAgentClass}]
     """
     return _trigger_callbacks_sync("register_agents")
+
+
+def on_register_cli_args(parser: Any) -> List[Any]:
+    """Let plugins contribute top-level arguments to the ``code-puppy`` CLI.
+
+    Called once during CLI bootstrap, *before* arguments are parsed. Each
+    callback receives the shared ``argparse.ArgumentParser`` (or an
+    argument group) and should register its own flags via the usual
+    ``parser.add_argument(...)`` calls. Plugins must use unique, namespaced
+    option strings (e.g. ``--myplugin-foo``) to avoid colliding with core
+    flags or one another.
+
+    Callback contract: ``(parser: argparse.ArgumentParser) -> None``.
+    Return values are ignored; mutate the parser in place.
+
+    Unlike most hooks, this phase does **not** isolate callback errors: a
+    duplicate/conflicting option string (or any other failure while building
+    the parser) is a fatal developer error, so the exception propagates
+    (fail-fast) instead of being swallowed.
+
+    Returns the list of (typically ``None``) callback results.
+    """
+    return _trigger_callbacks_sync("register_cli_args", parser, raise_on_error=True)
+
+
+def on_handle_cli_args(args: Any) -> List[Any]:
+    """Let plugins act on parsed CLI arguments before the app proceeds.
+
+    Called once after ``parse_args``, giving each plugin a chance to inspect
+    the parsed ``argparse.Namespace`` and react to its own flags. A plugin
+    that fully handles the invocation (and wants the process to exit instead
+    of continuing into the normal run) should return the sentinel dict::
+
+        {"handled": True, "exit_code": int}
+
+    The CLI runner scans the collected results for the first entry with
+    ``handled == True`` and exits with the supplied ``exit_code``. Plugins
+    that merely observe the args (without short-circuiting) should return
+    ``None``.
+
+    Callback contract: ``(args: argparse.Namespace) -> dict | None``.
+
+    Returns the list of callback results for the runner to scan.
+    """
+    return _trigger_callbacks_sync("handle_cli_args", args)
 
 
 def on_register_model_types() -> List[Dict[str, Any]]:

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -231,7 +231,20 @@ async def main():
     parser.add_argument(
         "command", nargs="*", help="Run a single command (deprecated, use -p instead)"
     )
+
+    # Let plugins contribute their own top-level CLI arguments. Plugins are
+    # already loaded at import time, so every register_cli_args callback is
+    # registered before the parser is built. Duplicate option strings raise
+    # here = fail fast.
+    callbacks.on_register_cli_args(parser)
+
     args = parser.parse_args()
+
+    # Give plugins a chance to act on parsed args and short-circuit startup.
+    # The first result dict with handled=True wins, exiting with its exit_code.
+    for result in callbacks.on_handle_cli_args(args):
+        if isinstance(result, dict) and result.get("handled"):
+            return result.get("exit_code", 0)
 
     from code_puppy.messaging import (
         RichConsoleRenderer,
@@ -1264,7 +1277,10 @@ def main_entry():
     """Entry point for the installed CLI tool."""
     _force_utf8_stdio()
     try:
-        asyncio.run(main())
+        # Capture main()'s return value so handle_cli_args plugins (and the
+        # normal return-0 path) actually influence the process exit status.
+        # main() may return None (treated as 0) or an int exit code.
+        rc = asyncio.run(main())
     except KeyboardInterrupt:
         # Note: Using sys.stderr for crash output - messaging system may not be available
         sys.stderr.write(traceback.format_exc())
@@ -1272,3 +1288,5 @@ def main_entry():
     finally:
         # Reset terminal on Unix-like systems (not Windows)
         reset_unix_terminal()
+    # Guard None -> 0 and propagate to the process exit status.
+    sys.exit(rc if rc is not None else 0)

--- a/tests/test_callbacks_extended.py
+++ b/tests/test_callbacks_extended.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from code_puppy.callbacks import (
+    _trigger_callbacks_sync,
     clear_callbacks,
     count_callbacks,
     get_callbacks,
@@ -14,6 +15,7 @@ from code_puppy.callbacks import (
     on_load_model_config,
     on_post_tool_call,
     on_pre_tool_call,
+    on_register_cli_args,
     on_replace_in_file,
     on_startup,
     on_stream_event,
@@ -662,3 +664,118 @@ class TestStreamEventCallback:
             assert results[1] == "OK"  # Survived
             assert successful_events == ["token"]
             mock_logger.error.assert_called_once()
+
+
+class TestTriggerCallbacksRaiseOnError:
+    """Regression coverage for the ``raise_on_error`` fail-fast knob.
+
+    Bug beadworks-dmg: ``register_cli_args`` argparse conflicts were silently
+    swallowed by the per-callback error isolation in ``_trigger_callbacks_sync``.
+    The fix added an opt-in ``raise_on_error`` flag so fatal phases surface the
+    exception instead of logging+swallowing it. These tests lock in that the
+    flag is *surgical*: it only changes behavior when explicitly requested, and
+    error isolation remains the default for every other phase.
+    """
+
+    def setup_method(self):
+        clear_callbacks()
+
+    def test_default_swallows_callback_exception(self):
+        """Default behavior (raise_on_error=False) keeps error isolation."""
+        survived = []
+
+        def boom():
+            raise ValueError("kaboom")
+
+        def survivor():
+            survived.append(True)
+            return "ok"
+
+        register_callback("startup", boom)
+        register_callback("startup", survivor)
+
+        with patch("code_puppy.callbacks.logger") as mock_logger:
+            results = _trigger_callbacks_sync("startup")
+
+        # The crash is swallowed (None) and the next callback still runs.
+        assert results == [None, "ok"]
+        assert survived == [True]
+        mock_logger.error.assert_called_once()
+
+    def test_raise_on_error_propagates_exception(self):
+        """raise_on_error=True re-raises the first failing callback."""
+
+        def boom():
+            raise ValueError("kaboom")
+
+        register_callback("startup", boom)
+
+        with pytest.raises(ValueError, match="kaboom"):
+            _trigger_callbacks_sync("startup", raise_on_error=True)
+
+    def test_raise_on_error_logs_before_raising(self):
+        """The failure is still logged for diagnostics before it propagates."""
+
+        def boom():
+            raise RuntimeError("explode")
+
+        register_callback("startup", boom)
+
+        with patch("code_puppy.callbacks.logger") as mock_logger:
+            with pytest.raises(RuntimeError, match="explode"):
+                _trigger_callbacks_sync("startup", raise_on_error=True)
+        mock_logger.error.assert_called_once()
+
+    def test_raise_on_error_stops_at_first_failure(self):
+        """A later callback never runs once an earlier one raises fatally."""
+        ran = []
+
+        def boom():
+            ran.append("boom")
+            raise ValueError("stop here")
+
+        def never():
+            ran.append("never")
+
+        register_callback("startup", boom)
+        register_callback("startup", never)
+
+        with pytest.raises(ValueError, match="stop here"):
+            _trigger_callbacks_sync("startup", raise_on_error=True)
+
+        assert ran == ["boom"]
+
+    def test_on_register_cli_args_fails_fast_on_callback_error(self):
+        """on_register_cli_args opts into fail-fast (the actual bug fix)."""
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--agent")  # core flag
+
+        def colliding_plugin(p):
+            # A plugin reusing a core option string is a fatal dev error.
+            p.add_argument("--agent")
+
+        register_callback("register_cli_args", colliding_plugin)
+
+        with pytest.raises(argparse.ArgumentError) as excinfo:
+            on_register_cli_args(parser)
+        assert "conflicting option string" in str(excinfo.value)
+
+    def test_other_phases_still_isolated(self):
+        """The sibling sync phase handle_cli_args must STILL swallow errors.
+
+        Proves the fail-fast change was surgical to register_cli_args only and
+        didn't accidentally flip the default for the whole hook system.
+        """
+        from code_puppy.callbacks import on_handle_cli_args
+
+        def boom(args):
+            raise ValueError("handler bug")
+
+        register_callback("handle_cli_args", boom)
+
+        with patch("code_puppy.callbacks.logger") as mock_logger:
+            results = on_handle_cli_args(object())  # must not raise
+        assert results == [None]
+        mock_logger.error.assert_called_once()

--- a/tests/test_cli_runner_coverage.py
+++ b/tests/test_cli_runner_coverage.py
@@ -250,12 +250,30 @@ class TestExecuteSinglePrompt:
 class TestMainEntry:
     @patch("asyncio.run")
     def test_normal_exit(self, mock_run):
+        import pytest
+
         from code_puppy.cli_runner import main_entry
 
+        # main() returning None must map to a clean exit code of 0.
         mock_run.return_value = None
         with patch("code_puppy.cli_runner.reset_unix_terminal"):
-            result = main_entry()
-        assert result is None
+            with pytest.raises(SystemExit) as exc_info:
+                main_entry()
+        assert exc_info.value.code == 0
+
+    @patch("asyncio.run")
+    def test_nonzero_exit_code_propagates(self, mock_run):
+        import pytest
+
+        from code_puppy.cli_runner import main_entry
+
+        # A handle_cli_args plugin asking for exit_code 7 flows up through
+        # main() -> main_entry() and must become the process exit code.
+        mock_run.return_value = 7
+        with patch("code_puppy.cli_runner.reset_unix_terminal"):
+            with pytest.raises(SystemExit) as exc_info:
+                main_entry()
+        assert exc_info.value.code == 7
 
     @patch("asyncio.run", side_effect=KeyboardInterrupt)
     def test_keyboard_interrupt(self, mock_run):

--- a/tests/test_cli_runner_plugin_cli_args.py
+++ b/tests/test_cli_runner_plugin_cli_args.py
@@ -1,0 +1,194 @@
+"""Tests for plugin-registered CLI args wiring in cli_runner.main().
+
+Covers the register_cli_args / handle_cli_args hooks added to main():
+- register_cli_args callbacks get the live parser before parse_args().
+- a plugin flag appears in parsed args and in ``code-puppy --help`` output.
+- handle_cli_args callbacks can short-circuit startup with a clean exit.
+- a handler returning None leaves normal startup intact.
+- duplicate option strings fail fast with an argparse.ArgumentError.
+"""
+
+import argparse
+import asyncio
+from contextlib import ExitStack
+from unittest.mock import patch
+
+import pytest
+
+from code_puppy import callbacks
+from code_puppy.cli_runner import main
+
+
+@pytest.fixture
+def clean_cli_hooks():
+    """Snapshot/restore the cli-arg callback registries around each test."""
+    register_before = list(callbacks._callbacks["register_cli_args"])
+    handle_before = list(callbacks._callbacks["handle_cli_args"])
+    callbacks._callbacks["register_cli_args"] = []
+    callbacks._callbacks["handle_cli_args"] = []
+    try:
+        yield
+    finally:
+        callbacks._callbacks["register_cli_args"] = register_before
+        callbacks._callbacks["handle_cli_args"] = handle_before
+
+
+def test_register_cli_args_runs_before_parse(clean_cli_hooks):
+    """A plugin-registered flag is added to the parser and parsed into args."""
+    seen = {}
+
+    def _register(parser):
+        parser.add_argument("--myplugin-foo", dest="myplugin_foo", default=None)
+
+    def _handle(args):
+        seen["foo"] = getattr(args, "myplugin_foo", "MISSING")
+        # Short-circuit so the rest of main() never runs.
+        return {"handled": True, "exit_code": 0}
+
+    callbacks.register_callback("register_cli_args", _register)
+    callbacks.register_callback("handle_cli_args", _handle)
+
+    with ExitStack() as stack:
+        stack.enter_context(patch("sys.argv", ["code-puppy", "--myplugin-foo", "bar"]))
+        result = asyncio.run(main())
+
+    assert result == 0
+    # The plugin flag was registered before parse_args and parsed correctly.
+    assert seen["foo"] == "bar"
+
+
+def test_plugin_flag_appears_in_help(clean_cli_hooks, capsys):
+    """A plugin-registered flag shows up in ``code-puppy --help`` output.
+
+    argparse prints help to stdout and exits 0, so we expect SystemExit and
+    then assert the flag + its help string made it into the rendered help.
+    """
+
+    def _register(parser):
+        parser.add_argument(
+            "--myplugin-xyz",
+            dest="myplugin_xyz",
+            help="the all-important xyz flag",
+        )
+
+    callbacks.register_callback("register_cli_args", _register)
+
+    with ExitStack() as stack:
+        stack.enter_context(patch("sys.argv", ["code-puppy", "--help"]))
+        with pytest.raises(SystemExit) as excinfo:
+            asyncio.run(main())
+
+    # --help is a clean exit.
+    assert excinfo.value.code == 0
+    out = capsys.readouterr().out
+    assert "--myplugin-xyz" in out
+    assert "the all-important xyz flag" in out
+
+
+def test_duplicate_option_strings_raise_argparse_error(clean_cli_hooks):
+    """Two callbacks declaring the same option string fail fast.
+
+    register_cli_args is intentionally NOT error-isolated: a conflicting
+    option string is a fatal developer error, so the argparse.ArgumentError
+    must propagate out of main() rather than being silently swallowed.
+    """
+
+    def _first(parser):
+        parser.add_argument("--dup-flag", dest="dup_flag_a")
+
+    def _second(parser):
+        parser.add_argument("--dup-flag", dest="dup_flag_b")
+
+    callbacks.register_callback("register_cli_args", _first)
+    callbacks.register_callback("register_cli_args", _second)
+
+    with ExitStack() as stack:
+        stack.enter_context(patch("sys.argv", ["code-puppy"]))
+        with pytest.raises(argparse.ArgumentError) as excinfo:
+            asyncio.run(main())
+
+    msg = str(excinfo.value)
+    assert "conflicting option string" in msg
+    assert "--dup-flag" in msg
+
+
+def test_handle_cli_args_short_circuits_with_exit_code(clean_cli_hooks):
+    """A handled=True result returns its exit_code from main()."""
+
+    def _handle(args):
+        return {"handled": True, "exit_code": 7}
+
+    callbacks.register_callback("handle_cli_args", _handle)
+
+    with ExitStack() as stack:
+        stack.enter_context(patch("sys.argv", ["code-puppy"]))
+        result = asyncio.run(main())
+
+    assert result == 7
+
+
+def test_handle_cli_args_default_exit_code_zero(clean_cli_hooks):
+    """A handled result without exit_code defaults to 0."""
+
+    def _handle(args):
+        return {"handled": True}
+
+    callbacks.register_callback("handle_cli_args", _handle)
+
+    with ExitStack() as stack:
+        stack.enter_context(patch("sys.argv", ["code-puppy"]))
+        result = asyncio.run(main())
+
+    assert result == 0
+
+
+def test_first_handled_result_wins(clean_cli_hooks):
+    """The first handled=True result short-circuits; later handlers ignored."""
+    calls = []
+
+    def _first(args):
+        calls.append("first")
+        return {"handled": True, "exit_code": 3}
+
+    def _second(args):
+        calls.append("second")
+        return {"handled": True, "exit_code": 99}
+
+    callbacks.register_callback("handle_cli_args", _first)
+    callbacks.register_callback("handle_cli_args", _second)
+
+    with ExitStack() as stack:
+        stack.enter_context(patch("sys.argv", ["code-puppy"]))
+        result = asyncio.run(main())
+
+    # Both callbacks execute (results collected), but the first handled wins.
+    assert result == 3
+    assert calls[0] == "first"
+
+
+def test_handler_returning_none_does_not_short_circuit(clean_cli_hooks):
+    """A handler returning None must not short-circuit; main() proceeds.
+
+    We bail out shortly after the hook by raising from a patched downstream
+    dependency, proving the early-return branch was *not* taken.
+    """
+
+    def _observe(args):
+        return None  # observe only
+
+    callbacks.register_callback("handle_cli_args", _observe)
+
+    sentinel = RuntimeError("proceeded past cli-args hook")
+
+    with ExitStack() as stack:
+        stack.enter_context(patch("sys.argv", ["code-puppy", "-p", "hi"]))
+        # First thing main() touches after the hook is the messaging import path;
+        # force a recognizable failure to confirm we got past the early return.
+        stack.enter_context(
+            patch(
+                "code_puppy.messaging.get_global_queue",
+                side_effect=sentinel,
+            )
+        )
+        with pytest.raises(RuntimeError, match="proceeded past cli-args hook"):
+            asyncio.run(main())


### PR DESCRIPTION
feat(callbacks): add register_cli_args/handle_cli_args plugin hooks
Allow plugins to contribute their own top-level CLI arguments to the
code-puppy CLI and act on them, without editing core command-line code.

- Add register_cli_args/handle_cli_args callback phases + wrappers in
  callbacks.py. register_cli_args fires with the live ArgumentParser
  before parse_args() (fail-fast: not error-isolated, so duplicate
  option strings raise). handle_cli_args fires after parse_args(); the
  first result dict with handled==True short-circuits startup.
- Wire both hooks into cli_runner.main(), returning the plugin's
  exit_code on short-circuit.
- Propagate main()'s return value through main_entry() via
  sys.exit(rc if rc is not None else 0) so plugin exit codes (and the
  normal return-0 path) reach the process exit status.
- Document the hooks and the terminal-exit contract in AGENTS.md.
- Add unit + end-to-end test coverage for the new hooks, the
  raise_on_error fail-fast path, and exit-code propagation.