### PR TITLE
fix: resolve git worktrees to main repo wing in kennel

### DIFF
--- a/code_puppy/plugins/puppy_kennel/wings.py
+++ b/code_puppy/plugins/puppy_kennel/wings.py
@@ -17,18 +17,75 @@ from pathlib import Path
 USER_WING = "user:default"
 
 
+def _resolve_worktree_root(git_path: Path) -> Path | None:
+    """Resolve main repo root from a worktree ``.git`` file.
+
+    Worktrees store ``.git`` as a file with a ``gitdir: ...`` pointer that
+    targets ``<main-repo>/.git/worktrees/<name>`` (absolute or relative).
+    This helper parses and resolves that pointer, then walks upward until it
+    finds the real ``.git`` directory and returns its parent repo root.
+    """
+    try:
+        content = git_path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        return None
+
+    gitdir_raw: str | None = None
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if line.lower().startswith("gitdir:"):
+            gitdir_raw = line[len("gitdir:") :].strip()
+            break
+
+    if not gitdir_raw:
+        return None
+
+    try:
+        gitdir_path = Path(gitdir_raw)
+        if not gitdir_path.is_absolute():
+            gitdir_path = git_path.parent / gitdir_path
+        gitdir_path = gitdir_path.resolve()
+    except (OSError, ValueError):
+        return None
+
+    # Only resolve worktrees, not submodules. Worktree gitdir paths contain
+    # a "worktrees" component (e.g. <main>/.git/worktrees/<name>), whereas
+    # submodules point to <superproject>/.git/modules/<name>. Submodules are
+    # distinct repos and should keep their own wing.
+    if "worktrees" not in gitdir_path.parts:
+        return None
+
+    for parent in (gitdir_path, *gitdir_path.parents):
+        if parent.name == ".git" and parent.is_dir():
+            return parent.parent
+
+    return None
+
+
 def repo_wing(start: Path | str | None = None) -> str:
     """Return the ``repo:<path>`` wing for the given (or current) directory.
 
-    Walks upward looking for a ``.git`` directory. If none is found, falls
+    Walks upward looking for ``.git``. For normal repos, ``.git`` is a
+    directory and that candidate directory is used. For git worktrees,
+    ``.git`` is a file; in that case this resolves the linked main repo root
+    and uses it so all worktrees share one repo wing. If none is found, falls
     back to the resolved start directory itself — bare directories are still
     legitimate project scopes.
     """
     here = Path(start) if start else Path.cwd()
     here = here.resolve()
     for candidate in (here, *here.parents):
-        if (candidate / ".git").exists():
-            return f"repo:{candidate}"
+        git_path = candidate / ".git"
+        if not git_path.exists():
+            continue
+
+        if git_path.is_file():
+            worktree_root = _resolve_worktree_root(git_path)
+            if worktree_root is not None:
+                return f"repo:{worktree_root}"
+
+        return f"repo:{candidate}"
+
     return f"repo:{here}"
 
 

--- a/tests/plugins/test_puppy_kennel.py
+++ b/tests/plugins/test_puppy_kennel.py
@@ -189,6 +189,117 @@ def test_wing_naming_conventions() -> None:
     assert wings.USER_WING == "user:default"
 
 
