### PR TITLE
fix(puppy_spinner): quicker classic puppy + gap before status text

### DIFF
--- a/code_puppy/plugins/puppy_spinner/README.md
+++ b/code_puppy/plugins/puppy_spinner/README.md
@@ -31,7 +31,8 @@ effect on the very next animation frame — no restart, even mid-run.
 ## Builtin spinners
 
 Every builtin runs at 0.2s per frame by default — per-spinner tuning is
-what the picker's speed keys and `spinners.json` tweaks are for.
+what the picker's speed keys and `spinners.json` tweaks are for. The
+one exception: the classic `puppy` trots at 0.06s out of the box.
 
 The puppy pack: `puppy` (default), `bone`, `zoomies`, `paws`, `dots`.
 

--- a/code_puppy/plugins/puppy_spinner/register_callbacks.py
+++ b/code_puppy/plugins/puppy_spinner/register_callbacks.py
@@ -158,10 +158,20 @@ def _current_frames_and_interval():
     return FRAMES, _TICK_INTERVAL_S
 
 
+#: Breathing room between the spinner frame and whatever the status bar
+#: renders next. Applied at paint time so every spinner -- builtin or
+#: user-authored -- gets the same gap without baking spaces into frames.
+_PREFIX_GAP = "  "
+
+
 def _paint_prefix(text: str) -> None:
-    """Best-effort paint -- a broken bar must never kill the ticker."""
+    """Best-effort paint -- a broken bar must never kill the ticker.
+
+    Non-empty frames get ``_PREFIX_GAP`` appended; clearing stays a
+    true empty string so nothing lingers in the prefix slot.
+    """
     try:
-        _bar().set_status_prefix(text)
+        _bar().set_status_prefix(text + _PREFIX_GAP if text else "")
     except Exception:
         logger.debug("puppy spinner paint failed", exc_info=True)
 

--- a/code_puppy/plugins/puppy_spinner/spinners.py
+++ b/code_puppy/plugins/puppy_spinner/spinners.py
@@ -58,6 +58,9 @@ MAX_INTERVAL = 1.0
 #: One speed to rule them all: every builtin ships at this, and it's the
 #: fallback when spinners.json omits (or fumbles) an interval.
 _DEFAULT_INTERVAL = 0.2
+#: ...except the classic. The kennel bounce was tuned for a quicker trot
+#: (0.05s originally) and looks sluggish at the pack default.
+_PUPPY_INTERVAL = 0.06
 _MAX_FRAME_LEN = 40  # the status-prefix slot is prime real estate
 
 # Escape-spelled glyphs (repo emoji filter).
@@ -103,7 +106,7 @@ def _kennel_bounce(critter: str) -> Tuple[str, ...]:
 _BUILTIN_SPECS = {
     "puppy": (
         _kennel_bounce(PUPPY),
-        _DEFAULT_INTERVAL,
+        _PUPPY_INTERVAL,
         "the classic kennel bounce (default)",
     ),
     "bone": (

--- a/tests/plugins/test_puppy_spinner.py
+++ b/tests/plugins/test_puppy_spinner.py
@@ -71,8 +71,10 @@ async def test_run_start_spins_and_run_end_clears(bar):
     painted = [p for p in bar.prefixes if p]
     assert painted, "ticker never painted a frame"
     assert all(rc._PUPPY in p for p in painted)
-    # Frames only -- no "<puppy> is thinking..." chatter on the status row.
-    assert all(p in rc.FRAMES for p in painted)
+    # Frames only -- no "<puppy> is thinking..." chatter on the status
+    # row -- each followed by the gap that pads out the next element.
+    assert all(p.endswith(rc._PREFIX_GAP) for p in painted)
+    assert all(p.removesuffix(rc._PREFIX_GAP) in rc.FRAMES for p in painted)
 
     await rc._on_run_end(agent_name="a", model_name="m", success=True)
     await asyncio.sleep(0.02)  # let the cancelled task run its finally

--- a/tests/plugins/test_puppy_spinner_styles.py
+++ b/tests/plugins/test_puppy_spinner_styles.py
@@ -59,12 +59,40 @@ def test_builtins_include_the_cli_spinners_pack():
         assert name in sp.BUILTIN_SPINNERS
 
 
-def test_every_builtin_defaults_to_point_two():
+def test_every_builtin_defaults_to_point_two_except_the_classic():
     """One speed to rule them all -- per-spinner tuning is what the
-    picker's speed keys and spinners.json tweaks are for.
+    picker's speed keys and spinners.json tweaks are for. The default
+    puppy is the lone exception: the kennel bounce trots at 0.06s.
     """
     for spinner in sp.BUILTIN_SPINNERS.values():
-        assert spinner.interval == pytest.approx(0.2), spinner.name
+        expected = 0.06 if spinner.name == sp.DEFAULT_SPINNER else 0.2
+        assert spinner.interval == pytest.approx(expected), spinner.name
+
+
+def test_tick_interval_follows_the_puppy_default():
+    """rc sources its fallback tempo from the catalogue, so the puppy's
+    0.06s default and the tick loop can never disagree.
+    """
+    assert rc._TICK_INTERVAL_S == pytest.approx(0.06)
+    assert rc._TICK_INTERVAL_S == sp.BUILTIN_SPINNERS[sp.DEFAULT_SPINNER].interval
+
+
+def test_paint_gap_separates_frame_from_status(monkeypatch):
+    """Non-empty frames get the gap appended; clearing paints a true
+    empty string so nothing lingers in the prefix slot.
+    """
+    painted = []
+
+    class FakeBar:
+        def set_status_prefix(self, text):
+            painted.append(text)
+
+    monkeypatch.setattr(
+        "code_puppy.messaging.bottom_bar.get_bottom_bar", lambda: FakeBar()
+    )
+    rc._paint_prefix("(x) ")
+    rc._clear_prefix()
+    assert painted == ["(x) " + rc._PREFIX_GAP, ""]
 
 
 def test_catalogue_is_alphabetical():


### PR DESCRIPTION
Two polish tweaks to the spinner feature (#528):