### PR TITLE
fix(key-listener): stop Windows arrow keys leaking 'à'+code into the …

### DIFF
--- a/code_puppy/agents/_key_listeners.py
+++ b/code_puppy/agents/_key_listeners.py
@@ -384,9 +384,17 @@ def _listen_windows(
         try:
             if msvcrt.kbhit():
                 key = msvcrt.getwch()
-                if key in ("\x00", "\xe0") and msvcrt.kbhit():
-                    # Extended key: translate the pair to the xterm seq
-                    # the editor understands; unknown pairs swallowed.
+                if key in ("\x00", "\xe0"):
+                    # Extended key: the second half of the pair sits in
+                    # the CRT's internal pushback buffer, which kbhit()
+                    # CANNOT see (it only peeks the console input queue)
+                    # — so per the _getwch docs we read again
+                    # unconditionally. Gating on kbhit() here leaked the
+                    # prefix into the editor as a literal 'à' (\xe0) on
+                    # every arrow press. Unknown pairs are swallowed.
+                    # Known wart: a literal typed 'à' (U+00E0, non-US
+                    # layouts) is indistinguishable from the prefix and
+                    # briefly blocks this read until the next keypress.
                     seq = _WIN_EXTENDED_KEYS.get(msvcrt.getwch())
                     if seq:
                         _feed_line_editor(seq)

--- a/tests/tools/test_shell_ctrlx_listener_pause.py
+++ b/tests/tools/test_shell_ctrlx_listener_pause.py
@@ -350,3 +350,46 @@ def test_windows_listener_skips_kbhit_while_suspended(monkeypatch):
     fake_msvcrt.kbhit.assert_not_called()
     on_escape.assert_not_called()
     assert released_event.is_set()
+
+
+def test_windows_listener_translates_extended_key_despite_kbhit_lie(monkeypatch):
+    """Arrow keys must translate even though kbhit() can't see the pair's tail.
+
+    Real CRT behaviour (verified on Windows): after ``getwch()`` returns
+    the ``\\xe0`` prefix of an extended key, the second half sits in the
+    CRT's internal pushback buffer — INVISIBLE to ``kbhit()``, which only
+    peeks the console input queue. Gating the second read on ``kbhit()``
+    leaked the prefix into the line editor as a literal 'à' on every
+    arrow press (the slash-menu mystery-character bug).
+    """
+    keys = iter(["\xe0", "K"])  # Left arrow pair
+    kbhits = iter([True])  # True before the prefix, False forever after
+
+    fake_msvcrt = MagicMock()
+    fake_msvcrt.kbhit.side_effect = lambda: next(kbhits, False)
+    fake_msvcrt.getwch.side_effect = lambda: next(keys)
+    monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
+
+    fed: list[str] = []
+    editor = MagicMock()
+    editor.feed.side_effect = fed.append
+    _key_listeners.set_line_editor(editor)
+
+    stop_event = threading.Event()
+
+    def stop_after_a_tick():
+        time.sleep(0.15)
+        stop_event.set()
+
+    stopper = threading.Thread(target=stop_after_a_tick)
+    stopper.start()
+    try:
+        _key_listeners._listen_windows(stop_event, MagicMock())
+    finally:
+        stopper.join()
+        _key_listeners.set_line_editor(None)
+
+    assert fed == ["\x1b[D"], (
+        "Left arrow must reach the editor as its xterm sequence — "
+        f"never as raw '\\xe0'/'K' literals (got {fed!r})"
+    )


### PR DESCRIPTION
…editor

The Windows listener gated the second half of an extended-key pair on msvcrt.kbhit():

    if key in ("\x00", "\xe0") and msvcrt.kbhit():

but after getwch() consumes the prefix, the pair's second half sits in the CRT's internal pushback buffer, which kbhit() CANNOT see -- it only peeks the console input queue. Verified empirically on Windows by injecting a real arrow key via WriteConsoleInputW: kbhit() reports False after the prefix read while getwch() returns the buffered scan code instantly.

The gate was therefore False on EVERY arrow press, so the prefix fell through to _dispatch_key, passed isprintable(), and landed in the line editor as a literal 'a-grave' (U+00E0); one poll tick later the orphaned scan code (H/P/K/M) followed as plain text. Typing a slash command and navigating the completion menu grew garbage like "exitàKàKàKà" in the prompt buffer (regression from the bottom-bar rewrite, ab0bcf5 -- the old prompt_toolkit path did its own console input handling).

Fix: after a "\x00"/"\xe0" prefix, read the second half unconditionally, exactly as the MSDN _getwch docs prescribe. All seven mapped extended keys (arrows, Home, End, Delete) verified against a live console to translate cleanly to their xterm sequences with no leftover input.

Known wart, documented inline: a literal typed 'a-grave' (non-US layouts) is indistinguishable from the extended-key prefix -- an inherent getwch API ambiguity -- and briefly blocks the listener until the next keypress.

Adds a regression test that simulates the kbhit-can't-see-the-pushback behaviour and asserts Left arrow reaches the editor as ESC[D, never as raw prefix/scan-code literals.