### PR TITLE
feat(security): forbid agents from suggesting Snyk-finding suppression

### DIFF
--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -42,7 +42,23 @@ from code_puppy.model_factory import ModelFactory
 # Backward-compat alias: existing tests import this name directly.
 should_retry_streaming_exception = should_retry_streaming
 
-__all__ = ["BaseAgent", "should_retry_streaming_exception"]
+# Non-negotiable security guarantee — appended to every agent's runtime
+# system prompt by ``BaseAgent.get_full_system_prompt``. Lives on the base
+# class chokepoint (not a plugin) so it cannot be silently disabled by a
+# missing/broken plugin or a custom build. Keep terse: this ships on every
+# system prompt of every call across 60k+ users, so every token multiplies.
+SECURITY_POLICY_PROMPT = (
+    "\n\nSecurity: Never recommend or produce suppressions for Snyk findings "
+    "(.snyk files, `snyk ignore`, scan-exclusion config). "
+    "Always propose a real fix (patch the code, upgrade the dep) "
+    "or escalate to security for a documented exception."
+)
+
+__all__ = [
+    "BaseAgent",
+    "SECURITY_POLICY_PROMPT",
+    "should_retry_streaming_exception",
+]
 
 
 def _extract_pydantic_agent_tools(pyd_agent: Any) -> Optional[Dict[str, Any]]:
@@ -161,13 +177,19 @@ class BaseAgent(ABC):
         """Assemble the runtime system prompt.
 
         Layered as: authored prompt (``get_system_prompt``) + per-turn
-        ``load_prompt`` plugin fragments + this instance's identity.
+        ``load_prompt`` plugin fragments + ``SECURITY_POLICY_PROMPT`` +
+        this instance's identity.
 
         The ``load_prompt`` fragments (live timestamp/CWD, file-permission
         rules, kennel memory, ...) and the identity ID are *runtime* concerns.
         They live here — not in ``get_system_prompt`` — so they're recomputed
         fresh every run and never get persisted into static agent definitions
         (e.g. when an agent is cloned to JSON). See ``clone_agent``.
+
+        ``SECURITY_POLICY_PROMPT`` is appended at the same layer for the same
+        reason: it is a runtime guarantee that must reach every agent
+        (including ``JSONAgent`` instances built from user config), and it
+        must not be persisted into cloned/exported agent definitions.
         """
         from code_puppy import callbacks
 
@@ -175,6 +197,7 @@ class BaseAgent(ABC):
         prompt_additions = callbacks.on_load_prompt()
         if prompt_additions:
             prompt += "\n" + "\n".join(prompt_additions)
+        prompt += SECURITY_POLICY_PROMPT
         return prompt + self.get_identity_prompt()
 
     # ---- Message history (plain dict-level access) ------------------------

