### PR TITLE
Fix/persistent prompt regressions

### DIFF
--- a/code_puppy/agents/_key_listeners.py
+++ b/code_puppy/agents/_key_listeners.py
@@ -360,6 +360,51 @@ _WIN_EXTENDED_KEYS = {
 }
 
 
+#: Max chars drained from the console input queue in one poll tick.
+_WIN_BURST_CAP = 4096
+
+#: Minimum all-text burst length treated as a paste. Two chars can be a
+#: fast typing roll landing inside one 50ms poll tick (e.g. 'i' + Enter);
+#: three-plus plain chars in under 50ms is effectively only ever a paste.
+_WIN_PASTE_MIN_CHARS = 3
+
+
+def _drain_windows_burst(msvcrt) -> list:
+    """Read every pending console char as ``(kind, value)`` items.
+
+    ``kind`` is ``"char"`` (regular key) or ``"seq"`` (extended key
+    already translated to its xterm sequence).
+    """
+    items: list = []
+    while msvcrt.kbhit() and len(items) < _WIN_BURST_CAP:
+        key = msvcrt.getwch()
+        if key in ("\x00", "\xe0"):
+            # Extended key pair — see the pushback-buffer note below.
+            seq = _WIN_EXTENDED_KEYS.get(msvcrt.getwch())
+            if seq:
+                items.append(("seq", seq))
+        else:
+            items.append(("char", key))
+    return items
+
+
+def _coalesce_paste_burst(items: list) -> Optional[str]:
+    """Return the paste payload for a large all-text burst, else ``None``.
+
+    The Windows console input queue has no bracketed paste: a paste
+    arrives as a flood of individual chars, which the old one-char-per-
+    tick loop rendered like slow typing — and every ``\\r`` in the flood
+    submitted as its own prompt. Mirroring the classic prompt_toolkit
+    win32 heuristic: many chars in a single read only ever means paste.
+    Bursts containing extended keys (arrows etc.) are real typing.
+    """
+    if len(items) < _WIN_PASTE_MIN_CHARS:
+        return None
+    if any(kind != "char" for kind, _ in items):
+        return None
+    return "".join(value for _, value in items)
+
+
 def _listen_windows(
     stop_event: threading.Event,
     on_escape: Callable[[], None],
@@ -383,23 +428,33 @@ def _listen_windows(
 
         try:
             if msvcrt.kbhit():
-                key = msvcrt.getwch()
-                if key in ("\x00", "\xe0"):
-                    # Extended key: the second half of the pair sits in
-                    # the CRT's internal pushback buffer, which kbhit()
-                    # CANNOT see (it only peeks the console input queue)
-                    # — so per the _getwch docs we read again
-                    # unconditionally. Gating on kbhit() here leaked the
-                    # prefix into the editor as a literal 'à' (\xe0) on
-                    # every arrow press. Unknown pairs are swallowed.
-                    # Known wart: a literal typed 'à' (U+00E0, non-US
-                    # layouts) is indistinguishable from the prefix and
-                    # briefly blocks this read until the next keypress.
-                    seq = _WIN_EXTENDED_KEYS.get(msvcrt.getwch())
-                    if seq:
-                        _feed_line_editor(seq)
+                # Drain the WHOLE pending burst this tick (one char per
+                # 50ms tick made a 200-char paste take ten seconds).
+                # Extended-key note: the second half of a \x00/\xe0 pair
+                # sits in the CRT's internal pushback buffer, which
+                # kbhit() CANNOT see (it only peeks the console input
+                # queue) — so per the _getwch docs the drain reads again
+                # unconditionally. Gating on kbhit() here leaked the
+                # prefix into the editor as a literal 'à' (\xe0) on
+                # every arrow press. Unknown pairs are swallowed.
+                # Known wart: a literal typed 'à' (U+00E0, non-US
+                # layouts) is indistinguishable from the prefix and
+                # briefly blocks the read until the next keypress.
+                items = _drain_windows_burst(msvcrt)
+                payload = _coalesce_paste_burst(items)
+                if payload is not None:
+                    # Synthesize a bracketed paste: the editor inserts
+                    # it atomically and newlines stay IN the buffer
+                    # instead of submitting one prompt per line.
+                    _feed_line_editor("\x1b[200~" + payload + "\x1b[201~")
                 else:
-                    _dispatch_key(key, on_escape, cancel_agent_char, on_cancel_agent)
+                    for kind, value in items:
+                        if kind == "seq":
+                            _feed_line_editor(value)
+                        else:
+                            _dispatch_key(
+                                value, on_escape, cancel_agent_char, on_cancel_agent
+                            )
             else:
                 # Idle tick: let a pending bare ESC expire.
                 _tick_line_editor()

--- a/code_puppy/agents/_key_listeners.py
+++ b/code_puppy/agents/_key_listeners.py
@@ -374,9 +374,16 @@ def _drain_windows_burst(msvcrt) -> list:
 
     ``kind`` is ``"char"`` (regular key) or ``"seq"`` (extended key
     already translated to its xterm sequence).
+
+    CONTRACT: the caller has already seen ``kbhit()`` return True, so
+    the FIRST read is unconditional — do-while, not while. ``kbhit()``
+    only peeks the console input queue and CANNOT see the CRT's
+    internal pushback buffer, so re-polling it before the first read
+    drops keys whose data already left the queue (an extended-key pair
+    read half-way is exactly that — the original 'kbhit lie' bug).
     """
     items: list = []
-    while msvcrt.kbhit() and len(items) < _WIN_BURST_CAP:
+    while len(items) < _WIN_BURST_CAP:
         key = msvcrt.getwch()
         if key in ("\x00", "\xe0"):
             # Extended key pair — see the pushback-buffer note below.
@@ -385,6 +392,8 @@ def _drain_windows_burst(msvcrt) -> list:
                 items.append(("seq", seq))
         else:
             items.append(("char", key))
+        if not msvcrt.kbhit():
+            break
     return items
 
 

--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -767,17 +767,30 @@ async def run_with_mcp(
 
     def graceful_sigint_handler(_sig, _frame):
         from code_puppy.keymap import get_cancel_agent_display_name
-        from code_puppy.terminal_utils import (
-            ensure_ctrl_c_disabled,
-            install_windows_ctrl_c_swallower,
-            reset_windows_terminal_full,
-        )
+        from code_puppy.terminal_utils import reset_windows_terminal_full
+        from code_puppy.uvx_detection import should_use_alternate_cancel_key
 
+        if is_awaiting_user_input():
+            return
         reset_windows_terminal_full()
-        # On Windows+uvx, a SIGINT slipping through means a guard dropped.
-        # Re-arm both layers before continuing so the next Ctrl+C is a no-op.
-        ensure_ctrl_c_disabled()
-        install_windows_ctrl_c_swallower()
+        if should_use_alternate_cancel_key():
+            # Windows+uvx ONLY: a SIGINT slipping through means a guard
+            # dropped — re-arm both layers so the next Ctrl+C is a no-op.
+            # NEVER arm these on plain Windows: the swallower is a
+            # process-wide PERMANENT console handler, so one mid-run
+            # Ctrl+C used to eat every future Ctrl+C for the whole
+            # session (including the idle prompt-clear).
+            from code_puppy.terminal_utils import (
+                ensure_ctrl_c_disabled,
+                install_windows_ctrl_c_swallower,
+            )
+
+            ensure_ctrl_c_disabled()
+            install_windows_ctrl_c_swallower()
+        # Buffer-first: composing input absorbs the press (clear + hint),
+        # matching keyboard_interrupt_handler's contract.
+        if not sigint_should_cancel():
+            return
         emit_info(f"Use {get_cancel_agent_display_name()} to cancel the agent task.")
 
     original_handler = None

--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -660,11 +660,17 @@ async def run_with_mcp(
                 "McpError during agent run: %s", mcp_error
             )
         except* asyncio.CancelledError:
-            emit_info("Cancelled")
+            # Leading newline: a mid-stream cancel aborts the drain tasks
+            # (event_stream_handler) before the "final newline after
+            # streaming" runs, so the transcript cursor is usually parked
+            # mid-line on a half-streamed thinking/answer row. Without it
+            # the banner glues onto that text ("...AaronCancelled").
+            # Mirrors the classic cli_runner emit_warning("\nCancelled").
+            emit_info("\nCancelled")
             drain_pause_state_on_cancel()
             await on_agent_run_cancel(group_id)
         except* InterruptedError as ie:
-            emit_info(f"Interrupted: {ie}")
+            emit_info(f"\nInterrupted: {ie}")
             drain_pause_state_on_cancel()
             await on_agent_run_cancel(group_id)
         except* Exception as other:

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -649,13 +649,22 @@ def _interactive_sigint_guard(_sig, _frame):
     # be installed instead of this one). Swallow the signal so a fast repeat
     # tap can't escape to main_entry and exit the process.
     #
-    # Persistent prompt: Ctrl+C at idle with text in the buffer clears it
-    # (classic readline feel); with an empty buffer it stays a no-op
-    # (Ctrl+D is quit). No-op in classic mode / while a run is active.
+    # Persistent prompt: Ctrl+C with text in the buffer clears it (classic
+    # readline feel); with an empty buffer it stays a no-op (Ctrl+D is
+    # quit). Mid-run this guard only owns SIGINT when the cancel key is
+    # remapped (e.g. Windows defaults to ctrl+k) — buffer-first clearing
+    # applies there too; cancellation stays with the remapped hotkey.
     try:
-        from code_puppy.messaging.run_ui import clear_idle_buffer
+        from code_puppy.messaging.run_ui import (
+            absorb_ctrl_c_if_composing,
+            clear_idle_buffer,
+            is_run_active,
+        )
 
-        clear_idle_buffer()
+        if is_run_active():
+            absorb_ctrl_c_if_composing()
+        else:
+            clear_idle_buffer()
     except Exception:
         pass
     return

--- a/code_puppy/command_line/attachments.py
+++ b/code_puppy/command_line/attachments.py
@@ -220,7 +220,15 @@ def _tokenise(prompt: str) -> Iterable[str]:
 def _strip_attachment_token(token: str) -> str:
     """Trim surrounding whitespace/punctuation terminals tack onto paths."""
 
-    return token.strip().strip(",;:()[]{}")
+    token = token.strip().strip(",;:()[]{}")
+    # Windows terminals paste copied files as fully-quoted paths
+    # ("C:\...\shot.png"). Non-POSIX shlex (used on Windows in
+    # _tokenise) keeps those quotes ON the token, so the path was never
+    # detected — peel one matching surrounding pair. POSIX shlex already
+    # strips quotes, making this a no-op elsewhere.
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in "\"'":
+        token = token[1:-1]
+    return token
 
 
 def _candidate_paths(

--- a/code_puppy/keymap.py
+++ b/code_puppy/keymap.py
@@ -55,15 +55,21 @@ class KeymapError(Exception):
 def get_cancel_agent_key() -> str:
     """Get the configured cancel agent key from config.
 
-    On Windows when launched via uvx, this automatically returns "ctrl+k"
-    to work around uvx capturing Ctrl+C before it reaches Python.
+    On Windows when launched via uvx, this always returns "ctrl+k"
+    (uvx captures Ctrl+C before it reaches Python — not configurable).
+
+    On any other Windows launch the DEFAULT is also "ctrl+k": Windows
+    terminals treat Ctrl+C with a selection as the COPY gesture, so
+    Ctrl+C-as-cancel meant copying agent output could kill the run.
+    Ctrl+C stays the clear-typed-input gesture. An explicit
+    ``cancel_agent_key`` in puppy.cfg is still honored.
 
     Returns:
         The key name (e.g., "ctrl+c", "ctrl+k") from config,
-        or the default if not configured.
+        or the platform default if not configured.
     """
     from code_puppy.config import get_value
-    from code_puppy.uvx_detection import should_use_alternate_cancel_key
+    from code_puppy.uvx_detection import is_windows, should_use_alternate_cancel_key
 
     # On Windows + uvx, force ctrl+k to bypass uvx's SIGINT capture
     if should_use_alternate_cancel_key():
@@ -71,7 +77,7 @@ def get_cancel_agent_key() -> str:
 
     key = get_value("cancel_agent_key")
     if key is None or key.strip() == "":
-        return DEFAULT_CANCEL_AGENT_KEY
+        return "ctrl+k" if is_windows() else DEFAULT_CANCEL_AGENT_KEY
     return key.strip().lower()
 
 

--- a/code_puppy/messaging/bottom_bar.py
+++ b/code_puppy/messaging/bottom_bar.py
@@ -407,6 +407,8 @@ class BottomBar(BarPainterMixin):
     def _establish(self) -> None:
         """Set the scroll region, park the cursor inside it, paint rows."""
         cols, rows = self._safe_size()
+        old_rows = self._rows
+        old_reserved = self._reserved if self._region_up else 0
         self._cols, self._rows = cols, rows
         reserved = self._total_reserved()
         if rows < reserved + 1:
@@ -428,7 +430,22 @@ class BottomBar(BarPainterMixin):
             self._region_up = False
             return
         top = rows - reserved
-        parts = [
+        parts = []
+        if old_reserved and old_rows > 0:
+            # Re-establish after a resize: the old bar rows were painted
+            # at the PREVIOUS geometry and nothing repaints over them —
+            # without an explicit erase they linger as ghost duplicates
+            # ("multiples of UI elements") at their old positions while
+            # the fresh bar paints at the new bottom. Reset the region
+            # first so the erases can reach rows outside the incoming
+            # one, then blank the old reserved band (clamped to the new
+            # screen height).
+            parts.append(_RESET_REGION)
+            for row in range(
+                max(1, old_rows - old_reserved + 1), min(old_rows, rows) + 1
+            ):
+                parts.append(f"\x1b[{row};1H{_CLEAR_LINE}")
+        parts += [
             # Push existing content up so the reserved rows start blank.
             "\n" * reserved,
             # DECSTBM: scrollable region = rows 1..H-reserved. Homes cursor.

--- a/code_puppy/messaging/editor_completion.py
+++ b/code_puppy/messaging/editor_completion.py
@@ -129,7 +129,7 @@ def should_autotrigger(text: str, cursor: int) -> bool:
 @dataclass
 class Item:
     text: str
-    start_position: int  # negative offset from the cursor (pt convention)
+    start_position: int  # negative offset from the QUERY cursor (pt convention)
     display: str
     meta: str = ""
 
@@ -145,17 +145,18 @@ class CompletionEngine:
     def __init__(
         self,
         loop: asyncio.AbstractEventLoop,
-        apply_edit: Callable[[int, str], None],
+        apply_edit: Callable[[int, int, str], None],
         repaint: Callable[[], None],
         completer_factory: Callable = build_completer,
     ) -> None:
         self._loop = loop
-        self._apply_edit = apply_edit  # (start_position, replacement) -> None
+        self._apply_edit = apply_edit  # (start, end, replacement) -> None (absolute)
         self._repaint = repaint  # repaints popup + prompt
         self._completer_factory = completer_factory
         self._completer = None
         self._lock = threading.Lock()
         self._items: List[Item] = []
+        self._anchor = -1  # buffer cursor at query time (start_position base)
         self._selected = -1
         self._open = False
         self._seq = 0  # stale-result discard token
@@ -180,6 +181,7 @@ class CompletionEngine:
         with self._lock:
             self._open = False
             self._items = []
+            self._anchor = -1
             self._selected = -1
             self._seq += 1  # invalidate in-flight queries
         self._repaint()
@@ -200,9 +202,13 @@ class CompletionEngine:
             self.close()
 
     def on_tab(self, text: str, cursor: int) -> bool:
-        """Tab: next item when open, else force-open. Returns handled."""
+        """Tab: accept the selection when open, else force-open.
+
+        Accept-on-Tab matches the classic prompt_toolkit prompt (and every
+        IDE popup ever); navigation stays on Up/Down/Shift-Tab.
+        """
         if self.is_open():
-            self.move(1)
+            self.accept()
             return True
         self._schedule_query(text, cursor, open_menu=True, debounce=False)
         return True
@@ -215,18 +221,28 @@ class CompletionEngine:
         self._repaint()
 
     def accept(self) -> bool:
-        """Apply the selected completion. Returns True if one was applied."""
+        """Apply the selected completion. Returns True if one was applied.
+
+        The replace range is anchored to the cursor captured WHEN THE
+        QUERY RAN, not the live cursor — the user may have arrowed away
+        since (menu stays open on movement), and applying a stale
+        relative offset against the new cursor would splice garbage
+        into the buffer.
+        """
         with self._lock:
             if not (self._open and self._items):
                 return False
             index = max(0, self._selected)
             item = self._items[index]
+            anchor = self._anchor
             self._open = False
             self._items = []
+            self._anchor = -1
             self._selected = -1
             self._seq += 1
         try:
-            self._apply_edit(item.start_position, item.text)
+            start = max(0, anchor + item.start_position)
+            self._apply_edit(start, anchor, item.text)
         except Exception:
             logger.debug("completion apply failed", exc_info=True)
         self._repaint()
@@ -296,6 +312,7 @@ class CompletionEngine:
             if seq != self._seq:
                 return  # buffer changed while we were querying — stale
             self._items = items
+            self._anchor = cursor if items else -1
             self._open = bool(items)
             self._selected = 0 if items else -1
         self._repaint()

--- a/code_puppy/messaging/editor_display.py
+++ b/code_puppy/messaging/editor_display.py
@@ -1,0 +1,132 @@
+"""Display-time attachment placeholders for the persistent editor.
+
+The classic prompt rendered recognised attachment paths as friendly
+tags ("[png image]") via a prompt_toolkit ``Processor``
+(``AttachmentPlaceholderProcessor`` in
+``command_line.prompt_toolkit_completion`` — source of truth; its
+span-location logic is mirrored here because a Processor can't run
+outside prompt_toolkit). The raw editor paints plain text, so the same
+transformation is applied to ``(buffer, cursor)`` right before the bar
+paints the prompt row.
+
+The REAL buffer keeps the path — submit-time attachment resolution
+(``command_line.attachments``) is untouched; this is presentation only.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Tuple
+
+logger = logging.getLogger(__name__)
+
+#: Skip detection for very long input — likely pasted content; matches
+#: the classic processor's ``_MAX_TEXT_LENGTH_FOR_REALTIME``.
+MAX_TEXT_LENGTH_FOR_REALTIME = 500
+
+_ESCAPE_MARKER = "\u0000ESCAPED_SPACE\u0000"
+
+
+def to_display(text: str, cursor: int) -> Tuple[str, int]:
+    """Map ``(buffer, cursor)`` to ``(display_text, display_cursor)``.
+
+    Recognised attachment spans render as ``[png image]`` /
+    ``[pdf document]`` / ``[file attachment]`` tags. Never raises — any
+    failure falls back to the untransformed input.
+    """
+    try:
+        return _transform(text, cursor)
+    except Exception:
+        logger.debug("attachment display transform failed", exc_info=True)
+        return text, cursor
+
+
+def _transform(text: str, cursor: int) -> Tuple[str, int]:
+    if not text or len(text) > MAX_TEXT_LENGTH_FOR_REALTIME:
+        return text, cursor
+    # Cheap pre-check: every detectable path/link contains a separator.
+    # Skips tokenisation + filesystem stats for ordinary typed prompts.
+    if "/" not in text and "\\" not in text:
+        return text, cursor
+
+    replacements = _find_spans(text)
+    if not replacements:
+        return text, cursor
+    replacements.sort(key=lambda item: item[0])
+
+    display_parts: List[str] = []
+    display_cursor = None
+    src = 0
+    disp = 0
+    for start, end, tag in replacements:
+        plain = text[src:start]
+        if src <= cursor < start:
+            display_cursor = disp + (cursor - src)
+        display_parts.append(plain)
+        disp += len(plain)
+        if start <= cursor < end:
+            # Classic parity: in-span source positions map to tag start.
+            display_cursor = disp
+        display_parts.append(tag)
+        disp += len(tag)
+        src = end
+    tail = text[src:]
+    display_parts.append(tail)
+    if display_cursor is None:
+        display_cursor = disp + max(0, min(cursor - src, len(tail)))
+    return "".join(display_parts), display_cursor
+
+
+def _find_spans(text: str) -> List[Tuple[int, int, str]]:
+    """Locate ``(start, end, tag)`` spans for recognised attachments.
+
+    Mirrors ``AttachmentPlaceholderProcessor.apply_transformation``'s
+    span lookup (masked escaped-space tokenisation + sequential find).
+    """
+    from code_puppy.command_line.attachments import (
+        DEFAULT_ACCEPTED_DOCUMENT_EXTENSIONS,
+        DEFAULT_ACCEPTED_IMAGE_EXTENSIONS,
+        _detect_path_tokens,
+        _tokenise,
+    )
+
+    detections, _warnings = _detect_path_tokens(text)
+    if not detections:
+        return []
+
+    masked_text = text.replace(r"\ ", _ESCAPE_MARKER)
+    token_view = list(_tokenise(masked_text))
+
+    spans: List[Tuple[int, int, str]] = []
+    search_cursor = 0
+    for detection in detections:
+        tag: str | None = None
+        if detection.path and detection.has_path():
+            suffix = detection.path.suffix.lower()
+            if suffix in DEFAULT_ACCEPTED_IMAGE_EXTENSIONS:
+                tag = f"[{suffix.lstrip('.') or 'image'} image]"
+            elif suffix in DEFAULT_ACCEPTED_DOCUMENT_EXTENSIONS:
+                tag = f"[{suffix.lstrip('.') or 'file'} document]"
+            else:
+                tag = "[file attachment]"
+        elif detection.link is not None:
+            tag = "[link]"
+        if not tag:
+            continue
+
+        span_tokens = token_view[detection.start_index : detection.consumed_until]
+        raw_span = " ".join(span_tokens).replace(_ESCAPE_MARKER, r"\ ")
+        index = text.find(raw_span, search_cursor)
+        span_len = len(raw_span)
+        if index == -1:
+            placeholder = detection.placeholder
+            index = text.find(placeholder, search_cursor)
+            span_len = len(placeholder)
+        if index == -1:
+            continue
+        spans.append((index, index + span_len, tag))
+        search_cursor = index + span_len
+    return spans
+
+
+__all__ = ["MAX_TEXT_LENGTH_FOR_REALTIME", "to_display"]

--- a/code_puppy/messaging/editor_keys.py
+++ b/code_puppy/messaging/editor_keys.py
@@ -16,6 +16,11 @@ CTRL_J = "\n"
 BACKSPACE_KEYS = ("\x7f", "\x08")
 TAB = "\t"
 CTRL_A = "\x01"  # beginning of (logical) line
+# NOTE: Ctrl+C normally never reaches the editor — the console turns it
+# into SIGINT and the REPL's handlers clear/cancel. On Windows+uvx we
+# strip ENABLE_PROCESSED_INPUT (terminal-bricking guard), so ^C arrives
+# as this raw byte through the key listener instead.
+CTRL_C = "\x03"
 CTRL_D = "\x04"
 CTRL_E = "\x05"  # end of (logical) line
 # NOTE: Ctrl+K (\x0b) doubles as a configurable cancel-agent hotkey

--- a/code_puppy/messaging/line_editor.py
+++ b/code_puppy/messaging/line_editor.py
@@ -52,7 +52,8 @@ DEFAULT_ESC_TIMEOUT = 0.05
 # Raw control chars live in editor_keys (see the Ctrl+K / Ctrl+V notes there).
 _ENTER, _CTRL_J, _TAB, _ESC = ek.ENTER, ek.CTRL_J, ek.TAB, ek.ESC
 _BACKSPACE_KEYS = ek.BACKSPACE_KEYS
-_CTRL_A, _CTRL_D, _CTRL_E, _CTRL_K = ek.CTRL_A, ek.CTRL_D, ek.CTRL_E, ek.CTRL_K
+_CTRL_A, _CTRL_C, _CTRL_D = ek.CTRL_A, ek.CTRL_C, ek.CTRL_D
+_CTRL_E, _CTRL_K = ek.CTRL_E, ek.CTRL_K
 _CTRL_R, _CTRL_U, _CTRL_V, _CTRL_W = ek.CTRL_R, ek.CTRL_U, ek.CTRL_V, ek.CTRL_W
 
 #: Callback signature: ``(text, mode)`` where mode is "now" or "queue".
@@ -313,6 +314,15 @@ class RunningLineEditor:
                 self._set_completion_suppressed(False)
                 self._repaint()
             self._esc_pending_at = self._now()
+            return None
+
+        if ch == _CTRL_C:
+            # Raw ^C only reaches the editor when the console can't turn
+            # it into SIGINT (Windows+uvx clamps ENABLE_PROCESSED_INPUT).
+            # Mirror the SIGINT path: discard composed input / cancel
+            # reverse search, never submit or kill anything — cancel
+            # semantics stay with the hotkey/signal layers.
+            self.clear_buffer()
             return None
 
         if self._rsearch.active:

--- a/code_puppy/messaging/line_editor.py
+++ b/code_puppy/messaging/line_editor.py
@@ -32,6 +32,7 @@ from typing import Callable, List, Optional
 from . import editor_keys as ek
 from .bottom_bar import get_bottom_bar
 from .editor_actions import apply_action
+from .editor_display import to_display
 from .editor_history import (
     HistoryNavigator,
     ReverseSearch,
@@ -607,8 +608,11 @@ class RunningLineEditor:
                 return
             # "[multiline] " suffix has no SGR entries: extra chars paint plain.
             prefix = self._prompt_prefix + ("[multiline] " if self._multiline else "")
+            # Attachment paths render as friendly tags ([png image]) —
+            # display only; the buffer keeps the real path for submit.
+            display_text, display_cursor = to_display(self._buffer, self._cursor)
             bar.set_prompt_text(
-                prefix, self._buffer, self._cursor, self._prompt_prefix_sgrs
+                prefix, display_text, display_cursor, self._prompt_prefix_sgrs
             )
         except Exception:
             # Painting is best-effort; the buffer state is the truth.

--- a/code_puppy/messaging/line_editor.py
+++ b/code_puppy/messaging/line_editor.py
@@ -206,13 +206,17 @@ class RunningLineEditor:
             except ValueError:
                 pass
 
-    def apply_completion(self, start_position: int, replacement: str) -> None:
-        """Apply a completion: replace [cursor+start_position, cursor)."""
+    def apply_completion(self, start: int, end: int, replacement: str) -> None:
+        """Apply a completion: replace buffer[start:end) with ``replacement``.
+
+        Absolute indices (clamped) — the CompletionEngine anchors them to
+        the cursor AT QUERY TIME, so the splice stays correct even when
+        the user moved the cursor while the menu was open.
+        """
         with self._lock:
-            start = max(0, self._cursor + start_position)
-            self._buffer = (
-                self._buffer[:start] + replacement + self._buffer[self._cursor :]
-            )
+            start = max(0, min(start, len(self._buffer)))
+            end = max(start, min(end, len(self._buffer)))
+            self._buffer = self._buffer[:start] + replacement + self._buffer[end:]
             self._cursor = start + len(replacement)
             self._history.reset()
             self._repaint()

--- a/code_puppy/messaging/run_ui.py
+++ b/code_puppy/messaging/run_ui.py
@@ -332,12 +332,30 @@ def absorb_ctrl_c_if_composing() -> bool:
         return False
     editor.clear_buffer()
     try:
-        get_bottom_bar().set_status(
-            "input cleared — press ctrl+c again to cancel the agent"
-        )
+        get_bottom_bar().set_status(_cleared_hint())
     except Exception:
         logger.debug("ctrl+c hint paint failed", exc_info=True)
     return True
+
+
+def _cleared_hint() -> str:
+    """Status hint after a buffer-first Ctrl+C — names the REAL cancel key.
+
+    "press ctrl+c again" is only true when SIGINT owns cancel; on
+    Windows (default ctrl+k) it would be a lie.
+    """
+    try:
+        from code_puppy.keymap import (
+            cancel_agent_uses_signal,
+            get_cancel_agent_display_name,
+        )
+
+        if cancel_agent_uses_signal():
+            return "input cleared — press ctrl+c again to cancel the agent"
+        key = get_cancel_agent_display_name().lower()
+        return f"input cleared — press {key} to cancel the agent"
+    except Exception:
+        return "input cleared"
 
 
 def _persistent_router(text: str, mode: str) -> Optional[str]:

--- a/tests/agents/test_windows_paste_burst.py
+++ b/tests/agents/test_windows_paste_burst.py
@@ -1,0 +1,82 @@
+"""Windows console paste coalescing (_key_listeners burst helpers).
+
+The console input queue has no bracketed paste: a paste arrives as a
+flood of individual chars. The old one-char-per-50ms-tick loop rendered
+it like slow typing and submitted a prompt per pasted newline. The
+listener now drains the whole burst per tick and wraps large all-text
+bursts in a synthesized bracketed paste.
+"""
+
+from code_puppy.agents._key_listeners import (
+    _WIN_BURST_CAP,
+    _WIN_PASTE_MIN_CHARS,
+    _coalesce_paste_burst,
+    _drain_windows_burst,
+)
+
+
+class FakeMsvcrt:
+    """Scripted console input queue."""
+
+    def __init__(self, keys):
+        self.keys = list(keys)
+
+    def kbhit(self):
+        return bool(self.keys)
+
+    def getwch(self):
+        return self.keys.pop(0)
+
+
+class TestDrain:
+    def test_drains_entire_pending_burst(self):
+        fake = FakeMsvcrt(list("hello"))
+        items = _drain_windows_burst(fake)
+        assert items == [("char", c) for c in "hello"]
+        assert fake.keys == []  # nothing left for the next tick
+
+    def test_extended_key_pair_translates_to_seq(self):
+        fake = FakeMsvcrt(["\xe0", "H"])  # Up arrow
+        assert _drain_windows_burst(fake) == [("seq", "\x1b[A")]
+
+    def test_unknown_extended_pair_swallowed(self):
+        fake = FakeMsvcrt(["\x00", "\x3b"])  # F1 — unmapped
+        assert _drain_windows_burst(fake) == []
+
+    def test_mixed_burst_preserves_order(self):
+        fake = FakeMsvcrt(["a", "\xe0", "K", "b"])
+        assert _drain_windows_burst(fake) == [
+            ("char", "a"),
+            ("seq", "\x1b[D"),
+            ("char", "b"),
+        ]
+
+    def test_burst_cap_leaves_remainder_queued(self):
+        fake = FakeMsvcrt(["x"] * (_WIN_BURST_CAP + 10))
+        items = _drain_windows_burst(fake)
+        assert len(items) == _WIN_BURST_CAP
+        assert len(fake.keys) == 10
+
+
+class TestCoalesce:
+    def test_single_char_is_not_paste(self):
+        assert _coalesce_paste_burst([("char", "a")]) is None
+
+    def test_typing_roll_below_threshold_is_not_paste(self):
+        # 'i' + Enter landing inside one poll tick must still SUBMIT.
+        items = [("char", "i"), ("char", "\r")]
+        assert len(items) < _WIN_PASTE_MIN_CHARS
+        assert _coalesce_paste_burst(items) is None
+
+    def test_large_text_burst_is_paste(self):
+        items = [("char", c) for c in "line one\rline two"]
+        assert _coalesce_paste_burst(items) == "line one\rline two"
+
+    def test_burst_with_extended_key_is_typing(self):
+        items = [("char", "a"), ("seq", "\x1b[A"), ("char", "b"), ("char", "c")]
+        assert _coalesce_paste_burst(items) is None
+
+    def test_min_chars_boundary(self):
+        items = [("char", c) for c in "abc"]
+        assert len(items) == _WIN_PASTE_MIN_CHARS
+        assert _coalesce_paste_burst(items) == "abc"

--- a/tests/agents/test_windows_paste_burst.py
+++ b/tests/agents/test_windows_paste_burst.py
@@ -57,6 +57,24 @@ class TestDrain:
         assert len(items) == _WIN_BURST_CAP
         assert len(fake.keys) == 10
 
+    def test_first_key_read_despite_kbhit_lie(self):
+        """The caller consumed the only kbhit() True; the drain must still
+        read the first key (and its pushback-buffered pair tail)
+        unconditionally — kbhit() cannot see either of them."""
+
+        class LyingMsvcrt:
+            def __init__(self, keys):
+                self.keys = list(keys)
+
+            def kbhit(self):
+                return False  # the lie: data pending but queue looks empty
+
+            def getwch(self):
+                return self.keys.pop(0)
+
+        items = _drain_windows_burst(LyingMsvcrt(["\xe0", "K"]))
+        assert items == [("seq", "\x1b[D")]
+
 
 class TestCoalesce:
     def test_single_char_is_not_paste(self):

--- a/tests/command_line/test_attachments.py
+++ b/tests/command_line/test_attachments.py
@@ -180,6 +180,38 @@ def test_strip_attachment_token():
     assert _strip_attachment_token("  (file.png),  ") == "file.png"
 
 
+def test_strip_attachment_token_peels_matching_quotes():
+    # Windows terminals paste copied files as fully-quoted paths; the
+    # non-POSIX shlex keeps those quotes on the token.
+    assert _strip_attachment_token('"C:\\pics\\shot.png"') == "C:\\pics\\shot.png"
+    assert _strip_attachment_token("'/tmp/shot.png'") == "/tmp/shot.png"
+
+
+def test_strip_attachment_token_leaves_unmatched_quote():
+    assert _strip_attachment_token('"unterminated.png') == '"unterminated.png'
+
+
+def test_detect_quoted_image_path(tmp_path):
+    # A quoted existing image (Windows Explorer copy -> terminal paste)
+    # must be detected on every platform.
+    png = tmp_path / "shot.png"
+    png.write_bytes(b"\x89PNG fake")
+    detections, warnings = _detect_path_tokens(f'"{png}"')
+    assert len(detections) == 1
+    assert detections[0].has_path()
+    assert detections[0].path.name == "shot.png"
+    assert warnings == []
+
+
+def test_parse_prompt_attachments_quoted_path(tmp_path):
+    png = tmp_path / "shot.png"
+    png.write_bytes(b"\x89PNG fake")
+    processed = parse_prompt_attachments(f'"{png}" describe this')
+    assert len(processed.attachments) == 1
+    assert "describe this" in processed.prompt
+    assert str(png) not in processed.prompt
+
+
 # ---------------------------------------------------------------------------
 # _candidate_paths
 # ---------------------------------------------------------------------------

--- a/tests/messaging/test_bottom_bar_resize_ghosts.py
+++ b/tests/messaging/test_bottom_bar_resize_ghosts.py
@@ -1,0 +1,106 @@
+"""Resize ghost-clearing: re-establish erases the OLD reserved band.
+
+Without the erase, the bar rows painted at the previous geometry linger
+as duplicates ("multiples of UI elements appear where they were and now
+where they are") after a terminal resize.
+"""
+
+import io
+
+from code_puppy.messaging.bar_rendering import CLEAR_LINE, RESET_REGION
+from code_puppy.messaging.bottom_bar import BottomBar
+
+
+class FakeTTY(io.StringIO):
+    def isatty(self):
+        return True
+
+
+class MutableSize:
+    def __init__(self, cols, rows):
+        self.cols = cols
+        self.rows = rows
+
+    def __call__(self):
+        return (self.cols, self.rows)
+
+
+def drain(stream):
+    value = stream.getvalue()
+    stream.truncate(0)
+    stream.seek(0)
+    return value
+
+
+def _bar(rows=24):
+    tty = FakeTTY()
+    size = MutableSize(80, rows)
+    bar = BottomBar(stream=tty, get_size=size)
+    return bar, tty, size
+
+
+def test_fresh_start_has_no_ghost_clear():
+    bar, tty, _ = _bar()
+    bar.start()
+    # First establish: nothing painted before -> no reset-region erase pass.
+    assert RESET_REGION not in drain(tty)
+
+
+def test_grow_clears_old_reserved_band():
+    bar, tty, size = _bar(rows=24)
+    bar.start()
+    old_reserved = bar._reserved
+    assert old_reserved > 0
+    drain(tty)
+
+    size.rows = 40  # terminal got taller
+    bar.set_prompt_text("> ", "hi", 2)  # any repaint re-polls geometry
+    out = drain(tty)
+
+    assert RESET_REGION in out
+    # Every row of the OLD band (bottom of the 24-row screen) is erased.
+    for row in range(24 - old_reserved + 1, 25):
+        assert f"\x1b[{row};1H{CLEAR_LINE}" in out
+    # And the new region is established at the new height.
+    assert f"\x1b[1;{40 - bar._reserved}r" in out
+
+
+def test_shrink_reestablishes_without_out_of_bounds_clears():
+    bar, tty, size = _bar(rows=40)
+    bar.start()
+    old_reserved = bar._reserved
+    drain(tty)
+
+    size.rows = 24  # terminal got shorter
+    bar.set_prompt_text("> ", "hi", 2)
+    out = drain(tty)
+
+    # Old band rows (37..40) are off-screen now — no erase beyond row 24.
+    for row in range(40 - old_reserved + 1, 41):
+        assert f"\x1b[{row};1H{CLEAR_LINE}" not in out
+    assert f"\x1b[1;{24 - bar._reserved}r" in out
+
+
+def test_width_only_resize_repaints_in_place():
+    bar, tty, size = _bar(rows=24)
+    bar.start()
+    old_reserved = bar._reserved
+    drain(tty)
+
+    size.cols = 120  # width change only
+    bar.set_prompt_text("> ", "hi", 2)
+    out = drain(tty)
+
+    # Same rows: the old band IS the new band; it must be erased before
+    # the repaint so narrower leftovers can't survive.
+    for row in range(24 - old_reserved + 1, 25):
+        assert f"\x1b[{row};1H{CLEAR_LINE}" in out
+
+
+def test_no_resize_no_reestablish():
+    bar, tty, _ = _bar()
+    bar.start()
+    drain(tty)
+    bar.set_prompt_text("> ", "hi", 2)
+    # Stable geometry: plain repaint, no region reset.
+    assert RESET_REGION not in drain(tty)

--- a/tests/messaging/test_ctrl_c_buffer_first.py
+++ b/tests/messaging/test_ctrl_c_buffer_first.py
@@ -129,7 +129,12 @@ def test_is_composing_reverse_search_counts_even_empty():
 # =========================================================================
 
 
-def test_midrun_text_absorbs_clears_and_hints(persistent_ui):
+def test_midrun_text_absorbs_clears_and_hints(persistent_ui, monkeypatch):
+    import code_puppy.keymap as keymap
+
+    # Pin the SIGINT-owns-cancel config (POSIX default) so the hint text
+    # is deterministic regardless of the test host's platform.
+    monkeypatch.setattr(keymap, "cancel_agent_uses_signal", lambda: True)
     editor, tty = persistent_ui
     for ch in "half-typed steer":
         editor.feed(ch)
@@ -140,6 +145,25 @@ def test_midrun_text_absorbs_clears_and_hints(persistent_ui):
     out = tty.getvalue()
     assert "input cleared" in out and "ctrl+c again" in out
     assert "\x1b[2minput cleared" in out  # hint rides the dim status row
+
+
+def test_hint_names_remapped_cancel_key(persistent_ui, monkeypatch):
+    """With cancel remapped (Windows default: ctrl+k), the hint must name
+    the REAL cancel key — 'press ctrl+c again' would be a lie."""
+    import code_puppy.keymap as keymap
+
+    monkeypatch.setattr(keymap, "cancel_agent_uses_signal", lambda: False)
+    monkeypatch.setattr(keymap, "get_cancel_agent_display_name", lambda: "Ctrl+K")
+    editor, tty = persistent_ui
+    for ch in "half-typed steer":
+        editor.feed(ch)
+    tty.truncate(0)
+    tty.seek(0)
+    assert sigint_should_cancel() is False
+    assert editor.buffer == ""
+    out = tty.getvalue()
+    assert "press ctrl+k to cancel the agent" in out
+    assert "again" not in out
 
 
 def test_second_press_on_now_empty_buffer_cancels(persistent_ui):

--- a/tests/messaging/test_editor_completion.py
+++ b/tests/messaging/test_editor_completion.py
@@ -130,16 +130,77 @@ async def test_typing_slash_opens_menu():
     assert selected == 0
 
 
-async def test_tab_navigates_and_enter_accepts_without_submitting():
+async def test_tab_accepts_selection_without_submitting():
+    """Tab completes the highlighted item (classic prompt behavior) —
+    it must NOT cycle to the next menu entry."""
     steers = []
     editor, engine = make_engine(["/help", "/hero"])
     editor.set_submit_router(lambda text, mode: steers.append(text) or None)
     editor.feed("/")
     await settle()
-    editor.feed("\t")  # next -> "/hero"
+    editor.feed("\t")  # accept "/help", NOT navigate
+    assert editor.buffer == "/help"
+    assert steers == []  # no submission happened
+    assert engine.is_open() is False
+
+
+async def test_down_then_tab_accepts_navigated_selection():
+    steers = []
+    editor, engine = make_engine(["/help", "/hero"])
+    editor.set_submit_router(lambda text, mode: steers.append(text) or None)
+    editor.feed("/")
+    await settle()
+    editor.feed("\x1b[B")  # Down -> "/hero"
+    editor.feed("\t")  # accept it
+    assert editor.buffer == "/hero"
+    assert steers == []
+    assert engine.is_open() is False
+
+
+async def test_enter_accepts_without_submitting():
+    steers = []
+    editor, engine = make_engine(["/help", "/hero"])
+    editor.set_submit_router(lambda text, mode: steers.append(text) or None)
+    editor.feed("/")
+    await settle()
+    editor.feed("\x1b[B")  # Down -> "/hero"
     editor.feed("\r")  # accept, NOT submit (classic behavior)
     assert editor.buffer == "/hero"
-    assert steers == []  # no submission happened
+    assert steers == []
+    assert engine.is_open() is False
+
+
+async def test_accept_after_cursor_moved_left_splices_correctly():
+    """Regression: completion offsets are anchored to the QUERY cursor.
+
+    Type "/he", arrow LEFT (menu stays open), then Enter: the completion
+    must replace the original "/he" cleanly — not splice against the
+    moved cursor and produce garbage like "/helpe" that later submits
+    as a plain prompt."""
+    steers = []
+    editor, engine = make_engine(["/help", "/hero"])
+    editor.set_submit_router(lambda text, mode: steers.append(text) or None)
+    for ch in "/he":
+        editor.feed(ch)
+    await settle()
+    assert engine.is_open() is True
+    editor.feed("\x1b[D")  # Left: cursor drifts, menu stays open
+    editor.feed("\r")  # accept — must use the query-time anchor
+    assert editor.buffer == "/help"
+    assert editor.cursor == len("/help")
+    assert steers == []  # accepted, never submitted
+    assert engine.is_open() is False
+
+
+async def test_tab_accept_after_cursor_moved_left_splices_correctly():
+    editor, engine = make_engine(["/help", "/hero"])
+    for ch in "/he":
+        editor.feed(ch)
+    await settle()
+    editor.feed("\x1b[D")  # Left
+    editor.feed("\x1b[D")  # Left again (cursor=1)
+    editor.feed("\t")  # Tab-accept — same anchor rules as Enter
+    assert editor.buffer == "/help"
     assert engine.is_open() is False
 
 

--- a/tests/messaging/test_editor_display.py
+++ b/tests/messaging/test_editor_display.py
@@ -1,0 +1,120 @@
+"""Attachment display tags for the persistent editor (editor_display).
+
+Classic parity: recognised attachment paths render as ``[png image]``
+tags in the prompt row (AttachmentPlaceholderProcessor behavior) while
+the REAL buffer keeps the path for submit-time resolution.
+"""
+
+from code_puppy.messaging.editor_display import (
+    MAX_TEXT_LENGTH_FOR_REALTIME,
+    to_display,
+)
+
+
+def _make_png(tmp_path, name="shot.png"):
+    p = tmp_path / name
+    p.write_bytes(b"\x89PNG\r\n\x1a\n fake")
+    return p
+
+
+class TestToDisplayBasics:
+    def test_plain_text_unchanged(self):
+        assert to_display("hello world", 5) == ("hello world", 5)
+
+    def test_empty_text_unchanged(self):
+        assert to_display("", 0) == ("", 0)
+
+    def test_no_separator_short_circuits(self, tmp_path):
+        # No / or \ anywhere -> detection skipped entirely.
+        assert to_display("look at shot.png", 16) == ("look at shot.png", 16)
+
+    def test_long_text_skipped(self, tmp_path):
+        png = _make_png(tmp_path)
+        text = f"{png} " + "x" * MAX_TEXT_LENGTH_FOR_REALTIME
+        assert to_display(text, 0) == (text, 0)
+
+    def test_nonexistent_path_unchanged(self):
+        text = "/nonexistent/path/to/nothing.png"
+        display, cursor = to_display(text, len(text))
+        assert display == text
+        assert cursor == len(text)
+
+
+class TestToDisplayTags:
+    def test_image_path_renders_png_tag(self, tmp_path):
+        png = _make_png(tmp_path)
+        text = f"look at {png}"
+        display, _ = to_display(text, len(text))
+        assert "[png image]" in display
+        assert str(png) not in display
+        assert display.startswith("look at ")
+
+    def test_unsupported_extension_no_tag(self, tmp_path):
+        # .txt is neither image nor document: detection marks it
+        # unsupported -> has_path() False -> no tag (classic parity).
+        f = tmp_path / "notes.txt"
+        f.write_text("hi")
+        text = f"read {f}"
+        display, _ = to_display(text, len(text))
+        assert display == text
+
+    def test_multiple_images_all_tagged(self, tmp_path):
+        a = _make_png(tmp_path, "a.png")
+        b = _make_png(tmp_path, "b.png")
+        text = f"{a} vs {b}"
+        display, _ = to_display(text, len(text))
+        assert display.count("[png image]") == 2
+
+    def test_quoted_path_renders_tag(self, tmp_path):
+        # Windows terminals paste copied files as quoted paths.
+        png = _make_png(tmp_path)
+        text = f'"{png}" describe'
+        display, _ = to_display(text, len(text))
+        assert "[png image]" in display
+        assert str(png) not in display
+
+
+class TestToDisplayCursor:
+    def test_cursor_before_span_identity(self, tmp_path):
+        png = _make_png(tmp_path)
+        text = f"look at {png}"
+        display, cursor = to_display(text, 4)
+        assert cursor == 4
+        assert display[:8] == "look at "
+
+    def test_cursor_at_end_maps_to_display_end(self, tmp_path):
+        png = _make_png(tmp_path)
+        text = f"look at {png}"
+        display, cursor = to_display(text, len(text))
+        assert cursor == len(display)
+
+    def test_cursor_inside_span_maps_to_tag_start(self, tmp_path):
+        png = _make_png(tmp_path)
+        text = f"look at {png}"
+        span_start = len("look at ")
+        display, cursor = to_display(text, span_start + 3)
+        assert cursor == span_start  # classic: in-span -> tag start
+
+    def test_cursor_after_span_offsets_by_delta(self, tmp_path):
+        png = _make_png(tmp_path)
+        text = f"{png} tail"
+        display, cursor = to_display(text, len(text) - 2)
+        assert display[cursor:] == "il"
+
+    def test_cursor_never_out_of_bounds(self, tmp_path):
+        png = _make_png(tmp_path)
+        text = f"x {png}"
+        for pos in range(len(text) + 1):
+            display, cursor = to_display(text, pos)
+            assert 0 <= cursor <= len(display)
+
+
+class TestNeverRaises:
+    def test_detection_failure_falls_back(self, monkeypatch):
+        import code_puppy.messaging.editor_display as mod
+
+        def boom(text):
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(mod, "_find_spans", boom)
+        assert to_display("a/b", 1) == ("a/b", 1)

--- a/tests/messaging/test_line_editor.py
+++ b/tests/messaging/test_line_editor.py
@@ -135,6 +135,54 @@ def test_backspace_on_empty_buffer_is_noop(editor, bar):
     assert bar.paints == []  # no-op edits don't repaint
 
 
+def test_raw_ctrl_c_clears_buffer(editor):
+    """Raw ^C (Windows+uvx: no SIGINT, byte reaches the editor) must
+    behave like Ctrl+C-at-idle everywhere else: wipe the typed text."""
+    feed_all(editor, "half-typed thought")
+    editor.feed("\x03")
+    assert editor.buffer == ""
+    assert editor.cursor == 0
+
+
+def test_raw_ctrl_c_on_empty_buffer_is_noop(editor):
+    editor.feed("\x03")
+    assert editor.buffer == ""
+    assert editor.cursor == 0
+
+
+def test_raw_ctrl_c_does_not_submit(editor, controller):
+    feed_all(editor, "do not send this")
+    editor.feed("\x03")
+    assert controller.steers == []
+
+
+def test_raw_ctrl_c_cancels_reverse_search(bar, controller, clock):
+    class ActiveRSearch:
+        def __init__(self):
+            self.active = True
+            self.cancelled = False
+
+        def cancel(self):
+            self.active = False
+            self.cancelled = True
+
+        def prompt_text(self):
+            return "(reverse-i-search)`': "
+
+    rsearch = ActiveRSearch()
+    editor = RunningLineEditor(
+        prompt_prefix="> ",
+        bar=bar,
+        pause_controller=controller,
+        now=clock,
+        history=FakeHistory(),
+        reverse_search=rsearch,
+    )
+    editor.feed("\x03")
+    assert rsearch.cancelled is True
+    assert editor.buffer == ""
+
+
 def test_ctrl_u_kills_line(editor):
     feed_all(editor, "kill me")
     editor.feed("\x15")

--- a/tests/messaging/test_line_editor.py
+++ b/tests/messaging/test_line_editor.py
@@ -487,3 +487,26 @@ def test_broken_bar_never_raises(controller, clock):
     feed_all(editor, "still works")
     editor.feed("\r")
     assert controller.steers == [("still works", "queue")]
+
+
+# =========================================================================
+# Attachment display tags (editor_display wiring)
+# =========================================================================
+
+
+def test_image_path_paints_as_tag_but_buffer_keeps_path(editor, bar, tmp_path):
+    """Classic parity: the prompt row shows [png image]; buffer keeps path."""
+    png = tmp_path / "shot.png"
+    png.write_bytes(b"\x89PNG fake")
+    feed_all(editor, f"look at {png}")
+    prefix, painted, cursor = bar.paints[-1]
+    assert "[png image]" in painted
+    assert str(png) not in painted
+    assert cursor == len(painted)
+    # The REAL buffer is untouched — submit-time resolution needs the path.
+    assert editor.buffer == f"look at {png}"
+
+
+def test_non_path_text_paints_verbatim(editor, bar):
+    feed_all(editor, "just words")
+    assert bar.paints[-1] == ("> ", "just words", 10)

--- a/tests/messaging/test_run_ui.py
+++ b/tests/messaging/test_run_ui.py
@@ -223,6 +223,34 @@ def test_dispatch_gives_cancel_key_priority_over_editor(tty_bar):
     assert editor.buffer == ""  # cancel key never reaches the editor
 
 
+def test_dispatch_windows_uvx_contract_ctrl_k_cancels_ctrl_c_clears(tty_bar):
+    """Windows+uvx config: cancel char is Ctrl+K, and Ctrl+C arrives as a
+    raw \\x03 (no SIGINT — ENABLE_PROCESSED_INPUT is clamped).
+
+    Ctrl+K must cancel the agent WITHOUT touching typed text; Ctrl+C
+    must clear the typed line WITHOUT cancelling the agent."""
+    editor = run_ui_mod.start_run_ui()
+    cancels = []
+    for ch in "half-typed":
+        _key_listeners._dispatch_key(ch, lambda: None, "\x0b", None)
+    assert editor.buffer == "half-typed"
+
+    # Ctrl+K: priority-dispatched to the cancel handler, editor untouched.
+    _key_listeners._dispatch_key(
+        "\x0b", lambda: None, "\x0b", lambda: cancels.append(1)
+    )
+    assert cancels == [1]
+    assert editor.buffer == "half-typed"
+
+    # Ctrl+C (raw \x03): falls through to the editor, clears the line —
+    # and must NOT fire the cancel handler.
+    _key_listeners._dispatch_key(
+        "\x03", lambda: None, "\x0b", lambda: cancels.append(2)
+    )
+    assert cancels == [1]
+    assert editor.buffer == ""
+
+
 def test_broken_editor_does_not_kill_feed(tty_bar):
     class ExplodingEditor:
         def feed(self, key):

--- a/tests/test_keymap_coverage.py
+++ b/tests/test_keymap_coverage.py
@@ -84,31 +84,67 @@ class TestGetCancelAgentKey:
         # get_value should NOT be called when uvx detection triggers
         mock_get_value.assert_not_called()
 
+    @patch("code_puppy.uvx_detection.is_windows")
     @patch("code_puppy.uvx_detection.should_use_alternate_cancel_key")
     @patch("code_puppy.config.get_value")
     def test_returns_default_when_config_is_none(
-        self, mock_get_value, mock_should_use_alt
+        self, mock_get_value, mock_should_use_alt, mock_is_windows
     ):
-        """Should return default when config value is None."""
+        """Should return default when config value is None (non-Windows)."""
         mock_should_use_alt.return_value = False
+        mock_is_windows.return_value = False
         mock_get_value.return_value = None
 
         result = get_cancel_agent_key()
 
         assert result == DEFAULT_CANCEL_AGENT_KEY
 
+    @patch("code_puppy.uvx_detection.is_windows")
     @patch("code_puppy.uvx_detection.should_use_alternate_cancel_key")
     @patch("code_puppy.config.get_value")
     def test_returns_default_when_config_is_empty(
-        self, mock_get_value, mock_should_use_alt
+        self, mock_get_value, mock_should_use_alt, mock_is_windows
     ):
         """Should return default when config value is empty string."""
         mock_should_use_alt.return_value = False
+        mock_is_windows.return_value = False
         mock_get_value.return_value = "   "  # Whitespace only
 
         result = get_cancel_agent_key()
 
         assert result == DEFAULT_CANCEL_AGENT_KEY
+
+    @patch("code_puppy.uvx_detection.is_windows")
+    @patch("code_puppy.uvx_detection.should_use_alternate_cancel_key")
+    @patch("code_puppy.config.get_value")
+    def test_windows_default_is_ctrl_k(
+        self, mock_get_value, mock_should_use_alt, mock_is_windows
+    ):
+        """Windows (any launch, not just uvx): unconfigured default is
+        ctrl+k — Ctrl+C is the terminal copy gesture and must not cancel."""
+        mock_should_use_alt.return_value = False
+        mock_is_windows.return_value = True
+        mock_get_value.return_value = None
+
+        result = get_cancel_agent_key()
+
+        assert result == "ctrl+k"
+
+    @patch("code_puppy.uvx_detection.is_windows")
+    @patch("code_puppy.uvx_detection.should_use_alternate_cancel_key")
+    @patch("code_puppy.config.get_value")
+    def test_windows_explicit_ctrl_c_config_is_honored(
+        self, mock_get_value, mock_should_use_alt, mock_is_windows
+    ):
+        """An explicit cancel_agent_key in puppy.cfg beats the Windows
+        default (only uvx hard-forces ctrl+k)."""
+        mock_should_use_alt.return_value = False
+        mock_is_windows.return_value = True
+        mock_get_value.return_value = "ctrl+c"
+
+        result = get_cancel_agent_key()
+
+        assert result == "ctrl+c"
 
     @patch("code_puppy.uvx_detection.should_use_alternate_cancel_key")
     @patch("code_puppy.config.get_value")


### PR DESCRIPTION

## 1. `02d9a8d` — Tab completed the wrong thing; mid-line completions mangled the buffer

**Symptoms:** Tab cycled the completion menu instead of accepting (classic
Tab = accept-and-advance was lost). Worse: typing a partial slash command,
moving the cursor left, then accepting spliced the completion at the *wrong
anchor* — the leftover text submitted as a garbage prompt to the model.

**Fixes:**
- Tab now **accepts** the highlighted completion (Shift+Tab/arrows still
  navigate) — classic parity.
- Completion splice is anchored to the **query cursor position**, not
  end-of-buffer, so mid-line accepts replace exactly the token being
  completed.

## 2. `9b69cb5` — Ctrl+C did nothing while composing (Windows raw `\x03` path)

**Symptom:** With console processed-input off, Ctrl+C arrives as a raw
`\x03` char, which the editor silently dropped — no line clear.

**Fix:** the editor treats raw `\x03` as **clear composed input** (+ hint),
matching the SIGINT-path behavior.

## 3. `2b0beda` — Test armor: the Windows+uvx key contract

No production change — locked in the dispatch contract (Ctrl+K cancels, raw
Ctrl+C clears, cancel key inert when idle) so the next rewrite can't
silently break it.

## 4. `0caf500` — Ctrl+K cancel didn't work on plain Windows

**Symptom:** Mid-run message *said* "Use Ctrl+K to cancel" but Ctrl+K did
nothing; Ctrl+C was still the real (and copy-hostile) cancel.

**Root cause:** the Ctrl+K default was gated to Windows+**uvx** only. Plain
Windows fell back to SIGINT-cancel, so the key listener never armed the
cancel char.

**Fix:** unconfigured cancel key defaults to **Ctrl+K on all Windows**
(explicit `puppy.cfg` still wins). Net contract: Ctrl+C never cancels on
Windows (safe for copy), Ctrl+K always does. Hints/banners read the real
keymap.

## 5. `4dbdba4` — `AaronCancelled`: cancel banner glued to streamed text

**Symptom:** cancelling mid-thinking-stream rendered `… AaronCancelled` on
one line.

**Root cause:** mid-stream cancel aborts the drain tasks before the "final
newline after streaming" runs, parking the cursor mid-line; the runtime then
emitted `"Cancelled"` with no leading newline. (The classic path already
knew: `emit_warning("\nCancelled")`.)

**Fix:** runtime `Cancelled`/`Interrupted` banners lead with `\n`.

## 6. `25790d1` — Image paste: no `[png image]` tag, and no image at all on Windows

**Symptoms:** pasting a PNG path showed the raw quoted path instead of the
classic `[png image]` tag — and on Windows the image was silently **never
attached**.

**Two root causes, two fixes:**
- **Display:** the classic `AttachmentPlaceholderProcessor` was
  prompt_toolkit-only. New `messaging/editor_display.py` mirrors it as a
  pure `(buffer, cursor) → (display, cursor)` transform; the prompt row
  shows `[png image]` while the buffer keeps the real path. Guards:
  500-char cap, separator pre-check (typing never pays for fs stats),
  never-raises.
- **Detection:** Windows terminals paste copied files as `"C:\…\shot.png"`
  *with quotes*; non-POSIX shlex keeps them on the token → path never
  existed → skipped. `_strip_attachment_token` now peels one matching quote
  pair (no-op on POSIX).

## 7. `1c2c09f` — Dead post-run Ctrl+C, molasses paste, resize ghost bars

- **Ctrl+C dies after one mid-run press:** the graceful SIGINT handler
  unconditionally re-armed the uvx protection layers — including a
  **permanent process-wide** `SetConsoleCtrlHandler` that swallows Ctrl+C
  forever. Now gated to Windows+uvx only; handler also gained buffer-first
  absorb.
- **Paste typed itself at 20 cps + submitted per line:** `_listen_windows`
  read one char per 50ms tick, and each pasted `\r` dispatched as Enter.
  Now drains the whole burst per tick; ≥3 all-text chars (the classic win32
  heuristic) get wrapped in a synthesized bracketed paste → atomic insert,
  newlines stay in-buffer. `i`+Enter typing rolls still submit.
- **Resize ghosts:** `_establish()` never erased rows painted at the old
  geometry. Re-establish now resets the region and blanks the old reserved
  band (clamped) first.

---

## Quality ledger

|                    |                                                                                                                          |
| ------------------ | ------------------------------------------------------------------------------------------------------------------------ |
| **New test files** | 4 (`test_editor_display`, `test_windows_paste_burst`, `test_bottom_bar_resize_ghosts`, key-dispatch contract)             |
| **Suites green**   | ~2,800 tests across messaging/agents/command_line; only 2 known pre-existing env failures (`puppy_rules`, TTY-detection)  |
| **Lint**           | ruff check + format clean on every commit                                                                                 |
| **Known debt**     | `line_editor.py` at ~645 lines (over the 600 cap) — pre-existing; splitting deserves its own PR, not a bugfix rider       |

**Theme of the branch:** the rebuild replicated the classic UI's *happy
paths* but dropped its hard-won edge-case scar tissue — leading `\n` before
banners, paste heuristics, quote peeling, display processors, uvx-only
gating. This branch stitched the scars back on. 