### PR TITLE
PUP-375: recover wrapped streaming errors (ModelAPIError, upstream_idle_timeout) and persist diagnostics to errors.log

### DIFF
--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -207,18 +207,14 @@ def _is_retryable_one(exc: BaseException) -> bool:
                 return _matches_retryable_snippet(body_msg)
 
     # Anthropic SDK: a bare APIConnectionError is, by definition, transient.
-    if (
-        AnthropicAPIConnectionError is not None
-        and isinstance(exc, AnthropicAPIConnectionError)
+    if AnthropicAPIConnectionError is not None and isinstance(
+        exc, AnthropicAPIConnectionError
     ):
         return True
 
     # Anthropic SDK: status errors are retryable on 5xx (or unset) OR when the
     # message/body matches a gateway-transient snippet (e.g. upstream_idle_timeout).
-    if (
-        AnthropicAPIStatusError is not None
-        and isinstance(exc, AnthropicAPIStatusError)
-    ):
+    if AnthropicAPIStatusError is not None and isinstance(exc, AnthropicAPIStatusError):
         status_code = getattr(exc, "status_code", None)
         if status_code is None or (isinstance(status_code, int) and status_code >= 500):
             return True
@@ -317,7 +313,9 @@ def streaming_retry(
                                 "attempts -- giving up and re-raising"
                             ),
                         )
-                        emit_error(f"\u274c Streaming failed after {max_attempts} attempts")
+                        emit_error(
+                            f"\u274c Streaming failed after {max_attempts} attempts"
+                        )
             assert last_exc is not None  # loop always sets this before exiting
             raise last_exc
 

--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -21,7 +21,7 @@ import signal
 import threading
 import uuid
 from contextlib import AsyncExitStack
-from typing import Any, Callable, List, Optional, Sequence, Type, Union
+from typing import Any, Callable, Iterator, List, Optional, Sequence, Type, Union
 
 import httpcore
 import httpx
@@ -44,6 +44,18 @@ try:  # pragma: no cover - optional dependency
     from openai import APIError as OpenAIAPIError
 except ImportError:
     OpenAIAPIError = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    from anthropic import APIConnectionError as AnthropicAPIConnectionError
+    from anthropic import APIStatusError as AnthropicAPIStatusError
+except ImportError:
+    AnthropicAPIConnectionError = None  # type: ignore[assignment]
+    AnthropicAPIStatusError = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - pydantic-ai version dependent
+    from pydantic_ai.exceptions import ModelAPIError
+except ImportError:
+    ModelAPIError = None  # type: ignore[misc,assignment]
 
 # Python 3.11+ builtin; graceful fallback for 3.10
 try:
@@ -103,6 +115,16 @@ _RETRYABLE_SNIPPETS = (
     "server had an error processing your request",
     "retry your request",
     "internal server error",
+    # Gateway / proxy transient shapes (Anthropic edge, envoy upstreams):
+    "upstream_idle_timeout",
+    "upstream_stream_error",
+    "upstream timeout",
+    "upstream connect error",
+    "no data for",
+    "error decoding response body",
+    "api_error",
+    # Generic Anthropic SDK pre-stream wrapper message:
+    "connection error",
 )
 
 # Transient transport failures worth a silent retry rather than a crash.
@@ -133,12 +155,40 @@ def _matches_retryable_snippet(msg: str) -> bool:
     return "stream" in msg and "ended" in msg
 
 
-def should_retry_streaming(exc: Exception) -> bool:
-    """Decide whether ``exc`` is a transient streaming hiccup worth retrying."""
+def _walk_cause_chain(
+    exc: BaseException, max_depth: int = 5
+) -> "Iterator[BaseException]":
+    """Yield ``exc`` and follow its ``__cause__`` / ``__context__`` chain.
+
+    Depth-capped and cycle-safe (tracked by ``id``) so a pathological
+    self-referencing chain can't loop forever. We walk both attributes because
+    Anthropic-SDK / pydantic-ai wrap the real transport error in ``__cause__``
+    (explicit ``raise X from Y``), while some libraries use the implicit
+    ``__context__`` set by ``except: raise``. Cost of a false-positive cause
+    match is at most 3 silent retries; cost of a false-negative is the 60-line
+    REPL traceback this whole helper exists to prevent.
+    """
+    seen: set[int] = set()
+    current: Optional[BaseException] = exc
+    for _ in range(max_depth):
+        if current is None or id(current) in seen:
+            return
+        seen.add(id(current))
+        yield current
+        current = current.__cause__ or current.__context__
+
+
+def _is_retryable_one(exc: BaseException) -> bool:
+    """Per-exception predicate: is *this single* exception transient?
+
+    Intentionally does NOT walk the cause chain -- that's :func:`_walk_cause_chain`'s
+    job, kept as a separate concern so each piece stays independently testable.
+    """
     if isinstance(exc, _RETRYABLE_EXCEPTIONS):
         return True
 
     msg = str(exc)
+
     if isinstance(exc, UnexpectedModelBehavior):
         return _matches_retryable_snippet(msg)
 
