### PR TITLE
feat(gemini): ship gemini_oauth plugin + fix Code Assist streaming

### DIFF
--- a/code_puppy/gemini_code_assist.py
+++ b/code_puppy/gemini_code_assist.py
@@ -28,7 +28,9 @@ from pydantic_ai.messages import (
     ToolReturnPart,
     UserPromptPart,
 )
-from pydantic_ai.models import Model, ModelRequestParameters
+from dataclasses import dataclass, field
+from pydantic_ai.messages import ModelResponseStreamEvent
+from pydantic_ai.models import Model, ModelRequestParameters, StreamedResponse
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RequestUsage
@@ -98,7 +100,8 @@ class GeminiCodeAssistModel(Model):
         messages: list[ModelMessage],
         model_settings: ModelSettings | None,
         model_request_parameters: ModelRequestParameters,
-    ) -> AsyncIterator[StreamedResponse]:
+        run_context: Any = None,
+    ) -> AsyncIterator[CodeAssistStreamedResponse]:
         """Make a streaming request to the Code Assist API."""
         request_body = self._build_request(
             messages, model_settings, model_request_parameters
@@ -117,7 +120,25 @@ class GeminiCodeAssistModel(Model):
                         f"Code Assist API error {response.status_code}: {error_text.decode()}"
                     )
 
-                yield StreamedResponse(response, self._model_name)
+                async def _sse_chunks() -> AsyncIterator[dict[str, Any]]:
+                    async for line in response.aiter_lines():
+                        line = line.strip()
+                        if line.startswith("data: "):
+                            data_str = line[6:]
+                            if data_str and data_str != "[DONE]":
+                                try:
+                                    data = json.loads(data_str)
+                                    # Unwrap the Code Assist outer `response` envelope
+                                    yield data.get("response", data)
+                                except json.JSONDecodeError:
+                                    logger.warning("Failed to parse SSE: %s", data_str)
+
+                yield CodeAssistStreamedResponse(
+                    model_request_parameters=model_request_parameters,
+                    _chunks=_sse_chunks(),
+                    _model_name_str=self._model_name,
+                    _timestamp_val=datetime.now(timezone.utc),
+                )
 
     def _get_headers(self) -> Dict[str, str]:
         """Get HTTP headers for the request."""
@@ -311,75 +332,79 @@ class GeminiCodeAssistModel(Model):
         )
 
 
-class StreamedResponse:
-    """Handler for streaming responses from Code Assist API."""
+def _generate_tool_call_id() -> str:
+    return str(uuid.uuid4())[:8]
 
-    def __init__(self, response: httpx.Response, model_name: str):
-        self._response = response
-        self._model_name = model_name
-        self._usage: Optional[RequestUsage] = None
-        self._timestamp = datetime.now(timezone.utc)
 
-    def __aiter__(self) -> AsyncIterator[str]:
-        return self._iter_chunks()
+@dataclass
+class CodeAssistStreamedResponse(StreamedResponse):
+    """pydantic_ai-compatible streaming response for Google Code Assist."""
 
-    async def _iter_chunks(self) -> AsyncIterator[str]:
-        """Iterate over SSE chunks from the response."""
-        async for line in self._response.aiter_lines():
-            line = line.strip()
+    _chunks: AsyncIterator[dict[str, Any]]
+    _model_name_str: str
+    _timestamp_val: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    _current_tool_call_id: str | None = field(default=None)
+    _current_tool_name: str | None = field(default=None)
+    _current_vendor_part_id: uuid.UUID | None = field(default=None)
+    _current_args: dict[str, Any] = field(default_factory=dict)
 
-            if line.startswith("data: "):
-                data_str = line[6:]
-                if data_str == "[DONE]":
-                    break
+    async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
+        async for chunk in self._chunks:
+            usage_meta = chunk.get("usageMetadata", {})
+            if usage_meta:
+                self._usage = RequestUsage(
+                    input_tokens=usage_meta.get("promptTokenCount", 0),
+                    output_tokens=usage_meta.get("candidatesTokenCount", 0),
+                )
 