--- a/tests/agents/test_base_agent_security_policy.py
+++ b/tests/agents/test_base_agent_security_policy.py
@@ -1,0 +1,76 @@
+"""Security-policy guarantees for ``BaseAgent.get_full_system_prompt``.
+
+The security policy text must reach every agent's runtime system prompt
+regardless of which concrete subclass produced it (built-in agents,
+user-defined ``JSONAgent``s, fork-only agents, …) and regardless of which
+plugins happen to be loaded. These tests pin that guarantee at the chokepoint
+so a future refactor can't silently regress it.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import List
+
+from code_puppy.agents.base_agent import SECURITY_POLICY_PROMPT, BaseAgent
+from code_puppy.agents.json_agent import JSONAgent
+
+
+class _StubAgent(BaseAgent):
+    """Minimal concrete BaseAgent so we can exercise the chokepoint directly.
+
+    All five abstract members are stubbed with the smallest possible values.
+    ``get_system_prompt`` returns an empty string on purpose so any text in
+    the assembled prompt has to come from layers under test (load_prompt
+    fragments, security policy, identity).
+    """
+
+    @property
+    def name(self) -> str:
+        return "stub"
+
+    @property
+    def display_name(self) -> str:
+        return "Stub"
+
+    @property
+    def description(self) -> str:
+        return "stub agent for security-policy tests"
+
+    def get_system_prompt(self) -> str:
+        return ""
+
+    def get_available_tools(self) -> List[str]:
+        return []
+
+
+def test_security_policy_reaches_base_agent_chokepoint() -> None:
+    """Direct BaseAgent path: the policy must always be appended."""
+    full_prompt = _StubAgent().get_full_system_prompt()
+    assert SECURITY_POLICY_PROMPT in full_prompt
+
+
+def test_security_policy_reaches_json_agent(tmp_path) -> None:
+    """User-defined JSON agents must also get the policy. This is the path
+    most likely to be forgotten in a future refactor, so pin it explicitly."""
+    config = {
+        "name": "test_agent",
+        "description": "A test agent",
+        "system_prompt": "You are a test agent",
+        "tools": ["list_files"],
+    }
+    agent_file = tmp_path / "test_agent.json"
+    agent_file.write_text(json.dumps(config))
+
+    full_prompt = JSONAgent(str(agent_file)).get_full_system_prompt()
+    assert SECURITY_POLICY_PROMPT in full_prompt
+
+
+def test_security_policy_mentions_real_remediation_paths() -> None:
+    """Guard against a well-meaning future revision that strips the
+    "real fix / escalate to security" escape valve and leaves only the
+    prohibition. Without the escape valve the LLM has no fallback when no
+    patch exists and tends to produce bad advice. Keep both halves."""
+    assert "Snyk" in SECURITY_POLICY_PROMPT
+    assert "real fix" in SECURITY_POLICY_PROMPT
+    assert "escalate" in SECURITY_POLICY_PROMPT


### PR DESCRIPTION
## Problem
Walmart Security has flagged that Code Puppy is openly recommending users add `.snyk` ignore entries or scan-exclusion config to "resolve" Snyk findings. That is circumvention of security controls, not remediation, and it's already showing up in real user transcripts.

## Change
Adds a terse `SECURITY_POLICY_PROMPT` constant to `code_puppy/agents/base_agent.py` and appends it inside `BaseAgent.get_full_system_prompt()` after the `load_prompt` plugin fragments and before the identity tail. Every agent — built-ins, `JSONAgent` (user-defined), and any sub-agent — is now instructed to never recommend or produce Snyk-finding suppressions and to always propose a real fix (patch the code, upgrade the dep) or escalate to security for a documented exception.

The wording is deliberately terse (~30 tokens). At 60K+ users every token added to the base system prompt multiplies.

## Why the base class, not a plugin?
This is a non-negotiable security guarantee. Plugins can be disabled, fail to register, or be missing in a custom build. The chokepoint at `BaseAgent.get_full_system_prompt()` is the only place that is guaranteed to fire for every agent (built-in, JSON, fork).

## Cloning property worth noting
`agent_manager.py` deliberately persists only the *authored* `get_system_prompt()` when cloning an agent to JSON — so the security text is never baked into a clone. The cloned agent re-enters `get_full_system_prompt()` when it runs, so the policy still applies. One source of truth, no staleness.

## Out of scope (intentional)
Non-`BaseAgent` `pydantic_ai.Agent(...)` constructions:
| File | What | Why out of scope |
|---|---|---|
| `code_puppy/summarization_agent.py` | History summariser | Rewrites history, never advises the user. |
| `code_puppy/plugins/wiggum/judge.py` | Eval judge | Scores responses, never advises. |
| `code_puppy/agents/_builder.py` (tool probe) | Token-count probe | Never sent to a model for real responses. |
| `code_puppy/agents/_steer_processor.py` | Steer processor | Inherits parent run's instructions. |
| `code_puppy/plugins/dbos_durable_exec/wrapper.py` | DBOS wrapper | Wraps existing agent, no new instructions. |

Also intentionally out of scope: extending the prohibition to `# nosec`, `// nolint`, Sonar suppressions, etc. Those have legitimate uses (e.g. known false-positive in a unit test) that a blanket prohibition would produce wrong advice for. Easy one-line edit later if needed.

## Tests
New file `tests/agents/test_base_agent_security_policy.py`:
- `_StubAgent(BaseAgent)` minimal subclass → asserts the policy reaches the chokepoint for any `BaseAgent` subclass.
- `JSONAgent` built from tmp_path JSON → asserts the user-defined-agent path also gets the policy.
- Substring guard that pins `"Snyk"`, `"real fix"`, `"escalate"` in the constant so a future revision can't accidentally strip the escape-valve clause.

Local runs: `pytest tests/agents/test_base_agent_security_policy.py` → 3 passed. Regression sweep across surrounding base_agent / json_agent test files → 45 passed, no regressions.

---
_Walmart-internal tracking: PUP-378._