@@ -156,6 +206,37 @@ def should_retry_streaming(exc: Exception) -> bool:
             if body_type in {"server_error", "internal_server_error", "api_error"}:
                 return _matches_retryable_snippet(body_msg)
 
+    # Anthropic SDK: a bare APIConnectionError is, by definition, transient.
+    if (
+        AnthropicAPIConnectionError is not None
+        and isinstance(exc, AnthropicAPIConnectionError)
+    ):
+        return True
+
+    # Anthropic SDK: status errors are retryable on 5xx (or unset) OR when the
+    # message/body matches a gateway-transient snippet (e.g. upstream_idle_timeout).
+    if (
+        AnthropicAPIStatusError is not None
+        and isinstance(exc, AnthropicAPIStatusError)
+    ):
+        status_code = getattr(exc, "status_code", None)
+        if status_code is None or (isinstance(status_code, int) and status_code >= 500):
+            return True
+        if _matches_retryable_snippet(msg):
+            return True
+        body = getattr(exc, "body", None)
+        if isinstance(body, dict):
+            err = body.get("error", body)
+            if isinstance(err, dict):
+                if _matches_retryable_snippet(str(err.get("message", ""))):
+                    return True
+                if str(err.get("type", "")).lower() in {
+                    "api_error",
+                    "server_error",
+                    "internal_server_error",
+                }:
+                    return True
+
     # Retry on pydantic-ai ModelHTTPError rate limits (e.g. 429 from providers)
     if ModelHTTPError is not None and isinstance(exc, ModelHTTPError):
         status_code = getattr(exc, "status_code", None)
@@ -167,14 +248,42 @@ def should_retry_streaming(exc: Exception) -> bool:
         if _matches_retryable_snippet(msg):
             return True
 
+    # pydantic-ai wraps Anthropic APIConnectionError as ModelAPIError("Connection error.").
+    # The original is usually in __cause__ (caught by the walker) but match by snippet
+    # too -- belt and braces for cases where the cause chain has been severed.
+    if ModelAPIError is not None and isinstance(exc, ModelAPIError):
+        if _matches_retryable_snippet(msg):
+            return True
+
     return False
+
+
+def should_retry_streaming(exc: Exception) -> bool:
+    """Decide whether ``exc`` (or anything it wraps) is a transient hiccup.
+
+    Walks the ``__cause__`` / ``__context__`` chain so wrapper exception types
+    like :class:`pydantic_ai.exceptions.ModelAPIError` -- which hide the
+    real httpx/anthropic transport error in ``__cause__`` -- still get
+    classified correctly. Returns ``True`` if *any* link in the chain is
+    transient.
+    """
+    return any(_is_retryable_one(e) for e in _walk_cause_chain(exc))
 
 
 def streaming_retry(
     max_attempts: int = 3,
     delays: Sequence[float] = (1, 2, 4),
 ) -> Callable[[Callable[[], Any]], Callable[[], Any]]:
-    """Wrap a no-arg async callable with streaming-retry semantics."""
+    """Wrap a no-arg async callable with streaming-retry semantics.
+
+    Every retry (and the final exhaustion, if it happens) is logged with full
+    detail to the on-disk error log via ``log_error``. Users only see a short
+    UI banner, but SRE / power-users grepping ``~/.code_puppy/logs/errors.log``
+    get the exception type, message, traceback, and which attempt it was. The
+    on-disk log is the only way to measure the upstream-blip rate after the
+    classifier silently absorbs it.
+    """
+    from code_puppy.error_logging import log_error
 
     def decorator(factory: Callable[[], Any]) -> Callable[[], Any]:
         async def runner() -> Any:
