### PR TITLE
feat: require explicit user trust before loading project plugins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,18 @@ and skills (`<CWD>/.code_puppy/skills/`).
 
 - **Directory must be created intentionally.** Code Puppy will never auto-create
   `.code_puppy/plugins/` — your team opts in by creating it.
+- **Disabled by default (trust gate).** Project plugins run arbitrary repo
+  code at import time, so none load until the user accepts them in the
+  `/plugins` TUI ceremony (select → Enter → type `trust`); accepted plugins
+  hot-load with no restart. Trust is a SHA-256 of the plugin dir, stored
+  user-side in `~/.code_puppy/trusted_plugins.json` and scoped to the project
+  path — any file change reverts the plugin to untrusted, and everything else
+  fails closed. `/plugins revoke <name>` removes trust. Full security model:
+  `code_puppy/plugins/trust.py`.
+- **Keep runtime state out of the plugin dir** — writing state (SQLite,
+  caches, logs) next to the code self-tampers the hash and demands
+  re-acceptance every boot. Use `~/.code_puppy/` like builtin plugins do, or
+  a dot-path (e.g. `.state/`), which is excluded from hashing.
 - **Load order is builtin → user → project.** Project plugins load last, giving
   them highest precedence for override-style hooks.
 - **Project wins on name collision.** If a project plugin shares a name with a

--- a/code_puppy/plugins/__init__.py
+++ b/code_puppy/plugins/__init__.py
@@ -6,6 +6,7 @@ import types
 from pathlib import Path
 
 from code_puppy.callbacks import clear_loading_context, set_loading_context
+from code_puppy.plugins import trust as _trust
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +19,11 @@ _PLUGINS_LOADED = False
 # Stores the loaded plugin names by tier after the first load_plugin_callbacks() call.
 # Populated once, then read by get_loaded_plugins().
 _loaded_plugin_names: dict[str, list[str]] = {"builtin": [], "user": [], "project": []}
+
+# Status of every discovered project plugin, keyed by name:
+# "loaded" | "untrusted" | "changed" | "disabled" | "error".
+# Read by /plugins UI via get_project_plugin_status().
+_project_plugin_status: dict[str, str] = {}
 
 
 def _load_builtin_plugins(plugins_dir: Path) -> list[str]:
@@ -261,23 +267,98 @@ def _ensure_plugin_package(plugin_dir: Path, plugin_name: str) -> bool:
         return False
 
 
+def _load_one_project_plugin(plugin_dir: Path, plugin_name: str) -> bool:
+    """Import a single (already trusted) project plugin.
+
+    SECURITY: callers MUST verify trust before invoking this — executing
+    ``register_callbacks.py`` / ``__init__.py`` is arbitrary code execution.
+
+    The plugins directory is only added to ``sys.path`` here, i.e. after a
+    trust decision, so an untrusted repo can never shadow stdlib/third-party
+    modules just by existing.
+
+    Returns True if the plugin executed successfully.
+    """
+    callbacks_file = plugin_dir / "register_callbacks.py"
+    init_file = plugin_dir / "__init__.py"
+
+    if not callbacks_file.exists() and not init_file.exists():
+        return False
+
+    # sys.path entry is earned by trust — inserted just-in-time so sibling
+    # top-level imports inside the plugin resolve during exec below.
+    parent_str = str(plugin_dir.parent)
+    if parent_str not in sys.path:
+        sys.path.insert(0, parent_str)
+
+    try:
+        if callbacks_file.exists():
+            # Register parent package so relative imports resolve
+            _ensure_plugin_package(plugin_dir, plugin_name)
+
+            module_name = f"{_PROJECT_PLUGINS_NS}.{plugin_name}.register_callbacks"
+            spec = importlib.util.spec_from_file_location(module_name, callbacks_file)
+            if spec is None or spec.loader is None:
+                logger.warning(
+                    f"Could not create module spec for project plugin: {plugin_name}"
+                )
+                return False
+
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[module_name] = module
+            set_loading_context(plugin_name)
+            try:
+                spec.loader.exec_module(module)
+            finally:
+                clear_loading_context()
+            return True
+
+        # Fallback to __init__.py (mirrors user plugin behavior)
+        set_loading_context(plugin_name)
+        try:
+            loaded_ok = _ensure_plugin_package(plugin_dir, plugin_name)
+        finally:
+            clear_loading_context()
+        if not loaded_ok:
+            logger.warning(
+                f"Could not load __init__.py for project plugin: {plugin_name}"
+            )
+        return loaded_ok
+
+    except ImportError as e:
+        logger.warning(
+            f"Failed to import callbacks from project plugin {plugin_name}: {e}"
+        )
+        return False
+    except Exception as e:
+        logger.error(
+            f"Unexpected error loading project plugin {plugin_name}: {e}",
+            exc_info=True,
+        )
+        return False
+
+
 def _load_project_plugins(
     project_plugins_dir: Path,
     builtin_names: set[str],
     user_names: set[str],
 ) -> list[str]:
-    """Load project plugins from <CWD>/.code_puppy/plugins/.
+    """Load TRUSTED project plugins from <CWD>/.code_puppy/plugins/.
 
-    Mirrors _load_user_plugins() but uses a ``project_plugins.`` sys.modules
-    namespace and warns on name collisions with builtin or user plugins.
+    Project plugins are disabled by default: a plugin is only imported when
+    the user previously accepted the risk via the /plugins TUI ceremony AND
+    its content hash still matches the accepted hash (see plugins.trust).
+    Everything else is recorded in ``_project_plugin_status`` and skipped
+    WITHOUT importing — import is code execution.
 
-    Before loading each plugin's ``register_callbacks.py``, a synthetic
-    parent package is registered in ``sys.modules`` so that relative
-    imports (``from . import state``, ``from .utils import …``) resolve
-    correctly.
+    NOTE: this is deliberately different from the ``disabled_plugins``
+    mechanism used by builtin/user tiers (loaded but callbacks skipped).
+    Do not "unify" them — non-enabled project plugins must never import.
 
     Returns list of successfully loaded plugin names.
     """
+    from code_puppy.plugins.config import is_plugin_disabled
+
     loaded = []
 
     if not project_plugins_dir.exists():
@@ -289,9 +370,7 @@ def _load_project_plugins(
         )
         return loaded
 
-    project_plugins_str = str(project_plugins_dir)
-    if project_plugins_str not in sys.path:
-        sys.path.insert(0, project_plugins_str)
+    project_root = project_plugins_dir.parent.parent
 
     # Create the top-level namespace package once
     _ensure_project_ns()
@@ -304,6 +383,36 @@ def _load_project_plugins(
         ):
             plugin_name = item.name
 
+            if (
+                not (item / "register_callbacks.py").exists()
+                and not (item / "__init__.py").exists()
+            ):
+                continue
+
+            # Trust gate — fail closed BEFORE any import machinery runs.
+            status = _trust.get_trust_status(project_root, plugin_name, item)
+            if status != _trust.TRUSTED:
+                # Recorded here; surfaced to the human by plugin_list's
+                # startup hook (orange banner) once renderers are live.
+                # logger.info only — a logger.warning would splat onto
+                # stderr above the logo, duplicating the banner.
+                _project_plugin_status[plugin_name] = status
+                logger.info(
+                    "Skipping project plugin '%s' (%s). "
+                    "Review and enable it in the /plugins TUI.",
+                    plugin_name,
+                    status,
+                )
+                continue
+
+            if is_plugin_disabled(plugin_name):
+                _project_plugin_status[plugin_name] = "disabled"
+                logger.info(
+                    "Project plugin '%s' is trusted but disabled — not loading",
+                    plugin_name,
+                )
+                continue
+
             # Warn if a project plugin shadows a builtin (user collisions
             # are handled earlier by skipping the user plugin entirely).
             if plugin_name in builtin_names:
@@ -311,65 +420,11 @@ def _load_project_plugins(
                     f"Project plugin '{plugin_name}' shadows builtin plugin of the same name"
                 )
 
-            callbacks_file = item / "register_callbacks.py"
-
-            if callbacks_file.exists():
-                try:
-                    # Register parent package so relative imports resolve
-                    _ensure_plugin_package(item, plugin_name)
-
-                    module_name = (
-                        f"{_PROJECT_PLUGINS_NS}.{plugin_name}.register_callbacks"
-                    )
-                    spec = importlib.util.spec_from_file_location(
-                        module_name, callbacks_file
-                    )
-                    if spec is None or spec.loader is None:
-                        logger.warning(
-                            f"Could not create module spec for project plugin: {plugin_name}"
-                        )
-                        continue
-
-                    module = importlib.util.module_from_spec(spec)
-                    sys.modules[module_name] = module
-                    set_loading_context(plugin_name)
-                    try:
-                        spec.loader.exec_module(module)
-                    finally:
-                        clear_loading_context()
-                    loaded.append(plugin_name)
-
-                except ImportError as e:
-                    logger.warning(
-                        f"Failed to import callbacks from project plugin {plugin_name}: {e}"
-                    )
-                except Exception as e:
-                    logger.error(
-                        f"Unexpected error loading project plugin {plugin_name}: {e}",
-                        exc_info=True,
-                    )
+            if _load_one_project_plugin(item, plugin_name):
+                loaded.append(plugin_name)
+                _project_plugin_status[plugin_name] = "loaded"
             else:
-                # Fallback to __init__.py (mirrors user plugin behavior)
-                init_file = item / "__init__.py"
-                if init_file.exists():
-                    try:
-                        set_loading_context(plugin_name)
-                        try:
-                            loaded_ok = _ensure_plugin_package(item, plugin_name)
-                        finally:
-                            clear_loading_context()
-                        if loaded_ok:
-                            loaded.append(plugin_name)
-                        else:
-                            logger.warning(
-                                f"Could not load __init__.py for project plugin: {plugin_name}"
-                            )
-
-                    except Exception as e:
-                        logger.error(
-                            f"Unexpected error loading project plugin {plugin_name}: {e}",
-                            exc_info=True,
-                        )
+                _project_plugin_status[plugin_name] = "error"
 
     return loaded
 
@@ -416,12 +471,18 @@ def load_plugin_callbacks() -> dict[str, list[str]]:
 
     # Pre-scan project plugin names so we can skip user plugins that the
     # project tier will supersede (project wins, matching agents dedup).
+    # SECURITY: only TRUSTED project plugins participate in dedup — otherwise
+    # an untrusted repo could knock out user plugins (e.g. force_push_guard)
+    # just by squatting on their names.
     project_plugins_dir = get_project_plugins_directory()
-    project_plugin_names = (
-        _scan_plugin_names(project_plugins_dir)
-        if project_plugins_dir is not None
-        else set()
-    )
+    project_plugin_names: set[str] = set()
+    if project_plugins_dir is not None:
+        project_root = project_plugins_dir.parent.parent
+        project_plugin_names = {
+            name
+            for name in _scan_plugin_names(project_plugins_dir)
+            if _trust.is_plugin_trusted(project_root, name, project_plugins_dir / name)
+        }
 
     builtin_loaded = _load_builtin_plugins(plugins_dir)
     user_skip_names = set(builtin_loaded) | project_plugin_names
@@ -461,6 +522,53 @@ def get_loaded_plugins() -> dict[str, list[str]]:
     call at any time — returns empty lists before plugins are loaded.
     """
     return dict(_loaded_plugin_names)