-                try:
-                    data = json.loads(data_str)
-                    # Unwrap Code Assist format
-                    inner = data.get("response", data)
+            candidates = chunk.get("candidates", [])
+            if not candidates:
+                continue
 
-                    # Extract usage if available
-                    if "usageMetadata" in inner:
-                        meta = inner["usageMetadata"]
-                        self._usage = RequestUsage(
-                            input_tokens=meta.get("promptTokenCount", 0),
-                            output_tokens=meta.get("candidatesTokenCount", 0),
+            candidate = candidates[0]
+            content = candidate.get("content", {})
+            parts = content.get("parts", [])
+
+            for part in parts:
+                if part.get("text") is not None:
+                    text = part["text"]
+                    if text:
+                        for event in self._parts_manager.handle_text_delta(
+                            vendor_part_id=None,
+                            content=text,
+                        ):
+                            yield event
+                elif part.get("functionCall"):
+                    fc = part["functionCall"]
+                    if fc.get("name"):
+                        self._current_tool_name = fc["name"]
+                        self._current_tool_call_id = fc.get("id") or _generate_tool_call_id()
+                        self._current_vendor_part_id = uuid.uuid4()
+                        self._current_args = {}
+                    args = fc.get("args", {})
+                    self._current_args.update(args)
+                    if self._current_vendor_part_id and self._current_tool_name:
+                        event = self._parts_manager.handle_tool_call_delta(
+                            vendor_part_id=self._current_vendor_part_id,
+                            tool_name=self._current_tool_name,
+                            args=args,
+                            tool_call_id=self._current_tool_call_id,
                         )
+                        if event is not None:
+                            yield event
 
-                    # Extract text from candidates
-                    for candidate in inner.get("candidates", []):
-                        content = candidate.get("content", {})
-                        for part in content.get("parts", []):
-                            if "text" in part:
-                                yield part["text"]
-
-                except json.JSONDecodeError:
-                    logger.warning("Failed to parse SSE data: %s", data_str)
-                    continue
-
-    async def get_response_parts(self) -> list[ModelResponsePart]:
-        """Get all response parts after streaming is complete."""
-        text_content = ""
-        tool_calls = []
-
-        async for chunk in self:
-            text_content += chunk
-
-        parts: list[ModelResponsePart] = []
-        if text_content:
-            parts.append(TextPart(content=text_content))
-        parts.extend(tool_calls)
-
-        return parts
-
-    def usage(self) -> RequestUsage:
-        """Get usage statistics."""
-        return self._usage or RequestUsage()
-
+    @property
     def model_name(self) -> str:
-        """Get the model name."""
-        return self._model_name
+        return self._model_name_str
 
+    @property
+    def provider_name(self) -> str | None:
+        return "google"
+
+    @property
+    def provider_url(self) -> str | None:
+        return None
+
+    @property
     def timestamp(self) -> datetime:
-        """Get the response timestamp."""
-        return self._timestamp
+        return self._timestamp_val

--- a/code_puppy/plugins/gemini_oauth/README.md
+++ b/code_puppy/plugins/gemini_oauth/README.md
@@ -1,0 +1,108 @@
+# Gemini OAuth (Google Code Assist) Plugin
+
+Use Google's **Gemini** models inside Code Puppy through the **local
+Gemini CLI's** existing OAuth login — **no API key required**.
+
+> **Note on "Antigravity":** Google has been rebranding its Gemini CLI
+> tooling as *Antigravity*. Whichever name your local install uses, both
+> write their OAuth credentials to the same `~/.gemini/` location, so this
+> plugin works with either.
+
+## How it works
+
+The [Gemini CLI](https://github.com/google-gemini/gemini-cli) stores an
+OAuth token at `~/.gemini/oauth_creds.json` after you sign in. This plugin
+reuses that token to call the **Code Assist API**
+(`https://cloudcode-pa.googleapis.com`) — the same endpoint the CLI uses —
+so you get Gemini access on your existing (often free) Code Assist tier
+without pasting an API key into Code Puppy.
+
+It provides the three symbols `model_factory.py` expects for the
+`gemini_oauth` model type:
+
+| Symbol | Purpose |
+|--------|---------|
+| `GEMINI_OAUTH_CONFIG` | Code Assist base URL + API version |
+| `get_valid_access_token()` | Reads `~/.gemini/oauth_creds.json`, auto-refreshes when expired |
+| `get_project_id()` | Discovers your managed GCP project via `loadCodeAssist`, caches it |
+
+Tokens are refreshed automatically using the refresh token the Gemini CLI
+already stored; refreshed credentials are written back with `chmod 600`.
+
+## Prerequisites
+
+1. Install and sign in to the Gemini CLI at least once so
+   `~/.gemini/oauth_creds.json` exists:
+   ```bash
+   npm install -g @google/gemini-cli   # or: brew install gemini-cli
+   gemini                              # complete the browser sign-in
+   ```
+
+2. **(Optional) Enable automatic token refresh.** Refreshing an expired token
+   requires the OAuth client credentials. These are the *public,
+   installed-application* values shipped in the open-source Gemini CLI. We do
+   **not** hardcode or paste the secret in this repo (secret scanners flag the
+   `GOCSPX-` pattern regardless of context). Instead, extract them from your
+   own installed Gemini CLI and export them once:
+
+   ```bash
+   # Locate the CLI's OAuth module and read the two constants from it:
+   grep -rhoE 'OAUTH_CLIENT_(ID|SECRET) *= *[^,]+' \
+     "$(dirname "$(readlink -f "$(command -v gemini)")")/.." 2>/dev/null
+
+   # Then export what you find (the ID ends in .apps.googleusercontent.com,
+   # the SECRET starts with GOCSPX-):
+   export GEMINI_OAUTH_CLIENT_ID="<...>.apps.googleusercontent.com"
+   export GEMINI_OAUTH_CLIENT_SECRET="<the GOCSPX-... value>"
+   ```
+
+   Without these, the plugin still works while your token is valid; when it
+   expires, just re-run `gemini` to refresh `~/.gemini/oauth_creds.json`.
+
+## Setup
+
+Add one or more Gemini models to `~/.code_puppy/extra_models.json`:
+
+```json
+{
+  "antigravity-flash": {
+    "type": "gemini_oauth",
+    "name": "gemini-2.5-flash",
+    "description": "Gemini 2.5 Flash via Code Assist OAuth",
+    "context_length": 1000000
+  },
+  "antigravity-pro": {
+    "type": "gemini_oauth",
+    "name": "gemini-2.5-pro",
+    "description": "Gemini 2.5 Pro via Code Assist OAuth",
+    "context_length": 1000000
+  }
+}
+```
+
+Then, inside Code Puppy:
+
+```text
+/model antigravity-flash
+```
+
+That's it — the first request discovers your Code Assist project ID and
+caches it to `~/.gemini/code_assist_project.json`.
+
+## Troubleshooting
+
+- **`credentials not found`** — run `gemini` once to sign in.
+- **`PERMISSION_DENIED` / `Gemini for Google Cloud API has not been used`** —
+  your account isn't onboarded to Code Assist; open the Gemini CLI once and
+  send a message so Google provisions the managed project.
+- **`RESOURCE_EXHAUSTED` (429)** — you hit the Code Assist rate limit for the
+  free tier; wait for the reset window shown in the error, or switch models.
+
+## Security
+
+- The OAuth `client_id` / `client_secret` in `config.py` are the **public,
+  installed-application** values embedded in the open-source Gemini CLI.
+  Per Google's own docs, the secret for installed apps
+  [is not treated as confidential](https://developers.google.com/identity/protocols/oauth2#installed).
+- Access and refresh tokens are read from and written to `~/.gemini/` only,
+  with `0600` permissions. They are never logged.

--- a/code_puppy/plugins/gemini_oauth/config.py
+++ b/code_puppy/plugins/gemini_oauth/config.py
@@ -1,0 +1,35 @@
+"""Configuration for the Gemini OAuth (Code Assist) plugin.
+
+The OAuth client_id/client_secret are the public, installed-application
+values embedded in the open-source Gemini CLI
+(github.com/google-gemini/gemini-cli). Google notes that the client secret
+for installed apps is NOT treated as confidential:
+  https://developers.google.com/identity/protocols/oauth2#installed
+
+We still avoid committing the secret literal here (GitHub push protection
+flags the ``GOCSPX-`` pattern). Instead the client credentials are read from
+the environment at runtime, falling back to the Gemini CLI's public
+client_id. Set these to enable automatic token refresh (see the plugin
+README for the public values, or just re-run ``gemini`` to refresh):
+
+    GEMINI_OAUTH_CLIENT_ID       (optional; defaults to the public CLI id)
+    GEMINI_OAUTH_CLIENT_SECRET   (required for auto-refresh)
+"""
+
+import os
+
+# Public installed-app client_id shipped by the Gemini CLI. Not a secret.
+DEFAULT_CLIENT_ID = (
+    "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com"
+)
+
+GEMINI_OAUTH_CONFIG = {
+    "api_base_url": "https://cloudcode-pa.googleapis.com",
+    "api_version": "v1internal",
+    "client_id": os.environ.get("GEMINI_OAUTH_CLIENT_ID", DEFAULT_CLIENT_ID),
+    "client_secret": os.environ.get("GEMINI_OAUTH_CLIENT_SECRET", ""),
+    "token_uri": "https://oauth2.googleapis.com/token",
+    # Paths (~ expanded at runtime)
+    "credentials_path": "~/.gemini/oauth_creds.json",
+    "projects_path": "~/.gemini/projects.json",
+}

--- a/code_puppy/plugins/gemini_oauth/utils.py
+++ b/code_puppy/plugins/gemini_oauth/utils.py
@@ -1,0 +1,192 @@
+"""Runtime helpers for the Gemini OAuth (Code Assist) plugin.
+
+Reads credentials written by the Gemini CLI from ~/.gemini/oauth_creds.json
+and refreshes them automatically when they expire.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+
+logger = logging.getLogger(__name__)
+
+_CREDS_PATH = os.path.expanduser("~/.gemini/oauth_creds.json")
+_PROJECTS_PATH = os.path.expanduser("~/.gemini/projects.json")
+
+# Public installed-app client_id shipped by the Gemini CLI. Not a secret.
+# The client_secret is read from the environment (see config.py / README);
+# we don't commit the ``GOCSPX-`` literal so GitHub push protection stays happy.
+_CLIENT_ID = os.environ.get(
+    "GEMINI_OAUTH_CLIENT_ID",
+    "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com",
+)
+_CLIENT_SECRET = os.environ.get("GEMINI_OAUTH_CLIENT_SECRET", "")
+_TOKEN_URI = "https://oauth2.googleapis.com/token"
+
+# Refresh the token this many seconds before it actually expires
+_BUFFER_SECONDS = 300
+
+
+def _load_creds() -> dict | None:
+    if not os.path.exists(_CREDS_PATH):
+        logger.warning(
+            "Gemini OAuth credentials not found at %s. "
+            "Run the Gemini CLI once to authenticate: gemini",
+            _CREDS_PATH,
+        )
+        return None
+    try:
+        with open(_CREDS_PATH) as f:
+            return json.load(f)
+    except Exception as exc:
+        logger.error("Failed to read Gemini credentials: %s", exc)
+        return None
+
+
+def _save_creds(creds: dict) -> None:
+    try:
+        with open(_CREDS_PATH, "w") as f:
+            json.dump(creds, f)
+        os.chmod(_CREDS_PATH, 0o600)
+    except Exception as exc:
+        logger.warning("Failed to save refreshed Gemini credentials: %s", exc)
+
+
+def _is_expired(creds: dict) -> bool:
+    expiry = creds.get("expiry_date", 0)
+    # Gemini CLI stores expiry_date in milliseconds
+    if expiry > 1_000_000_000_000:
+        return time.time() > (expiry / 1000) - _BUFFER_SECONDS
+    # Fallback: treat as seconds
+    return time.time() > expiry - _BUFFER_SECONDS
+
+
+def _refresh_token(refresh_token: str) -> dict | None:
+    if not _CLIENT_SECRET:
+        logger.error(
+            "Cannot refresh the Gemini token: GEMINI_OAUTH_CLIENT_SECRET is not "
+            "set. Either export it (see the plugin README for the public "
+            "Gemini CLI value) or re-run `gemini` to refresh ~/.gemini/oauth_creds.json."
+        )
+        return None
+    try:
+        import httpx
+
+        resp = httpx.post(
+            _TOKEN_URI,
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": _CLIENT_ID,
+                "client_secret": _CLIENT_SECRET,
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as exc:
+        logger.error("Gemini token refresh failed: %s", exc)
+        return None
+
+
+def get_valid_access_token() -> str | None:
+    """Return a valid Google access token, refreshing from ~/.gemini/oauth_creds.json if needed."""
+    creds = _load_creds()
+    if not creds:
+        return None
+
+    if _is_expired(creds):
+        refresh_token = creds.get("refresh_token")
+        if not refresh_token:
+            logger.error(
+                "Gemini OAuth token is expired and no refresh_token is available. "
+                "Re-authenticate by running: gemini"
+            )
+            return None
+
+        logger.info("Gemini OAuth token expired — refreshing...")
+        new_tokens = _refresh_token(refresh_token)
+        if not new_tokens:
+            logger.error(
+                "Token refresh failed. Re-authenticate by running: gemini"
+            )
+            return None
+
+        creds["access_token"] = new_tokens["access_token"]
+        if "expires_in" in new_tokens:
+            creds["expiry_date"] = int((time.time() + new_tokens["expires_in"]) * 1000)
+        if "refresh_token" in new_tokens:
+            creds["refresh_token"] = new_tokens["refresh_token"]
+        _save_creds(creds)
+        logger.info("Gemini OAuth token refreshed successfully")
+
+    token = creds.get("access_token")
+    if not token:
+        logger.error("Gemini credentials file has no access_token field")
+        return None
+    return token
+
+
+_PROJECT_CACHE_PATH = os.path.expanduser("~/.gemini/code_assist_project.json")
+_LOAD_CODE_ASSIST_URL = "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist"
+
+
+def _fetch_managed_project_id(access_token: str) -> str | None:
+    """Call the Code Assist loadCodeAssist endpoint to get the managed project ID."""
+    try:
+        import httpx
+
+        resp = httpx.post(
+            _LOAD_CODE_ASSIST_URL,
+            json={
+                "metadata": {
+                    "ideType": "IDE_UNSPECIFIED",
+                    "platform": "PLATFORM_UNSPECIFIED",
+                    "pluginType": "GEMINI",
+                }
+            },
+            headers={"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        project_id = data.get("cloudaicompanionProject")
+        if project_id:
+            # Cache so we don't call the API on every request
+            try:
+                with open(_PROJECT_CACHE_PATH, "w") as f:
+                    json.dump({"project_id": project_id}, f)
+                os.chmod(_PROJECT_CACHE_PATH, 0o600)
+            except Exception:
+                pass
+        return project_id
+    except Exception as exc:
+        logger.error("Failed to fetch Code Assist project ID: %s", exc)
+        return None
+
+
+def get_project_id() -> str | None:
+    """Return the Google Cloud project ID assigned by Code Assist for this account.
+
+    On first call, queries the Code Assist API (loadCodeAssist) to discover the
+    managed project, then caches it in ~/.gemini/code_assist_project.json.
+    """
+    # Try cached value first
+    if os.path.exists(_PROJECT_CACHE_PATH):
+        try:
+            with open(_PROJECT_CACHE_PATH) as f:
+                cached = json.load(f)
+            project_id = cached.get("project_id")
+            if project_id:
+                return project_id
+        except Exception:
+            pass
+
+    # Fetch from the API
+    token = get_valid_access_token()
+    if not token:
+        return None
+    return _fetch_managed_project_id(token)

--- a/docs/LOCAL_PROVIDERS.md
+++ b/docs/LOCAL_PROVIDERS.md
@@ -1,0 +1,160 @@
+# 🐶 Using Your Local CLI Tools as Code Puppy Providers
+
+Code Puppy can drive the AI CLIs you already have installed — **Ollama**,
+**Claude Code**, and the **Gemini / Antigravity CLI** — as interchangeable
+model providers, all switchable from a single `/model` picker. In most cases
+you **don't need to paste any API keys**: Code Puppy reuses the logins those
+tools already set up on your machine.
+
+This guide covers all three.
+
+---
+
+## 1. Ollama (local models, no key)
+
+[Ollama](https://ollama.com) serves models locally over an OpenAI-compatible
+API at `http://localhost:11434`. Code Puppy has a built-in `ollama` model type.
+
+**Prereqs:** `ollama serve` running, and at least one *tool-capable* model
+pulled. Older models like `llama3:8b` do **not** support function calling and
+will fail on agent tasks — prefer `llama3.1`, `qwen2.5`, `mistral-nemo`, etc.
+
+```bash
+ollama pull llama3.1:8b
+ollama pull qwen2.5:7b
+```
+
+Add them to `~/.code_puppy/extra_models.json`:
+
+```json
+{
+  "ollama-llama3.1": {
+    "type": "ollama",
+    "name": "llama3.1:8b",
+    "description": "Local Ollama: Llama 3.1 8B (supports tools)",
+    "context_length": 131072
+  },
+  "ollama-qwen2.5": {
+    "type": "ollama",
+    "name": "qwen2.5:7b",
+    "description": "Local Ollama: Qwen 2.5 7B (supports tools)",
+    "context_length": 32768
+  }
+}
+```
+
+The `ollama` type auto-detects `OLLAMA_HOST` and falls back to
+`localhost:11434`. No API key needed (a placeholder is sent automatically).
+
+### Optional: an Ollama pool
+
+Rotate across several local models with a round-robin pool so you can switch
+the whole group with one name:
+
+```json
+{
+  "ollama-pool": {
+    "type": "round_robin",
+    "description": "Local Ollama pool: rotates Llama 3.1 and Qwen 2.5",
+    "models": ["ollama-llama3.1", "ollama-qwen2.5"],
+    "rotate_every": 1
+  }
+}
+```
+
+```text
+/model ollama-pool
+```
+
+---
+
+## 2. Claude Code (reuse your Claude CLI / claude.ai login)
+
+The built-in `claude_code_oauth` plugin runs its own browser OAuth flow and
+discovers every Claude model your account can use — no API key.
+
+Inside Code Puppy:
+
+```text
+/claude-code-auth
+```
+
+Complete the browser sign-in. Models then appear prefixed as
+`claude-code-claude-sonnet-4-6`, `claude-code-claude-opus-4-8`, etc.
+
+```text
+/claude-code-status     # verify auth + list discovered models
+/model claude-code-claude-sonnet-4-6
+```
+
+Tokens refresh automatically in the background. See
+[`code_puppy/plugins/claude_code_oauth/`](../code_puppy/plugins/claude_code_oauth/)
+for details.
+
+---
+
+## 3. Gemini / Antigravity (reuse your Gemini CLI login)
+
+> **"Antigravity" = Gemini.** Google has been rebranding its Gemini CLI
+> tooling as *Antigravity*. Both write OAuth credentials to `~/.gemini/`, so
+> the same plugin handles either name.
+
+The `gemini_oauth` plugin reuses the token the **Gemini CLI** stores at
+`~/.gemini/oauth_creds.json` and calls the Code Assist API — **no API key**,
+often on a free tier.
+
+**Prereq:** sign in to the Gemini CLI once so the token file exists:
+
+```bash
+gemini    # complete the browser sign-in
+```
+
+Add Gemini models to `~/.code_puppy/extra_models.json`:
+
+```json
+{
+  "antigravity-flash": {
+    "type": "gemini_oauth",
+    "name": "gemini-2.5-flash",
+    "description": "Gemini 2.5 Flash via Code Assist OAuth",
+    "context_length": 1000000
+  },
+  "antigravity-pro": {
+    "type": "gemini_oauth",
+    "name": "gemini-2.5-pro",
+    "description": "Gemini 2.5 Pro via Code Assist OAuth",
+    "context_length": 1000000
+  }
+}
+```
+
+```text
+/model antigravity-flash
+```
+
+Full details and troubleshooting:
+[`code_puppy/plugins/gemini_oauth/README.md`](../code_puppy/plugins/gemini_oauth/README.md).
+
+---
+
+## Switching between them
+
+Once configured, everything lives in one picker:
+
+```text
+/model                       # interactive picker across ALL providers
+/model ollama-pool           # local
+/model antigravity-flash     # Gemini via CLI OAuth
+/model claude-code-claude-sonnet-4-6   # Claude via CLI OAuth
+```
+
+The active model is saved to `~/.code_puppy/puppy.cfg` and restored next launch.
+
+## Notes
+
+- `extra_models.json` lives in `~/.code_puppy/`, **not** in the repo — your
+  model list is personal and never committed.
+- All providers get the **same tools** when running as the main agent; tool
+  access depends on the active *agent*, not the model.
+- Editable installs (`pip install -e .`) pick up source changes on the next
+  launch — a running session must be restarted to see them.


### PR DESCRIPTION
## What & why

`model_factory.py` already references `code_puppy.plugins.gemini_oauth` for the
`gemini_oauth` model type, but **the plugin was never shipped** — so that model
type is a dangling import today. This PR ships the plugin and fixes two
streaming bugs, letting users run **Gemini** models through their **local
Gemini / Antigravity CLI's** existing OAuth login — **no API key**.

> Google has been rebranding the Gemini CLI tooling as *"Antigravity"*. Both
> write credentials to `~/.gemini/`, so the same plugin handles either name.

## Changes

### 1. New `gemini_oauth` plugin (`code_puppy/plugins/gemini_oauth/`)
Reuses the token the Gemini CLI stores at `~/.gemini/oauth_creds.json` and calls
the Code Assist API (`cloudcode-pa.googleapis.com`). Exposes the three symbols
`model_factory` expects:

- `GEMINI_OAUTH_CONFIG` — Code Assist base URL + API version
- `get_valid_access_token()` — reads the CLI creds, auto-refreshes when expired, writes back `chmod 600`
- `get_project_id()` — discovers the managed GCP project via `loadCodeAssist` and caches it

Client credentials (the public installed-app values from the Gemini CLI) are read
from `GEMINI_OAUTH_CLIENT_ID` / `GEMINI_OAUTH_CLIENT_SECRET` env vars — **no
secret is committed**. The plugin README explains how to extract them from a
local `gemini` install to enable auto-refresh.

### 2. Fix streaming in `gemini_code_assist.py`
Two bugs broke the streaming path (which is what the agent runtime uses by default):

- `request_stream()` was missing the `run_context` parameter the runtime passes
  → `TypeError: takes 4 positional arguments but 5 were given`
- the streaming response class didn't inherit from pydantic_ai's `StreamedResponse`
  ABC → `'StreamedResponse' object has no attribute 'get'`. Replaced with
  `CodeAssistStreamedResponse`, a proper `@dataclass` subclass implementing
  `_get_event_iterator()` (mirrors the existing `GeminiStreamingResponse`).

### 3. Docs
- `docs/LOCAL_PROVIDERS.md` — how to wire **Ollama**, **Claude Code**, and
  **Gemini/Antigravity** from their local CLIs, all switchable via `/model`.
- `code_puppy/plugins/gemini_oauth/README.md` — plugin setup + troubleshooting.

## Testing

Verified end-to-end through the `code-puppy` CLI against a real account:

- `/model antigravity-flash` → live `generateContent` call returns a response
- token auto-refresh from an expired `~/.gemini/oauth_creds.json` works
- managed project ID discovered via `loadCodeAssist` and cached
- non-streaming and streaming paths both exercised

## Notes for the maintainer

- Personal model lists live in `~/.code_puppy/extra_models.json` (not committed).
- If you'd prefer to hardcode the public client credentials rather than use env
  vars, that's a one-line change — I used env vars to keep secret scanners happy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)