### PR TITLE
fix(puppy_kennel): stop concurrent multiprocess writes from silently …

### DIFF
--- a/code_puppy/plugins/puppy_kennel/schema.py
+++ b/code_puppy/plugins/puppy_kennel/schema.py
@@ -70,9 +70,16 @@ END;
 
 # PRAGMAs applied on every connection. WAL is the headline: one writer +
 # unlimited readers, multi-process safe, the whole reason we picked SQLite.
+#
+# ORDER MATTERS: ``busy_timeout`` must come FIRST. Switching ``journal_mode``
+# to WAL takes a brief exclusive lock, and the very first concurrent
+# ``initialize()`` from N processes can collide on it. If the busy handler
+# isn't armed yet, that collision surfaces as an immediate
+# ``OperationalError: database is locked`` instead of politely waiting.
+# Arm the 5s grace BEFORE we attempt the WAL switch (or any write).
 PRAGMAS = (
+    "PRAGMA busy_timeout=5000",  # 5s grace for writers waiting on the lock.
     "PRAGMA journal_mode=WAL",
     "PRAGMA synchronous=NORMAL",  # WAL durability is fine at NORMAL; faster.
     "PRAGMA foreign_keys=ON",
-    "PRAGMA busy_timeout=5000",  # 5s grace for writers waiting on the lock.
 )

--- a/code_puppy/plugins/puppy_kennel/state.py
+++ b/code_puppy/plugins/puppy_kennel/state.py
@@ -15,13 +15,25 @@ ambiguity, refuse to guess.
 Reads and writes go through ``code_puppy.config.get_value`` /
 ``set_config_value``, the same helpers every other plugin (statusline,
 prompt_newline, ...) uses for puppy.cfg interop.
+
+An environment override, ``PUPPY_KENNEL_ENABLED``, takes precedence over
+the persisted cfg value. This mirrors ``PUPPY_KENNEL_ROOT`` in
+``config.py`` and -- crucially -- is the only knob that survives a
+``multiprocessing`` *spawn*. Spawned children start a fresh interpreter
+and re-read the developer's REAL ``puppy.cfg`` (the test harness's config
+isolation lives in the parent process only), so without an env override a
+child silently inherits whatever the developer happens to have toggled.
+Env vars, by contrast, are inherited across the spawn boundary.
 """
 
 from __future__ import annotations
 
+import os
+
 from code_puppy.config import get_value, set_config_value
 
 _CFG_KEY = "kennel_enabled"
+_ENV_KEY = "PUPPY_KENNEL_ENABLED"
 _FALSY = frozenset({"false", "0", "no", "off"})
 
 DISABLED_TOOL_ERROR = (
@@ -38,7 +50,9 @@ def is_enabled() -> bool:
     so flipping the toggle takes effect immediately -- no relaunch
     required.
     """
-    raw = get_value(_CFG_KEY)
+    raw = os.environ.get(_ENV_KEY)
+    if raw is None:
+        raw = get_value(_CFG_KEY)
     if raw is None:
         return True
     return str(raw).strip().lower() not in _FALSY

--- a/tests/plugins/test_puppy_kennel.py
+++ b/tests/plugins/test_puppy_kennel.py
@@ -26,6 +26,12 @@ def kennel_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Throwaway kennel directory per test, isolated from the user's real one."""
     root = tmp_path / "kennel"
     monkeypatch.setenv("PUPPY_KENNEL_ROOT", str(root))
+    # Force the kennel ON for the duration of the test, independent of the
+    # developer's real puppy.cfg. This env override is also inherited across
+    # the multiprocessing *spawn* boundary, so child workers in
+    # ``test_concurrent_multiprocess_writes_do_not_corrupt`` don't silently
+    # no-op when the dev happens to have ``kennel_enabled = false`` locally.
+    monkeypatch.setenv("PUPPY_KENNEL_ENABLED", "true")
 
     # Every submodule binds paths/flags from ``config`` (and ``state``) AT
     # IMPORT TIME. If the plugin was already imported earlier in the test
@@ -201,6 +207,10 @@ def test_default_recall_scope_combines_three_wings() -> None:
 def _concurrent_worker(worker_id: int, kennel_root: str, n: int = 25) -> int:
     """Run inside a child process — imports must happen here, not at import time."""
     os.environ["PUPPY_KENNEL_ROOT"] = kennel_root
+    # Spawned children re-read the developer's REAL puppy.cfg (config
+    # isolation only patches the parent process), so pin the toggle ON via
+    # the env override or every write silently no-ops.
+    os.environ["PUPPY_KENNEL_ENABLED"] = "true"
     import importlib
 
     from code_puppy.plugins.puppy_kennel import config as kennel_config


### PR DESCRIPTION
…dropping

bead-factory-bna

Two root causes made test_concurrent_multiprocess_writes_do_not_corrupt drop all 500 writes (count_drawers==0):

1. is_enabled() ignored spawn boundary. The test harness isolates config in the PARENT process only; spawned children re-read the developer's real puppy.cfg, so a local 'kennel_enabled = false' silently no-opped every child write. Add a PUPPY_KENNEL_ENABLED env override (mirrors PUPPY_KENNEL_ROOT) which IS inherited across spawn. Test pins it on in both the fixture and the worker.

2. PRAGMA busy_timeout was applied AFTER journal_mode=WAL, so the first concurrent initialize() could hit 'database is locked' before the busy handler was armed. Reorder so busy_timeout comes first.