+
+
+def get_project_plugin_status() -> dict[str, str]:
+    """Return status of every discovered project plugin.
+
+    Maps plugin name to one of ``loaded``, ``untrusted``, ``changed``,
+    ``disabled``, or ``error``.  Used by the /plugins UI to surface
+    project plugins that were skipped by the trust gate.
+    """
+    return dict(_project_plugin_status)
+
+
+def load_project_plugin_now(plugin_name: str) -> bool:
+    """Hot-load a single project plugin after the user granted trust.
+
+    Re-checks the trust store (fail closed) so callers can't accidentally
+    load an unaccepted plugin.  Registers callbacks immediately — no
+    restart required.
+    """
+    project_plugins_dir = get_project_plugins_directory()
+    if project_plugins_dir is None:
+        return False
+
+    plugin_dir = project_plugins_dir / plugin_name
+    if not plugin_dir.is_dir():
+        return False
+
+    project_root = project_plugins_dir.parent.parent
+    if not _trust.is_plugin_trusted(project_root, plugin_name, plugin_dir):
+        logger.warning(
+            "Refusing to hot-load project plugin '%s' — not trusted", plugin_name
+        )
+        return False
+
+    if plugin_name in _loaded_plugin_names["project"]:
+        # Already imported this session; callbacks are registered.
+        _project_plugin_status[plugin_name] = "loaded"
+        return True
+
+    _ensure_project_ns()
+    if _load_one_project_plugin(plugin_dir, plugin_name):
+        _loaded_plugin_names["project"].append(plugin_name)
+        _project_plugin_status[plugin_name] = "loaded"
+        return True
+
+    _project_plugin_status[plugin_name] = "error"
+    return False
 
 
 def get_user_plugins_dir() -> Path:

--- a/code_puppy/plugins/plugin_list/plugins_menu.py
+++ b/code_puppy/plugins/plugin_list/plugins_menu.py
@@ -17,10 +17,16 @@ import time
 from typing import List, Optional, Tuple
 
 from prompt_toolkit.application import Application
-from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.layout import Dimension, Layout, VSplit, Window
+from prompt_toolkit.application.current import get_app
+from prompt_toolkit.filters import Condition
+from prompt_toolkit.layout import Window
 from prompt_toolkit.layout.controls import FormattedTextControl
-from prompt_toolkit.widgets import Frame
+from prompt_toolkit.widgets import TextArea
+
+from code_puppy.plugins.plugin_list.plugins_menu_layout import (
+    build_key_bindings,
+    build_layout,
+)
 
 from code_puppy.command_line.pagination import (
     ensure_visible_page,
@@ -42,13 +48,20 @@ PAGE_SIZE = 20
 
 
 class _PluginEntry:
-    """Lightweight struct for a loaded plugin."""
+    """Lightweight struct for a plugin row.
 
-    __slots__ = ("name", "tier")
+    ``status`` is "loaded" for imported plugins; project plugins held back
+    by the trust gate carry their gate status instead ("untrusted",
+    "changed", "disabled", "error") so the TUI can show them without
+    pretending they're active.
+    """
 
-    def __init__(self, name: str, tier: str) -> None:
+    __slots__ = ("name", "tier", "status")
+
+    def __init__(self, name: str, tier: str, status: str = "loaded") -> None:
         self.name = name
         self.tier = tier
+        self.status = status
 
 
 class PluginsMenu:
@@ -58,14 +71,34 @@ class PluginsMenu:
     object — keep them stable to avoid breaking the render contract:
 
     * ``plugins``, ``disabled``, ``selected_idx``, ``current_page``, ``page_size``
+    * ``project_dir`` (posix string or None)
+    * ``trust_target``, ``trust_error``, ``trust_feedback`` (popup state)
     * ``_detail_cols``, ``_pane_rows``
     * ``_changed``
     * ``_current()``
+
+    Entries carry a ``status`` ("loaded" or a trust-gate status) — the
+    renderer branches on it, so keep it stable too.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, focus_plugin: Optional[str] = None) -> None:
+        """*focus_plugin* preselects that plugin; if it's trust-gated, the
+        risk-acceptance popup opens immediately (used by ``/plugins enable``
+        to bring the user straight to the ceremony)."""
         self.plugins: List[_PluginEntry] = []
         self.disabled: set[str] = set()
+        self.project_dir: Optional[str] = None
+
+        # Trust popup state. While ``trust_target`` is set, the modal is
+        # visible, ALL list keybindings are filter-disabled (so typing the
+        # accept word can't trigger shortcuts), and focus sits on the input.
+        self.trust_target: Optional[_PluginEntry] = None
+        self.trust_error: str = ""
+        self.trust_feedback: str = ""
+        self.trust_input: TextArea = TextArea(
+            multiline=False, height=1, accept_handler=self._accept_trust
+        )
+        self._modal_open = Condition(lambda: self.trust_target is not None)
 
         self.selected_idx = 0
         self.current_page = 0
@@ -91,19 +124,46 @@ class PluginsMenu:
 
         self._refresh_data()
 
+        if focus_plugin:
+            for i, entry in enumerate(self.plugins):
+                if entry.name == focus_plugin:
+                    self.selected_idx = i
+                    self.current_page = ensure_visible_page(
+                        i, self.current_page, len(self.plugins), PAGE_SIZE
+                    )
+                    if entry.status in ("untrusted", "changed"):
+                        self._open_trust_modal(entry)
+                    break
+
     # -- data helpers ------------------------------------------------------
 
     def _refresh_data(self) -> None:
-        from code_puppy.plugins import get_loaded_plugins
+        from code_puppy.plugins import (
+            get_loaded_plugins,
+            get_project_plugin_status,
+            get_project_plugins_directory,
+        )
         from code_puppy.plugins.config import get_disabled_plugins
 
         loaded = get_loaded_plugins()
         self.disabled = get_disabled_plugins()
 
+        project_dir = get_project_plugins_directory()
+        self.project_dir = project_dir.as_posix() if project_dir else None
+
         entries: List[_PluginEntry] = []
         for tier in ("builtin", "user", "project"):
             for name in sorted(loaded.get(tier, [])):
                 entries.append(_PluginEntry(name, tier))
+
+        # Project plugins held back by the trust gate — shown so Enter can
+        # open the ceremony popup on them.
+        statuses = get_project_plugin_status()
+        shown = {e.name for e in entries if e.tier == "project"}
+        for name in sorted(statuses):
+            if statuses[name] != "loaded" and name not in shown:
+                entries.append(_PluginEntry(name, "project", statuses[name]))
+
         self.plugins = entries
 
     def _current(self) -> Optional[_PluginEntry]:
@@ -115,6 +175,25 @@ class PluginsMenu:
         entry = self._current()
         if not entry:
             return
+        self.trust_feedback = ""
+
+        if entry.status in ("untrusted", "changed"):
+            # Ceremony required — open the risk-acceptance popup.
+            self._open_trust_modal(entry)
+            return
+        if entry.status in ("disabled", "error"):
+            # Already trusted; just (re)activate — no ceremony needed.
+            from code_puppy.plugins.plugin_list.project_trust_flow import (
+                activate_project_plugin,
+            )
+
+            _ok, message = activate_project_plugin(entry.name)
+            self.trust_feedback = message
+            self.detail_scroll = 0
+            self._refresh_data()
+            self.update_display()
+            return
+
         from code_puppy.plugins.config import set_plugin_disabled
 
         is_disabled = entry.name in self.disabled
@@ -123,6 +202,51 @@ class PluginsMenu:
         self.detail_scroll = 0
         self._refresh_data()
         self.update_display()
+
+    # -- trust popup ---------------------------------------------------------
+
+    def _open_trust_modal(self, entry: _PluginEntry) -> None:
+        self.trust_target = entry
+        self.trust_error = ""
+        self.trust_input.text = ""
+        try:
+            get_app().layout.focus(self.trust_input)
+        except Exception:
+            pass  # no running app (tests) — state alone drives the logic
+        self.update_display()
+
+    def _close_trust_modal(self) -> None:
+        self.trust_target = None
+        self.trust_error = ""
+        self.trust_input.text = ""
+        try:
+            get_app().layout.focus(self.menu_control)
+        except Exception:
+            pass
+        self.update_display()
+
+    def _accept_trust(self, buff) -> bool:
+        """Accept-handler for the popup input. Returns False to clear the box."""
+        entry = self.trust_target
+        if entry is None:
+            return False
+        from code_puppy.plugins.plugin_list.project_trust_flow import (
+            ACCEPT_WORD,
+            grant_trust_and_load,
+        )
+
+        if buff.text.strip().lower() != ACCEPT_WORD:
+            self.trust_error = (
+                f"That isn't '{ACCEPT_WORD}' — type it exactly, or press Esc to cancel."
+            )
+            self.update_display()
+            return False
+
+        _ok, message = grant_trust_and_load(entry.name)
+        self.trust_feedback = message
+        self._refresh_data()
+        self._close_trust_modal()
+        return False
 
     # -- display update ----------------------------------------------------
 
@@ -220,135 +344,21 @@ class PluginsMenu:
         self.current_page = new_page
         self._set_selection(self.current_page * PAGE_SIZE)
 
