### PR TITLE
fix(anthropic-thinking): route wire shape by model family (fixes HTTP 400 on classic Claude with adaptive)

### DIFF
--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -316,7 +316,7 @@ def make_model_settings(
 
         from code_puppy.model_utils import (
             get_default_extended_thinking,
-            should_use_anthropic_thinking_summary,
+            resolve_anthropic_thinking_payload,
         )
 
         actual_model_id = model_config.get("name", model_name)
@@ -331,38 +331,45 @@ def make_model_settings(
             extended_thinking = "off"
 
         budget_tokens = effective_settings.get("budget_tokens", 10000)
-        if extended_thinking in ("enabled", "adaptive"):
-            model_settings_dict["anthropic_thinking"] = {
-                "type": extended_thinking,
-            }
-            if (
-                extended_thinking == "adaptive"
-                and should_use_anthropic_thinking_summary(model_name, actual_model_id)
-            ):
-                model_settings_dict["anthropic_thinking"]["display"] = "summarized"
-            # Only send budget_tokens for classic "enabled" mode
-            if extended_thinking == "enabled" and budget_tokens:
-                model_settings_dict["anthropic_thinking"]["budget_tokens"] = (
-                    budget_tokens
-                )
+        # Single choke point: coerce the internal mode (enabled/adaptive/...) to
+        # whatever wire shape THIS model actually accepts. Different Claude
+        # generations disagree: classic models want type:enabled+budget_tokens,
+        # newer adaptive-supporting models (Opus 4.6+/Sonnet 5/Fable 5) want
+        # type:adaptive and reject type:enabled. The helper picks correctly.
+        thinking_payload = resolve_anthropic_thinking_payload(
+            extended_thinking,
+            budget_tokens=budget_tokens,
+            model_name=model_name,
+            actual_model_id=actual_model_id,
+        )
+        if thinking_payload is not None:
+            model_settings_dict["anthropic_thinking"] = thinking_payload
 
-        # Opus 4-6 models support the `effort` setting via output_config.
-        # pydantic-ai doesn't have a native field for output_config yet,
-        # so we inject it through extra_body which gets merged into the
-        # HTTP request body.
-        # NOTE: effort/output_config only applies to adaptive thinking.
-        # With standard "enabled" thinking, budget_tokens controls depth.
+        # Opus 4-6+ models support the `effort` setting via output_config.
+        # pydantic-ai has no native field for output_config yet, so we inject
+        # it through extra_body which gets merged into the HTTP request body.
+        # All three gate conditions are load-bearing and must stay:
+        #   1. `thinking_payload is not None` -- user turned thinking OFF
+        #      (mode was "off"/"disabled"); don't add effort where there's
+        #      no thinking to steer.
+        #   2. `type == "adaptive"` -- verified at wire level: classic
+        #      Claude models 400 on output_config.effort; only adaptive-
+        #      shape requests may carry it.
+        #   3. `model_supports_setting(..., "effort")` -- per-model opt-in
+        #      from models.json, gives operators a kill-switch without a
+        #      code change if a specific model regresses.
+        # "Simplify" this at your peril.
         if (
-            model_supports_setting(model_name, "effort")
-            and extended_thinking == "adaptive"
+            thinking_payload is not None
+            and thinking_payload.get("type") == "adaptive"
+            and model_supports_setting(model_name, "effort")
         ):
             effort = effective_settings.get(
                 "effort", model_config.get("default_effort", "high")
             )
-            if "anthropic_thinking" in model_settings_dict:
-                extra_body = model_settings_dict.get("extra_body") or {}
-                extra_body["output_config"] = {"effort": effort}
-                model_settings_dict["extra_body"] = extra_body
+            extra_body = model_settings_dict.get("extra_body") or {}
+            extra_body["output_config"] = {"effort": effort}
+            model_settings_dict["extra_body"] = extra_body
 
         model_settings = AnthropicModelSettings(**model_settings_dict)
 

--- a/code_puppy/model_utils.py
+++ b/code_puppy/model_utils.py
@@ -112,39 +112,98 @@ def prepare_prompt_for_model(
     )
 
 
+def _matches_model_tag(candidate: str, tag: str) -> bool:
+    """Return True when ``tag`` appears as a model-name segment.
+
+    Plain substring matching makes ``claude-3-5-sonnet`` and
+    ``claude-4-5-sonnet`` both look like a hypothetical ``5-sonnet`` model.
+    That is cute, but wrong: those are Sonnet 3.5 and Sonnet 4.5 respectively,
+    NOT Sonnet 5. Treat tags as alphanumeric-delimited segments and reject
+    any ``X-5-sonnet`` / ``X.5-sonnet`` (or ``-fable``) shape where ``X`` is
+    any leading major-version digit.
+    """
+    start = 0
+    while True:
+        index = candidate.find(tag, start)
+        if index == -1:
+            return False
+
+        end = index + len(tag)
+        left_is_boundary = index == 0 or not candidate[index - 1].isalnum()
+        right_is_boundary = end == len(candidate) or not candidate[end].isalnum()
+        old_minor_version_shape = (
+            tag in {"5-sonnet", "5-fable"}
+            and index >= 2
+            and candidate[index - 1] in "-."
+            and candidate[index - 2].isdigit()
+        )
+        if left_is_boundary and right_is_boundary and not old_minor_version_shape:
+            return True
+        start = index + 1
+
+
+def _model_matches_any_tag(
+    model_name: str, actual_model_id: str | None, tags: tuple[str, ...]
+) -> bool:
+    """Return True when ``model_name`` OR ``actual_model_id`` matches any tag.
+
+    Shared classifier body for the various ``supports_*`` / ``should_use_*``
+    predicates. Checks both the alias/key and the real model ID so
+    Bedrock-style names like ``us.anthropic.claude-opus-4-7`` still route
+    correctly when only the wrapper alias is passed in.
+    """
+    candidates = [model_name.lower()]
+    if actual_model_id:
+        candidates.append(actual_model_id.lower())
+    return any(
+        _matches_model_tag(candidate, tag)
+        for candidate in candidates
+        for tag in tags
+    )
+
+
+_ADAPTIVE_TAGS: tuple[str, ...] = (
+    "opus-4-6",
+    "4-6-opus",
+    "opus-4-7",
+    "4-7-opus",
+    "opus-4-8",
+    "4-8-opus",
+    "sonnet-4-6",
+    "4-6-sonnet",
+    "sonnet-5",
+    "5-sonnet",
+    "fable-5",
+    "5-fable",
+)
+
+_SUMMARY_TAGS: tuple[str, ...] = (
+    "opus-4-7",
+    "4-7-opus",
+    "opus-4-8",
+    "4-8-opus",
+    "sonnet-5",
+    "5-sonnet",
+    "fable-5",
+    "5-fable",
+)
+
+
 def supports_adaptive_thinking(
     model_name: str, actual_model_id: str | None = None
 ) -> bool:
-    """Return whether a model should default to adaptive thinking.
+    """Return whether a model supports adaptive extended-thinking.
 
-    Opus 4-6, Opus 4-7, Opus 4-8, Sonnet 4-6, and Sonnet 5 models support
-    adaptive thinking. Checks both the alias/key and the real model ID to handle
-    Bedrock-style names like ``us.anthropic.claude-opus-4-7``.
+    Opus 4-6/4-7/4-8, Sonnet 4-6, Sonnet 5, and Fable 5 accept (and require)
+    ``thinking={"type": "adaptive"}`` at the wire level. Every other Claude
+    variant wants the classic ``type: "enabled"`` shape.
 
     Args:
         model_name: The model alias/key (e.g. ``"bedrock-opus-4-7"``).
         actual_model_id: The real model ID from config (e.g.
             ``"us.anthropic.claude-opus-4-7"``).
     """
-    candidates = [model_name.lower()]
-    if actual_model_id:
-        candidates.append(actual_model_id.lower())
-
-    _ADAPTIVE_TAGS = (
-        "opus-4-6",
-        "4-6-opus",
-        "opus-4-7",
-        "4-7-opus",
-        "opus-4-8",
-        "4-8-opus",
-        "sonnet-4-6",
-        "4-6-sonnet",
-        "sonnet-5",
-        "5-sonnet",
-        "fable-5",
-        "5-fable",
-    )
-    return any(tag in c for c in candidates for tag in _ADAPTIVE_TAGS)
+    return _model_matches_any_tag(model_name, actual_model_id, _ADAPTIVE_TAGS)
 
 
 def get_default_extended_thinking(
@@ -174,23 +233,62 @@ def should_use_anthropic_thinking_summary(
 ) -> bool:
     """Return whether Anthropic adaptive thinking should request summary display.
 
-    Anthropic's newer Opus 4.7+, Opus 4.8, Sonnet 5, and Fable 5 models require
-    ``display: \"summarized\"`` alongside ``thinking={"type": "adaptive"}``.
+    Anthropic's newer Opus 4.7+, Opus 4.8, Sonnet 5, and Fable 5 models accept
+    ``display: \"summarized\"`` alongside ``thinking={"type": "adaptive"}`` to
+    surface a condensed reasoning trace instead of the full block.
     """
-    _SUMMARY_TAGS = (
-        "opus-4-7",
-        "4-7-opus",
-        "opus-4-8",
-        "4-8-opus",
-        "sonnet-5",
-        "5-sonnet",
-        "fable-5",
-        "5-fable",
-    )
-    candidates = [model_name.lower()]
-    if actual_model_id:
-        candidates.append(actual_model_id.lower())
-    return any(tag in c for c in candidates for tag in _SUMMARY_TAGS)
+    return _model_matches_any_tag(model_name, actual_model_id, _SUMMARY_TAGS)
+
+
+def resolve_anthropic_thinking_payload(
+    extended_thinking: str,
+    *,
+    budget_tokens: int,
+    model_name: str,
+    actual_model_id: str | None,
+) -> dict | None:
+    """Map Code Puppy's internal thinking mode to the shape THIS model accepts.
+
+    Anthropic-family models split into two camps that reject each other's shape:
+
+    * **Classic** (Sonnet 4.5 and earlier, Haiku, etc.): only ``type: "enabled"``
+      (with ``budget_tokens``) or ``type: "disabled"``. Sending ``"adaptive"``
+      yields the reporter's error:
+      ``Input tag 'adaptive' does not match any of the expected tags: 'disabled', 'enabled'``.
+    * **Adaptive** (Opus 4.6/4.7/4.8, Sonnet 4.6, Sonnet 5, Fable 5): the
+      opposite — rejects ``type: "enabled"`` with
+      ``"thinking.type.enabled" is not supported for this model. Use adaptive."``.
+      These models want ``type: "adaptive"`` and optionally ``display: "summarized"``.
+
+    This helper picks the right shape based on ``supports_adaptive_thinking``
+    so a user's choice of ``"enabled"`` / ``"adaptive"`` (from the settings
+    menu, from defaults, or from legacy booleans) always translates to a
+    wire payload the specific target model actually accepts.
+
+    Args:
+        extended_thinking: The internal mode. Any of ``"enabled"`` /
+            ``"adaptive"`` produces a payload (coerced to the model's shape).
+            Anything else (``"off"``, ``"disabled"``, unknown, ``None``)
+            returns ``None`` so the caller omits ``anthropic_thinking``.
+        budget_tokens: Token budget for classic ``type: "enabled"`` mode.
+            Ignored on adaptive-supporting models (they compute their own).
+        model_name: The model alias/key (drives adaptive/summary detection).
+        actual_model_id: The real model ID from config (also checked so
+            Bedrock-style aliases like ``us.anthropic.claude-opus-4-7`` still
+            route correctly).
+
+    Returns:
+        Dict suitable for ``AnthropicModelSettings.anthropic_thinking``,
+        or ``None`` when thinking should be omitted entirely.
+    """
+    if extended_thinking not in ("enabled", "adaptive"):
+        return None
+    if supports_adaptive_thinking(model_name, actual_model_id):
+        payload: dict = {"type": "adaptive"}
+        if should_use_anthropic_thinking_summary(model_name, actual_model_id):
+            payload["display"] = "summarized"
+        return payload
+    return {"type": "enabled", "budget_tokens": budget_tokens}
 
 
 def get_glm_version(model_name: str) -> float | None:

--- a/code_puppy/model_utils.py
+++ b/code_puppy/model_utils.py
@@ -156,9 +156,7 @@ def _model_matches_any_tag(
     if actual_model_id:
         candidates.append(actual_model_id.lower())
     return any(
-        _matches_model_tag(candidate, tag)
-        for candidate in candidates
-        for tag in tags
+        _matches_model_tag(candidate, tag) for candidate in candidates for tag in tags
     )
 
 

--- a/tests/test_model_factory_coverage.py
+++ b/tests/test_model_factory_coverage.py
@@ -351,83 +351,54 @@ class TestMakeModelSettings:
 
 
 class TestOpus46EffortSetting:
-    """Test the effort setting for Opus 4-6 models.
+    """Tests for the effort setting + adaptive/enabled routing.
 
-    The Anthropic API expects effort as a separate top-level parameter:
-        output_config: {"effort": "high"}
-    Since pydantic-ai doesn't natively support output_config yet,
-    we inject it via extra_body which gets merged into the HTTP request.
+    Two orthogonal facts (verified against real API endpoints):
+
+    1. Adaptive-supporting Claude models (Opus 4.6/4.7/4.8, Sonnet 4.6,
+       Sonnet 5, Fable 5) accept ``thinking.type = "adaptive"`` and
+       optionally ``output_config.effort`` alongside it. Classic Claude
+       models (Sonnet 4.5 and earlier) reject both.
+    2. Code Puppy's internal ``"adaptive"`` mode is not itself a wire
+       value; the resolver picks the wire shape (``adaptive`` vs
+       ``enabled``) based on the target model.
     """
 
-    def test_opus_46_gets_effort_in_extra_body(self):
-        """Opus 4-6 should inject effort via extra_body.output_config."""
-        from code_puppy.model_factory import make_model_settings
-
-        settings = make_model_settings("claude-opus-4-6", max_tokens=4096)
-        extra_body = settings.get("extra_body", {})
-        assert "output_config" in extra_body
-        assert "effort" in extra_body["output_config"]
-
-    def test_opus_46_effort_default_is_high(self):
-        """Default effort for Opus 4-6 should be 'high'."""
-        from code_puppy.model_factory import make_model_settings
-
-        settings = make_model_settings("claude-opus-4-6", max_tokens=4096)
-        assert settings["extra_body"]["output_config"]["effort"] == "high"
-
-    def test_opus_46_effort_user_override(self):
-        """User-configured effort value should be respected."""
-        from code_puppy.model_factory import make_model_settings
-
-        with patch(
-            "code_puppy.config.get_effective_model_settings",
-            return_value={"effort": "low", "extended_thinking": "adaptive"},
-        ):
-            settings = make_model_settings("claude-opus-4-6", max_tokens=4096)
-            assert settings["extra_body"]["output_config"]["effort"] == "low"
-
-    def test_opus_46_reverse_name_also_works(self):
-        """claude-4-6-opus variant should also get effort."""
-        from code_puppy.model_factory import make_model_settings
-
-        settings = make_model_settings("claude-4-6-opus", max_tokens=4096)
-        extra_body = settings.get("extra_body", {})
-        assert "output_config" in extra_body
-        assert "effort" in extra_body["output_config"]
-
-    def test_non_opus_46_does_not_get_effort(self):
-        """Non Opus 4-6 Claude models should NOT have extra_body.output_config."""
-        from code_puppy.model_factory import make_model_settings
-
-        settings = make_model_settings("claude-sonnet-4-20250514", max_tokens=4096)
-        extra_body = settings.get("extra_body", {})
-        assert "output_config" not in extra_body
-
-    def test_opus_45_does_not_get_effort(self):
-        """Opus 4-5 should NOT have effort — it's 4-6 only."""
-        from code_puppy.model_factory import make_model_settings
-
-        settings = make_model_settings("claude-opus-4-5", max_tokens=4096)
-        extra_body = settings.get("extra_body", {})
-        assert "output_config" not in extra_body
-
-    def test_opus_46_thinking_type_is_adaptive_by_default(self):
-        """Opus 4-6 should default to adaptive thinking (from previous change)."""
+    def test_opus_46_injects_output_config_effort_on_adaptive(self):
+        """Opus 4-6 default -> adaptive shape + output_config.effort."""
         from code_puppy.model_factory import make_model_settings
 
         settings = make_model_settings("claude-opus-4-6", max_tokens=4096)
         assert settings["anthropic_thinking"]["type"] == "adaptive"
+        extra_body = settings.get("extra_body", {}) or {}
+        assert extra_body.get("output_config", {}).get("effort") == "high"
 
-    def test_opus_46_effort_not_in_anthropic_thinking(self):
-        """Effort should NOT be inside anthropic_thinking — it's a separate param."""
+    def test_classic_sonnet_does_not_get_output_config(self):
+        """Classic Sonnet -> enabled shape, no output_config injection."""
+        from code_puppy.model_factory import make_model_settings
+
+        settings = make_model_settings("claude-sonnet-4-5", max_tokens=4096)
+        assert settings["anthropic_thinking"]["type"] == "enabled"
+        extra_body = settings.get("extra_body", {}) or {}
+        assert "output_config" not in extra_body
+
+    def test_opus_45_does_not_get_output_config(self):
+        """Opus 4-5 is classic-shape (not in the adaptive-supporting set)."""
+        from code_puppy.model_factory import make_model_settings
+
+        settings = make_model_settings("claude-opus-4-5", max_tokens=4096)
+        extra_body = settings.get("extra_body", {}) or {}
+        assert "output_config" not in extra_body
+
+    def test_opus_46_effort_not_nested_in_anthropic_thinking(self):
+        """Effort belongs in extra_body.output_config, NOT anthropic_thinking."""
         from code_puppy.model_factory import make_model_settings
 
         settings = make_model_settings("claude-opus-4-6", max_tokens=4096)
-        thinking = settings.get("anthropic_thinking", {})
-        assert "effort" not in thinking
+        assert "effort" not in settings.get("anthropic_thinking", {})
 
     def test_opus_4_7_adaptive_thinking_adds_summary_display(self):
-        """Opus 4.7 adaptive thinking should include display=summarized."""
+        """Opus 4.7 under adaptive: wire type=adaptive + display=summarized."""
         from code_puppy.model_factory import make_model_settings
 
         with patch(
@@ -438,8 +409,8 @@ class TestOpus46EffortSetting:
         assert settings["anthropic_thinking"]["type"] == "adaptive"
         assert settings["anthropic_thinking"]["display"] == "summarized"
 
-    def test_non_opus_4_7_adaptive_thinking_does_not_add_summary_display(self):
-        """Other Anthropic adaptive-thinking models should not get display=summarized."""
+    def test_opus_4_6_adaptive_thinking_no_display(self):
+        """Opus 4-6 gets adaptive but no display (only 4.7+ gets summary)."""
         from code_puppy.model_factory import make_model_settings
 
         with patch(
@@ -449,6 +420,98 @@ class TestOpus46EffortSetting:
             settings = make_model_settings("claude-opus-4-6", max_tokens=4096)
         assert settings["anthropic_thinking"]["type"] == "adaptive"
         assert "display" not in settings["anthropic_thinking"]
+
+    def test_adaptive_forced_on_classic_model_gets_downgraded(self):
+        """Regression: adaptive on a classic-only model must NOT leak.
+
+        Reporter's original scenario: a Sonnet 4-5 variant with
+        ``extended_thinking="adaptive"`` set. Pre-fix this produced
+        ``type: "adaptive"`` on the wire and Anthropic returned HTTP 400
+        (``Input tag 'adaptive' does not match any of the expected tags:
+        'disabled', 'enabled'``). Post-fix it coerces to type:enabled.
+        """
+        from code_puppy.model_factory import make_model_settings
+
+        with patch(
+            "code_puppy.config.get_effective_model_settings",
+            return_value={"extended_thinking": "adaptive"},
+        ):
+            settings = make_model_settings("claude-sonnet-4-5", max_tokens=4096)
+        thinking = settings["anthropic_thinking"]
+        assert thinking["type"] == "enabled"
+        assert "budget_tokens" in thinking
+
+    def test_enabled_forced_on_adaptive_only_model_gets_upgraded(self):
+        """Regression (opposite direction): enabled on an adaptive-only model.
+
+        Opus 4.7 rejects ``thinking.type="enabled"`` with a different HTTP 400
+        (``"thinking.type.enabled" is not supported for this model. Use
+        adaptive.``). The resolver must upgrade enabled -> adaptive shape.
+        """
+        from code_puppy.model_factory import make_model_settings
+
+        with patch(
+            "code_puppy.config.get_effective_model_settings",
+            return_value={"extended_thinking": "enabled"},
+        ):
+            settings = make_model_settings("claude-opus-4-7", max_tokens=4096)
+        assert settings["anthropic_thinking"]["type"] == "adaptive"
+
+    def test_no_combination_ever_produces_wire_invalid_type(self):
+        """Fuzz: every mode x model combination yields a wire-valid type."""
+        from code_puppy.model_factory import make_model_settings
+
+        for mode in ("enabled", "adaptive"):
+            for model in (
+                "claude-opus-4-6",
+                "claude-opus-4-7",
+                "claude-opus-4-8",
+                "claude-sonnet-4-6",
+                "claude-sonnet-5",
+                "claude-4-5-sonnet",
+                "claude-sonnet-4-5",
+                "claude-3-5-sonnet",
+            ):
+                with patch(
+                    "code_puppy.config.get_effective_model_settings",
+                    return_value={"extended_thinking": mode},
+                ):
+                    settings = make_model_settings(model, max_tokens=4096)
+                wire_type = settings.get("anthropic_thinking", {}).get("type")
+                assert wire_type in ("enabled", "adaptive", "disabled"), (
+                    f"leak: mode={mode!r} model={model!r} wire_type={wire_type!r}"
+                )
+
+    def test_off_modes_omit_anthropic_thinking_entirely(self):
+        """Companion fuzz: 'off'/'disabled'/None must NOT emit thinking at all.
+
+        The resolver returns None for these modes; the factory must translate
+        that to 'omit anthropic_thinking from the settings dict', not
+        'emit an empty dict'. Empty dicts have been known to serialize as
+        ``"thinking": {}`` on the wire and get their own validation errors.
+        """
+        from code_puppy.model_factory import make_model_settings
+
+        for mode in ("off", "disabled", None):
+            for model in (
+                "claude-opus-4-7",
+                "claude-sonnet-4-5",
+                "claude-3-5-sonnet",
+            ):
+                with patch(
+                    "code_puppy.config.get_effective_model_settings",
+                    return_value={"extended_thinking": mode},
+                ):
+                    settings = make_model_settings(model, max_tokens=4096)
+                assert "anthropic_thinking" not in settings, (
+                    f"leak: mode={mode!r} model={model!r} still emitted "
+                    f"anthropic_thinking={settings.get('anthropic_thinking')!r}"
+                )
+                # And no orphaned output_config.effort either.
+                extra_body = settings.get("extra_body") or {}
+                assert "output_config" not in extra_body, (
+                    f"orphan output_config: mode={mode!r} model={model!r}"
+                )
 
 
 class TestZaiChatModel:

--- a/tests/test_opus_47_thinking_display.py
+++ b/tests/test_opus_47_thinking_display.py
@@ -1,9 +1,14 @@
-"""Tests for Opus 4.7 wire-level thinking.display='summary' enforcement.
+"""Tests for Opus 4.7 wire-level thinking.display='summarized' enforcement.
 
-The Opus 4.7 family requires ``display: "summarized"`` alongside
-``type: "adaptive"`` in the thinking dict, otherwise the API rejects the
-request. We enforce this at the wire level in the claude cache client so
+The Opus 4.7 family accepts ``display: "summarized"`` alongside
+``type: "adaptive"`` in the thinking dict to surface a condensed reasoning
+trace. We enforce this at the wire level in the claude cache client so
 it's guaranteed regardless of how upstream model settings are built.
+
+The enforcer itself keys off ``model`` (via
+``_model_requires_thinking_summary``), not off ``type``, so it works no
+matter which thinking shape the caller sent. Fixtures use ``"adaptive"``
+to reflect what Code Puppy actually puts on the wire for Opus 4.7 today.
 """
 
 from __future__ import annotations
@@ -86,7 +91,7 @@ class TestEnforceThinkingDisplaySummary:
 
     def test_no_op_when_thinking_not_a_dict(self):
         # thinking might be e.g. a string or list in weird serialization paths
-        payload = {"model": "claude-opus-4-7", "thinking": "adaptive"}
+        payload = {"model": "claude-opus-4-7", "thinking": "enabled"}
         changed = _enforce_thinking_display_summary(payload)
         assert changed is False
 
@@ -109,7 +114,7 @@ class TestInjectCacheControlInPayloadEnforcesSummary:
     def test_payload_path_skips_non_opus_4_7(self):
         payload = {
             "model": "claude-sonnet-4-5",
-            "thinking": {"type": "adaptive"},
+            "thinking": {"type": "enabled"},
             "messages": [{"role": "user", "content": "hi"}],
         }
         _inject_cache_control_in_payload(payload)

--- a/tests/test_resolve_anthropic_thinking_payload.py
+++ b/tests/test_resolve_anthropic_thinking_payload.py
@@ -1,0 +1,185 @@
+"""Tests for ``code_puppy.model_utils.resolve_anthropic_thinking_payload``.
+
+Ground truth (verified against puppy-backend.walmart.com/anthropic on real
+Claude endpoints, 2026-07-01):
+
+* Classic Claude (Sonnet 4.5 and earlier, Haiku, etc.) accepts
+  ``{"type": "enabled", "budget_tokens": N}`` and ``{"type": "disabled"}``.
+  Sending ``"adaptive"`` yields HTTP 400
+  ``Input tag 'adaptive' found using 'type' does not match any of the expected
+  tags: 'disabled', 'enabled'``.
+* Adaptive-supporting Claude (Opus 4.6/4.7/4.8, Sonnet 4.6, Sonnet 5, Fable 5)
+  accepts ``{"type": "adaptive"}`` (optionally with ``"display": "summarized"``
+  and/or ``output_config.effort``). Sending ``"enabled"`` yields HTTP 400
+  ``"thinking.type.enabled" is not supported for this model. Use adaptive.``
+
+The helper's job is to translate Code Puppy's internal thinking mode
+(``"enabled"`` / ``"adaptive"`` / ``"off"`` / ``"disabled"``) into whichever
+of those two wire shapes the target model actually accepts.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from code_puppy.model_utils import resolve_anthropic_thinking_payload
+
+
+class TestClassicModelsGetEnabledShape:
+    """Classic Claude models (Sonnet 4.5 and earlier) want type:enabled."""
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "claude-4-5-sonnet",
+            "claude-sonnet-4-5",
+            "claude-3-5-sonnet",
+            "claude-4-5-haiku",
+        ],
+    )
+    @pytest.mark.parametrize("mode", ["enabled", "adaptive"])
+    def test_classic_models_always_get_enabled_shape(self, model_name, mode):
+        payload = resolve_anthropic_thinking_payload(
+            mode,
+            budget_tokens=10000,
+            model_name=model_name,
+            actual_model_id=None,
+        )
+        assert payload is not None
+        assert payload["type"] == "enabled"
+        assert payload["budget_tokens"] == 10000
+        assert "display" not in payload
+
+
+class TestAdaptiveModelsGetAdaptiveShape:
+    """Adaptive-supporting Claude models want type:adaptive."""
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "claude-opus-4-6",
+            "claude-opus-4-7",
+            "claude-opus-4-8",
+            "claude-sonnet-4-6",
+            "claude-sonnet-5",
+            "claude-5-sonnet",
+            "claude-fable-5",
+        ],
+    )
+    @pytest.mark.parametrize("mode", ["enabled", "adaptive"])
+    def test_adaptive_models_always_get_adaptive_shape(self, model_name, mode):
+        payload = resolve_anthropic_thinking_payload(
+            mode,
+            budget_tokens=10000,
+            model_name=model_name,
+            actual_model_id=None,
+        )
+        assert payload is not None
+        assert payload["type"] == "adaptive"
+        # budget_tokens is meaningless on adaptive and must NOT be included
+        assert "budget_tokens" not in payload
+
+    def test_summary_display_added_for_opus_4_7(self):
+        payload = resolve_anthropic_thinking_payload(
+            "adaptive",
+            budget_tokens=8000,
+            model_name="claude-opus-4-7",
+            actual_model_id=None,
+        )
+        assert payload == {"type": "adaptive", "display": "summarized"}
+
+    def test_summary_display_added_for_sonnet_5(self):
+        payload = resolve_anthropic_thinking_payload(
+            "enabled",
+            budget_tokens=8000,
+            model_name="claude-sonnet-5",
+            actual_model_id=None,
+        )
+        assert payload == {"type": "adaptive", "display": "summarized"}
+
+    def test_summary_display_not_added_for_opus_4_6(self):
+        payload = resolve_anthropic_thinking_payload(
+            "adaptive",
+            budget_tokens=8000,
+            model_name="claude-opus-4-6",
+            actual_model_id=None,
+        )
+        assert payload == {"type": "adaptive"}
+
+    def test_uses_actual_model_id_for_adaptive_detection(self):
+        # Bedrock-style alias where only actual_model_id reveals the family.
+        payload = resolve_anthropic_thinking_payload(
+            "enabled",
+            budget_tokens=10000,
+            model_name="my-custom-alias",
+            actual_model_id="us.anthropic.claude-opus-4-7",
+        )
+        assert payload is not None
+        assert payload["type"] == "adaptive"
+        assert payload["display"] == "summarized"
+
+
+class TestOffAndUnknownModesReturnNone:
+    """Anything that isn't a documented 'thinking on' mode must return None."""
+
+    @pytest.mark.parametrize(
+        "mode",
+        ["off", "disabled", "", "nonsense", "true", None],
+    )
+    @pytest.mark.parametrize(
+        "model_name",
+        ["claude-opus-4-7", "claude-sonnet-4-5", "claude-3-5-sonnet"],
+    )
+    def test_returns_none_for_off_and_unknown(self, mode, model_name):
+        payload = resolve_anthropic_thinking_payload(
+            mode,
+            budget_tokens=10000,
+            model_name=model_name,
+            actual_model_id=None,
+        )
+        assert payload is None
+
+
+class TestNoWireLeaks:
+    """Fuzz-style: no combination should ever produce a wire-invalid type."""
+
+    def test_every_combination_produces_a_wire_valid_type_or_none(self):
+        modes = ["enabled", "adaptive", "off", "disabled", "unknown", "", None]
+        models = [
+            "claude-4-5-sonnet",
+            "claude-sonnet-4-5",
+            "claude-3-5-sonnet",
+            "claude-opus-4-6",
+            "claude-opus-4-7",
+            "claude-opus-4-8",
+            "claude-sonnet-5",
+            "claude-fable-5",
+        ]
+        for mode in modes:
+            for model in models:
+                payload = resolve_anthropic_thinking_payload(
+                    mode,
+                    budget_tokens=10000,
+                    model_name=model,
+                    actual_model_id=None,
+                )
+                if payload is None:
+                    continue
+                assert payload["type"] in ("enabled", "adaptive", "disabled"), (
+                    f"leak: mode={mode!r} model={model!r} "
+                    f"produced type={payload['type']!r}"
+                )
+                # Regression assertion tied to the reporter's exact error:
+                # never mix adaptive on a classic-only model, and vice versa.
+                is_adaptive_model = model in {
+                    "claude-opus-4-6",
+                    "claude-opus-4-7",
+                    "claude-opus-4-8",
+                    "claude-sonnet-5",
+                    "claude-fable-5",
+                }
+                expected_type = "adaptive" if is_adaptive_model else "enabled"
+                assert payload["type"] == expected_type, (
+                    f"routing bug: mode={mode!r} model={model!r} "
+                    f"produced type={payload['type']!r} but expected {expected_type!r}"
+                )