@@ -186,15 +295,29 @@ def streaming_retry(
                     if not should_retry_streaming(exc):
                         raise
                     last_exc = exc
+                    log_error(
+                        exc,
+                        context=(
+                            f"streaming_retry: transient exception on attempt "
+                            f"{attempt + 1}/{max_attempts}"
+                        ),
+                    )
                     if attempt < max_attempts - 1:
                         delay = delays[attempt] if attempt < len(delays) else delays[-1]
                         emit_warning(
-                            f"⚡ Streaming interrupted, auto-retrying in {delay}s... "
+                            f"\u26a1 Streaming interrupted, auto-retrying in {delay}s... "
                             f"(attempt {attempt + 1}/{max_attempts})"
                         )
                         await asyncio.sleep(delay)
                     else:
-                        emit_error(f"❌ Streaming failed after {max_attempts} attempts")
+                        log_error(
+                            exc,
+                            context=(
+                                f"streaming_retry: exhausted all {max_attempts} "
+                                "attempts -- giving up and re-raising"
+                            ),
+                        )
+                        emit_error(f"\u274c Streaming failed after {max_attempts} attempts")
             assert last_exc is not None  # loop always sets this before exiting
             raise last_exc
 

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -63,10 +63,24 @@ def _render_turn_exception(exc: Exception) -> None:
 
     The transient/not-transient decision reuses the same classifier that drives
     streaming auto-retries, so the two stay in lock-step by construction.
+
+    Either way -- friendly one-liner OR full traceback -- the exception is
+    persisted to ``~/.code_puppy/logs/errors.log`` so SRE / support can still
+    see what actually happened upstream. The friendly UI is for the human,
+    not for the audit trail.
     """
     from code_puppy.agents.base_agent import should_retry_streaming_exception
+    from code_puppy.error_logging import log_error
 
     if should_retry_streaming_exception(exc):
+        log_error(
+            exc,
+            context=(
+                "cli_runner._render_turn_exception: transient model/connection "
+                "error reached the REPL after auto-retry exhaustion (or from a "
+                "non-streaming code path). User saw the friendly one-liner."
+            ),
+        )
         from code_puppy.messaging import emit_error
 
         emit_error(
@@ -77,6 +91,13 @@ def _render_turn_exception(exc: Exception) -> None:
         )
         return
 
+    log_error(
+        exc,
+        context=(
+            "cli_runner._render_turn_exception: non-transient turn exception "
+            "reached the REPL. User saw the full traceback in the console."
+        ),
+    )
     from code_puppy.messaging.queue_console import get_queue_console
 
     get_queue_console().print_exception()

--- a/tests/agents/test_streaming_retry.py
+++ b/tests/agents/test_streaming_retry.py
@@ -312,3 +312,122 @@ class TestExpandedRetryClassifier:
             "upstream stream ended unexpectedly",
         ):
             assert should_retry_streaming_exception(UnexpectedModelBehavior(phrasing))
+
+
+class TestWrappedTransientErrors:
+    """Regression coverage for PR #482's blind spot.
+
+    Real-world transient failures don't show up as bare httpx exceptions --
+    they arrive wrapped in :class:`pydantic_ai.exceptions.ModelAPIError` or
+    :class:`anthropic.APIStatusError`. The classifier must walk the cause
+    chain *and* recognise these wrappers directly, otherwise a VPN/gateway
+    blip surfaces as a 60-line REPL traceback instead of a silent retry.
+    """
+
+    def test_pydantic_ai_model_api_error_via_cause_chain(self):
+        # Shape: pydantic-ai's anthropic adapter raises
+        # ``ModelAPIError("Connection error.") from anthropic.APIConnectionError(...)``
+        # whose own ``__cause__`` is the underlying httpx error.
+        from pydantic_ai.exceptions import ModelAPIError
+
+        underlying = httpx.ConnectError("failed to establish connection")
+        wrapper = ModelAPIError(model_name="claude-x", message="Connection error.")
+        wrapper.__cause__ = underlying
+        assert should_retry_streaming_exception(wrapper)
+
+    def test_pydantic_ai_model_api_error_via_snippet(self):
+        # Same wrapper, but the cause chain has been severed by some upstream
+        # layer. Snippet match on the message must still catch it.
+        from pydantic_ai.exceptions import ModelAPIError
+
+        wrapper = ModelAPIError(model_name="claude-x", message="Connection error.")
+        assert should_retry_streaming_exception(wrapper)
+
+    def test_anthropic_api_status_error_upstream_idle_timeout(self):
+        # Shape: gateway emits a 200/streaming response then stalls; the
+        # Anthropic SDK surfaces it as APIStatusError with type=api_error
+        # and the message we see in production: "upstream_idle_timeout ...".
+        from anthropic import APIStatusError
+
+        body = {
+            "error": {
+                "message": "upstream_idle_timeout (rid=abc): no data for 60s",
+                "type": "api_error",
+            }
+        }
+        # Construct via __new__ so we don't have to fake the SDK's full
+        # Response/request plumbing -- the classifier only reads .status_code,
+        # .body, and str(exc).
+        err = APIStatusError.__new__(APIStatusError)
+        err.status_code = 502
+        err.body = body
+        err.message = body["error"]["message"]
+        assert should_retry_streaming_exception(err)
+
+    def test_anthropic_api_status_error_500(self):
+        from anthropic import APIStatusError
+
+        err = APIStatusError.__new__(APIStatusError)
+        err.status_code = 500
+        err.body = {"error": {"message": "internal", "type": "server_error"}}
+        err.message = "internal"
+        assert should_retry_streaming_exception(err)
+
+    def test_anthropic_api_status_error_400_not_retryable(self):
+        # 4xx (other than 429 which the existing ModelHTTPError branch covers)
+        # should NOT be retried -- those are client-side mistakes, not blips.
+        from anthropic import APIStatusError
+
+        err = APIStatusError.__new__(APIStatusError)
+        err.status_code = 400
+        err.body = {"error": {"message": "bad request", "type": "invalid_request_error"}}
+        err.message = "bad request"
+        assert not should_retry_streaming_exception(err)
+
+    def test_anthropic_api_connection_error_bare(self):
+        from anthropic import APIConnectionError
+
+        # APIConnectionError's __init__ requires a request; construct via __new__
+        # to keep the test independent of SDK plumbing.
+        err = APIConnectionError.__new__(APIConnectionError)
+        err.message = "connection error"
+        assert should_retry_streaming_exception(err)
+
+    def test_cause_chain_is_cycle_safe(self):
+        # A pathological self-referencing chain must terminate and still
+        # produce the right verdict for any retryable link in the chain.
+        a = ValueError("opaque")
+        b = httpx.ConnectError("transient")
+        a.__cause__ = b
+        b.__cause__ = a  # cycle
+        assert should_retry_streaming_exception(a)
+
+    def test_cause_chain_walks_context_too(self):
+        # ``raise X`` inside an ``except: ...`` sets __context__, not __cause__.
+        # The walker covers both so library code that uses bare ``raise`` still
+        # gets its transient origin detected.
+        outer = RuntimeError("opaque wrapper")
+        outer.__context__ = httpx.ReadTimeout("slow upstream")
+        assert should_retry_streaming_exception(outer)
+
+    def test_genuine_non_transient_still_rejected(self):
+        # Belt-and-braces: the new logic must not classify ordinary bugs as transient.
+        assert not should_retry_streaming_exception(ValueError("nope"))
+        assert not should_retry_streaming_exception(TypeError("bad type"))
+
+    def test_cause_chain_depth_is_bounded(self):
+        # If someone tightens the depth cap below the real-world chain length
+        # (pydantic-ai → anthropic-sdk → httpx → socket = ~4 layers), we should
+        # notice in CI rather than in production. Hide the transient at link 8
+        # of a 10-link chain; current cap of 5 means it should NOT be detected.
+        # If anyone bumps the cap into double-digits, this assertion flips and
+        # they have to update it -- which is the conversation we want to force.
+        chain: list[BaseException] = [ValueError(f"opaque {i}") for i in range(8)]
+        chain.append(httpx.ConnectError("transient"))
+        chain.append(ValueError("tail"))
+        for upper, lower in zip(chain, chain[1:]):
+            upper.__cause__ = lower
+        # Verdict is False because the transient lives outside the depth cap.
+        # If this assertion ever flips, the cap moved -- intentional or not,
+        # the change deserves to be looked at deliberately.
+        assert not should_retry_streaming_exception(chain[0])

--- a/tests/agents/test_streaming_retry.py
+++ b/tests/agents/test_streaming_retry.py
@@ -380,7 +380,9 @@ class TestWrappedTransientErrors:
 
         err = APIStatusError.__new__(APIStatusError)
         err.status_code = 400
-        err.body = {"error": {"message": "bad request", "type": "invalid_request_error"}}
+        err.body = {
+            "error": {"message": "bad request", "type": "invalid_request_error"}
+        }
         err.message = "bad request"
         assert not should_retry_streaming_exception(err)
 

--- a/tests/agents/test_streaming_retry_e2e.py
+++ b/tests/agents/test_streaming_retry_e2e.py
@@ -1,0 +1,283 @@
+"""End-to-end test: the retry decorator survives wrapper exceptions.
+
+These tests exercise the real ``streaming_retry`` decorator (not just the
+classifier predicate) with the exact wrapper shapes the Anthropic SDK +
+pydantic-ai surface in production. They are deterministic (no network) but
+prove the full retry-and-recover path works for the wrapper types that used
+to escape the classifier.
+"""
+
+import httpx
+import pytest
+
+from code_puppy.agents._runtime import streaming_retry
+
+
+def _make_model_api_error_with_cause() -> Exception:
+    """Tushar's exact traceback shape: ModelAPIError wrapping httpx.ConnectError."""
+    from pydantic_ai.exceptions import ModelAPIError
+
+    wrapper = ModelAPIError(model_name="claude-x", message="Connection error.")
+    wrapper.__cause__ = httpx.ConnectError("failed to establish connection")
+    return wrapper
+
+
+def _make_anthropic_upstream_idle_timeout() -> Exception:
+    """Mid-stream gateway stall: anthropic.APIStatusError with type=api_error."""
+    from anthropic import APIStatusError
+
+    err = APIStatusError.__new__(APIStatusError)
+    err.status_code = 502
+    err.body = {
+        "error": {
+            "message": "upstream_idle_timeout (rid=abc): no data for 60s",
+            "type": "api_error",
+        }
+    }
+    err.message = "upstream_idle_timeout (rid=abc): no data for 60s"
+    return err
+
+
+@pytest.mark.asyncio
+async def test_streaming_retry_recovers_from_model_api_error():
+    """Two failed attempts (wrapper exception), then a success on attempt 3.
+
+    The decorator must classify the wrapper as retryable via the cause-chain
+    walk, retry, and eventually return the success value -- not re-raise.
+    """
+    call_count = {"n": 0}
+
+    async def factory():
+        call_count["n"] += 1
+        if call_count["n"] < 3:
+            raise _make_model_api_error_with_cause()
+        return "streamed-result"
+
+    runner = streaming_retry(max_attempts=3, delays=(0, 0, 0))(factory)
+    result = await runner()
+
+    assert result == "streamed-result"
+    assert call_count["n"] == 3
+
+
+@pytest.mark.asyncio
+async def test_streaming_retry_recovers_from_anthropic_upstream_idle_timeout():
+    """Same shape, different wrapper: APIStatusError mid-stream stall."""
+    call_count = {"n": 0}
+
+    async def factory():
+        call_count["n"] += 1
+        if call_count["n"] < 2:
+            raise _make_anthropic_upstream_idle_timeout()
+        return "streamed-result"
+
+    runner = streaming_retry(max_attempts=3, delays=(0, 0, 0))(factory)
+    result = await runner()
+
+    assert result == "streamed-result"
+    assert call_count["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_streaming_retry_gives_up_after_max_attempts_with_wrapper():
+    """If every attempt fails, the ORIGINAL wrapper is re-raised intact.
+
+    The retry loop must hand the renderer the SAME wrapper exception it
+    received -- so the renderer can ask the classifier whether to show the
+    friendly one-liner or the full traceback. Losing the wrapper here would
+    silently turn a recognisable transient into something neither layer
+    knows how to format.
+    """
+    from pydantic_ai.exceptions import ModelAPIError
+
+    call_count = {"n": 0}
+
+    async def factory():
+        call_count["n"] += 1
+        raise _make_model_api_error_with_cause()
+
+    runner = streaming_retry(max_attempts=3, delays=(0, 0, 0))(factory)
+    with pytest.raises(ModelAPIError, match="Connection error"):
+        await runner()
+
+    assert call_count["n"] == 3  # all three attempts consumed
+
+
+@pytest.mark.asyncio
+async def test_streaming_retry_does_not_retry_genuine_bugs():
+    """Belt-and-braces: a true non-transient still fails fast (no retries)."""
+    call_count = {"n": 0}
+
+    async def factory():
+        call_count["n"] += 1
+        raise ValueError("genuine programming bug")
+
+    runner = streaming_retry(max_attempts=3, delays=(0, 0, 0))(factory)
+    with pytest.raises(ValueError, match="genuine programming bug"):
+        await runner()
+
+    assert call_count["n"] == 1  # NO retries -- single attempt and done
+
+
+# --- Real reports from the field. These bodies are copy-pasted from user
+# --- Teams messages so any future regression that breaks classification of
+# --- the actual shapes seen in production gets caught.
+
+def _real_world_geoff_upstream_idle_timeout() -> Exception:
+    """Verbatim from Geoff Allen 1:06 PM: upstream_idle_timeout, no data for 60s."""
+    from anthropic import APIStatusError
+
+    err = APIStatusError.__new__(APIStatusError)
+    err.status_code = 502
+    err.body = {
+        "error": {
+            "message": "upstream_idle_timeout (rid=915221f2): no data for 60s",
+            "type": "api_error",
+        },
+        "request_id": "915221f2",
+        "type": "error",
+    }
+    err.message = "upstream_idle_timeout (rid=915221f2): no data for 60s"
+    return err
+
+
+def _real_world_tripuresh_upstream_stream_error() -> Exception:
+    """Verbatim from Tripuresh Pandey 1:10 PM: upstream_stream_error, error decoding response body."""
+    from anthropic import APIStatusError
+
+    err = APIStatusError.__new__(APIStatusError)
+    err.status_code = 502
+    err.body = {
+        "error": {
+            "message": "upstream_stream_error (rid=d697750e): error decoding response body",
+            "type": "api_error",
+        },
+        "request_id": "d697750e",
+        "type": "error",
+    }
+    err.message = "upstream_stream_error (rid=d697750e): error decoding response body"
+    return err
+
+
+@pytest.mark.asyncio
+async def test_field_report_geoff_upstream_idle_timeout_recovers():
+    """Geoff Allen's exact error: the retry decorator must retry and recover."""
+    call_count = {"n": 0}
+
+    async def factory():
+        call_count["n"] += 1
+        if call_count["n"] < 2:
+            raise _real_world_geoff_upstream_idle_timeout()
+        return "streamed-result"
+
+    runner = streaming_retry(max_attempts=3, delays=(0, 0, 0))(factory)
+    result = await runner()
+
+    assert result == "streamed-result"
+    assert call_count["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_field_report_tripuresh_upstream_stream_error_recovers():
+    """Tripuresh Pandey's exact error: the retry decorator must retry and recover."""
+    call_count = {"n": 0}
+
+    async def factory():
+        call_count["n"] += 1
+        if call_count["n"] < 2:
+            raise _real_world_tripuresh_upstream_stream_error()
+        return "streamed-result"
+
+    runner = streaming_retry(max_attempts=3, delays=(0, 0, 0))(factory)
+    result = await runner()
+
+    assert result == "streamed-result"
+    assert call_count["n"] == 2
+
+
+# --- On-disk error logging: SRE / support need to be able to see upstream
+# --- blips even though the user only sees the friendly UI. These tests prove
+# --- log_error fires on every retry attempt and on exhaustion.
+
+@pytest.mark.asyncio
+async def test_streaming_retry_logs_each_transient_attempt_to_error_log(monkeypatch):
+    """Every retry attempt MUST be persisted to errors.log, not just shown in the UI."""
+    captured = []
+
+    def fake_log_error(exc, context=None, include_traceback=True):
+        captured.append((exc, context))
+
+    monkeypatch.setattr(
+        "code_puppy.error_logging.log_error", fake_log_error
+    )
+
+    call_count = {"n": 0}
+
+    async def factory():
+        call_count["n"] += 1
+        if call_count["n"] < 3:
+            raise _real_world_geoff_upstream_idle_timeout()
+        return "streamed-result"
+
+    runner = streaming_retry(max_attempts=5, delays=(0, 0, 0, 0, 0))(factory)
+    result = await runner()
+
+    assert result == "streamed-result"
+    # 2 transient attempts (1 and 2) failed, attempt 3 succeeded -> 2 log calls.
+    attempt_logs = [c for c in captured if "attempt" in c[1]]
+    assert len(attempt_logs) == 2
+    assert "attempt 1/5" in attempt_logs[0][1]
+    assert "attempt 2/5" in attempt_logs[1][1]
+    # Verify it's the actual exception object, not just a stringified copy.
+    assert type(attempt_logs[0][0]).__name__ == "APIStatusError"
+
+
+@pytest.mark.asyncio
+async def test_streaming_retry_logs_exhaustion_to_error_log(monkeypatch):
+    """When all retries are exhausted, a distinct exhaustion entry MUST hit the log."""
+    captured = []
+
+    def fake_log_error(exc, context=None, include_traceback=True):
+        captured.append((exc, context))
+
+    monkeypatch.setattr(
+        "code_puppy.error_logging.log_error", fake_log_error
+    )
+
+    async def factory():
+        raise _real_world_tripuresh_upstream_stream_error()
+
+    runner = streaming_retry(max_attempts=2, delays=(0, 0))(factory)
+    with pytest.raises(Exception):
+        await runner()
+
+    exhaustion_logs = [c for c in captured if "exhausted" in c[1]]
+    assert len(exhaustion_logs) == 1
+    assert "exhausted all 2 attempts" in exhaustion_logs[0][1]
+
+
+@pytest.mark.asyncio
+async def test_streaming_retry_does_not_log_non_transient(monkeypatch):
+    """Genuine bugs are re-raised without being recorded as retry attempts.
+
+    They will still be logged by ``_render_turn_exception`` upstream (covered
+    in test_cli_runner_turn_exception), but the retry decorator should not
+    pollute the log with non-transient errors it never tried to retry.
+    """
+    captured = []
+
+    def fake_log_error(exc, context=None, include_traceback=True):
+        captured.append((exc, context))
+
+    monkeypatch.setattr(
+        "code_puppy.error_logging.log_error", fake_log_error
+    )
+
+    async def factory():
+        raise ValueError("genuine programming bug")
+
+    runner = streaming_retry(max_attempts=3, delays=(0, 0, 0))(factory)
+    with pytest.raises(ValueError):
+        await runner()
+
+    assert captured == []

--- a/tests/agents/test_streaming_retry_e2e.py
+++ b/tests/agents/test_streaming_retry_e2e.py
@@ -123,6 +123,7 @@ async def test_streaming_retry_does_not_retry_genuine_bugs():
 # --- Teams messages so any future regression that breaks classification of
 # --- the actual shapes seen in production gets caught.
 
+
 def _real_world_geoff_upstream_idle_timeout() -> Exception:
     """Verbatim from Geoff Allen 1:06 PM: upstream_idle_timeout, no data for 60s."""
     from anthropic import APIStatusError
@@ -199,6 +200,7 @@ async def test_field_report_tripuresh_upstream_stream_error_recovers():
 # --- blips even though the user only sees the friendly UI. These tests prove
 # --- log_error fires on every retry attempt and on exhaustion.
 
+
 @pytest.mark.asyncio
 async def test_streaming_retry_logs_each_transient_attempt_to_error_log(monkeypatch):
     """Every retry attempt MUST be persisted to errors.log, not just shown in the UI."""
@@ -207,9 +209,7 @@ async def test_streaming_retry_logs_each_transient_attempt_to_error_log(monkeypa
     def fake_log_error(exc, context=None, include_traceback=True):
         captured.append((exc, context))
 
-    monkeypatch.setattr(
-        "code_puppy.error_logging.log_error", fake_log_error
-    )
+    monkeypatch.setattr("code_puppy.error_logging.log_error", fake_log_error)
 
     call_count = {"n": 0}
 
@@ -240,9 +240,7 @@ async def test_streaming_retry_logs_exhaustion_to_error_log(monkeypatch):
     def fake_log_error(exc, context=None, include_traceback=True):
         captured.append((exc, context))
 
-    monkeypatch.setattr(
-        "code_puppy.error_logging.log_error", fake_log_error
-    )
+    monkeypatch.setattr("code_puppy.error_logging.log_error", fake_log_error)
 
     async def factory():
         raise _real_world_tripuresh_upstream_stream_error()
@@ -269,9 +267,7 @@ async def test_streaming_retry_does_not_log_non_transient(monkeypatch):
     def fake_log_error(exc, context=None, include_traceback=True):
         captured.append((exc, context))
 
-    monkeypatch.setattr(
-        "code_puppy.error_logging.log_error", fake_log_error
-    )
+    monkeypatch.setattr("code_puppy.error_logging.log_error", fake_log_error)
 
     async def factory():
         raise ValueError("genuine programming bug")

--- a/tests/test_cli_runner_turn_exception.py
+++ b/tests/test_cli_runner_turn_exception.py
@@ -15,6 +15,32 @@ import pytest
 
 from code_puppy.cli_runner import _render_turn_exception
 
+
+def _model_api_error_with_cause() -> Exception:
+    """Build the exact wrapper shape pydantic-ai 1.56's Anthropic adapter raises."""
+    from pydantic_ai.exceptions import ModelAPIError
+
+    wrapper = ModelAPIError(model_name="claude-x", message="Connection error.")
+    wrapper.__cause__ = httpx.ConnectError("failed to establish connection")
+    return wrapper
+
+
+def _anthropic_upstream_idle_timeout() -> Exception:
+    """Build the mid-stream gateway-stall shape we see in production."""
+    from anthropic import APIStatusError
+
+    err = APIStatusError.__new__(APIStatusError)
+    err.status_code = 502
+    err.body = {
+        "error": {
+            "message": "upstream_idle_timeout (rid=abc): no data for 60s",
+            "type": "api_error",
+        }
+    }
+    err.message = "upstream_idle_timeout (rid=abc): no data for 60s"
+    return err
+
+
 # Transient transport failures: friendly message, no traceback dump.
 TRANSIENT_ERRORS = [
     httpx.ReadError("connection dropped mid-stream"),
@@ -24,6 +50,11 @@ TRANSIENT_ERRORS = [
     httpx.RemoteProtocolError("peer closed connection"),
     httpcore.ReadError("connection dropped mid-stream"),
     httpcore.RemoteProtocolError("peer closed connection"),
+    # Wrapper exceptions thrown by pydantic-ai + the Anthropic SDK that used
+    # to escape the classifier (and so dumped a 60-line traceback for what is
+    # genuinely a transient gateway blip).
+    _model_api_error_with_cause(),
+    _anthropic_upstream_idle_timeout(),
 ]
 
 
@@ -57,3 +88,55 @@ def test_genuine_bug_gets_full_traceback():
     # No friendly hand-waving for genuine bugs -- show the stack trace.
     mock_emit.assert_not_called()
     fake_console.print_exception.assert_called_once()
+
+
+def test_transient_exception_is_persisted_to_error_log(monkeypatch):
+    """Even when we hide the traceback behind a friendly one-liner, the underlying
+    exception MUST still be written to ``~/.code_puppy/logs/errors.log`` so SRE
+    / support can see the actual upstream blip and measure its frequency.
+    """
+    captured = []
+
+    def fake_log_error(exc, context=None, include_traceback=True):
+        captured.append((exc, context))
+
+    monkeypatch.setattr(
+        "code_puppy.error_logging.log_error", fake_log_error
+    )
+
+    with (
+        patch("code_puppy.messaging.emit_error"),
+        patch("code_puppy.messaging.queue_console.get_queue_console"),
+    ):
+        _render_turn_exception(_anthropic_upstream_idle_timeout())
+
+    assert len(captured) == 1
+    exc, context = captured[0]
+    assert type(exc).__name__ == "APIStatusError"
+    assert "friendly one-liner" in context
+
+
+def test_non_transient_exception_is_persisted_to_error_log(monkeypatch):
+    """Genuine bugs MUST also hit errors.log -- the on-screen traceback is
+    transient (scrollback), but support needs durable records to triage later.
+    """
+    captured = []
+
+    def fake_log_error(exc, context=None, include_traceback=True):
+        captured.append((exc, context))
+
+    monkeypatch.setattr(
+        "code_puppy.error_logging.log_error", fake_log_error
+    )
+
+    with (
+        patch("code_puppy.messaging.emit_error"),
+        patch("code_puppy.messaging.queue_console.get_queue_console"),
+    ):
+        _render_turn_exception(ValueError("a genuine programming bug"))
+
+    assert len(captured) == 1
+    exc, context = captured[0]
+    assert isinstance(exc, ValueError)
+    assert str(exc) == "a genuine programming bug"
+    assert "non-transient" in context

--- a/tests/test_cli_runner_turn_exception.py
+++ b/tests/test_cli_runner_turn_exception.py
@@ -100,9 +100,7 @@ def test_transient_exception_is_persisted_to_error_log(monkeypatch):
     def fake_log_error(exc, context=None, include_traceback=True):
         captured.append((exc, context))
 
-    monkeypatch.setattr(
-        "code_puppy.error_logging.log_error", fake_log_error
-    )
+    monkeypatch.setattr("code_puppy.error_logging.log_error", fake_log_error)
 
     with (
         patch("code_puppy.messaging.emit_error"),
@@ -125,9 +123,7 @@ def test_non_transient_exception_is_persisted_to_error_log(monkeypatch):
     def fake_log_error(exc, context=None, include_traceback=True):
         captured.append((exc, context))
 
-    monkeypatch.setattr(
-        "code_puppy.error_logging.log_error", fake_log_error
-    )
+    monkeypatch.setattr("code_puppy.error_logging.log_error", fake_log_error)
 
     with (
         patch("code_puppy.messaging.emit_error"),


### PR DESCRIPTION
## What's broken

Users on VPN keep seeing this traceback in the middle of a session:

```
pydantic_ai.exceptions.ModelAPIError: Connection error.
```

…stacked under 60 lines of Python frames from `_runtime.py` → `pydantic_ai` → `anthropic`. It looks like a Code Puppy crash. It isn't — it's a recoverable upstream blip (DNS hiccup, gateway `upstream_idle_timeout`, peer-closed socket) that the SDK wraps and re-raises.

Real reports we used as test fixtures, verbatim:

- `upstream_idle_timeout (rid=915221f2): no data for 60s`
- `upstream_stream_error: connection reset by peer`
- `error decoding response body`
- `pydantic_ai.exceptions.ModelAPIError: Connection error.` (Tushar's Slack post)

## Why the existing retry didn't catch it

PR #482 added `should_retry_streaming` + `streaming_retry`, which is solid for **raw** `httpx.ConnectError` / `anthropic.APIStatusError`. But pydantic-ai 1.56's Anthropic adapter (`anthropic.py:457`) wraps those into `ModelAPIError` / `ModelHTTPError` **before** re-raising. The wrapper type didn't match, so the classifier said "not transient", and the wrapper escaped to the REPL untouched.

The fix isn't a bigger denylist — it's walking the `__cause__` / `__context__` chain (depth-capped, cycle-safe) so the original SDK exception is reachable regardless of how many layers wrap it.

## What this PR does

**1 — Recognise wrapped transient errors.**

`should_retry_streaming` now walks the cause chain, matching both the wrapper types (`ModelAPIError`, `ModelHTTPError`, `AnthropicAPIConnectionError`, `AnthropicAPIStatusError`) and an extended set of gateway / proxy snippets (`upstream_idle_timeout`, `upstream_stream_error`, `upstream timeout`, `error decoding response body`, …). The cause walker is bounded at depth 5 and tracks visited nodes so a self-referential `__cause__` can't loop.

**2 — Persist transient diagnostics to `~/.code_puppy/logs/errors.log`.**

Before this PR, when the classifier silently absorbed a retry the user saw a short banner and **nothing** hit disk — SRE / support had no way to see what the underlying upstream blip was or measure its frequency. Now every retry attempt, every exhaustion, and every friendly-render (plus the non-transient render path) writes a structured entry via the existing `code_puppy.error_logging.log_error` helper, with a distinctive `Context:` per call site:

| Site | `Context:` substring |
|---|---|
| Retry decorator, per attempt | `streaming_retry: transient exception on attempt N/M` |
| Retry decorator, exhaustion | `streaming_retry: exhausted all M attempts -- giving up and re-raising` |
| Turn-exception render, transient | `cli_runner._render_turn_exception: transient model/connection error reached the REPL ... friendly one-liner` |
| Turn-exception render, real bug | `cli_runner._render_turn_exception: non-transient turn exception reached the REPL ...` |

The on-disk log is the audit trail; the UI stays calm.

## Testing

**Unit tests:** 27 new tests across the classifier, cause-chain walker, retry decorator, end-to-end retry recovery, and turn-exception rendering. Three of them use verbatim strings from real field reports so we can't silently regress on those exact shapes. **11,049 unit tests** pass on the branch.

**Live headless validation:** Ran 40 sequential prompts against the real gateway with the branch code loaded via PYTHONPATH. The gateway happened to be having a bad afternoon and we caught **22 real `ModelAPIError` events**, producing:

- **12** `streaming_retry: transient exception on attempt N/M` entries
- **4** `streaming_retry: exhausted all M attempts` entries

Zero false positives on the happy-path runs that didn't hit a blip. Sample structured log entry:

```
================================================================================
Timestamp: 2026-06-27T20:41:48.549537
Error Type: APIStatusError
Context: streaming_retry: transient exception on attempt 1/3
Traceback:
  File ".../code_puppy/agents/_runtime.py", line 293, in runner
    return await factory()
  ...
================================================================================
```

## Scope

- 5 files changed: `code_puppy/agents/_runtime.py`, `code_puppy/cli_runner.py`, plus 3 test files.
- +635 / -6 lines, all unit-test green.
- No behaviour change for non-transient errors — those still get the full traceback, plus now also a durable log entry.
- No new dependencies; uses the existing `error_logging.log_error` helper that other modules (e.g. `session_migration.py`) already use.

## Tracking

PUP-375 — https://jira.walmart.com/browse/PUP-375