-    def _build_key_bindings(self) -> KeyBindings:
-        """Wire keys to match the ``inspect_history`` plugin's mental model.
-
-        Both plugins share the same split-pane shape (list + scrollable
-        detail). Keeping the bindings aligned means muscle memory carries
-        over. The mental model (lifted from inspect_history):
-
-        * Left-hand keys (``h``, ``j``) move things UP.
-        * Right-hand keys (``k``, ``l``) move things DOWN.
-        * ``h``/``l`` (and ``left``/``right``) scroll the *detail* pane.
-        * ``j``/``k`` (and ``up``/``down``, ``c-p``/``c-n``) move the
-          *selection* in the list.
-        * ``pageup``/``pagedown`` page through the list.
-        * ``g``/``home`` and ``G``/``end`` jump to first/last.
-        """
-        kb = KeyBindings()
-
-        # -- Selection (j = up, k = down -- inspect_history convention) ---
-        @kb.add("up")
-        @kb.add("c-p")
-        @kb.add("j")
-        def _(event):
-            self._move_selection(-1)
-            self.update_display()
-
-        @kb.add("down")
-        @kb.add("c-n")
-        @kb.add("k")
-        def _(event):
-            self._move_selection(+1)
-            self.update_display()
-
-        # -- Page through the list -----------------------------------------
-        @kb.add("pageup")
-        def _(event):
-            self._change_page(-1)
-            self.update_display()
-
-        @kb.add("pagedown")
-        def _(event):
-            self._change_page(+1)
-            self.update_display()
-
-        # -- Jump to first / last ------------------------------------------
-        @kb.add("home")
-        @kb.add("g")
-        def _(event):
-            self._set_selection(0)
-            self.update_display()
-
-        @kb.add("end")
-        @kb.add("G")
-        def _(event):
-            self._set_selection(len(self.plugins) - 1)
-            self.update_display()
-
-        # -- Detail pane scroll (h/left = up, l/right = down) --------------
-        @kb.add("h")
-        @kb.add("left")
-        def _(event):
-            self._scroll_detail(-1)
-
-        @kb.add("l")
-        @kb.add("right")
-        def _(event):
-            self._scroll_detail(+1)
-
-        # -- Actions / exit ------------------------------------------------
-        @kb.add("enter")
-        def _(event):
-            self._toggle_current()
-            self.result = "changed"
-
-        @kb.add("q")
-        @kb.add("escape")
-        @kb.add("c-c")
-        def _(event):
-            self.result = "quit"
-            event.app.exit()
-
-        return kb
-
-    def _build_layout(self) -> Layout:
-        """Build the side-by-side Plugins / Details layout.
-
-        Pane widths are *callables* so they track the live terminal: when the
-        window is resized, ``_recompute_dimensions`` updates the cached cols
-        and these closures hand prompt_toolkit the fresh numbers on the very
-        next render. ``wrap_lines=False`` is critical: auto-wrap bleeds
-        characters into the divider/border column and leaves stale glyphs on
-        redraw. Long lines (description, path) are pre-wrapped by the renderer.
-        """
-
-        def menu_width() -> Dimension:
-            return Dimension(min=20, max=self._menu_cols, preferred=self._menu_cols)
-
-        def detail_width() -> Dimension:
-            return Dimension(min=20, max=self._detail_cols, preferred=self._detail_cols)
-
-        def pane_height() -> Dimension:
-            return Dimension(min=5, max=self._pane_rows, preferred=self._pane_rows)
-
-        menu_window = Window(
-            content=self.menu_control,
-            wrap_lines=False,
-            width=menu_width,
-            height=pane_height,
-        )
-        detail_window = Window(
-            content=self.detail_control,
-            wrap_lines=False,
-            width=detail_width,
-            height=pane_height,
-        )
-        self.detail_window = detail_window
-
-        menu_frame = Frame(menu_window, title="Plugins")
-        detail_frame = Frame(detail_window, title="Details")
-
-        return Layout(VSplit([menu_frame, detail_frame]))
-
     def run(self) -> Optional[str]:
-        self.menu_control = FormattedTextControl(text="")
+        self.menu_control = FormattedTextControl(text="", focusable=True)
         self.detail_control = FormattedTextControl(text="")
 
         self._recompute_dimensions()
 