### PR DESCRIPTION
## Reported error

```
anthropic.APIStatusError: {error: {message: [HTTP 400] thinking: Input tag
'adaptive' found using 'type' does not match any of the expected tags:
'disabled', 'enabled', type: invalid_request_error}, type: error}
```

Hit on the `claude-4-5-sonnet` alias with default settings.

## Root cause (verified against `puppy-backend.walmart.com/anthropic`)

Anthropic-family Claude models bifurcate into two mutually-exclusive wire
shapes for the `thinking` field:

| Family | Models | Accepts | Rejects |
|---|---|---|---|
| **Classic** | Sonnet 4.5 & earlier, Haiku, Opus ≤ 4.5 | `type:"enabled"` + `budget_tokens`, `type:"disabled"` | `type:"adaptive"` (reporter's error) |
| **Adaptive** | Opus 4.6/4.7/4.8, Sonnet 4.6, Sonnet 5, Fable 5 | `type:"adaptive"` (+ optional `display:"summarized"`, `output_config.effort`) | `type:"enabled"` (`"thinking.type.enabled" is not supported for this model. Use adaptive.`) |

Two bugs conspired to produce the reporter's error:

1. **`_matches_model_tag` boundary check was incomplete.** It only guarded
   `3-5-sonnet` from wrongly matching the `5-sonnet` adaptive tag; it missed
   `4-5-sonnet`. This finishes the fix started in commit `705828e1` which
   caught the Sonnet 3.5 case only.
2. **No wire-shape resolver existed.** `model_factory.py` passed the
   internal `"adaptive"` mode string straight through as `thinking.type`,
   leaking a non-wire-valid value to the API on classic models.

## Fix

- **New `resolve_anthropic_thinking_payload()`** in `model_utils.py` picks
  the wire shape based on `supports_adaptive_thinking()`. Adaptive-
  supporting models get `{type:"adaptive"}` (+ optional
  `display:"summarized"` on 4.7+/Sonnet 5/Fable 5). Classic models get
  `{type:"enabled", budget_tokens:N}`. `off`/`disabled`/unknown returns
  `None` and the caller omits the field.
- **Tightened `_matches_model_tag`**: the old-minor-version guard now
  rejects any `X-5-sonnet` / `X.5-sonnet` pattern where X is a digit, not
  just X=3.
- **`model_factory.py`** calls the resolver and gates
  `output_config.effort` injection on
  *resolved-payload-is-adaptive* AND `model_supports_setting(m, "effort")`.
  Classic models never receive `output_config` (verified: they 400 on it).
- **Extracted `_model_matches_any_tag()`** helper to DRY the two
  classifier predicates.
- Public repo also gets the boundary-aware `_matches_model_tag` ported
  over (it was using naive `tag in c` matching), so classifier behavior is
  identical across both trees.

## Verification

- Direct HTTP probes to `puppy-backend.walmart.com/anthropic` against
  Sonnet 4.5 and Opus 4.7 endpoints confirmed the accept/reject matrix
  above.
- **Private repo**: 246 tests pass.
- **Public repo**: 146 tests pass (2 pre-existing SSL env failures
  unrelated to this change).
- Headless CLI runs on both `claude-4-5-sonnet` and `claude-4-7-opus`
  succeed cleanly end-to-end.

## Blast radius pre-fix

- Users of `claude-4-5-sonnet` alias with default settings → **HTTP 400 on every request**
- Users who manually set `extended_thinking = "adaptive"` in the settings
  menu on a classic model → **HTTP 400**
- Users on canonical model spellings (`claude-sonnet-4-5`, Opus 4.6+,
  Sonnet 5) → unaffected

## Follow-ups (not this PR)

- Settings menu should filter thinking modes by model support — currently
  offers `"adaptive"` on Sonnet 4.5 and `"enabled"` on Opus 4.7 even
  though the API rejects both. Wire is now safe, UX still misleading.
- `_SUMMARY_TAGS ⊂ _ADAPTIVE_TAGS` invariant is implicit — when Sonnet 6
  ships someone will add it to one tuple and forget the other. Worth
  deriving one from the other or pinning with a comment.
- Mode string matching (`enabled`/`adaptive`) is case-sensitive. Could
  `.lower()` for defense in depth.

## Jira

Tried to file a ticket via `pup-ticket-creator`; Jira's
Application/Service option-lookup endpoint is 403'ing right now.
Description above stands in for the ticket body — happy to add a ticket
link in a follow-up commit once Jira is back up.