+def test_repo_wing_resolves_worktree_to_main_repo(tmp_path: Path) -> None:
+    """Worktrees use a .git *file* pointing to the main repo — wing must resolve to main."""
+    from code_puppy.plugins.puppy_kennel import wings
+
+    # Set up a fake main repo
+    main_repo = tmp_path / "main-repo"
+    main_git = main_repo / ".git"
+    main_git.mkdir(parents=True)
+    worktrees_dir = main_git / "worktrees" / "feature-branch"
+    worktrees_dir.mkdir(parents=True)
+
+    # Set up a fake worktree with a .git file
+    worktree = tmp_path / "main-repo-feature-branch"
+    worktree.mkdir()
+    git_file = worktree / ".git"
+    git_file.write_text(f"gitdir: {worktrees_dir}\n")
+
+    assert wings.repo_wing(worktree) == f"repo:{main_repo.resolve()}"
+    # Main repo should still resolve to itself
+    assert wings.repo_wing(main_repo) == f"repo:{main_repo.resolve()}"
+
+
+def test_repo_wing_worktree_relative_gitdir(tmp_path: Path) -> None:
+    """Worktree .git files can have relative gitdir paths."""
+    from code_puppy.plugins.puppy_kennel import wings
+
+    main_repo = tmp_path / "repos" / "my-project"
+    main_git = main_repo / ".git"
+    main_git.mkdir(parents=True)
+    worktrees_dir = main_git / "worktrees" / "hotfix"
+    worktrees_dir.mkdir(parents=True)
+
+    worktree = tmp_path / "repos" / "my-project-hotfix"
+    worktree.mkdir(parents=True)
+    git_file = worktree / ".git"
+    # Relative path from worktree to main repo's .git/worktrees/hotfix
+    git_file.write_text("gitdir: ../my-project/.git/worktrees/hotfix\n")
+
+    assert wings.repo_wing(worktree) == f"repo:{main_repo.resolve()}"
+
+
+def test_repo_wing_malformed_git_file_falls_back(tmp_path: Path) -> None:
+    """If .git file is malformed, fall back to worktree dir itself."""
+    from code_puppy.plugins.puppy_kennel import wings
+
+    worktree = tmp_path / "broken-worktree"
+    worktree.mkdir()
+    git_file = worktree / ".git"
+    git_file.write_text("garbage content\n")
+
+    # Should fall back to the directory containing .git
+    assert wings.repo_wing(worktree) == f"repo:{worktree.resolve()}"
+
+
+def test_repo_wing_subdirectory_in_worktree(tmp_path: Path) -> None:
+    """Querying from a subdirectory inside a worktree resolves to main repo."""
+    from code_puppy.plugins.puppy_kennel import wings
+
+    main_repo = tmp_path / "main"
+    main_git = main_repo / ".git"
+    main_git.mkdir(parents=True)
+    worktrees_dir = main_git / "worktrees" / "dev"
+    worktrees_dir.mkdir(parents=True)
+
+    worktree = tmp_path / "main-dev"
+    worktree.mkdir()
+    (worktree / ".git").write_text(f"gitdir: {worktrees_dir}\n")
+    subdir = worktree / "src" / "com" / "deep"
+    subdir.mkdir(parents=True)
+
+    assert wings.repo_wing(subdir) == f"repo:{main_repo.resolve()}"
+
+
+def test_repo_wing_binary_git_file_falls_back(tmp_path: Path) -> None:
+    """A .git file with non-UTF-8 bytes must not crash — falls back gracefully."""
+    from code_puppy.plugins.puppy_kennel import wings
+
+    worktree = tmp_path / "corrupt-worktree"
+    worktree.mkdir()
+    git_file = worktree / ".git"
+    git_file.write_bytes(b"\xff\xfe\x00garbage\x80\x81")
+
+    # Should not raise, falls back to the directory itself
+    assert wings.repo_wing(worktree) == f"repo:{worktree.resolve()}"
+
+
+def test_repo_wing_submodule_stays_siloed(tmp_path: Path) -> None:
+    """Submodules should NOT merge into the superproject's wing."""
+    from code_puppy.plugins.puppy_kennel import wings
+
+    # Set up a fake superproject
+    superproject = tmp_path / "superproject"
+    super_git = superproject / ".git"
+    super_git.mkdir(parents=True)
+    modules_dir = super_git / "modules" / "my-submodule"
+    modules_dir.mkdir(parents=True)
+
+    # Set up a fake submodule with a .git file pointing to modules/
+    submodule = superproject / "vendor" / "my-submodule"
+    submodule.mkdir(parents=True)
+    git_file = submodule / ".git"
+    git_file.write_text(f"gitdir: {modules_dir}\n")
+
+    # Submodule should keep its OWN wing, not merge into superproject
+    result = wings.repo_wing(submodule)
+    # It should resolve to the submodule dir (since .git file resolution
+    # returns None for submodules, it falls back to the candidate dir)
+    assert result == f"repo:{submodule.resolve()}"
+    assert result != f"repo:{superproject.resolve()}"
+
+
 def test_default_recall_scope_combines_three_wings() -> None:
     from code_puppy.plugins.puppy_kennel import wings
 


### PR DESCRIPTION
## Problem

Git worktrees get their own `.git` **file** (not directory) pointing to
the main repo's `.git/worktrees/<name>/` directory. The kennel's
`repo_wing()` function checks for `.git` existence but doesn't
distinguish files from directories, so each worktree gets scoped to
its own wing instead of sharing the main repo's wing.

**Impact:** Memories saved in a worktree are invisible when working
from the main repo or another worktree of the same project — and
become permanently orphaned if the worktree is deleted.

## Fix

Add `_resolve_worktree_root()` helper to `wings.py`:

1. Detects `.git` files (worktree indicator)
2. Reads the `gitdir:` pointer inside
3. Resolves absolute/relative paths to the main repo root
4. Guards against submodules (which also use `.git` files but should stay siloed)

`repo_wing()` now calls this helper first, falling through to the
existing logic for normal repos.

## Tests

6 new tests covering:
- Worktree with absolute `gitdir:` path
- Worktree with relative `gitdir:` path
- Subdirectory within a worktree
- Malformed `.git` file (graceful fallback)
- Binary `.git` file (no crash)
- Submodule stays in its own wing (not collapsed)

All existing kennel tests continue to pass.