-        layout = self._build_layout()
-        kb = self._build_key_bindings()
+        layout = build_layout(self)
+        if self.trust_target is not None:
+            # Popup pre-opened (focus_plugin ceremony): focus its input now
+            # that the layout exists — _open_trust_modal ran before any app.
+            try:
+                layout.focus(self.trust_input)
+            except Exception:
+                pass
+        kb = build_key_bindings(self)
 
         app = Application(
             layout=layout,
@@ -402,11 +412,15 @@ class PluginsMenu:
         return self.result
 
 
-def run_plugins_menu() -> Optional[str]:
-    """Entry point: create and run the plugins TUI, return the result."""
+def run_plugins_menu(focus_plugin: Optional[str] = None) -> Optional[str]:
+    """Entry point: create and run the plugins TUI, return the result.
+
+    *focus_plugin* preselects a plugin and, when it's trust-gated, opens
+    the risk-acceptance popup straight away.
+    """
     from code_puppy.messaging import emit_warning
 
-    menu = PluginsMenu()
+    menu = PluginsMenu(focus_plugin=focus_plugin)
     result = menu.run()
 
     if menu._changed:

--- a/code_puppy/plugins/plugin_list/plugins_menu_layout.py
+++ b/code_puppy/plugins/plugin_list/plugins_menu_layout.py
@@ -1,0 +1,197 @@
+"""Layout + keybinding construction for the /plugins TUI.
+
+Split from ``plugins_menu`` the same way ``plugins_menu_render`` was: these
+are pure *construction* helpers that read the menu's state and hand back
+prompt_toolkit objects. No app state lives here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.layout import (
+    ConditionalContainer,
+    Dimension,
+    Float,
+    FloatContainer,
+    HSplit,
+    Layout,
+    VSplit,
+    Window,
+)
+from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.widgets import Frame
+
+if TYPE_CHECKING:  # pragma: no cover - import-cycle guard
+    from code_puppy.plugins.plugin_list.plugins_menu import PluginsMenu
+
+
+def build_key_bindings(menu: "PluginsMenu") -> KeyBindings:
+    """Wire keys to match the ``inspect_history`` plugin's mental model.
+
+    Both plugins share the same split-pane shape (list + scrollable
+    detail). Keeping the bindings aligned means muscle memory carries
+    over. The mental model (lifted from inspect_history):
+
+    * Left-hand keys (``h``, ``j``) move things UP.
+    * Right-hand keys (``k``, ``l``) move things DOWN.
+    * ``h``/``l`` (and ``left``/``right``) scroll the *detail* pane.
+    * ``j``/``k`` (and ``up``/``down``, ``c-p``/``c-n``) move the
+      *selection* in the list.
+    * ``pageup``/``pagedown`` page through the list.
+    * ``g``/``home`` and ``G``/``end`` jump to first/last.
+    """
+    kb = KeyBindings()
+
+    # Every list binding is gated on the trust popup being CLOSED —
+    # single-letter shortcuts (j/k/g/q...) must not fire while the user
+    # is typing the accept word into the popup's text field.
+    no_modal = ~menu._modal_open
+
+    # -- Selection (j = up, k = down -- inspect_history convention) ---
+    @kb.add("up", filter=no_modal)
+    @kb.add("c-p", filter=no_modal)
+    @kb.add("j", filter=no_modal)
+    def _(event):
+        menu._move_selection(-1)
+        menu.update_display()
+
+    @kb.add("down", filter=no_modal)
+    @kb.add("c-n", filter=no_modal)
+    @kb.add("k", filter=no_modal)
+    def _(event):
+        menu._move_selection(+1)
+        menu.update_display()
+
+    # -- Page through the list -----------------------------------------
+    @kb.add("pageup", filter=no_modal)
+    def _(event):
+        menu._change_page(-1)
+        menu.update_display()
+
+    @kb.add("pagedown", filter=no_modal)
+    def _(event):
+        menu._change_page(+1)
+        menu.update_display()
+
+    # -- Jump to first / last ------------------------------------------
+    @kb.add("home", filter=no_modal)
+    @kb.add("g", filter=no_modal)
+    def _(event):
+        menu._set_selection(0)
+        menu.update_display()
+
+    @kb.add("end", filter=no_modal)
+    @kb.add("G", filter=no_modal)
+    def _(event):
+        menu._set_selection(len(menu.plugins) - 1)
+        menu.update_display()
+
+    # -- Detail pane scroll (h/left = up, l/right = down) --------------
+    @kb.add("h", filter=no_modal)
+    @kb.add("left", filter=no_modal)
+    def _(event):
+        menu._scroll_detail(-1)
+
+    @kb.add("l", filter=no_modal)
+    @kb.add("right", filter=no_modal)
+    def _(event):
+        menu._scroll_detail(+1)
+
+    # -- Actions / exit ------------------------------------------------
+    @kb.add("enter", filter=no_modal)
+    def _(event):
+        menu._toggle_current()
+        menu.result = "changed"
+
+    @kb.add("q", filter=no_modal)
+    @kb.add("escape", filter=no_modal)
+    @kb.add("c-c", filter=no_modal)
+    def _(event):
+        menu.result = "quit"
+        event.app.exit()
+
+    # -- Trust popup: Esc / Ctrl+C cancel (Enter is handled by the
+    #    focused TextArea's accept_handler) ----------------------------
+    @kb.add("escape", filter=menu._modal_open)
+    @kb.add("c-c", filter=menu._modal_open)
+    def _(event):
+        menu._close_trust_modal()
+
+    return kb
+
+
+def build_layout(menu: "PluginsMenu") -> Layout:
+    """Build the side-by-side Plugins / Details layout plus the trust float.
+
+    Pane widths are *callables* so they track the live terminal: when the
+    window is resized, ``_recompute_dimensions`` updates the cached cols
+    and these closures hand prompt_toolkit the fresh numbers on the very
+    next render. ``wrap_lines=False`` is critical: auto-wrap bleeds
+    characters into the divider/border column and leaves stale glyphs on
+    redraw. Long lines (description, path) are pre-wrapped by the renderer.
+    """
+
+    def menu_width() -> Dimension:
+        return Dimension(min=20, max=menu._menu_cols, preferred=menu._menu_cols)
+
+    def detail_width() -> Dimension:
+        return Dimension(min=20, max=menu._detail_cols, preferred=menu._detail_cols)
+
+    def pane_height() -> Dimension:
+        return Dimension(min=5, max=menu._pane_rows, preferred=menu._pane_rows)
+
+    menu_window = Window(
+        content=menu.menu_control,
+        wrap_lines=False,
+        width=menu_width,
+        height=pane_height,
+    )
+    detail_window = Window(
+        content=menu.detail_control,
+        wrap_lines=False,
+        width=detail_width,
+        height=pane_height,
+    )
+    menu.detail_window = detail_window
+
+    menu_frame = Frame(menu_window, title="Plugins")
+    detail_frame = Frame(detail_window, title="Details")
+
+    # Trust popup: a centered float over the panes, only rendered while
+    # a ceremony is in progress. The FormattedTextControl re-renders via
+    # its callable, and the TextArea receives focus (and thus all
+    # printable keys — the list shortcuts are filter-disabled).
+    from code_puppy.plugins.plugin_list.plugins_menu_render import (
+        render_trust_modal,
+    )
+
+    def modal_width() -> Dimension:
+        cols = min(64, max(40, menu._menu_cols + menu._detail_cols - 8))
+        return Dimension(min=40, max=cols, preferred=cols)
+
+    modal_body = HSplit(
+        [
+            Window(
+                content=FormattedTextControl(lambda: render_trust_modal(menu)),
+                wrap_lines=False,
+                dont_extend_height=True,
+            ),
+            menu.trust_input,
+        ],
+        width=modal_width,
+    )
+    modal_float = Float(
+        content=ConditionalContainer(
+            Frame(modal_body, title="Enable project plugin?"),
+            filter=menu._modal_open,
+        )
+    )
+
+    return Layout(
+        FloatContainer(
+            content=VSplit([menu_frame, detail_frame]),
+            floats=[modal_float],
+        )
+    )

--- a/code_puppy/plugins/plugin_list/plugins_menu_render.py
+++ b/code_puppy/plugins/plugin_list/plugins_menu_render.py
@@ -89,8 +89,13 @@ def render_list(menu: "PluginsMenu") -> Fragments:
         is_selected = i == menu.selected_idx
         is_disabled = entry.name in menu.disabled
 
-        icon = "x" if is_disabled else "+"
-        icon_style = "fg:ansired" if is_disabled else "fg:ansigreen"
+        if entry.status == "loaded":
+            icon = "x" if is_disabled else "+"
+            icon_style = "fg:ansired" if is_disabled else "fg:ansigreen"
+        else:
+            # Trust-gated project plugin: discovered but never imported.
+            icon = "!"
+            icon_style = "fg:ansired" if entry.status == "error" else "fg:ansiyellow"
         prefix = " > " if is_selected else "   "
 
         if is_selected:
@@ -121,7 +126,7 @@ def _render_hints(lines: Fragments) -> None:
         ("fg:ansibrightblack", "  PgUp/PgDn      ", "Page"),
         ("fg:ansibrightblack", "  g / G          ", "First / Last"),
         ("fg:ansibrightblack", "  h/l or \u2190/\u2192    ", "Scroll details"),
-        ("fg:ansigreen", "  Enter          ", "Toggle"),
+        ("fg:ansigreen", "  Enter          ", "Toggle / Enable"),
         ("fg:ansired", "  q / Esc        ", "Exit"),
     ]
     lines.append(("", "\n"))
@@ -133,11 +138,123 @@ def _render_hints(lines: Fragments) -> None:
 # ---------------------------------------------------------------------------
 # Detail pane (right)
 # ---------------------------------------------------------------------------
+
+# Status line + explanation for project plugins the trust gate held back.
+# ``{name}`` is substituted with the plugin name in the hint text.
+_GATE_STATUS_DETAILS = {
+    "untrusted": (
+        "fg:ansiyellow bold",
+        "Not enabled (project plugins are disabled by default)",
+        "Press Enter to review its files and enable it.",
+    ),
+    "changed": (
+        "fg:ansiyellow bold",
+        "Changed since you accepted it",
+        "Its files were modified after you trusted it, so trust was "
+        "revoked. Press Enter to re-review and re-enable.",
+    ),
+    "disabled": (
+        "fg:ansired bold",
+        "Disabled (trusted, but not loaded)",
+        "Press Enter to load it.",
+    ),
+    "error": (
+        "fg:ansired bold",
+        "Failed to load",
+        "Check the logs, then press Enter to retry.",
+    ),
+}
+
+
+def _render_gate_status(lines: Fragments, menu: "PluginsMenu", entry) -> None:
+    """Status + hint for a project plugin that was never imported."""
+    style, label, hint = _GATE_STATUS_DETAILS.get(
+        entry.status,
+        ("fg:ansiyellow bold", entry.status, "See '/plugins list' for details."),
+    )
+    lines.append(("bold", "  Status: "))
+    lines.append((style, label))
+    lines.append(("", "\n"))
+    inner = max(20, menu._detail_cols - 4)
+    _append_wrapped(
+        lines, "fg:ansibrightblack", "  ", hint.format(name=entry.name), inner
+    )
+    lines.append(("", "\n"))
+
+
+def render_trust_modal(menu: "PluginsMenu") -> Fragments:
+    """Body of the trust popup (the input box is a separate widget below).
+
+    Kept deliberately stark: this is the security decision point, so it
+    restates the risk and lists the files about to be executed.
+    """
+    from code_puppy.plugins.plugin_list.project_trust_flow import (
+        ACCEPT_WORD,
+        plugin_file_listing,
+    )
+
+    entry = menu.trust_target
+    lines: Fragments = []
+    if entry is None:
+        return lines
+    inner = 58  # popup is width-capped at 64; leave room for the frame
+
+    reason = (
+        "has CHANGED since you last accepted it"
+        if entry.status == "changed"
+        else "has never been enabled for this project"
+    )
+    _append_wrapped(
+        lines, "fg:ansiyellow bold", " ", f"'{entry.name}' {reason}.", inner
+    )
+    lines.append(("", "\n"))
+    _append_wrapped(
+        lines,
+        "",
+        " ",
+        "Project plugins run arbitrary code with YOUR permissions the "
+        "moment they load. Only enable plugins you have reviewed.",
+        inner,
+    )
+    lines.append(("", "\n"))
+
+    if menu.project_dir:
+        lines.append(("bold", " Files:"))
+        lines.append(("", "\n"))
+        from pathlib import Path
+
+        listing = plugin_file_listing(Path(menu.project_dir) / entry.name, limit=8)
+        for row in listing.splitlines():
+            for piece in wrap_text(row.strip(), inner - 2):
+                lines.append(("fg:ansicyan", f"   {piece}"))
+                lines.append(("", "\n"))
+        lines.append(("", "\n"))
+
+    if menu.trust_error:
+        _append_wrapped(lines, "fg:ansired bold", " ", menu.trust_error, inner)
+        lines.append(("", "\n"))
+
+    _append_wrapped(
+        lines,
+        "bold",
+        " ",
+        f"Type '{ACCEPT_WORD}' and press Enter to accept the risk — Esc cancels:",
+        inner,
+    )
+    return lines
+
+
 def render_detail(menu: "PluginsMenu") -> Fragments:
     lines: Fragments = []
 
     lines.append(("dim cyan", " PLUGIN DETAILS"))
     lines.append(("", "\n\n"))
+
+    # Outcome of the most recent enable/activate action, if any.
+    if menu.trust_feedback:
+        inner = max(20, menu._detail_cols - 4)
+        _append_wrapped(lines, "fg:ansigreen", "  ", menu.trust_feedback, inner)
+        lines.append(("", "\n"))
 
     entry = menu._current()
     if not entry:
@@ -162,6 +279,25 @@ def render_detail(menu: "PluginsMenu") -> Fragments:
     lines.append(("bold", "  Tier: "))
     lines.append(("", entry.tier))
     lines.append(("", "\n\n"))
+
+    # Trust is scoped per project path — always show which project this is.
+    if entry.tier == "project" and menu.project_dir:
+        lines.append(("bold", "  Project:"))
+        lines.append(("", "\n"))
+        inner = max(20, menu._detail_cols - 6)
+        _append_wrapped(lines, "fg:ansibrightblack", "    ", menu.project_dir, inner)
+        lines.append(("", "\n"))
+
+    if entry.status != "loaded":
+        # Trust-gated: never imported, so hooks/contributions don't exist.
+        _render_gate_status(lines, menu, entry)
+        path = f"{menu.project_dir}/{entry.name}/" if menu.project_dir else None
+        if path:
+            lines.append(("bold", "  Path:"))
+            lines.append(("", "\n"))
+            inner = max(20, menu._detail_cols - 6)
+            _append_wrapped(lines, "fg:ansibrightblack", "    ", path, inner)
+        return lines
 
     lines.append(("bold", "  Status: "))
     if is_disabled:

--- a/code_puppy/plugins/plugin_list/project_trust_flow.py
+++ b/code_puppy/plugins/plugin_list/project_trust_flow.py
@@ -1,0 +1,164 @@
+"""Risk-acceptance flow for enabling project-level plugins.
+
+Project plugins (``<CWD>/.code_puppy/plugins/``) are **disabled by default**
+because they execute arbitrary repo-supplied code at import time.
+
+The risk-acceptance ceremony lives in the ``/plugins`` TUI (select the
+plugin, press Enter, type ``trust`` in the popup). This module provides the
+non-interactive primitives the TUI calls — ``grant_trust_and_load`` and
+``activate_project_plugin`` — plus the slash-command handlers, which for
+untrusted plugins LAUNCH the TUI (preselected, popup open) rather than
+prompting inline.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# The word the user must type in the TUI popup to accept the risk. A y/n
+# would be too easy to fat-finger; typing the word is a deliberate speed bump.
+ACCEPT_WORD = "trust"
+
+
+def plugin_file_listing(plugin_dir: Path, limit: int = 20) -> str:
+    """Bullet list of the files the user is about to trust."""
+    try:
+        files = sorted(
+            p.relative_to(plugin_dir).as_posix()
+            for p in plugin_dir.rglob("*")
+            if p.is_file() and "__pycache__" not in p.relative_to(plugin_dir).parts
+        )
+    except OSError as exc:
+        logger.warning("Could not list plugin dir %s: %s", plugin_dir, exc)
+        return "  (unreadable)"
+    lines = [f"  • {name}" for name in files[:limit]]
+    if len(files) > limit:
+        lines.append(f"  … and {len(files) - limit} more")
+    return "\n".join(lines) if lines else "  (no files)"
+
+
+def activate_project_plugin(plugin_name: str) -> tuple[bool, str]:
+    """Clear the disabled flag and hot-load an ALREADY TRUSTED project plugin.
+
+    Fail closed: ``load_project_plugin_now`` re-checks the trust store, so
+    calling this for an untrusted plugin loads nothing.
+
+    Returns ``(ok, human_message)``.
+    """
+    from code_puppy.plugins import get_loaded_plugins, load_project_plugin_now
+    from code_puppy.plugins.config import set_plugin_disabled
+
+    set_plugin_disabled(plugin_name, False)
+
+    if plugin_name in get_loaded_plugins()["project"]:
+        return True, f"Project plugin '{plugin_name}' enabled."
+    if load_project_plugin_now(plugin_name):
+        return True, (
+            f"Project plugin '{plugin_name}' trusted and loaded — no restart needed."
+        )
+    return False, f"Loading '{plugin_name}' failed — check the logs."
+
+
+def grant_trust_and_load(plugin_name: str) -> tuple[bool, str]:
+    """Record trust at the current content hash, then activate.
+
+    ONLY call this after the user completed the TUI risk-acceptance popup
+    (typed the accept word). This function does no prompting itself.
+
+    Returns ``(ok, human_message)``.
+    """
+    from code_puppy.plugins import get_project_plugins_directory
+    from code_puppy.plugins import trust as plugin_trust
+
+    project_dir = get_project_plugins_directory()
+    if project_dir is None:
+        return False, "No project plugins directory in this project."
+    plugin_dir = project_dir / plugin_name
+    if not plugin_dir.is_dir():
+        return False, f"'{plugin_name}' is not a project plugin here."
+
+    project_root = project_dir.parent.parent
+    if not plugin_trust.trust_plugin(project_root, plugin_name, plugin_dir):
+        return False, f"Could not record trust for '{plugin_name}' — see logs."
+    return activate_project_plugin(plugin_name)
+
+
+def try_enable_project_plugin(plugin_name: str) -> bool:
+    """Handle ``/plugins enable`` for project plugins.
+
+    Trusted plugins (e.g. previously disabled) are activated directly.
+    Untrusted/changed plugins are NOT prompted for inline — the ceremony
+    lives in the TUI, so we open it with the plugin preselected and the
+    popup already up. Returns True if *plugin_name* is a project plugin
+    (fully handled either way); False lets the generic enable path run.
+    """
+    from code_puppy.messaging import emit_error, emit_info, emit_success
+    from code_puppy.plugins import get_project_plugins_directory
+    from code_puppy.plugins import trust as plugin_trust
+
+    project_dir = get_project_plugins_directory()
+    if project_dir is None:
+        return False
+    plugin_dir = project_dir / plugin_name
+    if not plugin_dir.is_dir():
+        return False  # not a project plugin — let the generic toggle handle it
+
+    project_root = project_dir.parent.parent
+    status = plugin_trust.get_trust_status(project_root, plugin_name, plugin_dir)
+
+    if status != plugin_trust.TRUSTED:
+        # Don't tell the user where the ceremony lives — take them there,
+        # preselected with the popup already open. Text fallback only if
+        # the TUI can't run (headless/non-tty).
+        try:
+            from code_puppy.plugins.plugin_list.plugins_menu import (
+                run_plugins_menu,
+            )
+
+            run_plugins_menu(focus_plugin=plugin_name)
+        except Exception as exc:
+            logger.warning("Plugins TUI failed for enable ceremony: %s", exc)
+            emit_info(
+                f"Project plugin '{plugin_name}' requires the review "
+                "ceremony: run /plugins, select it, press Enter, and type "
+                f"'{ACCEPT_WORD}'."
+            )
+        return True
+
+    ok, message = activate_project_plugin(plugin_name)
+    (emit_success if ok else emit_error)(message)
+    return True
+
+
+def revoke_project_plugin(plugin_name: str) -> bool:
+    """Handle ``/plugins revoke <name>`` — remove trust for a project plugin.
+
+    Always returns True (the command is fully handled, with messaging).
+    """
+    from code_puppy.messaging import emit_info, emit_success, emit_warning
+    from code_puppy.plugins import get_loaded_plugins, get_project_plugins_directory
+    from code_puppy.plugins import trust as plugin_trust
+    from code_puppy.plugins.config import set_plugin_disabled
+
+    project_dir = get_project_plugins_directory()
+    if project_dir is None:
+        emit_info("No project plugins directory in this project.")
+        return True
+
+    project_root = project_dir.parent.parent
+    if plugin_trust.revoke_plugin(project_root, plugin_name):
+        emit_success(f"Trust revoked for project plugin '{plugin_name}'.")
+        if plugin_name in get_loaded_plugins()["project"]:
+            # Already imported this session — best we can do is stop its
+            # callbacks now; a restart fully unloads it.
+            set_plugin_disabled(plugin_name, True)
+            emit_warning(
+                "It was already loaded this session — callbacks are now "
+                "skipped; restart Code Puppy to fully unload it."
+            )
+    else:
+        emit_info(f"'{plugin_name}' was not trusted — nothing to revoke.")
+    return True

--- a/code_puppy/plugins/plugin_list/register_callbacks.py
+++ b/code_puppy/plugins/plugin_list/register_callbacks.py
@@ -5,7 +5,9 @@ Usage::
     /plugins                   -- open interactive TUI
     /plugins list              -- print loaded plugins with status
     /plugins disable <name>    -- disable a plugin (callbacks are skipped)
-    /plugins enable <name>     -- re-enable a disabled plugin
+    /plugins enable <name>     -- enable a plugin; untrusted project plugins
+                                  open the TUI trust ceremony directly
+    /plugins revoke <name>     -- revoke trust for a project plugin
 
 Dogfoods the plugin system by implementing itself as a builtin plugin that
 hooks into ``custom_command`` and ``custom_command_help``.
@@ -35,16 +37,50 @@ def _format_plugin_list(names: list[str], disabled: set[str]) -> str:
     return "\n".join(lines)
 
 
+_PROJECT_STATUS_LABELS = {
+    "untrusted": "(not enabled -- review & enable in the /plugins TUI)",
+    "changed": "(changed since accepted -- re-review in the /plugins TUI)",
+    "disabled": "(disabled)",
+    "error": "(failed to load -- see logs)",
+}
+
+
+def _format_project_plugin_list(
+    loaded_names: list[str],
+    statuses: dict[str, str],
+    disabled: set[str],
+) -> str:
+    """Project tier listing: loaded plugins plus skipped-by-trust ones.
+
+    Project plugins are disabled by default; unlike other tiers we also
+    show plugins that were discovered but NOT imported, with the reason.
+    """
+    names = sorted(set(loaded_names) | set(statuses))
+    if not names:
+        return "  (none)"
+    lines = []
+    for name in names:
+        status = statuses.get(name, "loaded" if name in loaded_names else "untrusted")
+        if status == "loaded":
+            suffix = "  (disabled)" if name in disabled else ""
+        else:
+            suffix = "  " + _PROJECT_STATUS_LABELS.get(status, f"({status})")
+        lines.append(f"   {name}{suffix}")
+    return "\n".join(lines)
+
+
 def _build_output() -> str:
     """Build the full /plugins list display string."""
     from code_puppy.plugins import (
         get_loaded_plugins,
         get_project_plugins_directory,
+        get_project_plugin_status,
     )
     from code_puppy.plugins.config import get_disabled_plugins
 
     loaded = get_loaded_plugins()
     disabled = get_disabled_plugins()
+    project_status = get_project_plugin_status()
 
     # Display paths with forward slashes regardless of OS so the output is
     # consistent across Windows / POSIX (and easier to copy-paste).
@@ -65,7 +101,7 @@ def _build_output() -> str:
         _format_plugin_list(loaded["user"], disabled),
         "",
         f"Project ({project_path}):",
-        _format_plugin_list(loaded["project"], disabled),
+        _format_project_plugin_list(loaded["project"], project_status, disabled),
     ]
 
     if disabled:
@@ -73,7 +109,7 @@ def _build_output() -> str:
             [
                 "",
                 f"Disabled: {', '.join(sorted(disabled))}",
-                "Use /plugins enable <name> to re-enable.",
+                "Re-enable it in the /plugins TUI.",
             ]
         )
 
@@ -117,11 +153,31 @@ def _handle_toggle(plugin_name: str, *, disabled: bool) -> bool:
     return True
 
 
+# -- startup hook ----------------------------------------------------------
+
+
+def _on_startup() -> None:
+    """Surface project plugins held back by the trust gate.
+
+    Runs via the ``startup`` callback, which fires after the renderers are
+    live — so the orange banner lands inline with the other startup
+    messages instead of rotting in the legacy queue's startup buffer
+    (which SynchronousInteractiveRenderer never replays).
+    """
+    try:
+        from code_puppy.plugins import get_project_plugin_status
+        from code_puppy.plugins.trust_notice import emit_skipped_plugin_notice
+
+        emit_skipped_plugin_notice(get_project_plugin_status())
+    except Exception as exc:
+        logger.debug(f"Trust-notice startup hook failed: {exc}")
+
+
 # -- custom_command hooks --------------------------------------------------
 
 
 def _custom_help() -> list[tuple[str, str]]:
-    return [("plugins", "List, enable, or disable plugins")]
+    return [("plugins", "List, enable/disable, or trust project plugins")]
 
 
 def _run_interactive_menu() -> None:
@@ -149,7 +205,35 @@ def _sub_disable(tokens: list[str]) -> bool:
 
 
 def _sub_enable(tokens: list[str]) -> bool:
-    return _sub_toggle(tokens, disabled=False)
+    from code_puppy.messaging import emit_error
+
+    if len(tokens) < 3:
+        emit_error("Usage: /plugins enable <plugin-name>")
+        return True
+
+    # Project plugins get the trust/risk-acceptance flow; anything else
+    # falls through to the regular enable toggle.
+    from code_puppy.plugins.plugin_list.project_trust_flow import (
+        try_enable_project_plugin,
+    )
+
+    if try_enable_project_plugin(tokens[2]):
+        return True
+    return _handle_toggle(tokens[2], disabled=False)
+
+
+def _sub_revoke(tokens: list[str]) -> bool:
+    from code_puppy.messaging import emit_error
+
+    if len(tokens) < 3:
+        emit_error("Usage: /plugins revoke <plugin-name>")
+        return True
+
+    from code_puppy.plugins.plugin_list.project_trust_flow import (
+        revoke_project_plugin,
+    )
+
+    return revoke_project_plugin(tokens[2])
 
 
 def _sub_toggle(tokens: list[str], *, disabled: bool) -> bool:
@@ -166,6 +250,7 @@ _SUBCOMMANDS = {
     "list": _sub_list,
     "disable": _sub_disable,
     "enable": _sub_enable,
+    "revoke": _sub_revoke,
 }
 
 
@@ -185,11 +270,12 @@ def _handle_custom_command(command: str, name: str) -> Optional[bool]:
 
         emit_error(
             f"Unknown subcommand: '{tokens[1]}'. "
-            "Usage: /plugins [list | enable <name> | disable <name>]"
+            "Usage: /plugins [list | enable <name> | disable <name> | revoke <name>]"
         )
         return True
     return handler(tokens)
 
 
+register_callback("startup", _on_startup)
 register_callback("custom_command_help", _custom_help)
 register_callback("custom_command", _handle_custom_command)

--- a/code_puppy/plugins/trust.py
+++ b/code_puppy/plugins/trust.py
@@ -1,0 +1,146 @@
+"""Content-hash trust store for project-level plugins.
+
+Project plugins (``<CWD>/.code_puppy/plugins/``) execute arbitrary code at
+import time, so they are **disabled by default**.  A plugin only loads after
+the user explicitly accepts the risk in the ``/plugins`` TUI ceremony, which
+records a SHA-256 hash of the plugin's contents here.
+
+Key properties:
+
+* **Store lives user-side** (``~/.code_puppy/trusted_plugins.json``) — never
+  in the repo, so a repository can never self-trust.
+* **Trust is per-plugin and content-addressed.**  If any file in the plugin
+  directory changes, the hash no longer matches and the plugin reverts to
+  requiring re-acceptance ("changed" status).  This blocks silent-update
+  attacks against previously trusted plugins (same model as direnv's
+  ``allow`` mechanism).
+* **Fail closed.**  Unreadable store, malformed JSON, or unhashable plugin
+  directories all resolve to "not trusted".
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+TRUST_STORE_FILE = Path.home() / ".code_puppy" / "trusted_plugins.json"
+
+_STORE_VERSION = 1
+
+# Trust statuses
+TRUSTED = "trusted"  # entry exists and hash matches current contents
+CHANGED = "changed"  # entry exists but contents differ since acceptance
+UNTRUSTED = "untrusted"  # no entry — user never accepted this plugin
+
+
+def _project_key(project_root: Path) -> str:
+    """Canonical store key for a project root (resolved absolute path)."""
+    return str(Path(project_root).resolve())
+
+
+def _load_store() -> dict:
+    """Read the trust store, returning an empty store on any problem."""
+    try:
+        if TRUST_STORE_FILE.is_file():
+            data = json.loads(TRUST_STORE_FILE.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and isinstance(data.get("projects"), dict):
+                return data
+            logger.warning(
+                "Malformed trust store at %s — treating as empty", TRUST_STORE_FILE
+            )
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        logger.warning("Could not read trust store %s: %s", TRUST_STORE_FILE, exc)
+    return {"version": _STORE_VERSION, "projects": {}}
+
+
+def _save_store(store: dict) -> bool:
+    """Persist the trust store. Returns False (and logs) on failure."""
+    try:
+        TRUST_STORE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        TRUST_STORE_FILE.write_text(
+            json.dumps(store, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        return True
+    except OSError as exc:
+        logger.error("Could not write trust store %s: %s", TRUST_STORE_FILE, exc)
+        return False
+
+
+def compute_plugin_hash(plugin_dir: Path) -> str | None:
+    """SHA-256 over every file in *plugin_dir* (recursive, deterministic).
+
+    Includes relative paths in the digest so renames count as changes.
+    Skips ``__pycache__``, hidden path components, and ``.pyc`` artifacts.
+    Returns ``None`` if the directory cannot be read (callers must treat
+    that as not-trusted).
+    """
+    plugin_dir = Path(plugin_dir)
+    digest = hashlib.sha256()
+    try:
+        files = sorted(
+            p
+            for p in plugin_dir.rglob("*")
+            if p.is_file()
+            and p.suffix != ".pyc"
+            and "__pycache__" not in p.relative_to(plugin_dir).parts
+            and not any(
+                part.startswith(".") for part in p.relative_to(plugin_dir).parts
+            )
+        )
+        for path in files:
+            digest.update(path.relative_to(plugin_dir).as_posix().encode("utf-8"))
+            digest.update(b"\0")
+            digest.update(path.read_bytes())
+            digest.update(b"\0")
+    except OSError as exc:
+        logger.warning("Could not hash plugin dir %s: %s", plugin_dir, exc)
+        return None
+    return digest.hexdigest()
+
+
+def get_trust_status(project_root: Path, plugin_name: str, plugin_dir: Path) -> str:
+    """Return TRUSTED, CHANGED, or UNTRUSTED for a project plugin."""
+    store = _load_store()
+    entry = store["projects"].get(_project_key(project_root), {}).get(plugin_name)
+    if not isinstance(entry, dict) or not entry.get("hash"):
+        return UNTRUSTED
+    current = compute_plugin_hash(plugin_dir)
+    if current is not None and current == entry["hash"]:
+        return TRUSTED
+    return CHANGED
+
+
+def is_plugin_trusted(project_root: Path, plugin_name: str, plugin_dir: Path) -> bool:
+    """True only when a stored hash exists AND matches current contents."""
+    return get_trust_status(project_root, plugin_name, plugin_dir) == TRUSTED
+
+
+def trust_plugin(project_root: Path, plugin_name: str, plugin_dir: Path) -> bool:
+    """Record acceptance of *plugin_name* at its current content hash."""
+    plugin_hash = compute_plugin_hash(plugin_dir)
+    if plugin_hash is None:
+        return False
+    store = _load_store()
+    store["projects"].setdefault(_project_key(project_root), {})[plugin_name] = {
+        "hash": plugin_hash,
+        "accepted_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+    return _save_store(store)
+
+
+def revoke_plugin(project_root: Path, plugin_name: str) -> bool:
+    """Remove trust for *plugin_name*. Returns True if an entry was removed."""
+    store = _load_store()
+    key = _project_key(project_root)
+    project_entries = store["projects"].get(key)
+    if not project_entries or plugin_name not in project_entries:
+        return False
+    del project_entries[plugin_name]
+    if not project_entries:
+        del store["projects"][key]
+    return _save_store(store)

--- a/code_puppy/plugins/trust_notice.py
+++ b/code_puppy/plugins/trust_notice.py
@@ -1,0 +1,69 @@
+"""User-facing startup notice for project plugins held back by the trust gate.
+
+Kept separate from the loader (``plugins/__init__``) and the trust store
+(``plugins/trust``) — this is presentation, they are policy.
+
+Called from plugin_list's ``startup`` callback, which fires AFTER the
+renderers are live — so the banner prints inline with the version/help
+startup text. Do NOT emit this at plugin-load (import) time: the legacy
+message queue buffers pre-renderer emits and never replays them.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Match the renderer's standard WARNING style (_classify_style -> "yellow")
+# so the banner reads as one of the family; bold spans give it the pop.
+_STYLE = "yellow"
+_STYLE_BOLD = "bold yellow"
+
+_REASONS = {
+    "untrusted": "never enabled",
+    "changed": "changed since you accepted it",
+}
+
+
+def emit_skipped_plugin_notice(statuses: dict[str, str]) -> None:
+    """Emit one orange banner listing project plugins that were NOT loaded.
+
+    *statuses* is the full ``get_project_plugin_status()`` map; only
+    ``untrusted``/``changed`` entries need the user's attention (``disabled``
+    was their own choice, ``loaded``/``error`` are handled elsewhere).
+    Never raises — a broken banner must not break startup (rule 4).
+    """
+    skipped = {n: s for n, s in statuses.items() if s in _REASONS}
+    if not skipped:
+        return
+    try:
+        from rich.text import Text
+
+        from code_puppy.messaging import emit_warning
+
+        text = Text()
+        text.append(
+            "Project plugins found but NOT loaded (disabled by default):\n",
+            style=_STYLE_BOLD,
+        )
+        # Name the project explicitly — trust is scoped per project path,
+        # so "which project am I in?" must never be a guessing game.
+        from code_puppy.plugins import get_project_plugins_directory
+
+        project_dir = get_project_plugins_directory()
+        if project_dir is not None:
+            text.append(f"  in {project_dir.as_posix()}\n", style=_STYLE)
+        for name, status in sorted(skipped.items()):
+            reason = _REASONS.get(status, status)
+            text.append(f"  - {name}  ({reason})\n", style=_STYLE)
+        text.append("Review and enable in ", style=_STYLE)
+        text.append("/plugins", style=_STYLE_BOLD)
+        text.append(
+            " (select the plugin, press Enter) -- project plugins run "
+            "arbitrary code; only enable ones you trust.",
+            style=_STYLE,
+        )
+        emit_warning(text)
+    except Exception as exc:
+        logger.debug(f"Could not emit skipped-plugin notice: {exc}")

--- a/tests/plugins/test_plugin_list.py
+++ b/tests/plugins/test_plugin_list.py
@@ -163,6 +163,265 @@ class TestHandleCustomCommand:
             assert "Loaded Plugins" in mock_emit.call_args[0][0]
 
 
+class TestMenuShowsGatedProjectPlugins:
+    """The TUI must show project plugins the trust gate held back."""
+
+    def _make_menu(self, loaded, statuses, project_dir=None):
+        from code_puppy.plugins.plugin_list.plugins_menu import PluginsMenu
+
+        with (
+            patch(f"{_PLUGINS_MOD}.get_loaded_plugins", return_value=loaded),
+            patch(
+                f"{_PLUGINS_MOD}.get_project_plugin_status",
+                return_value=statuses,
+            ),
+            patch(
+                f"{_PLUGINS_MOD}.get_project_plugins_directory",
+                return_value=project_dir,
+            ),
+            patch(
+                f"{_PLUGINS_CONFIG_MOD}.get_disabled_plugins",
+                return_value=set(),
+            ),
+        ):
+            return PluginsMenu()
+
+    def test_gated_plugins_appear_with_status(self):
+        loaded = {"builtin": ["plugin_list"], "user": [], "project": ["trusted_one"]}
+        statuses = {
+            "trusted_one": "loaded",
+            "sketchy": "untrusted",
+            "drifted": "changed",
+        }
+        menu = self._make_menu(loaded, statuses, Path("/proj/.code_puppy/plugins"))
+
+        by_name = {e.name: e for e in menu.plugins if e.tier == "project"}
+        assert set(by_name) == {"trusted_one", "sketchy", "drifted"}
+        assert by_name["trusted_one"].status == "loaded"
+        assert by_name["sketchy"].status == "untrusted"
+        assert by_name["drifted"].status == "changed"
+        assert menu.project_dir == "/proj/.code_puppy/plugins"
+
+    def test_toggle_is_noop_for_gated_plugin(self):
+        loaded = {"builtin": [], "user": [], "project": []}
+        menu = self._make_menu(loaded, {"sketchy": "untrusted"})
+        menu.selected_idx = 0
+
+        with patch(f"{_PLUGINS_CONFIG_MOD}.set_plugin_disabled") as mock_toggle:
+            menu._toggle_current()
+
+        mock_toggle.assert_not_called()
+        assert menu._changed is False
+
+    def test_detail_pane_shows_enable_hint(self):
+        from code_puppy.plugins.plugin_list.plugins_menu_render import render_detail
+
+        loaded = {"builtin": [], "user": [], "project": []}
+        menu = self._make_menu(
+            loaded, {"sketchy": "untrusted"}, Path("/proj/.code_puppy/plugins")
+        )
+        menu.selected_idx = 0
+
+        text = "".join(frag for _style, frag in render_detail(menu))
+        assert "Press Enter" in text
+        assert "disabled by default" in text
+        assert "/proj/.code_puppy/plugins" in text  # project path visible
+
+
+class TestSlashEnableOpensTUI:
+    """Slash enable never prompts inline — it opens the TUI ceremony."""
+
+    _MENU = "code_puppy.plugins.plugin_list.plugins_menu.run_plugins_menu"
+
+    def _run_enable(self, tmp_path: Path, status: str, menu_effect=None):
+        from code_puppy.plugins.plugin_list.project_trust_flow import (
+            try_enable_project_plugin,
+        )
+
+        plugin_dir = tmp_path / ".code_puppy" / "plugins" / "sketchy"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "register_callbacks.py").write_text("# sketchy\n")
+
+        with (
+            patch(
+                f"{_PLUGINS_MOD}.get_project_plugins_directory",
+                return_value=plugin_dir.parent,
+            ),
+            patch(
+                "code_puppy.plugins.trust.get_trust_status",
+                return_value=status,
+            ),
+            patch("code_puppy.plugins.trust.trust_plugin") as mock_trust,
+            patch(
+                f"{_PLUGINS_MOD}.load_project_plugin_now", return_value=True
+            ) as mock_load,
+            patch(
+                f"{_PLUGINS_MOD}.get_loaded_plugins",
+                return_value={"builtin": [], "user": [], "project": []},
+            ),
+            patch(f"{_PLUGINS_CONFIG_MOD}.set_plugin_disabled"),
+            patch("code_puppy.messaging.emit_info") as mock_info,
+            patch(self._MENU, side_effect=menu_effect) as mock_menu,
+        ):
+            handled = try_enable_project_plugin("sketchy")
+        return handled, mock_trust, mock_load, mock_info, mock_menu
+
+    def test_untrusted_opens_tui_preselected(self, tmp_path: Path):
+        handled, mock_trust, mock_load, _info, mock_menu = self._run_enable(
+            tmp_path, "untrusted"
+        )
+        assert handled is True  # fully handled — no dispatcher leak
+        mock_menu.assert_called_once_with(focus_plugin="sketchy")
+        mock_trust.assert_not_called()  # only the popup grants trust
+        mock_load.assert_not_called()
+
+    def test_changed_opens_tui_preselected(self, tmp_path: Path):
+        handled, _trust, _load, _info, mock_menu = self._run_enable(tmp_path, "changed")
+        assert handled is True
+        mock_menu.assert_called_once_with(focus_plugin="sketchy")
+
+    def test_tui_failure_falls_back_to_text(self, tmp_path: Path):
+        handled, mock_trust, _load, mock_info, _menu = self._run_enable(
+            tmp_path, "untrusted", menu_effect=RuntimeError("no tty")
+        )
+        assert handled is True
+        mock_trust.assert_not_called()
+        assert "/plugins" in mock_info.call_args[0][0]
+
+    def test_trusted_activates_directly(self, tmp_path: Path):
+        handled, mock_trust, mock_load, _info, mock_menu = self._run_enable(
+            tmp_path, "trusted"
+        )
+        assert handled is True
+        mock_trust.assert_not_called()  # no re-hash on activate
+        mock_load.assert_called_once_with("sketchy")
+        mock_menu.assert_not_called()
+
+
+class TestTrustModal:
+    """The in-TUI ceremony: popup state, accept word, cancel."""
+
+    def _gated_menu(self):
+        from code_puppy.plugins.plugin_list.plugins_menu import PluginsMenu
+
+        with (
+            patch(
+                f"{_PLUGINS_MOD}.get_loaded_plugins",
+                return_value={"builtin": [], "user": [], "project": []},
+            ),
+            patch(
+                f"{_PLUGINS_MOD}.get_project_plugin_status",
+                return_value={"sketchy": "untrusted"},
+            ),
+            patch(
+                f"{_PLUGINS_MOD}.get_project_plugins_directory",
+                return_value=Path("/proj/.code_puppy/plugins"),
+            ),
+            patch(
+                f"{_PLUGINS_CONFIG_MOD}.get_disabled_plugins",
+                return_value=set(),
+            ),
+        ):
+            menu = PluginsMenu()
+            menu.selected_idx = 0
+            yield menu
+
+    def test_enter_on_gated_entry_opens_modal(self):
+        gen = self._gated_menu()
+        menu = next(gen)
+        menu._toggle_current()
+        assert menu.trust_target is not None
+        assert menu.trust_target.name == "sketchy"
+
+    def test_focus_plugin_preselects_and_opens_modal(self):
+        from code_puppy.plugins.plugin_list.plugins_menu import PluginsMenu
+
+        with (
+            patch(
+                f"{_PLUGINS_MOD}.get_loaded_plugins",
+                return_value={"builtin": ["plugin_list"], "user": [], "project": []},
+            ),
+            patch(
+                f"{_PLUGINS_MOD}.get_project_plugin_status",
+                return_value={"sketchy": "untrusted"},
+            ),
+            patch(
+                f"{_PLUGINS_MOD}.get_project_plugins_directory",
+                return_value=Path("/proj/.code_puppy/plugins"),
+            ),
+            patch(
+                f"{_PLUGINS_CONFIG_MOD}.get_disabled_plugins",
+                return_value=set(),
+            ),
+        ):
+            menu = PluginsMenu(focus_plugin="sketchy")
+
+        entry = menu.plugins[menu.selected_idx]
+        assert entry.name == "sketchy"  # preselected, not index 0
+        assert menu.trust_target is entry  # ceremony popup already open
+
+    def test_wrong_word_sets_error_and_grants_nothing(self):
+        from types import SimpleNamespace
+
+        gen = self._gated_menu()
+        menu = next(gen)
+        menu._toggle_current()
+        with patch(
+            "code_puppy.plugins.plugin_list.project_trust_flow.grant_trust_and_load"
+        ) as mock_grant:
+            keep = menu._accept_trust(SimpleNamespace(text="nope"))
+        mock_grant.assert_not_called()
+        assert keep is False  # box clears for retry
+        assert menu.trust_error
+        assert menu.trust_target is not None  # modal stays open
+
+    def test_accept_word_grants_and_closes(self):
+        from types import SimpleNamespace
+
+        gen = self._gated_menu()
+        menu = next(gen)
+        menu._toggle_current()
+        with (
+            patch(
+                "code_puppy.plugins.plugin_list.project_trust_flow.grant_trust_and_load",
+                return_value=(True, "loaded!"),
+            ) as mock_grant,
+            patch.object(menu, "_refresh_data"),
+        ):
+            menu._accept_trust(SimpleNamespace(text="  TRUST  "))
+        mock_grant.assert_called_once_with("sketchy")
+        assert menu.trust_target is None  # modal closed
+        assert menu.trust_feedback == "loaded!"
+
+    def test_escape_cancels_without_granting(self):
+        gen = self._gated_menu()
+        menu = next(gen)
+        menu._toggle_current()
+        with patch(
+            "code_puppy.plugins.plugin_list.project_trust_flow.grant_trust_and_load"
+        ) as mock_grant:
+            menu._close_trust_modal()
+        mock_grant.assert_not_called()
+        assert menu.trust_target is None
+
+
+class TestBannerShowsProjectPath:
+    def test_banner_names_the_project(self):
+        from code_puppy.plugins.trust_notice import emit_skipped_plugin_notice
+
+        with (
+            patch(
+                f"{_PLUGINS_MOD}.get_project_plugins_directory",
+                return_value=Path("/proj/.code_puppy/plugins"),
+            ),
+            patch("code_puppy.messaging.emit_warning") as mock_warn,
+        ):
+            emit_skipped_plugin_notice({"sketchy": "untrusted"})
+
+        banner = mock_warn.call_args[0][0]
+        assert "/proj/.code_puppy/plugins" in banner.plain
+
+
 class TestCustomHelp:
     def test_returns_plugins_entry(self):
         entries = _custom_help()

--- a/tests/plugins/test_plugin_trust.py
+++ b/tests/plugins/test_plugin_trust.py
@@ -1,0 +1,119 @@
+"""Tests for the project-plugin trust store (code_puppy.plugins.trust)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from code_puppy.plugins import trust
+
+
+@pytest.fixture(autouse=True)
+def _isolated_store(tmp_path: Path, monkeypatch):
+    """Point the trust store at a throwaway file for every test."""
+    monkeypatch.setattr(trust, "TRUST_STORE_FILE", tmp_path / "trusted_plugins.json")
+
+
+@pytest.fixture()
+def plugin_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "proj" / ".code_puppy" / "plugins" / "my_plugin"
+    d.mkdir(parents=True)
+    (d / "register_callbacks.py").write_text("# hello\n")
+    return d
+
+
+@pytest.fixture()
+def project_root(plugin_dir: Path) -> Path:
+    return plugin_dir.parent.parent.parent
+
+
+class TestComputePluginHash:
+    def test_deterministic(self, plugin_dir: Path):
+        assert trust.compute_plugin_hash(plugin_dir) == trust.compute_plugin_hash(
+            plugin_dir
+        )
+
+    def test_content_change_changes_hash(self, plugin_dir: Path):
+        before = trust.compute_plugin_hash(plugin_dir)
+        (plugin_dir / "register_callbacks.py").write_text("# tampered\n")
+        assert trust.compute_plugin_hash(plugin_dir) != before
+
+    def test_new_file_changes_hash(self, plugin_dir: Path):
+        before = trust.compute_plugin_hash(plugin_dir)
+        (plugin_dir / "payload.py").write_text("x = 1\n")
+        assert trust.compute_plugin_hash(plugin_dir) != before
+
+    def test_rename_changes_hash(self, plugin_dir: Path):
+        (plugin_dir / "a.py").write_text("same\n")
+        before = trust.compute_plugin_hash(plugin_dir)
+        (plugin_dir / "a.py").rename(plugin_dir / "b.py")
+        assert trust.compute_plugin_hash(plugin_dir) != before
+
+    def test_pycache_and_hidden_ignored(self, plugin_dir: Path):
+        before = trust.compute_plugin_hash(plugin_dir)
+        cache = plugin_dir / "__pycache__"
+        cache.mkdir()
+        (cache / "junk.cpython-312.pyc").write_bytes(b"\x00\x01")
+        (plugin_dir / ".secret").write_text("shh\n")
+        assert trust.compute_plugin_hash(plugin_dir) == before
+
+
+class TestTrustLifecycle:
+    def test_untrusted_by_default(self, project_root: Path, plugin_dir: Path):
+        assert (
+            trust.get_trust_status(project_root, "my_plugin", plugin_dir)
+            == trust.UNTRUSTED
+        )
+        assert not trust.is_plugin_trusted(project_root, "my_plugin", plugin_dir)
+
+    def test_trust_then_trusted(self, project_root: Path, plugin_dir: Path):
+        assert trust.trust_plugin(project_root, "my_plugin", plugin_dir)
+        assert trust.is_plugin_trusted(project_root, "my_plugin", plugin_dir)
+
+    def test_modification_revokes_trust(self, project_root: Path, plugin_dir: Path):
+        trust.trust_plugin(project_root, "my_plugin", plugin_dir)
+        (plugin_dir / "register_callbacks.py").write_text("import os  # evil\n")
+        assert (
+            trust.get_trust_status(project_root, "my_plugin", plugin_dir)
+            == trust.CHANGED
+        )
+        assert not trust.is_plugin_trusted(project_root, "my_plugin", plugin_dir)
+
+    def test_revoke(self, project_root: Path, plugin_dir: Path):
+        trust.trust_plugin(project_root, "my_plugin", plugin_dir)
+        assert trust.revoke_plugin(project_root, "my_plugin")
+        assert (
+            trust.get_trust_status(project_root, "my_plugin", plugin_dir)
+            == trust.UNTRUSTED
+        )
+
+    def test_revoke_missing_returns_false(self, project_root: Path):
+        assert not trust.revoke_plugin(project_root, "never_trusted")
+
+    def test_trust_scoped_per_project(
+        self, project_root: Path, plugin_dir: Path, tmp_path: Path
+    ):
+        trust.trust_plugin(project_root, "my_plugin", plugin_dir)
+        other_root = tmp_path / "other_project"
+        other_root.mkdir()
+        assert not trust.is_plugin_trusted(other_root, "my_plugin", plugin_dir)
+
+
+class TestStoreRobustness:
+    def test_malformed_json_fails_closed(self, project_root: Path, plugin_dir: Path):
+        trust.TRUST_STORE_FILE.write_text("{not json!!", encoding="utf-8")
+        assert (
+            trust.get_trust_status(project_root, "my_plugin", plugin_dir)
+            == trust.UNTRUSTED
+        )
+
+    def test_wrong_shape_fails_closed(self, project_root: Path, plugin_dir: Path):
+        trust.TRUST_STORE_FILE.write_text('{"projects": []}', encoding="utf-8")
+        assert not trust.is_plugin_trusted(project_root, "my_plugin", plugin_dir)
+
+    def test_trust_survives_reload(self, project_root: Path, plugin_dir: Path):
+        trust.trust_plugin(project_root, "my_plugin", plugin_dir)
+        # Fresh read from disk (no in-memory caching to go stale)
+        assert trust.is_plugin_trusted(project_root, "my_plugin", plugin_dir)
+        assert trust.TRUST_STORE_FILE.is_file()

--- a/tests/test_project_plugins.py
+++ b/tests/test_project_plugins.py
@@ -54,6 +54,31 @@ def _cleanup_sys_path():
             sys.path.remove(entry)
 
 
+@pytest.fixture(autouse=True)
+def _trust_everything():
+    """Bypass the trust gate for legacy loader tests.
+
+    Project plugins are disabled-by-default (trust gate); these tests
+    exercise the loading machinery itself, so trust is granted wholesale.
+    Trust-gate behavior is tested separately in TestTrustGate.
+    """
+    import code_puppy.plugins as plugins_module
+
+    plugins_module._project_plugin_status.clear()
+    with (
+        patch(
+            "code_puppy.plugins.trust.get_trust_status",
+            return_value="trusted",
+        ),
+        patch(
+            "code_puppy.plugins.config.is_plugin_disabled",
+            return_value=False,
+        ),
+    ):
+        yield
+    plugins_module._project_plugin_status.clear()
+
+
 # ---------------------------------------------------------------------------
 # 1. Project dir does not exist → no plugins loaded, no errors
 # ---------------------------------------------------------------------------
@@ -489,7 +514,11 @@ class TestEdgeCases:
         result = _load_project_plugins(project_plugins_dir, set(), set())
         assert result == []
 
-    def test_adds_project_dir_to_sys_path(self, project_plugins_dir: Path):
+    def test_adds_project_dir_to_sys_path_on_trusted_load(
+        self, project_plugins_dir: Path
+    ):
+        """sys.path entry is earned only when a trusted plugin loads."""
+        _make_plugin(project_plugins_dir, "path_earner")
         project_str = str(project_plugins_dir)
         if project_str in sys.path:
             sys.path.remove(project_str)
@@ -497,7 +526,17 @@ class TestEdgeCases:
         _load_project_plugins(project_plugins_dir, set(), set())
         assert project_str in sys.path
 
+    def test_no_sys_path_when_nothing_loads(self, project_plugins_dir: Path):
+        """Empty plugins dir must not leak onto sys.path (stdlib shadowing)."""
+        project_str = str(project_plugins_dir)
+        if project_str in sys.path:
+            sys.path.remove(project_str)
+
+        _load_project_plugins(project_plugins_dir, set(), set())
+        assert project_str not in sys.path
+
     def test_no_duplicate_sys_path_entries(self, project_plugins_dir: Path):
+        _make_plugin(project_plugins_dir, "dup_check")
         project_str = str(project_plugins_dir)
         if project_str not in sys.path:
             sys.path.insert(0, project_str)
@@ -505,3 +544,178 @@ class TestEdgeCases:
         count_before = sys.path.count(project_str)
         _load_project_plugins(project_plugins_dir, set(), set())
         assert sys.path.count(project_str) == count_before
+
+
+# ---------------------------------------------------------------------------
+# Trust gate (project plugins are disabled by default)
+# ---------------------------------------------------------------------------
+
+
+class TestTrustGate:
+    """Untrusted/changed project plugins must never be imported."""
+
+    def test_untrusted_plugin_not_loaded(self, project_plugins_dir: Path, caplog):
+        import logging
+
+        _make_plugin(project_plugins_dir, "sketchy")
+
+        with (
+            caplog.at_level(logging.INFO, logger="code_puppy.plugins"),
+            patch(
+                "code_puppy.plugins.trust.get_trust_status",
+                return_value="untrusted",
+            ),
+            patch(
+                "code_puppy.plugins.importlib.util.spec_from_file_location",
+            ) as mock_sfl,
+        ):
+            result = _load_project_plugins(project_plugins_dir, set(), set())
+
+        assert result == []
+        mock_sfl.assert_not_called()  # import machinery never touched
+        assert "Skipping project plugin 'sketchy'" in caplog.text
+
+    def test_changed_plugin_not_loaded(self, project_plugins_dir: Path, caplog):
+        import logging
+
+        _make_plugin(project_plugins_dir, "drifted")
+
+        with (
+            caplog.at_level(logging.INFO, logger="code_puppy.plugins"),
+            patch(
+                "code_puppy.plugins.trust.get_trust_status",
+                return_value="changed",
+            ),
+        ):
+            result = _load_project_plugins(project_plugins_dir, set(), set())
+
+        assert result == []
+        assert "changed" in caplog.text
+
+    def test_untrusted_plugin_keeps_dir_off_sys_path(self, project_plugins_dir: Path):
+        _make_plugin(project_plugins_dir, "sketchy")
+        project_str = str(project_plugins_dir)
+        if project_str in sys.path:
+            sys.path.remove(project_str)
+
+        with patch(
+            "code_puppy.plugins.trust.get_trust_status",
+            return_value="untrusted",
+        ):
+            _load_project_plugins(project_plugins_dir, set(), set())
+
+        assert project_str not in sys.path
+
+    def test_status_recorded_for_skipped_plugins(self, project_plugins_dir: Path):
+        import code_puppy.plugins as plugins_module
+
+        _make_plugin(project_plugins_dir, "sketchy")
+
+        with patch(
+            "code_puppy.plugins.trust.get_trust_status",
+            return_value="untrusted",
+        ):
+            _load_project_plugins(project_plugins_dir, set(), set())
+
+        assert plugins_module.get_project_plugin_status()["sketchy"] == "untrusted"
+
+    def test_trusted_but_disabled_not_loaded(self, project_plugins_dir: Path):
+        import code_puppy.plugins as plugins_module
+
+        _make_plugin(project_plugins_dir, "napping")
+
+        with patch(
+            "code_puppy.plugins.config.is_plugin_disabled",
+            return_value=True,
+        ):
+            # _trust_everything fixture already returns "trusted"
+            result = _load_project_plugins(project_plugins_dir, set(), set())
+
+        assert result == []
+        assert plugins_module.get_project_plugin_status()["napping"] == "disabled"
+
+    def test_startup_notice_lists_skipped_plugins(self):
+        """The startup-hook banner names every held-back plugin, in orange."""
+        from code_puppy.plugins.trust_notice import emit_skipped_plugin_notice
+
+        with patch("code_puppy.messaging.emit_warning") as mock_warn:
+            emit_skipped_plugin_notice(
+                {
+                    "sketchy": "untrusted",
+                    "drifted": "changed",
+                    "napping": "disabled",  # user's own choice — not nagged
+                    "fine": "loaded",
+                }
+            )
+
+        mock_warn.assert_called_once()
+        banner = mock_warn.call_args[0][0]
+        text = banner.plain if hasattr(banner, "plain") else str(banner)
+        assert "sketchy" in text
+        assert "drifted" in text
+        assert "napping" not in text
+        assert "fine" not in text
+        assert "NOT loaded" in text
+        assert "/plugins" in text
+        # Standard warning yellow (matches _classify_style), bold for pop
+        assert "bold yellow" in str(banner.spans)
+
+    def test_no_notice_when_nothing_skipped(self):
+        """Fully trusted (or empty) project tier stays quiet."""
+        from code_puppy.plugins.trust_notice import emit_skipped_plugin_notice
+
+        with patch("code_puppy.messaging.emit_warning") as mock_warn:
+            emit_skipped_plugin_notice({"fine": "loaded", "napping": "disabled"})
+
+        mock_warn.assert_not_called()
+
+    def test_plugin_list_startup_hook_emits_notice(self, project_plugins_dir: Path):
+        """plugin_list's startup callback wires statuses into the banner."""
+        from code_puppy.plugins.plugin_list.register_callbacks import _on_startup
+
+        with (
+            patch(
+                "code_puppy.plugins.get_project_plugin_status",
+                return_value={"sketchy": "untrusted"},
+            ),
+            patch("code_puppy.messaging.emit_warning") as mock_warn,
+        ):
+            _on_startup()
+
+        mock_warn.assert_called_once()
+
+    def test_untrusted_names_do_not_suppress_user_plugins(self, tmp_path: Path):
+        """An untrusted repo must not knock out user plugins via name squatting."""
+        import code_puppy.plugins as plugins_module
+
+        project_dir = tmp_path / ".code_puppy" / "plugins"
+        project_dir.mkdir(parents=True)
+        _make_plugin(project_dir, "force_push_guard")
+
+        original_loaded = plugins_module._PLUGINS_LOADED
+        plugins_module._PLUGINS_LOADED = False
+
+        with (
+            patch("code_puppy.plugins._load_builtin_plugins", return_value=[]),
+            patch(
+                "code_puppy.plugins._load_user_plugins", return_value=[]
+            ) as mock_user,
+            patch(
+                "code_puppy.plugins.get_project_plugins_directory",
+                return_value=project_dir,
+            ),
+            patch(
+                "code_puppy.plugins.trust.is_plugin_trusted",
+                return_value=False,
+            ),
+            patch("code_puppy.plugins._load_project_plugins", return_value=[]),
+        ):
+            try:
+                plugins_module.load_plugin_callbacks()
+            finally:
+                plugins_module._PLUGINS_LOADED = original_loaded
+
+        # skip_names passed to the user loader must NOT contain the
+        # untrusted project plugin's name.
+        _, kwargs = mock_user.call_args
+        assert "force_push_guard" not in kwargs["skip_names"]


### PR DESCRIPTION
Project plugins execute arbitrary repo code at import time, so they are now disabled by default and gated behind a user-side, content-addressed trust store (~/.code_puppy/trusted_plugins.json, SHA-256 per plugin dir, keyed by resolved project path). Any file change reverts a plugin to untrusted, blocking silent-update attacks; unreadable stores and hash mismatches fail closed. Untrusted plugins never touch sys.path and never participate in name-collision dedup.

Enabling runs a risk-acceptance ceremony in the /plugins TUI: a popup (prompt_toolkit float; list keybinds filter-disabled while open) shows the plugin's files and requires typing 'trust', then hot-loads the plugin with no restart. '/plugins enable <name>' opens the TUI preselected with the popup up, and activates already-trusted plugins directly; '/plugins revoke <name>' removes trust. Held-back plugins are surfaced via a startup banner, '/plugins list', and the TUI (yellow '!' entries), each naming the project path they are scoped to.

plugins_menu.py crossed the 600-line cap and its layout/keybinding construction was split into plugins_menu_layout.py.