### PR TITLE
feat: native Agent Client Protocol (ACP) agent + host-agnostic FileSystemBackend seam

### DIFF
--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -815,10 +815,19 @@ async def _run_with_mcp_impl(
             # console clamp on Windows), ^C arrives as \x03 and the key
             # listener handles cancellation. SIGINT only fires out-of-band
             # (kill -INT, piped stdin with no listener, cooked-mode gaps
-            # between raw readers) — the handler installed here is that
+            # between raw readers) -- the handler installed here is that
             # fallback: it cancels when ^C IS the cancel gesture, and only
             # hints at the real key when cancel is remapped.
-            if sigint_fallback_cancels():
+            #
+            # Off the main thread (ACP server, embeds, worker threads) we skip
+            # SIGINT wiring entirely: signal handlers are main-thread-only in
+            # CPython, so installing one there raises "signal only works in
+            # main thread". Cancellation still flows through
+            # schedule_agent_cancel, and the stdin key listener no-ops when
+            # stdin isn't a TTY, so no cancel affordance is lost.
+            if threading.current_thread() is not threading.main_thread():
+                pass  # original_handler stays None -> restore is a no-op
+            elif sigint_fallback_cancels():
                 original_handler = signal.signal(
                     signal.SIGINT, keyboard_interrupt_handler
                 )

--- a/code_puppy/plugins/acp/README.md
+++ b/code_puppy/plugins/acp/README.md
@@ -1,0 +1,266 @@
+# `acp` — Code Puppy as a native ACP agent
+
+Run Code Puppy inside any ACP-capable editor's agent panel (e.g.
+[Zed](https://github.com/zed-industries/zed))
+by speaking the **Agent Client Protocol (ACP)** — the same JSON-RPC-over-stdio
+protocol these editors use to host Gemini CLI and Claude Code.
+
+This plugin is built on the **official [`agent-client-protocol`](https://pypi.org/project/agent-client-protocol/)
+Python SDK** (`acp`). The SDK owns the wire — stdio binding, JSON-RPC framing,
+typed Pydantic models, and the bidirectional connection — so this plugin is
+pure *behaviour*: mapping ACP sessions to Code Puppy agents, translating
+runtime events into `session/update`s, and routing Code Puppy's I/O + approval
+edges to the client.
+
+> **Status:** live over real stdio. Implemented: `initialize`, `session/new`,
+> `session/load` (replays persisted history), `session/prompt`,
+> `session/cancel` (also kills local shells), `session/list`, `session/close`,
+> `session/fork` (duplicates history), `session/resume` (rehydrates across
+restarts), `session/set_mode`, `session/set_config_option`. Assistant text +
+> thinking stream as `agent_message_chunk` / `agent_thought_chunk`; tool calls
+> stream as `tool_call` / `tool_call_update` (with `kind`, file `locations`,
+> friendly titles, and inline diffs); slash commands are advertised via
+> `available_commands_update` **and executed** when the client sends one. Prompt
+> turns report token usage; **image** input is accepted. Client-injected MCP
+> servers and multi-root `additionalDirectories` are honoured. Workspace file
+> I/O and shell delegate to the client (capability-gated), and **permissions**
+> for file writes and shell commands are surfaced in the client's own allow/deny
+> dialog in non-yolo mode.
+>
+> Not implemented: `elicitation/*` (the SDK's connection API exposes no
+> elicitation call in 0.10.1), `plan` updates (Code Puppy has no plan model),
+> and the unstable `document/*` / `nes/*` / `providers/*` surface.
+
+---
+
+## How the client hosts an external agent
+
+1. The client launches the agent as a **subprocess** and talks JSON-RPC 2.0 over the
+   process's **stdin/stdout** (stderr is free for logging).
+2. The agent advertises what it can do in an `initialize` handshake; the client
+   advertises what *it* can do (read/write files, run terminals, permissions).
+3. The client drives with `session/new` then `session/prompt`; the agent streams
+   progress back with `session/update` notifications and can call *back into
+   the client* for file I/O, terminals, and permission prompts.
+
+This is a **bidirectional** JSON-RPC connection: both sides send requests.
+
+### Registering us in a client
+
+Registration is client-specific. Example — Zed's `settings.json`:
+
+```jsonc
+{
+  "agent_servers": {
+    "Code Puppy": { "command": "code-puppy", "args": ["--acp"], "env": {} }
+  }
+}
+```
+
+Then "Code Puppy" appears in the agent panel's "New Thread" menu.
+
+---
+
+## Why the official SDK
+
+We adopted `agent-client-protocol` instead of hand-rolling JSON-RPC because it
+gives us, maintained and spec-accurate:
+
+* **Typed models** for the entire protocol (`InitializeResponse`,
+  `SessionNotification`, all content/capability/tool-call types).
+* **`acp.run_agent(agent)`** — binds stdio, frames ndjson JSON-RPC, parses
+  params into models, dispatches to our `Agent`, and hands us a `Client`
+  connection for talking back.
+* **Update builders** (`update_agent_message_text`, `start_tool_call`, …).
+
+Net effect: ~400 lines of hand-rolled transport/framing/capability code
+deleted, correct-by-construction wire behaviour, and a PR that speaks the
+project's own library. Our two small **core seams stay unchanged** — only the
+plugin's protocol layer changed.
+
+---
+
+## Design decisions (locked in)
+
+| Decision | Choice |
+|----------|--------|
+| **Protocol layer** | **Official `acp` SDK.** We implement its `Agent` interface; `acp.run_agent` owns stdio + framing. |
+| **Who does I/O** | **Delegated to the client when the client supports it.** Workspace file reads/writes go through the client's `fs/read_text_file` / `fs/write_text_file` (edits land in the client's diff UI; reads see unsaved buffers), and shell commands run via the client's `terminal/*`. This rides two small, general **I/O-backend seams** in core (`code_puppy/tools/io_backends.py`): a sync `FileSystemBackend` and an async `CommandExecutor`, both `None` by default (local I/O) and installed by this plugin, capability-gated, after `initialize`. Internal writes (config, session state, agent metadata) deliberately stay local — only *workspace* edits reroute (via `common.write_project_file`). |
+| **Permissions** | **the client is the authority (non-yolo).** Every approval — file writes and shell commands — is surfaced in the client's own allow/deny dialog via `session/request_permission`. No yolo forcing, no terminal prompts. |
+| **Entry point** | A `--acp` CLI flag contributed via the `register_cli_args` hook; `handle_cli_args` boots the agent (on its own loop, in a thread) and short-circuits normal TUI startup. |
+| **Core footprint** | Small, general, additive core seams — **no monkeypatching**: (1) a pluggable *approval backend* (`common.set_approval_backend`), (2) a *workspace write* wrapper (`common.write_project_file`) + backend-aware `_read_file`, and (3) `FileSystemBackend` / `CommandExecutor` registries (`tools/io_backends.py`). Each is useful to any non-terminal embedder, not ACP-specific. Everything else is this plugin + existing public hooks + the SDK. |
+
+### Permissions in non-yolo mode (the important part)
+
+Code Puppy has two approval edges. In a headless ACP server there is no TTY, so
+the built-in stdin prompt would **fail closed** (auto-deny every file op — a
+latent bug this integration also fixes). We route both edges to the client *without*
+forcing yolo and *without* patching tool logic:
+
+* **File operations** use the **approval-backend seam** in `tools.common`. Sync
+  file tools run in Code Puppy's tool threadpool, so the backend
+  (`permissions.py`) bridges to the ACP event loop with
+  `run_coroutine_threadsafe` to ask the client via the SDK's `request_permission`,
+  then blocks the worker thread for the answer. The loop is free to service the
+  round-trip → no deadlock (guarded against being called on the loop itself).
+* **Shell commands** use the async `run_shell_command` hook (it runs on the ACP
+  loop and can `await` the client directly).
+
+Both edges **fail closed** if the connection drops or the client errors.
+
+---
+
+## Module layout
+
+Every file stays well under the 600-line cap and owns one concern.
+
+| File | Responsibility |
+|------|----------------|
+| `register_callbacks.py` | Register the `--acp` flag; when present, redirect the console to stderr, run `acp.run_agent(CodePuppyAgent())` on its own loop in a thread, and return `{"handled": True}` so the TUI never starts. |
+| `agent.py` | `CodePuppyAgent(acp.Agent)` — the SDK agent implementation: initialize, new/load/resume/fork/list/close session, prompt, cancel, set_session_mode/model, set_config_option, authenticate, plus `on_connect` (stashes the client handle + installs approvals). |
+| `capabilities.py` | Declarative capability negotiation in SDK models: our `AgentCapabilities`, and parsing the client's `ClientCapabilities` into `(fs_read, fs_write, terminal)`. |
+| `content.py` | Parse ACP prompt content blocks → text + multimodal attachments (`BinaryContent` / `ImageUrl`), honouring `embeddedContext` + `image`. |
+| `session.py` | `ACPSession`: one ACP session ⇄ one `BaseAgent` + its `_message_history`. Runs each turn as a cancellable `asyncio.Task`; persists history after each turn; owns the final-result fallback. |
+| `commands.py` | Execute client-typed `/slash` commands via `command_handler`, capturing MessageBus output and forwarding it (never touches stdin). |
+| `persistence.py` | Pickle each session's history under `AUTOSAVE_DIR/acp` keyed by session id, plus an ACP metadata sidecar (`cwd` + `additionalDirectories` + title). Rehydrate on `load`/`resume`/`fork`; enumerate for `session/list` (`list_persisted`); tombstone on `session/close` (`delete`). |
+| `replay.py` | On `load`/`resume`, stream the rehydrated history back to the client as ordered `session/update`s (user / agent text / thinking / past tool calls) so the client rebuilds the thread UI. |
+| `mcp_config.py` | Translate client-injected ACP MCP server specs → pydantic-ai servers on the session agent. |
+| `session_config.py` | Build the model list (surfaced as ACP *modes*) + safe config options; apply `set_mode` / `set_config_option`. |
+| `bridge.py` | `EventBridge`: registers `stream_event` / `pre_tool_call` / `post_tool_call` hooks and translates them into SDK `session/update`s via `connection.session_update`. (Hooks, **not** MessageBus — see *Event source*.) |
+| `permissions.py` | Wires Code Puppy's two approval edges to the client via the SDK's `request_permission`: the `tools.common` approval backend (files, cross-thread) and the `run_shell_command` hook (shell). Fails closed. |
+| `io_delegation.py` | `DelegatedFileSystemBackend` (sync, cross-thread) + `DelegatedCommandExecutor` (async terminal lifecycle) that plug into the core I/O seams, capability-gated. |
+| `state.py` | Process-wide run context: the SDK connection + its loop, the active session id, and the open-tool-call stack — so the permission/I/O seams (plain module functions) can reach the running connection and correlate events. |
+
+```
+Client ──stdin──▶ acp.run_agent ──▶ CodePuppyAgent.prompt ──▶ ACPSession ──▶ agent.run_with_mcp
+                                                                 │
+   stream_event / pre_tool_call / post_tool_call hooks fire ─────┘
+      │
+      ▼
+  bridge ──▶ connection.session_update ──stdout──▶ the client
+      ▲
+      │ agent needs to read/write/run/ask
+      └── permissions / io_delegation ──▶ connection.{request_permission,
+              read_text_file, write_text_file, create_terminal, …} ──▶ the client
+```
+
+### Event source: hooks, not the MessageBus
+
+Code Puppy's `MessageBus` is **single-consumer** and *buffers* until a renderer
+attaches; agent text streams through pydantic-ai's `event_stream_handler`
+(which fires the `stream_event` callback), not the bus. So the bridge taps the
+**callback hooks** — the same seam the shipping `frontend_emitter` plugin uses:
+
+| Hook | Fires with | ACP update |
+|------|-----------|------------|
+| `stream_event` (`part_delta`, `TextPartDelta`) | `event_data.delta.content_delta` | `agent_message_chunk` |
+| `stream_event` (`part_delta`, `ThinkingPartDelta`) | `event_data.delta.content_delta` | `agent_thought_chunk` |
+| `pre_tool_call` | `tool_name`, `tool_args` | `tool_call` (status `in_progress`) |
+| `post_tool_call` | `tool_name`, `result` | `tool_call_update` (status `completed`/`failed`) |
+
+Run context (active session id, whether text streamed, the open-tool-call
+stack) lives in `state`, so `bridge`, `permissions`, and `io_delegation` share
+one source of truth. `set_session_context(session_id)` is also set around each
+run so streamed events carry the right session id.
+
+### stdout is sacred
+
+ACP speaks JSON-RPC on **stdout**, so nothing else may write there. At boot we
+point the streaming console (`set_streaming_console`) and the root logger at
+**stderr**; the interactive path that normally configures the console is
+short-circuited in `--acp` mode.
+
+### Streaming-off fallback
+
+`use_streaming` is config-gated. When off, no `stream_event` deltas fire, so the
+session sends the return value of `run_with_mcp` as a single final
+`agent_message_chunk`. `state` tracks whether any text streamed so we never
+double-send.
+
+---
+
+## ACP surface we implement
+
+### Inbound (the client → us)
+
+| Method | Behaviour |
+|--------|-----------|
+| `initialize` | Negotiate version + capabilities; install capability-gated I/O delegation. |
+| `authenticate` / `logout` | No-op (auth is via Code Puppy's own model config/env). |
+| `session/new` | Create an `ACPSession` (fresh `BaseAgent`) from `cwd` + `additionalDirectories`; attach client `mcpServers`; return models + config options; schedule `available_commands_update`. |
+| `session/load` | Re-open a thread: **replay persisted history into the agent AND stream it back to the client** as `session/update`s so the client rebuilds the thread UI. |
+| `session/resume` | Rehydrate + replay a session across a restart from persisted history. |
+| `session/fork` | Branch a session: copy its history into a new id. Works on a live session **or** one persisted by a prior process (rehydrated from disk), so forking survives a restart. |
+| `session/prompt` | Parse content blocks (text + image attachments) or execute a `/slash` command; run the agent as a cancellable task; stream updates; return stop reason **+ token usage**. |
+| `session/cancel` | Cancel the in-flight run's task **and kill local shells** → `cancelled`. |
+| `session/list` / `session/close` | List sessions (**live in-memory + persisted on disk**, deduped, so threads survive a restart and stay revivable) / drop a session (also deletes its persisted copy). |
+| `session/set_mode` | Switch the active model, rebinding the session agent (history preserved). Code Puppy surfaces its model list as ACP *modes* (0.11 removed the separate models API). |
+| `session/set_config_option` | Apply a safe config change (streaming toggle); never yolo. |
+| `session/set_mode` | No-op (Code Puppy has one mode). |
+
+Not implemented: `elicitation/*` (the SDK connection exposes no elicitation
+call in 0.10.1), `plan` updates (no native plan model), and the unstable
+`document/*` / `nes/*` / `providers/*` surface. The SDK router resolves any
+unimplemented method to a clean "method not found", so we advertise honestly
+and stub nothing.
+
+### Outbound notifications (us → the client) — `session/update`
+
+`agent_message_chunk`, `agent_thought_chunk`, `tool_call`, `tool_call_update`,
+`available_commands_update`. Tool calls carry human-friendly titles
+("Edit foo.py", "Run: pytest"), a `kind`, file `locations`, and — on completion
+— the unified diff as an inline `diff` content block so edits are visible in
+the client's tool-call entry.
+
+### Outbound requests (us → the client)
+
+`session/request_permission` (approvals), and — when the client advertises the
+capability — `fs/read_text_file`, `fs/write_text_file`, and the `terminal/*`
+family (`create`, `wait_for_exit`, `output`, `kill`, `release`).
+
+---
+
+## Session & history model
+
+- One ACP session id ⇄ one `ACPSession` ⇄ one `BaseAgent` instance.
+- Multi-turn is native: `_message_history` persists across `session/prompt`
+  calls within the same session.
+- `cwd` from `session/new` anchors that session's tools.
+
+---
+
+## Interactive tools (`ask_user_question`)
+
+Code Puppy's `ask_user_question` renders a terminal picker and reads stdin —
+neither is available over ACP (stdin *is* the JSON-RPC pipe). The tool's own
+`isatty()` guard already makes it fail closed there (no stdout corruption), but
+the default "not an interactive terminal" error is a dead end.
+
+So in ACP mode the `EventBridge` **blocks** `ask_user_question` at the
+`pre_tool_call` seam (before any tool-call entry is opened) and returns guidance
+steering the model to *ask the user directly in its normal text response* — which
+the client renders as a regular assistant message the user can reply to. This is
+the pragmatic stand-in until ACP ratifies structured **elicitation** (currently
+only an [RFD](https://agentclientprotocol.com), not in stable v1 — no client,
+including Zed, implements it yet). When elicitation lands and the SDK exposes a
+connection method for it, this block becomes a real native picker.
+
+---
+
+## Testing
+
+`tests/test_acp_plugin.py` drives `CodePuppyAgent` directly against a fake SDK
+connection (no real stdio) and covers:
+
+- capability negotiation + client-cap parsing,
+- content-block flattening (incl. embedded resources),
+- lifecycle: initialize / new_session / prompt (stream + fallback) / cancel /
+  list / close / unknown-session error,
+- tool-call `kind` / `locations` / pre↔post correlation,
+- the core approval-backend seam (sync + async) + the shell hook,
+- the **cross-thread approval bridge** (worker thread → ACP loop → the client → back),
+- I/O delegation core seams + the client fs/terminal backends (capability-gated).
+
+Real end-to-end: `code-puppy --acp` spawned as a subprocess answers
+`initialize` + `session/new` with clean JSON-RPC on stdout. Manual: point a
+real client at `code-puppy --acp` via `agent_servers`.

--- a/code_puppy/plugins/acp/__init__.py
+++ b/code_puppy/plugins/acp/__init__.py
@@ -1,0 +1,8 @@
+"""Code Puppy as a native Agent Client Protocol (ACP) agent.
+
+This plugin lets Code Puppy run as an external agent inside the client's agent
+panel by speaking the Agent Client Protocol (ACP) — JSON-RPC 2.0 over
+stdio. See ``README.md`` in this directory for the full design.
+
+Boot it with ``code-puppy --acp`` (the client does this for you once configured).
+"""

--- a/code_puppy/plugins/acp/agent.py
+++ b/code_puppy/plugins/acp/agent.py
@@ -1,0 +1,456 @@
+"""``CodePuppyAgent`` — Code Puppy as a native Agent Client Protocol agent.
+
+This implements the official SDK's ``Agent`` interface, so Code Puppy runs as
+an external agent in any ACP client (Zed, and other editors that speak ACP).
+The SDK owns the wire: ``acp.run_agent`` binds stdio, frames JSON-RPC, parses
+params into typed models, and hands us a ``Client`` connection (via
+``on_connect``) for talking back to the client. We own the behaviour: mapping ACP sessions to Code Puppy agents,
+running prompts, and translating events (through ``EventBridge``) and I/O
+(through ``permissions`` + ``io_delegation``).
+
+Only capability-gated methods we actually support are implemented; the SDK's
+router resolves unimplemented ones to a clean "method not found", so we never
+have to stub protocol surface we don't mean.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any, Dict, List, Optional
+
+from acp import Agent
+from acp.schema import (
+    AgentCapabilities,
+    AuthenticateResponse,
+    AvailableCommand,
+    AvailableCommandsUpdate,
+    ClientCapabilities,
+    CloseSessionResponse,
+    Implementation,
+    InitializeResponse,
+    ListSessionsResponse,
+    LoadSessionResponse,
+    NewSessionResponse,
+    PromptResponse,
+    SessionInfo,
+    SetSessionModeResponse,
+)
+
+from code_puppy.plugins.acp import (
+    capabilities,
+    io_delegation,
+    mcp_config,
+    permissions,
+    persistence,
+    replay,
+    session_config,
+    state,
+)
+from code_puppy.plugins.acp.bridge import EventBridge
+from code_puppy.plugins.acp.session import ACPSession
+
+logger = logging.getLogger(__name__)
+
+# The ACP protocol version this plugin targets. Source it from the SDK rather
+# than hardcoding a literal, so a library upgrade can't leave us silently
+# advertising a stale version. Falls back to v1 (the stable baseline) if an
+# older SDK doesn't export the constant.
+try:
+    from acp import PROTOCOL_VERSION as PROTOCOL_VERSION
+except ImportError:  # pragma: no cover - defensive for older SDKs
+    PROTOCOL_VERSION = 1
+
+
+def _code_puppy_version() -> str:
+    try:
+        return version("code-puppy")
+    except PackageNotFoundError:
+        return "0.0.0"
+
+
+class CodePuppyAgent(Agent):
+    """One ACP connection's worth of Code Puppy, spread across client threads."""
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, ACPSession] = {}
+        self._bridge = EventBridge()
+        self._client_caps: Optional[ClientCapabilities] = None
+
+    # ---- Connection lifecycle ---------------------------------------------
+    def on_connect(self, conn: Any) -> None:
+        """Store the client handle + loop, wire events, install approvals.
+
+        Called synchronously by the SDK from inside ``run_agent`` — already on
+        the running event loop — so ``get_running_loop`` returns the loop our
+        permission and I/O bridges marshal onto.
+        """
+        state.set_connection(conn, asyncio.get_running_loop())
+        self._bridge.register()
+        permissions.install()
+
+    def shutdown(self) -> None:
+        """Unwire this agent's event hooks. Call once the connection ends.
+
+        ``permissions`` and ``io_delegation`` are torn down by the plugin entry
+        point; this drops the ``EventBridge`` hooks it owns so a closed
+        connection leaves the global callback registry clean.
+        """
+        self._bridge.unregister()
+
+    # ---- Handshake --------------------------------------------------------
+    async def initialize(
+        self,
+        protocol_version: int,
+        client_capabilities: Optional[ClientCapabilities] = None,
+        client_info: Optional[Implementation] = None,
+        **kwargs: Any,
+    ) -> InitializeResponse:
+        """Negotiate capabilities and install matching I/O delegation.
+
+        Once we know what the client can do, reroute Code Puppy's workspace
+        file I/O and shell to the client's ``fs/*`` / ``terminal/*`` methods
+        (only the edges
+        the client advertises). Everything else stays local.
+        """
+        self._client_caps = client_capabilities
+        io_delegation.install(client_capabilities)
+        return InitializeResponse(
+            protocol_version=PROTOCOL_VERSION,
+            agent_capabilities=self._agent_capabilities(),
+            agent_info=Implementation(
+                name="code-puppy",
+                title="Code Puppy",
+                version=_code_puppy_version(),
+            ),
+        )
+
+    async def authenticate(self, method_id: str, **kwargs: Any) -> AuthenticateResponse:
+        """No auth flow — Code Puppy authenticates via its own model config."""
+        return AuthenticateResponse()
+
+    # ---- Session lifecycle ------------------------------------------------
+    async def new_session(
+        self,
+        cwd: str,
+        additional_directories: Optional[List[str]] = None,
+        mcp_servers: Optional[List[Any]] = None,
+        **kwargs: Any,
+    ) -> NewSessionResponse:
+        """Create a session bound to a fresh agent instance.
+
+        Uses ``load_agent`` (not the cached ``get_current_agent``) so each
+        client thread gets its own ``_message_history``. ``cwd`` +
+        ``additional_directories`` anchor the session's tools; ``mcp_servers``
+        the client injects are attached to the agent.
+        """
+        session_id = f"sess_{uuid.uuid4().hex[:16]}"
+        self._make_session(session_id, cwd, additional_directories, mcp_servers)
+        self._announce_commands_soon(session_id)
+        return NewSessionResponse(
+            session_id=session_id,
+            config_options=session_config.config_options() or None,
+        )
+
+    async def load_session(
+        self,
+        cwd: str,
+        session_id: str,
+        additional_directories: Optional[List[str]] = None,
+        mcp_servers: Optional[List[Any]] = None,
+        **kwargs: Any,
+    ) -> LoadSessionResponse:
+        """Re-open a thread the client remembers, replaying persisted history.
+
+        If we have the session's history on disk (persisted after each turn),
+        it is rehydrated into the fresh agent so the model continues the real
+        conversation, AND replayed to the client as ``session/update``
+        notifications so the client rebuilds the thread UI (without this the
+        client shows -- and may discard -- an empty thread). Otherwise the
+        thread is re-created empty but functional.
+        """
+        session = self._make_session(
+            session_id, cwd, additional_directories, mcp_servers, rehydrate=True
+        )
+        await replay.replay_history(session_id, session.agent.get_message_history())
+        self._announce_commands_soon(session_id)
+        return LoadSessionResponse(
+            config_options=session_config.config_options() or None,
+        )
+
+    async def resume_session(
+        self,
+        cwd: str,
+        session_id: str,
+        additional_directories: Optional[List[str]] = None,
+        mcp_servers: Optional[List[Any]] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Resume a session across a restart, rehydrating + replaying history."""
+        from acp.schema import ResumeSessionResponse
+
+        session = self._make_session(
+            session_id, cwd, additional_directories, mcp_servers, rehydrate=True
+        )
+        await replay.replay_history(session_id, session.agent.get_message_history())
+        self._announce_commands_soon(session_id)
+        return ResumeSessionResponse(
+            config_options=session_config.config_options() or None,
+        )
+
+    async def fork_session(
+        self,
+        cwd: str,
+        session_id: str,
+        additional_directories: Optional[List[str]] = None,
+        mcp_servers: Optional[List[Any]] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Branch a session: duplicate its history into a new session id.
+
+        The source's history is copied into a fresh agent so the fork continues
+        the conversation independently. The source may be a live in-memory
+        session OR one persisted by a prior process -- forking must survive a
+        restart just like ``load``/``resume`` do, so we fall back to the
+        pickled history when the source isn't live.
+        """
+        from acp.schema import ForkSessionResponse
+
+        source = self._sessions.get(session_id)
+        if source is not None:
+            source_history = list(source.agent.get_message_history())
+            source_cwd = source.cwd
+        else:
+            source_history = persistence.load_history(session_id)
+            if source_history is None:
+                raise ValueError(f"unknown session to fork: {session_id}")
+            source_cwd = None
+        new_id = f"sess_{uuid.uuid4().hex[:16]}"
+        session = self._make_session(
+            new_id,
+            cwd or source_cwd or "",
+            additional_directories,
+            mcp_servers,
+        )
+        try:
+            session.agent.set_message_history(source_history)
+        except Exception:  # noqa: BLE001
+            logger.debug("ACP: fork history copy failed", exc_info=True)
+        self._announce_commands_soon(new_id)
+        return ForkSessionResponse(
+            session_id=new_id,
+            config_options=session_config.config_options() or None,
+        )
+
+    async def set_session_mode(
+        self, mode_id: str, session_id: str, **kwargs: Any
+    ) -> SetSessionModeResponse:
+        """No-op mode handler.
+
+        Code Puppy has no ACP *session modes* (e.g. plan vs default); model
+        selection is exposed as a ``model`` config option instead (that is what
+        clients bind their model picker to -- see ``session_config``). This
+        method exists only to satisfy the SDK router's ``session/set_mode``
+        route; any mode id is accepted as a no-op.
+        """
+        return SetSessionModeResponse()
+
+    def _rebind_session_model(self, session_id: str) -> None:
+        """Rebuild a live session's agent on the current model, keeping state.
+
+        Message history and any client-injected MCP servers are preserved, so
+        the switch is invisible to the conversation. Best-effort: a rebind
+        failure leaves the existing agent in place.
+        """
+        session = self._sessions.get(session_id)
+        if session is None:
+            return
+        try:
+            history = list(session.agent.get_message_history())
+            session.agent = self._new_agent()
+            session.agent.set_message_history(history)
+            if session.mcp_specs:
+                mcp_config.attach(session.agent, session.mcp_specs)
+        except Exception:  # noqa: BLE001
+            logger.debug("ACP: model rebind failed", exc_info=True)
+
+    async def set_config_option(
+        self, config_id: str, session_id: str, value: Any, **kwargs: Any
+    ) -> Any:
+        """Apply a config-option change and return the refreshed options.
+
+        A change to the ``model`` option rebinds the live session's agent to the
+        newly-selected model (history + client MCP servers preserved), so the
+        client's model picker switches the model mid-thread.
+        """
+        from acp.schema import SetSessionConfigOptionResponse
+
+        options = session_config.apply_config_option(config_id, value)
+        if config_id == session_config.MODEL_OPTION_ID:
+            self._rebind_session_model(session_id)
+        return SetSessionConfigOptionResponse(config_options=options or None)
+
+    async def list_sessions(
+        self, cursor: Optional[str] = None, cwd: Optional[str] = None, **kwargs: Any
+    ) -> ListSessionsResponse:
+        """List every revivable session: live in-memory + persisted on disk.
+
+        Live sessions (this process) merge with sessions persisted to disk in
+        prior runs, so a client's picker still shows -- and can
+        ``session/load`` / ``session/resume`` -- threads that outlived the
+        process that made them. Live wins on id collision (it carries the
+        freshest state). Uncursored single page; optional ``cwd`` filter.
+        """
+        infos: List[SessionInfo] = []
+        seen: set[str] = set()
+        for s in self._sessions.values():
+            if cwd is not None and s.cwd != cwd:
+                continue
+            seen.add(s.session_id)
+            infos.append(
+                SessionInfo(
+                    session_id=s.session_id,
+                    cwd=s.cwd or cwd or "",
+                    additional_directories=s.additional_directories or None,
+                )
+            )
+        for record in persistence.list_persisted():
+            if record.session_id in seen:
+                continue
+            if cwd is not None and record.cwd != cwd:
+                continue
+            seen.add(record.session_id)
+            infos.append(
+                SessionInfo(
+                    session_id=record.session_id,
+                    cwd=record.cwd or cwd or "",
+                    additional_directories=record.additional_directories or None,
+                )
+            )
+        return ListSessionsResponse(sessions=infos, next_cursor=None)
+
+    async def close_session(
+        self, session_id: str, **kwargs: Any
+    ) -> CloseSessionResponse:
+        """Drop a session, cancelling any in-flight run first.
+
+        A close is a deliberate act, so its persisted history is deleted too --
+        otherwise the session would resurrect in the next ``list_sessions``,
+        which is exactly the "disappeared session that won't stay gone" bug in
+        reverse.
+        """
+        session = self._sessions.pop(session_id, None)
+        if session is not None:
+            session.cancel()
+        persistence.delete(session_id)
+        return CloseSessionResponse()
+
+    # ---- Prompt turn ------------------------------------------------------
+    async def prompt(
+        self, prompt: List[Any], session_id: str, **kwargs: Any
+    ) -> PromptResponse:
+        """Run the agent on a user prompt, streaming updates via the bridge."""
+        session = self._sessions.get(session_id)
+        if session is None:
+            raise ValueError(f"unknown session: {session_id}")
+        outcome = await session.prompt(prompt)
+        return PromptResponse(stop_reason=outcome.stop_reason, usage=outcome.usage)
+
+    async def cancel(self, session_id: str, **kwargs: Any) -> None:
+        """Cancel the in-flight run for a session (notification)."""
+        session = self._sessions.get(session_id)
+        if session is not None:
+            session.cancel()
+
+    # ---- Helpers ----------------------------------------------------------
+    def _agent_capabilities(self) -> AgentCapabilities:
+        return capabilities.agent_capabilities()
+
+    def _make_session(
+        self,
+        session_id: str,
+        cwd: str,
+        additional_directories: Optional[List[str]],
+        mcp_servers: Optional[List[Any]],
+        *,
+        rehydrate: bool = False,
+    ) -> ACPSession:
+        """Build + register an ``ACPSession`` with a fresh agent.
+
+        When ``rehydrate`` is set, any persisted history for ``session_id`` is
+        replayed into the agent so the model continues the real conversation.
+        Client-injected ``mcp_servers`` are attached best-effort.
+        """
+        agent = self._new_agent()
+        if rehydrate:
+            history = persistence.load_history(session_id)
+            if history:
+                try:
+                    agent.set_message_history(history)
+                except Exception:  # noqa: BLE001
+                    logger.debug("ACP: history rehydrate failed", exc_info=True)
+        if mcp_servers:
+            mcp_config.attach(agent, mcp_servers)
+        session = ACPSession(
+            session_id,
+            agent,
+            cwd=cwd,
+            additional_directories=additional_directories,
+            mcp_specs=mcp_servers,
+        )
+        self._sessions[session_id] = session
+        return session
+
+    @staticmethod
+    def _new_agent() -> Any:
+        from code_puppy.agents.agent_manager import get_current_agent_name, load_agent
+
+        return load_agent(get_current_agent_name())
+
+    def _announce_commands_soon(self, session_id: str) -> None:
+        """Schedule an ``available_commands_update`` after the response ships.
+
+        We must not send the update before the ``new_session``/``load_session``
+        reply reaches the client (it wouldn't know the session yet).
+        Scheduling a
+        task defers it until this coroutine yields, i.e. after the reply.
+        """
+        loop = state.get_loop()
+        if loop is not None:
+            loop.create_task(self._announce_commands(session_id))
+
+    async def _announce_commands(self, session_id: str) -> None:
+        """Tell the client which slash commands Code Puppy exposes.
+
+        Deferred behind a short delay: ``create_task`` only yields one tick,
+        which isn't enough to guarantee the ``new_session`` reply has been
+        serialized onto the wire. Without this the client can receive the
+        notification before it knows the session id and drop it as "unknown
+        session". 100ms is imperceptible and comfortably after the reply.
+        """
+        await asyncio.sleep(0.1)
+        connection = state.get_connection()
+        if connection is None:
+            return
+        try:
+            from code_puppy.command_line.command_registry import get_unique_commands
+
+            available = [
+                AvailableCommand(name=c.name, description=c.description)
+                for c in get_unique_commands()
+            ]
+        except Exception:  # noqa: BLE001
+            logger.debug("ACP: could not enumerate slash commands", exc_info=True)
+            return
+        if not available:
+            return
+        update = AvailableCommandsUpdate(
+            session_update="available_commands_update",
+            available_commands=available,
+        )
+        try:
+            await connection.session_update(session_id, update)
+        except Exception:  # noqa: BLE001
+            logger.debug("ACP: available_commands_update failed", exc_info=True)

--- a/code_puppy/plugins/acp/bridge.py
+++ b/code_puppy/plugins/acp/bridge.py
@@ -1,0 +1,311 @@
+"""``EventBridge`` — translate Code Puppy runtime events into ACP updates.
+
+While Code Puppy runs a turn, pydantic-ai's ``event_stream_handler`` fires the
+``stream_event`` callback for each streamed text/thinking delta, and the tool
+layer fires ``pre_tool_call`` / ``post_tool_call``. This bridge registers those
+hooks (the same seam the shipping ``frontend_emitter`` plugin uses) and maps
+each event to a ``session/update`` notification sent through the SDK's
+``AgentSideConnection.session_update``.
+
+We use hooks rather than consuming the ``MessageBus`` because the bus is
+single-consumer and buffers until a renderer attaches, and agent text does not
+arrive there as clean deltas. See ``README.md`` → *Event source*.
+
+Tool calls get human-friendly titles ("Edit foo.py", "Run: pytest"), a ``kind``
+so the client picks the right icon, file ``locations``, and — on completion —
+the unified diff as inline content so edits are visible in the client's UI.
+
+Routing/run-context (which session is active, whether text streamed, the
+open-tool-call stack) lives in ``state`` so the permission and I/O backends can
+share it. This bridge is pure translation.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from acp.helpers import (
+    start_tool_call,
+    text_block,
+    tool_content,
+    update_agent_message_text,
+    update_agent_thought_text,
+    update_tool_call,
+)
+from acp.schema import ToolCallLocation
+
+from code_puppy.callbacks import register_callback, unregister_callback
+from code_puppy.plugins.acp import state
+from code_puppy.tools.common import resolve_path
+
+logger = logging.getLogger(__name__)
+
+# Map Code Puppy tool names to ACP tool-call ``kind`` values so the client
+# picks the right icon/affordance. Unknown tools fall back to "other".
+_TOOL_KINDS = {
+    "read_file": "read",
+    "list_files": "read",
+    "grep": "search",
+    "edit_file": "edit",
+    "create_file": "edit",
+    "replace_in_file": "edit",
+    "delete_snippet": "edit",
+    "delete_file": "delete",
+    "agent_run_shell_command": "execute",
+    "agent_share_your_reasoning": "think",
+}
+
+# Human-readable verbs for building tool-call titles like "Edit foo.py".
+_TOOL_VERBS = {
+    "read_file": "Read",
+    "list_files": "List",
+    "grep": "Search",
+    "edit_file": "Edit",
+    "create_file": "Create",
+    "replace_in_file": "Edit",
+    "delete_snippet": "Edit",
+    "delete_file": "Delete",
+}
+
+# Tool-arg keys that commonly carry the target file path, in priority order.
+_PATH_ARG_KEYS = ("file_path", "path", "target_file", "filename")
+
+# Cap on inline diff/output content so a huge edit never floods the client.
+_MAX_DIFF_CHARS = 8000
+
+# Interactive TUI tools that can't run headless over ACP (they'd render a
+# terminal picker + read stdin, which is the JSON-RPC pipe). Until ACP ratifies
+# structured elicitation (currently an RFD), we block these and steer the model
+# to ask the user in plain text instead — which the client shows as a normal
+# assistant message. See README → *Interactive tools*.
+_INTERACTIVE_TOOLS = {"ask_user_question"}
+_INTERACTIVE_BLOCK = {
+    "blocked": True,
+    "error_message": (
+        "[BLOCKED] Interactive pickers aren't available over ACP. Ask the user "
+        "your question(s) directly in your normal text response and wait for "
+        "their reply — do not call this tool."
+    ),
+}
+
+
+class EventBridge:
+    """Forward Code Puppy runtime hook events to the client as updates."""
+
+    def register(self) -> None:
+        """Register the runtime hooks. Call once when the connection opens."""
+        register_callback("stream_event", self._on_stream_event)
+        register_callback("pre_tool_call", self._on_pre_tool_call)
+        register_callback("post_tool_call", self._on_post_tool_call)
+
+    def unregister(self) -> None:
+        """Remove the runtime hooks. Call on teardown so no callbacks leak.
+
+        Mirrors ``register`` so a closed connection leaves no dangling bridge
+        callbacks wired into the global registry (which would double-emit if a
+        second connection opened in the same process).
+        """
+        for phase, handler in (
+            ("stream_event", self._on_stream_event),
+            ("pre_tool_call", self._on_pre_tool_call),
+            ("post_tool_call", self._on_post_tool_call),
+        ):
+            try:
+                unregister_callback(phase, handler)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "ACP: bridge unregister failed for %s", phase, exc_info=True
+                )
+
+    # ---- Hook handlers ----------------------------------------------------
+    async def _on_stream_event(
+        self, event_type: str, event_data: Any, agent_session_id: Optional[str] = None
+    ) -> None:
+        """Map streamed text/thinking to message/thought chunks.
+
+        Two event shapes carry visible content and BOTH must be forwarded:
+
+        * ``part_start`` -- a new text/thinking part whose *initial* content
+          (``part.content``) is the opening of the message. pydantic-ai often
+          packs the first token(s) here rather than in the first delta.
+        * ``part_delta`` -- each subsequent chunk (``delta.content_delta``).
+
+        Start-content and delta-content are disjoint (deltas are only the
+        *additions* after the start), so emitting both reconstructs the full
+        message with no overlap. Forwarding only ``part_delta`` -- as this
+        bridge used to -- silently drops the opening chunk whenever the model
+        front-loads it into the start event.
+
+        The per-run ``state`` session id wins over ``agent_session_id``: the
+        former is a ``ContextVar`` isolated to this prompt's task, whereas
+        ``agent_session_id`` is derived from the process-wide message-bus
+        session context, which a concurrent prompt on the same connection can
+        overwrite. We only fall back to it when no run is active in this context.
+        """
+        session_id = state.get_active_session_id() or agent_session_id
+        if session_id is None:
+            return
+        data = event_data if isinstance(event_data, dict) else {}
+        if event_type == "part_start":
+            part = data.get("part")
+            content = getattr(part, "content", None)
+            is_thinking = "Thinking" in (data.get("part_type", "") or "")
+        elif event_type == "part_delta":
+            delta = data.get("delta")
+            content = (
+                getattr(delta, "content_delta", None) if delta is not None else None
+            )
+            is_thinking = "Thinking" in (data.get("delta_type", "") or "")
+        else:
+            return
+        if not content:
+            return
+        if is_thinking:
+            update = update_agent_thought_text(content)
+        else:
+            state.note_streamed_text()
+            update = update_agent_message_text(content)
+        await self._send(session_id, update)
+
+    async def _on_pre_tool_call(
+        self, tool_name: str, tool_args: Dict[str, Any], context: Any = None
+    ) -> Any:
+        """Announce a tool call starting (status ``in_progress``).
+
+        Interactive TUI tools that can't run over ACP are blocked here (via the
+        ``pre_tool_call`` blocking contract) *before* we open a tool-call entry,
+        so the client never sees a dangling in-progress call.
+        """
+        session_id = state.get_active_session_id()
+        if session_id is None:
+            return None
+        if tool_name in _INTERACTIVE_TOOLS:
+            return dict(_INTERACTIVE_BLOCK)
+        tool_call_id = state.push_tool_call(tool_name)
+        update = start_tool_call(
+            tool_call_id,
+            self._title_for(tool_name, tool_args),
+            kind=_TOOL_KINDS.get(tool_name, "other"),
+            status="in_progress",
+            locations=self._locations_for(tool_args) or None,
+            raw_input=tool_args if isinstance(tool_args, dict) else {},
+        )
+        await self._send(session_id, update)
+
+    async def _on_post_tool_call(
+        self,
+        tool_name: str,
+        tool_args: Dict[str, Any],
+        result: Any,
+        duration_ms: float,
+        context: Any = None,
+    ) -> None:
+        """Report a tool call finishing (status ``completed`` / ``failed``)."""
+        session_id = state.get_active_session_id()
+        if session_id is None:
+            return
+        tool_call_id = state.pop_tool_call(tool_name)
+        if tool_call_id is None:
+            return
+        status = "completed" if self._is_success(result) else "failed"
+        update = update_tool_call(
+            tool_call_id,
+            status=status,
+            content=self._content_for(result) or None,
+            raw_output=self._summarize(result),
+        )
+        await self._send(session_id, update)
+
+    # ---- Helpers ----------------------------------------------------------
+    @staticmethod
+    def _title_for(tool_name: str, tool_args: Any) -> str:
+        """Build a human-friendly tool-call title (e.g. ``Edit foo.py``)."""
+        if tool_name == "agent_run_shell_command" and isinstance(tool_args, dict):
+            command = str(tool_args.get("command", "")).strip()
+            if command:
+                short = command if len(command) <= 60 else command[:57] + "..."
+                return f"Run: {short}"
+        verb = _TOOL_VERBS.get(tool_name)
+        path = EventBridge._first_path(tool_args)
+        if verb and path:
+            return f"{verb} {os.path.basename(path)}"
+        return tool_name
+
+    @staticmethod
+    def _first_path(tool_args: Any) -> Optional[str]:
+        if not isinstance(tool_args, dict):
+            return None
+        for key in _PATH_ARG_KEYS:
+            value = tool_args.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return None
+
+    @staticmethod
+    def _locations_for(tool_args: Any) -> List[ToolCallLocation]:
+        """Extract ACP ``locations`` (files this tool touches) from its args.
+
+        Lets the client highlight the affected file in the agent panel.
+        Best-effort: empty list when no recognizable path arg is present.
+
+        Uses ``resolve_path`` (not ``os.path.abspath``) so a relative tool-arg
+        path is absolutized against the *session's* cwd -- the same base the
+        tools themselves resolve against -- rather than the ACP process cwd,
+        which would point the client at the wrong file.
+        """
+        path = EventBridge._first_path(tool_args)
+        return [ToolCallLocation(path=resolve_path(path))] if path else []
+
+    @staticmethod
+    def _content_for(result: Any) -> list:
+        """Attach the unified diff (if any) as an inline content block.
+
+        File-edit tools return a ``diff`` (unified diff text). We surface it as
+        a fenced ``diff`` code block so the change is visible inline in the
+        client's tool-call entry, in every ACP client — independent of whether
+        filesystem delegation is rendering a native diff too.
+        """
+        if not isinstance(result, dict):
+            return []
+        diff = result.get("diff")
+        if not isinstance(diff, str) or not diff.strip():
+            return []
+        if len(diff) > _MAX_DIFF_CHARS:
+            diff = diff[: _MAX_DIFF_CHARS - 3] + "..."
+        return [tool_content(text_block(f"```diff\n{diff}\n```"))]
+
+    async def _send(self, session_id: str, update: Any) -> None:
+        """Emit one ``session/update`` notification, swallowing failures.
+
+        A translation/transport hiccup on one event must never abort the agent
+        run, so we log and move on.
+        """
+        connection = state.get_connection()
+        if connection is None:
+            return
+        try:
+            await connection.session_update(session_id, update)
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to emit session/update")
+
+    @staticmethod
+    def _is_success(result: Any) -> bool:
+        """Best-effort success check mirroring frontend_emitter's heuristic."""
+        if isinstance(result, dict):
+            if result.get("error"):
+                return False
+            if result.get("success") is False:
+                return False
+        return True
+
+    @staticmethod
+    def _summarize(result: Any) -> Any:
+        """Return a JSON-safe, size-bounded view of a tool result."""
+        if result is None or isinstance(result, (str, int, float, bool, dict, list)):
+            if isinstance(result, str) and len(result) > 4000:
+                return result[:3997] + "..."
+            return result
+        rendered = str(result)
+        return rendered[:3997] + "..." if len(rendered) > 4000 else rendered

--- a/code_puppy/plugins/acp/capabilities.py
+++ b/code_puppy/plugins/acp/capabilities.py
@@ -1,0 +1,73 @@
+"""ACP capability negotiation, expressed in the official SDK models.
+
+Both sides of an ACP connection describe what they can do. The client sends its
+``ClientCapabilities`` (can it read/write files? run terminals?) and expects
+our ``AgentCapabilities`` back. The SDK provides typed models for both, so
+this module is a thin, declarative mapping — no hand-rolled JSON.
+
+Keeping the shapes here means ``agent.py`` stays about lifecycle, and the one
+place we decide "what does Code Puppy advertise" is obvious and reviewable.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from acp.schema import (
+    AgentCapabilities,
+    ClientCapabilities,
+    PromptCapabilities,
+    SessionAdditionalDirectoriesCapabilities,
+    SessionCapabilities,
+    SessionCloseCapabilities,
+    SessionForkCapabilities,
+    SessionListCapabilities,
+    SessionResumeCapabilities,
+)
+
+
+def agent_capabilities() -> AgentCapabilities:
+    """Describe what Code Puppy can do, for the ``initialize`` response.
+
+    * ``prompt_capabilities.embedded_context`` — we splice embedded text
+      resources into the prompt (see ``content.py``), so this is honestly
+      ``True``. ``image`` is also ``True``: image blocks are decoded into
+      ``BinaryContent`` / ``ImageUrl`` attachments (see ``content.py``). Audio
+      input is not consumed yet, so ``audio`` stays ``False``.
+    * ``load_session`` — we accept ``session/load`` and rehydrate the
+      session's persisted history into a fresh agent, so re-opened threads
+      continue the real conversation.
+    * ``session_capabilities`` — we support ``list``, ``close``, ``fork``
+      (in-memory history duplication), ``resume`` (persisted rehydration), and
+      ``additional_directories`` (multi-root), all advertised via the SDK's
+      marker sub-models.
+    """
+    return AgentCapabilities(
+        prompt_capabilities=PromptCapabilities(
+            image=True, audio=False, embedded_context=True
+        ),
+        load_session=True,
+        session_capabilities=SessionCapabilities(
+            list=SessionListCapabilities(),
+            close=SessionCloseCapabilities(),
+            fork=SessionForkCapabilities(),
+            resume=SessionResumeCapabilities(),
+            additional_directories=SessionAdditionalDirectoriesCapabilities(),
+        ),
+    )
+
+
+def client_io_caps(caps: ClientCapabilities | None) -> Tuple[bool, bool, bool]:
+    """Return ``(fs_read, fs_write, terminal)`` from the client's capabilities.
+
+    Drives which I/O edges we delegate to the client vs run locally. Defensive: a
+    ``None`` blob or a newer client that omits fields degrades to "run
+    locally", never to a crash.
+    """
+    if caps is None:
+        return False, False, False
+    fs = getattr(caps, "fs", None)
+    fs_read = bool(getattr(fs, "read_text_file", False)) if fs else False
+    fs_write = bool(getattr(fs, "write_text_file", False)) if fs else False
+    terminal = bool(getattr(caps, "terminal", False))
+    return fs_read, fs_write, terminal

--- a/code_puppy/plugins/acp/commands.py
+++ b/code_puppy/plugins/acp/commands.py
@@ -1,0 +1,116 @@
+"""Execute client-typed slash commands headless and return their output.
+
+The advertised ``available_commands_update`` tells the client which ``/commands``
+Code Puppy exposes; when the user picks one, the client sends it as a prompt.
+Rather than feed ``/help`` to the model, we route it through Code Puppy's
+``command_handler`` and forward whatever it emits on the message bus back as an
+``agent_message_chunk``.
+
+Command side-effects go to the ``MessageBus`` (``emit_info`` etc.), which has no
+renderer in ACP mode. We capture that output by attaching a listener + draining
+the queue around the call. We deliberately do **not** touch ``sys.stdin`` — the
+SDK reads the JSON-RPC pipe from it — so interactive prompt_toolkit menus (a TUI
+affordance) simply aren't driven over ACP; non-interactive commands (``/help``,
+status-style commands) work well. Everything is best-effort and never raises
+into the turn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, List, Optional
+
+from code_puppy.plugins.acp import state
+
+logger = logging.getLogger(__name__)
+
+
+def is_command(text: str) -> bool:
+    """True if ``text`` is a leading ``/slash`` command."""
+    return text.strip().startswith("/")
+
+
+async def run(session_id: str, command: str) -> Optional[str]:
+    """Execute ``command`` and forward its bus output to the client.
+
+    Returns ``None`` when the command was fully handled (its output has been
+    forwarded to the client). Returns a **string** when the command handler
+    signalled "process this as user input" -- i.e. a custom/markdown command
+    that expands into a prompt for the model. The caller then runs the agent on
+    that string, exactly as ``cli_runner`` does with a string command result.
+    Internal ``__SENTINEL__`` strings (e.g. ``__AUTOSAVE_LOAD__``) are TUI-only
+    affordances with no ACP meaning, so they are treated as handled, not modelled.
+    """
+    from code_puppy.command_line.command_handler import handle_command
+    from code_puppy.messaging.message_queue import get_global_queue
+
+    queue = get_global_queue()
+    collected: List[Any] = []
+
+    def _listener(message: Any) -> None:
+        collected.append(message)
+
+    queue.add_listener(_listener)
+    result: Any = None
+    try:
+        result = await asyncio.to_thread(handle_command, command.strip())
+    except Exception:  # noqa: BLE001
+        logger.debug("ACP: slash command failed", exc_info=True)
+    finally:
+        # Drain anything still queued (no renderer thread runs in ACP mode).
+        while True:
+            message = queue.get_nowait()
+            if message is None:
+                break
+            collected.append(message)
+        queue.remove_listener(_listener)
+
+    text = _render(collected)
+    if _is_prompt_expansion(result):
+        # Handler expanded the command into a prompt for the model. Surface any
+        # incidental bus output first, then hand the prompt back to the caller
+        # to run through the agent (not display it as a canned answer).
+        if text:
+            await _emit(session_id, text)
+        return result.strip()
+    await _emit(session_id, text or f"Ran `{command.strip()}`.")
+    return None
+
+
+def _is_prompt_expansion(result: Any) -> bool:
+    """True if ``handle_command`` returned a string to be modelled as a prompt.
+
+    A non-empty string means "process as user input"; ``__SENTINEL__`` strings
+    are internal TUI markers (e.g. ``__AUTOSAVE_LOAD__``) that must not reach
+    the model.
+    """
+    if not isinstance(result, str):
+        return False
+    stripped = result.strip()
+    if not stripped:
+        return False
+    return not (stripped.startswith("__") and stripped.endswith("__"))
+
+
+def _render(messages: List[Any]) -> str:
+    """Flatten captured bus messages into display text."""
+    out: List[str] = []
+    for message in messages:
+        content = getattr(message, "content", None)
+        if content is None:
+            continue
+        out.append(content if isinstance(content, str) else str(content))
+    return "\n".join(s for s in out if s).strip()
+
+
+async def _emit(session_id: str, text: str) -> None:
+    from acp.helpers import update_agent_message_text
+
+    connection = state.get_connection()
+    if connection is None or not text:
+        return
+    try:
+        await connection.session_update(session_id, update_agent_message_text(text))
+    except Exception:  # noqa: BLE001
+        logger.debug("ACP: command output emit failed", exc_info=True)

--- a/code_puppy/plugins/acp/content.py
+++ b/code_puppy/plugins/acp/content.py
@@ -1,0 +1,115 @@
+"""Parse ACP prompt content blocks into a Code Puppy prompt.
+
+The client delivers a prompt as a list of typed content blocks. The SDK parses
+the wire into pydantic models before our ``prompt`` handler runs, so we work
+with objects (``TextContentBlock``, ``ImageContentBlock``,
+``EmbeddedResourceContentBlock``, …) rather than raw dicts.
+
+We split a prompt into three parts that map onto ``run_with_mcp``'s signature:
+
+* **text** — text blocks, embedded text resources (spliced in under a header,
+  honouring the advertised ``embeddedContext`` capability), and resource-link
+  references.
+* **attachments** — image blocks carrying base64 data → pydantic-ai
+  ``BinaryContent`` (honouring the advertised ``image`` capability).
+* **link_attachments** — image blocks carrying only a URI → ``ImageUrl``.
+
+Blocks are duck-typed (``getattr``) so a newer SDK adding fields never breaks
+parsing. Audio is not advertised, so audio blocks degrade to a text note.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from dataclasses import dataclass, field
+from typing import Any, List
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ParsedPrompt:
+    """A prompt split into text + multimodal attachments for ``run_with_mcp``."""
+
+    text: str = ""
+    attachments: List[Any] = field(default_factory=list)  # BinaryContent
+    link_attachments: List[Any] = field(default_factory=list)  # ImageUrl
+
+
+def parse_prompt(blocks: List[Any]) -> ParsedPrompt:
+    """Split a list of ACP content blocks into text + attachments."""
+    parts: List[str] = []
+    result = ParsedPrompt()
+    for block in blocks or []:
+        text = _render_block(block, result)
+        if text:
+            parts.append(text)
+    result.text = "\n\n".join(parts)
+    return result
+
+
+def flatten_prompt(blocks: List[Any]) -> str:
+    """Back-compat text-only view (used where attachments aren't needed)."""
+    return parse_prompt(blocks).text
+
+
+def _render_block(block: Any, result: ParsedPrompt) -> str:
+    block_type = getattr(block, "type", None)
+
+    if block_type == "text":
+        return getattr(block, "text", "") or ""
+
+    if block_type == "resource":
+        return _render_embedded_resource(getattr(block, "resource", None))
+
+    if block_type == "resource_link":
+        uri = getattr(block, "uri", "") or ""
+        name = getattr(block, "name", "") or uri
+        return f"[Referenced resource: {name} ({uri})]" if uri else ""
+
+    if block_type == "image":
+        _collect_image(block, result)
+        return ""
+
+    if block_type == "audio":
+        return "[Audio attached]"
+
+    # Unknown/newer block type: fall back to any ``text`` it carries.
+    return getattr(block, "text", "") or ""
+
+
+def _collect_image(block: Any, result: ParsedPrompt) -> None:
+    """Turn an image block into a BinaryContent (data) or ImageUrl (uri)."""
+    data = getattr(block, "data", None)
+    mime = getattr(block, "mime_type", None) or "image/png"
+    if data:
+        try:
+            from pydantic_ai import BinaryContent
+
+            result.attachments.append(
+                BinaryContent(data=base64.b64decode(data), media_type=mime)
+            )
+            return
+        except Exception:  # noqa: BLE001
+            logger.debug("ACP: could not decode image data", exc_info=True)
+    uri = getattr(block, "uri", None)
+    if uri:
+        try:
+            from pydantic_ai import ImageUrl
+
+            result.link_attachments.append(ImageUrl(url=uri))
+        except Exception:  # noqa: BLE001
+            logger.debug("ACP: could not build ImageUrl", exc_info=True)
+
+
+def _render_embedded_resource(resource: Any) -> str:
+    """Render an embedded resource; only the text variant carries usable text."""
+    if resource is None:
+        return ""
+    text = getattr(resource, "text", None)
+    if not text:
+        uri = getattr(resource, "uri", "") or ""
+        return f"[Embedded binary resource: {uri}]" if uri else ""
+    uri = getattr(resource, "uri", "") or "embedded"
+    return f"<context uri={uri!r}>\n{text}\n</context>"

--- a/code_puppy/plugins/acp/io_delegation.py
+++ b/code_puppy/plugins/acp/io_delegation.py
@@ -1,0 +1,185 @@
+"""Wire Code Puppy's I/O backends to the client (file reads/writes + terminal).
+
+This is the delegation layer that makes Code Puppy *truly native* inside the client:
+workspace file reads/writes go through the client's ``fs/*`` methods (so edits show in
+the client's diff UI and reads see unsaved buffers), and shell commands run through
+the client's ``terminal/*`` methods (so they execute in the client's terminal).
+
+It plugs into the two general core seams in ``code_puppy.tools.io_backends``:
+
+* ``FileSystemBackend`` is **synchronous** — file tools run in Code Puppy's
+  tool threadpool, so ``DelegatedFileSystemBackend`` bridges to the ACP event loop
+  with ``run_coroutine_threadsafe`` (same pattern as the approval backend).
+* ``CommandExecutor`` is **asynchronous** — the shell tool awaits it on the
+  loop, so ``DelegatedCommandExecutor`` calls the client directly.
+
+Both are installed only when the connected client advertises the matching
+capability in ``initialize``; otherwise Code Puppy keeps doing that I/O
+locally. Everything talks to the client through the SDK's ``AgentSideConnection``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from typing import Any, List, Optional, Tuple
+
+from code_puppy.plugins.acp import capabilities, state
+from code_puppy.tools.io_backends import (
+    ExecResult,
+    set_command_executor,
+    set_filesystem_backend,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def shell_invocation(command: str) -> Tuple[str, List[str]]:
+    """Split a shell string into ``(program, args)`` for ``terminal/create``.
+
+    ACP's ``terminal/create`` takes a program + argv, so we run the command
+    string through the platform shell (``sh -c`` / ``cmd /c``).
+    """
+    if sys.platform.startswith("win"):
+        return "cmd", ["/c", command]
+    return "/bin/sh", ["-c", command]
+
+
+class DelegatedFileSystemBackend:
+    """Synchronous workspace file I/O that delegates to the client's ``fs/*``.
+
+    Called from Code Puppy's tool threadpool, so each method bridges to the ACP
+    loop via ``run_coroutine_threadsafe`` and blocks the worker for the answer.
+    The loop stays free to service the round-trip, so there's no deadlock; a
+    guard bails out if we ever end up on the loop thread itself.
+    """
+
+    def read_text_file(
+        self, path: str, line: Optional[int] = None, limit: Optional[int] = None
+    ) -> str:
+        async def _read(conn: Any, sid: str) -> str:
+            response = await conn.read_text_file(
+                path=path, session_id=sid, line=line, limit=limit
+            )
+            return getattr(response, "content", "") or ""
+
+        return self._bridge(_read)
+
+    def write_text_file(self, path: str, content: str) -> None:
+        async def _write(conn: Any, sid: str) -> None:
+            await conn.write_text_file(content=content, path=path, session_id=sid)
+
+        self._bridge(_write)
+
+    def _bridge(self, make_coro):
+        connection = state.get_connection()
+        loop = state.get_loop()
+        session_id = state.get_active_session_id()
+        if connection is None or loop is None:
+            raise RuntimeError("ACP filesystem backend used with no active connection")
+        if session_id is None:
+            raise RuntimeError("ACP filesystem backend used outside a session")
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        if running is loop:
+            raise RuntimeError("ACP fs backend hit on the ACP loop (would deadlock)")
+        return asyncio.run_coroutine_threadsafe(
+            make_coro(connection, session_id), loop
+        ).result()
+
+
+class DelegatedCommandExecutor:
+    """Asynchronous shell execution that delegates to the client's ``terminal/*``.
+
+    Awaited on the ACP loop, so it talks to the client directly. Creates a terminal,
+    waits for exit (honoring ``timeout`` — kills on overrun), collects the
+    combined output, and always releases the terminal handle.
+    """
+
+    async def run(self, command: str, cwd: Optional[str], timeout: int) -> ExecResult:
+        connection = state.get_connection()
+        session_id = state.get_active_session_id()
+        if connection is None:
+            raise RuntimeError("ACP command executor used with no active connection")
+        if session_id is None:
+            raise RuntimeError("ACP command executor used outside a session")
+
+        program, args = shell_invocation(command)
+        created = await connection.create_terminal(
+            command=program, session_id=session_id, args=args, cwd=cwd
+        )
+        terminal_id = getattr(created, "terminal_id", None)
+        if not terminal_id:
+            raise RuntimeError("the client did not return a terminalId")
+
+        timed_out = False
+        exit_code: Optional[int] = None
+        try:
+            try:
+                exited = await asyncio.wait_for(
+                    connection.wait_for_terminal_exit(
+                        session_id=session_id, terminal_id=terminal_id
+                    ),
+                    timeout=timeout,
+                )
+                exit_code = getattr(exited, "exit_code", None)
+            except asyncio.TimeoutError:
+                timed_out = True
+                await self._kill(connection, session_id, terminal_id)
+
+            out = await connection.terminal_output(
+                session_id=session_id, terminal_id=terminal_id
+            )
+            output = getattr(out, "output", "") or ""
+            if exit_code is None:
+                status = getattr(out, "exit_status", None)
+                exit_code = getattr(status, "exit_code", None) if status else None
+        finally:
+            await self._release(connection, session_id, terminal_id)
+
+        if exit_code is None:
+            exit_code = -1 if timed_out else 0
+        return ExecResult(exit_code=int(exit_code), output=output, timed_out=timed_out)
+
+    @staticmethod
+    async def _kill(connection: Any, session_id: str, terminal_id: str) -> None:
+        try:
+            await connection.kill_terminal(
+                session_id=session_id, terminal_id=terminal_id
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("terminal/kill failed", exc_info=True)
+
+    @staticmethod
+    async def _release(connection: Any, session_id: str, terminal_id: str) -> None:
+        try:
+            await connection.release_terminal(
+                session_id=session_id, terminal_id=terminal_id
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("terminal/release failed", exc_info=True)
+
+
+def install(client_capabilities: Any) -> None:
+    """Install the client-backed I/O backends the client can actually service.
+
+    Capability-gated: only reroute reads/writes if the client advertises fs support,
+    and only reroute shell if the client advertises terminal support. Unsupported
+    edges keep running locally.
+    """
+    fs_read, fs_write, terminal = capabilities.client_io_caps(client_capabilities)
+    if fs_read and fs_write:
+        set_filesystem_backend(DelegatedFileSystemBackend())
+        logger.debug("ACP: delegating workspace file I/O to the client")
+    if terminal:
+        set_command_executor(DelegatedCommandExecutor())
+        logger.debug("ACP: delegating shell execution to the client's terminal")
+
+
+def uninstall() -> None:
+    """Clear both backends so Code Puppy resumes local I/O."""
+    set_filesystem_backend(None)
+    set_command_executor(None)

--- a/code_puppy/plugins/acp/io_delegation.py
+++ b/code_puppy/plugins/acp/io_delegation.py
@@ -22,11 +22,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import sys
 from typing import Any, List, Optional, Tuple
 
 from code_puppy.plugins.acp import capabilities, state
 from code_puppy.tools.io_backends import (
+    DirEntry,
     ExecResult,
     set_command_executor,
     set_filesystem_backend,
@@ -47,12 +49,21 @@ def shell_invocation(command: str) -> Tuple[str, List[str]]:
 
 
 class DelegatedFileSystemBackend:
-    """Synchronous workspace file I/O that delegates to the client's ``fs/*``.
+    """Workspace file I/O that delegates *content* to the client's ``fs/*``.
 
-    Called from Code Puppy's tool threadpool, so each method bridges to the ACP
-    loop via ``run_coroutine_threadsafe`` and blocks the worker for the answer.
-    The loop stays free to service the round-trip, so there's no deadlock; a
-    guard bails out if we ever end up on the loop thread itself.
+    Called from Code Puppy's tool threadpool, so the content methods bridge to
+    the ACP loop via ``run_coroutine_threadsafe`` and block the worker for the
+    answer. The loop stays free to service the round-trip, so there's no
+    deadlock; a guard bails out if we ever end up on the loop thread itself.
+
+    Topology/metadata (exists / is_file / is_dir / list_dir / delete /
+    make_dirs) is served from the **local disk**: an ACP editor host runs on
+    the same machine and workspace as the agent, so the local filesystem is the
+    authoritative source for what exists and how the tree is shaped -- only
+    *content* carries the host's unsaved-buffer overlay. This "topology is
+    local" decision lives here, in the adapter that legitimately knows its host
+    shares the disk, and never leaks into the general ``FileSystemBackend``
+    seam (a remote/virtual backend would implement these against its own store).
     """
 
     def read_text_file(
@@ -71,6 +82,41 @@ class DelegatedFileSystemBackend:
             await conn.write_text_file(content=content, path=path, session_id=sid)
 
         self._bridge(_write)
+
+    # --- topology / metadata: local disk (host shares it) ------------------
+    def exists(self, path: str) -> bool:
+        return os.path.exists(path)
+
+    def is_file(self, path: str) -> bool:
+        return os.path.isfile(path)
+
+    def is_dir(self, path: str) -> bool:
+        return os.path.isdir(path)
+
+    def list_dir(self, path: str) -> List[DirEntry]:
+        if not os.path.exists(path):
+            raise FileNotFoundError(path)
+        if not os.path.isdir(path):
+            raise NotADirectoryError(path)
+        entries: List[DirEntry] = []
+        for name in os.listdir(path):
+            full = os.path.join(path, name)
+            try:
+                if os.path.isdir(full):
+                    entries.append(DirEntry(name=name, is_dir=True, size=0))
+                elif os.path.isfile(full):
+                    size = os.path.getsize(full)
+                    entries.append(DirEntry(name=name, is_dir=False, size=size))
+            except OSError:
+                continue
+        return entries
+
+    def delete_file(self, path: str) -> None:
+        os.remove(path)
+
+    def make_dirs(self, path: str) -> None:
+        if path:
+            os.makedirs(path, exist_ok=True)
 
     def _bridge(self, make_coro):
         connection = state.get_connection()

--- a/code_puppy/plugins/acp/mcp_config.py
+++ b/code_puppy/plugins/acp/mcp_config.py
@@ -1,0 +1,66 @@
+"""Attach client-injected MCP servers (from ``session/new``) to a session agent.
+
+ACP lets the client pass MCP server specs per session. We translate each into a
+pydantic-ai MCP server and append it to the agent's ``_mcp_servers`` list;
+``run_with_mcp`` starts them for that session's runs. Best-effort: a malformed
+spec is skipped, never fatal.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _kv(items: Any) -> Dict[str, str]:
+    """Turn a list of ``{name, value}`` models into a plain dict."""
+    out: Dict[str, str] = {}
+    for item in items or []:
+        name = getattr(item, "name", None)
+        if name is not None:
+            out[name] = getattr(item, "value", "") or ""
+    return out
+
+
+def _translate(spec: Any) -> Optional[Any]:
+    """Map one ACP MCP server spec to a pydantic-ai MCP server instance."""
+    from pydantic_ai.mcp import (
+        MCPServerSSE,
+        MCPServerStdio,
+        MCPServerStreamableHTTP,
+    )
+
+    name = getattr(spec, "name", None) or None
+    if getattr(spec, "command", None):
+        return MCPServerStdio(
+            command=spec.command,
+            args=list(getattr(spec, "args", None) or []),
+            env=_kv(getattr(spec, "env", None)) or None,
+            tool_prefix=name,
+        )
+    url = getattr(spec, "url", None)
+    if not url:
+        return None
+    headers = _kv(getattr(spec, "headers", None)) or None
+    if getattr(spec, "type", None) == "sse":
+        return MCPServerSSE(url=url, headers=headers, tool_prefix=name)
+    return MCPServerStreamableHTTP(url=url, headers=headers, tool_prefix=name)
+
+
+def attach(agent: Any, specs: List[Any]) -> None:
+    """Append the translated MCP servers from ``specs`` to ``agent``."""
+    servers: List[Any] = []
+    for spec in specs or []:
+        try:
+            translated = _translate(spec)
+        except Exception:  # noqa: BLE001
+            logger.debug("ACP: could not translate MCP server spec", exc_info=True)
+            continue
+        if translated is not None:
+            servers.append(translated)
+    if not servers:
+        return
+    existing = getattr(agent, "_mcp_servers", None) or []
+    agent._mcp_servers = list(existing) + servers

--- a/code_puppy/plugins/acp/permissions.py
+++ b/code_puppy/plugins/acp/permissions.py
@@ -1,0 +1,160 @@
+"""ACP permission integration — the client's dialog becomes the approval authority.
+
+Code Puppy has two approval edges, and this module wires both to the client via the
+SDK's ``AgentSideConnection.request_permission`` — without touching core tool
+logic or forcing yolo mode:
+
+* **File operations** go through the pluggable *approval backend* seam in
+  ``code_puppy.tools.common``. Sync file tools run in Code Puppy's tool
+  threadpool, so the backend bridges to the ACP event loop via
+  ``run_coroutine_threadsafe`` to ask the client, then blocks the worker thread for
+  the answer. The loop stays free to service the round-trip — no deadlock.
+* **Shell commands** go through the ``run_shell_command`` hook, which is async
+  and already runs on the ACP loop, so it can ``await`` the client directly.
+
+Both edges fail **closed** (deny) if the connection is gone or the client errors.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from typing import Any, Dict, Optional, Tuple
+
+from acp.schema import PermissionOption, ToolCallUpdate
+
+from code_puppy.callbacks import register_callback
+from code_puppy.plugins.acp import state
+
+logger = logging.getLogger(__name__)
+
+# How long to wait for a human in the client to answer a permission dialog. Dialogs
+# can sit for a while; deny (fail closed) if it's truly abandoned.
+_PERMISSION_TIMEOUT_S = 600
+
+# The allow/deny options we present. The client echoes back the chosen ``option_id``.
+_OPTIONS = [
+    PermissionOption(option_id="allow_once", name="Allow", kind="allow_once"),
+    PermissionOption(option_id="reject_once", name="Reject", kind="reject_once"),
+]
+_ALLOW_IDS = {"allow_once"}
+
+
+def _tool_call_ref(title: str) -> ToolCallUpdate:
+    """Build the ``toolCall`` ref a permission request attaches to.
+
+    Reuses the id/title of the tool call currently open (set by
+    ``pre_tool_call``) so the client pins the dialog to the right agent-panel entry;
+    falls back to a standalone id when no tool call is active.
+    """
+    current = state.current_tool_call()
+    if current is not None:
+        name, tool_call_id = current
+        return ToolCallUpdate(tool_call_id=tool_call_id, title=name)
+    return ToolCallUpdate(tool_call_id=f"perm_{uuid.uuid4().hex[:12]}", title=title)
+
+
+async def _ask_client(session_id: str, title: str) -> bool:
+    """Show an allow/deny dialog in the client; return ``True`` if allowed."""
+    connection = state.get_connection()
+    if connection is None:
+        return False
+    try:
+        response = await connection.request_permission(
+            options=list(_OPTIONS),
+            session_id=session_id,
+            tool_call=_tool_call_ref(title),
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("session/request_permission failed; denying")
+        return False
+    outcome = getattr(response, "outcome", None)
+    if getattr(outcome, "outcome", None) == "selected":
+        return getattr(outcome, "option_id", None) in _ALLOW_IDS
+    return False
+
+
+def _approval_backend(
+    title: str, message: str, preview: Optional[str]
+) -> Tuple[bool, Optional[str]]:
+    """Approval backend for file ops; asks the client from the tool threadpool.
+
+    Returns ``(approved, feedback)``. Feedback is always ``None`` — the client's
+    dialog is yes/no, not a free-text channel.
+    """
+    loop = state.get_loop()
+    session_id = state.get_active_session_id()
+    if loop is None or session_id is None:
+        return False, None
+
+    # Guard against being called on the loop thread itself: blocking on
+    # run_coroutine_threadsafe there would deadlock. File tools run off-loop,
+    # so this is belt-and-suspenders.
+    try:
+        running = asyncio.get_running_loop()
+    except RuntimeError:
+        running = None
+    if running is loop:
+        logger.error("Approval backend hit on the ACP loop; denying to avoid deadlock")
+        return False, None
+
+    future = asyncio.run_coroutine_threadsafe(_ask_client(session_id, title), loop)
+    try:
+        allowed = future.result(_PERMISSION_TIMEOUT_S)
+    except Exception:  # noqa: BLE001 - includes TimeoutError
+        # Abandon the in-flight request so it doesn't linger on the loop.
+        future.cancel()
+        logger.exception("ACP approval bridge failed; denying")
+        return False, None
+    return bool(allowed), None
+
+
+async def _on_run_shell_command(
+    context: Any, command: str, cwd: Optional[str] = None, timeout: int = 60
+) -> Optional[Dict[str, Any]]:
+    """``run_shell_command`` hook: gate shell execution through the client.
+
+    Returns ``None`` to allow (the hook's "no objection"), or a
+    ``{"blocked": True, ...}`` dict to deny. Inert outside ACP mode.
+
+    Honors yolo mode: when the user has opted out of approvals we do *not*
+    surface a client dialog, matching Code Puppy's file-permission edge (which
+    skips its prompt in yolo mode). Otherwise ACP + yolo would silently
+    auto-approve file writes yet still prompt for every shell command.
+    """
+    session_id = state.get_active_session_id()
+    if state.get_connection() is None or session_id is None:
+        return None
+    from code_puppy.config import get_yolo_mode
+
+    if get_yolo_mode():
+        return None
+    allowed = await _ask_client(session_id, f"Run shell command: {command}")
+    if allowed:
+        return None
+    return {
+        "blocked": True,
+        "error_message": "Command rejected in the client",
+        "reasoning": "The user denied this shell command in the client's permission dialog.",
+    }
+
+
+def install() -> None:
+    """Install the file approval backend + the shell permission hook."""
+    from code_puppy.tools.common import set_approval_backend
+
+    set_approval_backend(_approval_backend)
+    register_callback("run_shell_command", _on_run_shell_command)
+
+
+def uninstall() -> None:
+    """Remove the approval backend + shell hook so normal stdin prompting resumes."""
+    from code_puppy.callbacks import unregister_callback
+    from code_puppy.tools.common import set_approval_backend
+
+    set_approval_backend(None)
+    try:
+        unregister_callback("run_shell_command", _on_run_shell_command)
+    except Exception:  # noqa: BLE001
+        logger.debug("ACP: run_shell_command unregister failed", exc_info=True)

--- a/code_puppy/plugins/acp/persistence.py
+++ b/code_puppy/plugins/acp/persistence.py
@@ -1,0 +1,197 @@
+"""Persist ACP session history so ``session/load`` and ``session/resume``
+rehydrate real turns across process restarts.
+
+Each session's pydantic-ai message history is pickled under a dedicated
+directory keyed by the ACP session id, reusing code-puppy's existing
+``session_storage`` layer. We keep it separate from the user's autosaves
+(``AUTOSAVE_DIR/acp``) so ACP threads never pollute the ``/resume`` picker.
+
+Alongside the pickle we write a small ACP metadata sidecar (``*_acp.json``)
+recording the session's own ``cwd`` + ``additional_directories``. This is what
+lets ``list_persisted`` surface revivable sessions after a
+restart *with the ``cwd`` that ACP's ``SessionInfo`` requires* -- the pickle
+alone can't answer "where did this thread live?", and ``session_storage``'s
+own ``_meta.json`` records the *process* cwd, which is wrong for per-session
+ACP threads.
+
+Every public entry point takes an optional ``base_dir``: production callers
+omit it (it defaults to ``AUTOSAVE_DIR/acp``), while tests pass an explicit
+directory so persistence is exercised end-to-end with zero shared global
+state -- no monkeypatching of a module-level location.
+
+All operations are best-effort: persistence must never break a live turn, so
+failures are logged and swallowed.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PersistedSession:
+    """On-disk record of an ACP session, enough to re-list + revive it."""
+
+    session_id: str
+    cwd: Optional[str] = None
+    additional_directories: Optional[List[str]] = None
+    updated_at: Optional[str] = None
+
+
+def _base_dir() -> Path:
+    from code_puppy.config import AUTOSAVE_DIR
+
+    return Path(AUTOSAVE_DIR) / "acp"
+
+
+def _resolve_base(base_dir: Optional[Path]) -> Path:
+    """Return the caller's ``base_dir`` or the default ``AUTOSAVE_DIR/acp``."""
+    return Path(base_dir) if base_dir is not None else _base_dir()
+
+
+def _safe_name(session_id: str) -> str:
+    """Sanitise a session id into a filesystem-safe pickle stem."""
+    return "".join(c if (c.isalnum() or c in "-_") else "_" for c in session_id)
+
+
+# Sidecar suffix for ACP-specific metadata. Distinct from ``session_storage``'s
+# own ``_meta.json`` so the two never collide.
+_ACP_META_SUFFIX = "_acp.json"
+
+
+def _acp_meta_path(base: Path, session_id: str) -> Path:
+    return base / f"{_safe_name(session_id)}{_ACP_META_SUFFIX}"
+
+
+def save(
+    session_id: str,
+    agent: Any,
+    cwd: Optional[str] = None,
+    additional_directories: Optional[List[str]] = None,
+    base_dir: Optional[Path] = None,
+) -> None:
+    """Persist ``agent``'s message history under ``session_id`` (best-effort).
+
+    Also writes an ACP metadata sidecar carrying the session's ``cwd`` +
+    ``additional_directories`` so ``list_persisted`` can surface it after a
+    restart.
+    """
+    try:
+        from code_puppy.session_storage import save_session
+
+        base = _resolve_base(base_dir)
+        history = list(agent.get_message_history())
+        if not history:
+            return
+        timestamp = datetime.datetime.now().isoformat()
+        save_session(
+            history=history,
+            session_name=_safe_name(session_id),
+            base_dir=base,
+            timestamp=timestamp,
+            token_estimator=getattr(agent, "estimate_tokens_for_message", lambda _m: 0),
+            auto_saved=True,
+        )
+        _write_acp_meta(
+            base,
+            PersistedSession(
+                session_id=session_id,
+                cwd=cwd,
+                additional_directories=list(additional_directories or []) or None,
+                updated_at=timestamp,
+            ),
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("ACP: session persist failed", exc_info=True)
+
+
+def _write_acp_meta(base: Path, record: PersistedSession) -> None:
+    """Write the ACP metadata sidecar for ``record`` (best-effort, atomic)."""
+    try:
+        base.mkdir(parents=True, exist_ok=True)
+        path = _acp_meta_path(base, record.session_id)
+        payload = {
+            "session_id": record.session_id,
+            "cwd": record.cwd,
+            "additional_directories": record.additional_directories,
+            "updated_at": record.updated_at,
+        }
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        tmp.replace(path)
+    except Exception:  # noqa: BLE001
+        logger.debug("ACP: session meta persist failed", exc_info=True)
+
+
+def load_history(
+    session_id: str, base_dir: Optional[Path] = None
+) -> Optional[List[Any]]:
+    """Return the persisted history for ``session_id``, or ``None`` if none."""
+    try:
+        from code_puppy.session_storage import load_session
+
+        return list(load_session(_safe_name(session_id), _resolve_base(base_dir)))
+    except FileNotFoundError:
+        return None
+    except Exception:  # noqa: BLE001
+        logger.debug("ACP: session load failed", exc_info=True)
+        return None
+
+
+def list_persisted(base_dir: Optional[Path] = None) -> List[PersistedSession]:
+    """Return every ACP session persisted on disk (newest first).
+
+    Reads the ACP metadata sidecars so revivable sessions survive process
+    restarts. A session whose pickle vanished (only the sidecar remains) is
+    skipped -- there is nothing left to rehydrate.
+    """
+    base = _resolve_base(base_dir)
+    if not base.exists():
+        return []
+    records: List[PersistedSession] = []
+    for meta_path in base.glob(f"*{_ACP_META_SUFFIX}"):
+        try:
+            data = json.loads(meta_path.read_text(encoding="utf-8"))
+            session_id = data.get("session_id")
+            if not session_id:
+                continue
+            if not (base / f"{_safe_name(session_id)}.pkl").exists():
+                continue
+            records.append(
+                PersistedSession(
+                    session_id=session_id,
+                    cwd=data.get("cwd"),
+                    additional_directories=data.get("additional_directories"),
+                    updated_at=data.get("updated_at"),
+                )
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("ACP: skipping unreadable session meta", exc_info=True)
+    records.sort(key=lambda r: r.updated_at or "", reverse=True)
+    return records
+
+
+def delete(session_id: str, base_dir: Optional[Path] = None) -> None:
+    """Remove a persisted session's pickle + sidecars (best-effort).
+
+    Called when a client explicitly closes a session so a deliberate close
+    doesn't leave a ghost that reappears in the next ``list_sessions``.
+    """
+    try:
+        base = _resolve_base(base_dir)
+        stem = _safe_name(session_id)
+        for path in (
+            base / f"{stem}.pkl",
+            base / f"{stem}_meta.json",
+            _acp_meta_path(base, session_id),
+        ):
+            path.unlink(missing_ok=True)
+    except Exception:  # noqa: BLE001
+        logger.debug("ACP: session delete failed", exc_info=True)

--- a/code_puppy/plugins/acp/register_callbacks.py
+++ b/code_puppy/plugins/acp/register_callbacks.py
@@ -1,0 +1,110 @@
+"""Plugin registration: the ``--acp`` entry point.
+
+This is the only place the ACP plugin touches Code Puppy's CLI. It:
+  1. contributes a ``--acp`` flag via the ``register_cli_args`` hook, and
+  2. in ``handle_cli_args``, when ``--acp`` is present, boots the ACP server
+     over stdio and returns the short-circuit sentinel so the normal
+     interactive TUI never starts.
+
+Per the contributing guide, all of this rides on existing hooks — no edits to
+``code_puppy/command_line`` or the core CLI runner.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, Optional
+
+from code_puppy.callbacks import register_callback
+
+logger = logging.getLogger(__name__)
+
+
+def _register_cli_args(parser: Any) -> None:
+    """Add the ``--acp`` flag to Code Puppy's argument parser."""
+    parser.add_argument(
+        "--acp",
+        action="store_true",
+        help="Run as a native agent over the Agent Client Protocol (ACP), speaking JSON-RPC over stdio.",
+    )
+
+
+def _handle_cli_args(args: Any) -> Optional[Dict[str, Any]]:
+    """Boot the ACP server when ``--acp`` is set; otherwise stand down.
+
+    Returns the ``{"handled": True, "exit_code": ...}`` sentinel so the CLI
+    runner exits after the ACP session ends instead of falling through to the
+    interactive TUI. Any other invocation returns ``None`` (not ours).
+
+    This hook is invoked *synchronously from within* Code Puppy's already-
+    running ``asyncio.run(main())`` loop, so we cannot start a nested loop
+    here. Instead we run the server on its own event loop in a dedicated
+    thread and block until it finishes — which keeps ``main()`` parked so the
+    TUI never starts.
+    """
+    if not getattr(args, "acp", False):
+        return None
+
+    import threading
+
+    box: Dict[str, int] = {"exit_code": 0}
+
+    def _run() -> None:
+        try:
+            box["exit_code"] = asyncio.run(_serve())
+        except Exception:  # noqa: BLE001 - never leak a traceback onto stdout
+            logger.exception("ACP server crashed")
+            box["exit_code"] = 1
+
+    thread = threading.Thread(target=_run, name="acp-server")
+    thread.start()
+    thread.join()
+    return {"handled": True, "exit_code": box["exit_code"]}
+
+
+async def _serve() -> int:
+    """Bind stdio via the ACP SDK and run one connection to completion.
+
+    Before serving we protect stdout — the JSON-RPC channel — by pointing
+    Code Puppy's streaming console and the root logger at stderr. In ACP mode
+    the interactive path that normally calls ``set_streaming_console`` is
+    short-circuited, so without this the streaming console would fall back to a
+    plain ``Console()`` on stdout and corrupt the protocol.
+
+    ``acp.run_agent`` owns the wire (stdio binding, JSON-RPC framing, param
+    parsing); we hand it a ``CodePuppyAgent`` and tear down the approval + I/O
+    backends afterwards so the process leaves no global seams set.
+    """
+    import sys
+
+    from acp import run_agent
+    from rich.console import Console
+
+    from code_puppy.agents.event_stream_handler import set_streaming_console
+    from code_puppy.plugins.acp import io_delegation, permissions, state
+    from code_puppy.plugins.acp.agent import CodePuppyAgent
+
+    # Route all incidental console output to stderr; stdout is JSON-RPC only.
+    set_streaming_console(Console(file=sys.stderr))
+    logging.basicConfig(stream=sys.stderr, level=logging.WARNING)
+
+    agent = CodePuppyAgent()
+    try:
+        await run_agent(agent)
+    finally:
+        agent.shutdown()
+        permissions.uninstall()
+        io_delegation.uninstall()
+        state.set_connection(None, None)
+    return 0
+
+
+def register() -> None:
+    """Register the ACP CLI hooks."""
+    register_callback("register_cli_args", _register_cli_args)
+    register_callback("handle_cli_args", _handle_cli_args)
+    logger.debug("ACP plugin callbacks registered")
+
+
+register()

--- a/code_puppy/plugins/acp/replay.py
+++ b/code_puppy/plugins/acp/replay.py
@@ -1,0 +1,114 @@
+"""Replay a rehydrated session's history back to the client on load/resume.
+
+The ACP ``session/load`` (and ``session/resume``) contract is not just "rebuild
+the agent's memory" -- the client rebuilds its *own* thread UI from the
+``session/update`` notifications the agent streams while handling the request.
+An agent that only rehydrates its internal ``_message_history`` (and streams
+nothing) leaves the client with an empty thread: the conversation looks gone,
+and clients that treat an empty replayed thread as dead will discard it
+outright.
+
+So on load/resume we walk the rehydrated pydantic-ai message history and emit
+one ``session/update`` per visible turn -- user prompts, assistant text,
+assistant thinking, and past tool calls (as already-``completed`` entries) --
+in order, before the load response returns. System prompts and tool-return
+plumbing are intentionally skipped: they are model-plumbing, not conversation
+the user needs to see re-rendered.
+
+Everything here is best-effort: a replay hiccup must never fail the load, so
+per-update send failures are logged and swallowed.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any, Iterable, List
+
+from acp.helpers import (
+    start_tool_call,
+    update_agent_message_text,
+    update_agent_thought_text,
+    update_user_message_text,
+)
+
+from code_puppy.plugins.acp import state
+
+logger = logging.getLogger(__name__)
+
+
+async def replay_history(session_id: str, history: Iterable[Any]) -> None:
+    """Stream ``history`` back to the client as ordered ``session/update``s.
+
+    No-op when there is no connection or nothing to replay.
+    """
+    connection = state.get_connection()
+    if connection is None:
+        return
+    for message in history or []:
+        for update in _updates_for_message(message):
+            try:
+                await connection.session_update(session_id, update)
+            except Exception:  # noqa: BLE001
+                logger.debug("ACP: history replay update failed", exc_info=True)
+
+
+def _updates_for_message(message: Any) -> List[Any]:
+    """Map one pydantic-ai message to zero or more ACP updates.
+
+    Discriminates on each part's ``part_kind`` (stable across pydantic-ai
+    versions) rather than importing concrete part classes, so a version bump
+    that renames a class doesn't silently drop history.
+    """
+    updates: List[Any] = []
+    for part in getattr(message, "parts", None) or []:
+        kind = getattr(part, "part_kind", None)
+        if kind == "user-prompt":
+            text = _text_of(getattr(part, "content", None))
+            if text:
+                updates.append(update_user_message_text(text))
+        elif kind == "text":
+            text = _text_of(getattr(part, "content", None))
+            if text:
+                updates.append(update_agent_message_text(text))
+        elif kind == "thinking":
+            text = _text_of(getattr(part, "content", None))
+            if text:
+                updates.append(update_agent_thought_text(text))
+        elif kind == "tool-call":
+            updates.append(_tool_call_update(part))
+        # system-prompt / tool-return: model plumbing, not replayed.
+    return updates
+
+
+def _tool_call_update(part: Any) -> Any:
+    """Render a past tool call as an already-``completed`` tool-call entry.
+
+    Replayed tool calls are historical, so they open and close in one update
+    (status ``completed``). A fresh id is minted -- the original call id isn't
+    needed since nothing will update this entry again.
+    """
+    tool_name = str(getattr(part, "tool_name", "") or "tool")
+    return start_tool_call(
+        f"tc_{uuid.uuid4().hex[:12]}",
+        tool_name,
+        kind="other",
+        status="completed",
+    )
+
+
+def _text_of(content: Any) -> str:
+    """Flatten a part's content to plain text.
+
+    Handles the string case and pydantic-ai's multimodal list form (where a
+    user prompt is a list of str + binary/image blocks): string items are
+    kept, non-text blocks are dropped, since replay is a text reconstruction.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, (list, tuple)):
+        parts = [item for item in content if isinstance(item, str)]
+        return "\n".join(p for p in parts if p).strip()
+    return str(content).strip()

--- a/code_puppy/plugins/acp/session.py
+++ b/code_puppy/plugins/acp/session.py
@@ -1,0 +1,294 @@
+"""``ACPSession`` — one client thread bound to one Code Puppy agent.
+
+Each ACP session id maps to a single ``BaseAgent`` instance whose
+``_message_history`` persists across ``session/prompt`` calls, giving native
+multi-turn conversations. The session also carries the ``cwd`` the client
+opened the thread in, so tools resolve paths relative to the right project.
+
+Cancellation (``session/cancel``) is real: the prompt runs as an
+``asyncio.Task`` we hold a handle to, so a cancel notification cancels that
+task. pydantic-ai surfaces the ``CancelledError``, which we translate into the
+``cancelled`` stop reason for the in-flight ``session/prompt`` reply.
+
+Each turn also reports token usage (mapped from the pydantic-ai run result)
+back on the ``PromptResponse`` so the client can show cost/usage.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, List, Optional
+
+from acp.schema import Usage
+
+from code_puppy.plugins.acp import commands, content, persistence, state
+
+if TYPE_CHECKING:
+    from code_puppy.agents.base_agent import BaseAgent
+
+logger = logging.getLogger(__name__)
+
+# ACP stop reasons a ``session/prompt`` may resolve to.
+STOP_END_TURN = "end_turn"
+STOP_CANCELLED = "cancelled"
+STOP_REFUSAL = "refusal"
+
+
+@dataclass
+class PromptResult:
+    """Outcome of one turn: an ACP stop reason plus optional token usage."""
+
+    stop_reason: str
+    usage: Optional[Usage] = None
+
+
+class ACPSession:
+    """State + run lifecycle for a single client agent thread."""
+
+    def __init__(
+        self,
+        session_id: str,
+        agent: "BaseAgent",
+        cwd: Optional[str] = None,
+        additional_directories: Optional[List[str]] = None,
+        mcp_specs: Optional[List[Any]] = None,
+    ) -> None:
+        self.session_id = session_id
+        self.agent = agent
+        self.cwd = cwd
+        self.additional_directories = list(additional_directories or [])
+        # Raw client-injected ACP MCP specs, retained so they can be re-attached
+        # if the session's agent is rebuilt (e.g. on ``session/set_mode``).
+        self.mcp_specs = list(mcp_specs or [])
+        # Set while a ``session/prompt`` is in flight so ``cancel`` has a task
+        # to cancel. ``None`` means idle.
+        self._task: Optional["asyncio.Task[Any]"] = None
+
+    async def prompt(self, blocks: List[Any]) -> PromptResult:
+        """Run the agent on a user turn and return the stop reason + usage.
+
+        Flow:
+          1. Flatten ACP content blocks into the user text.
+          2. Point the messaging session context + run context at this session
+             so streamed deltas and tool calls are tagged/correlated.
+          3. Run ``agent.run_with_mcp(text)`` as a cancellable task — history
+             stays on the agent instance, so the next turn continues.
+          4. If nothing streamed (streaming disabled/empty), send the final
+             result text as one ``agent_message_chunk`` so the client sees it.
+        """
+        from code_puppy.messaging import set_session_context
+
+        parsed = content.parse_prompt(blocks)
+        text = parsed.text
+        if not text.strip() and not parsed.attachments and not parsed.link_attachments:
+            return PromptResult(STOP_END_TURN)
+        # A leading /slash command is executed by Code Puppy's command handler
+        # (not the model), with its output forwarded to the client. If the
+        # handler expands the command into a prompt (a string result, e.g. a
+        # markdown/custom command), we fall through and run the model on it,
+        # exactly as cli_runner does with a string command result.
+        if (
+            not parsed.attachments
+            and not parsed.link_attachments
+            and commands.is_command(text)
+        ):
+            expanded = await commands.run(self.session_id, text)
+            if not expanded:
+                return PromptResult(STOP_END_TURN)
+            text = expanded
+        # Resolve this session's relative paths against its own cwd -- WITHOUT
+        # a process-global os.chdir (which would corrupt the SDK's own I/O,
+        # subprocesses, and any concurrent session). The ContextVar is copied
+        # into the run task + its tool threads.
+        from code_puppy.tools.common import (
+            reset_working_directory,
+            set_working_directory,
+        )
+
+        cwd_token = set_working_directory(self.cwd) if self.cwd else None
+
+        set_session_context(self.session_id)
+        state.begin_run(self.session_id)
+        result: Any = None
+        error: Optional[BaseException] = None
+        try:
+            self._task = asyncio.ensure_future(
+                self.agent.run_with_mcp(
+                    text,
+                    attachments=parsed.attachments or None,
+                    link_attachments=parsed.link_attachments or None,
+                )
+            )
+            result = await self._task
+            self._absorb_history(result)
+            stop_reason = STOP_END_TURN
+        except asyncio.CancelledError:
+            # Two ways we land here:
+            #  * our own session/cancel cancelled the inner run task -> it is
+            #    cancelled and we report ``cancelled``.
+            #  * THIS prompt coroutine was cancelled (e.g. SDK connection
+            #    teardown) while the inner task is still live -> cancel it so it
+            #    can't outlive us, then propagate the cancellation rather than
+            #    silently reporting a normal ``cancelled`` turn.
+            task = self._task
+            if task is not None and not task.cancelled():
+                task.cancel()
+                raise
+            stop_reason = STOP_CANCELLED
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("ACP: agent run failed")
+            error = exc
+            stop_reason = STOP_REFUSAL
+        finally:
+            streamed = state.streamed_text()
+            self._task = None
+            state.end_run()
+            set_session_context(None)
+            if cwd_token is not None:
+                reset_working_directory(cwd_token)
+
+        # Persist off the event loop so pickling a large history can't stall
+        # other sessions' streaming. Best-effort; never fails the turn. (Skipped
+        # on the propagate-cancellation path above, which re-raises before here.)
+        try:
+            await asyncio.to_thread(
+                persistence.save,
+                self.session_id,
+                self.agent,
+                self.cwd,
+                self.additional_directories,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("ACP: async persist failed", exc_info=True)
+
+        if stop_reason == STOP_END_TURN and not streamed and result is not None:
+            await self._send_final_result(result)
+        elif stop_reason == STOP_REFUSAL:
+            await self._send_error_notice(error)
+        return PromptResult(stop_reason, _to_acp_usage(result))
+
+    def _absorb_history(self, result: Any) -> None:
+        """Fold a completed run's full message list back into the agent.
+
+        ``run_with_mcp`` (the shared runtime) does NOT write the turn's
+        request+response back onto ``agent._message_history`` on the normal
+        path -- the caller must, exactly as ``cli_runner`` does after each
+        interactive turn. Without this the agent forgets every turn the moment
+        it ends: the next prompt runs with empty history, and persistence saves
+        a history containing only the user's prompt (no assistant reply). So we
+        replace the agent's history with ``result.all_messages()`` here, which
+        is what makes ACP multi-turn memory *and* load/resume replay real.
+        """
+        if result is None:
+            return
+        try:
+            messages = result.all_messages()
+        except Exception:  # noqa: BLE001
+            return
+        if messages:
+            self.agent.set_message_history(list(messages))
+
+    def cancel(self) -> None:
+        """Cancel the in-flight run, if any. No-op when idle.
+
+        Besides cancelling the asyncio task, force-kill any local shell
+        processes the run spawned so they don't orphan. (Shells delegated to
+        the client run client-side and are unaffected.)
+        """
+        task = self._task
+        if task is not None and not task.done():
+            task.cancel()
+        try:
+            from code_puppy.tools.command_runner import (
+                kill_all_running_shell_processes,
+            )
+
+            kill_all_running_shell_processes()
+        except Exception:  # noqa: BLE001
+            logger.debug("ACP: shell kill on cancel failed", exc_info=True)
+
+    async def _send_error_notice(self, error: Optional[BaseException]) -> None:
+        """Tell the client a turn failed, so it isn't a silent empty response.
+
+        A ``refusal`` stop reason alone renders as nothing in most clients; a
+        short message chunk makes the failure visible without leaking a stack
+        trace (the full traceback is logged to stderr).
+        """
+        from acp.helpers import update_agent_message_text
+
+        connection = state.get_connection()
+        if connection is None:
+            return
+        detail = f": {error}" if error else "."
+        try:
+            await connection.session_update(
+                self.session_id,
+                update_agent_message_text(f"\u26a0\ufe0f The agent run failed{detail}"),
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("ACP: failed to send error notice", exc_info=True)
+
+    async def _send_final_result(self, result: Any) -> None:
+        """Emit the run's final text when nothing streamed during the turn."""
+        from acp.helpers import update_agent_message_text
+
+        final_text = self._extract_result_text(result)
+        if not final_text:
+            return
+        connection = state.get_connection()
+        if connection is None:
+            return
+        try:
+            await connection.session_update(
+                self.session_id, update_agent_message_text(final_text)
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception("ACP: failed to send final result")
+
+    @staticmethod
+    def _extract_result_text(result: Any) -> str:
+        """Pull display text out of a pydantic-ai run result.
+
+        Mirrors ``_runtime``'s output extraction: prefer ``output``, then the
+        legacy ``data`` attribute, then ``str()``.
+        """
+        for attr in ("output", "data"):
+            value = getattr(result, attr, None)
+            if value:
+                return str(value)
+        return str(result) if result else ""
+
+
+def _to_acp_usage(result: Any) -> Optional[Usage]:
+    """Map a pydantic-ai run result's usage onto ACP's ``Usage`` model.
+
+    Field names have drifted across pydantic-ai versions, so each ACP field is
+    resolved from a list of candidate attributes. Returns ``None`` when no
+    usage is available so we simply omit it from the response.
+    """
+    if result is None:
+        return None
+    try:
+        usage = result.usage()
+    except Exception:  # noqa: BLE001
+        return None
+    if usage is None:
+        return None
+
+    def pick(*names: str) -> Optional[int]:
+        for name in names:
+            value = getattr(usage, name, None)
+            if value is not None:
+                return int(value)
+        return None
+
+    return Usage(
+        input_tokens=pick("input_tokens", "request_tokens", "prompt_tokens"),
+        output_tokens=pick("output_tokens", "response_tokens", "completion_tokens"),
+        total_tokens=pick("total_tokens"),
+        cached_read_tokens=pick("cache_read_tokens", "cached_read_tokens"),
+        cached_write_tokens=pick("cache_write_tokens", "cached_write_tokens"),
+        thought_tokens=pick("thinking_tokens", "thought_tokens", "reasoning_tokens"),
+    )

--- a/code_puppy/plugins/acp/session_config.py
+++ b/code_puppy/plugins/acp/session_config.py
@@ -1,0 +1,180 @@
+"""Session model selection + config options exposed to the ACP client.
+
+Everything is delivered as ACP **config options** (``session/set_config_option``)
+-- clients (Zed, opencode, oh-my-pi) bind each bottom-bar dropdown to a config
+option by its ``category``, so this is the shape that actually populates them:
+
+* **Model picker** — a ``select`` option tagged ``category="model"``:
+  ``{id: "model", category: "model", type: "select", ...}``. Backed by
+  ``model_picker_completion.load_model_names`` + ``config.get_global_model_name``
+  / ``set_model_name``. Changing it rebinds the live session's model.
+* **Mode picker** — a ``select`` option tagged ``category="mode"``. Code Puppy
+  has exactly one operating mode, so this is a single "Default" entry; we still
+  send it so the client's mode dropdown reads "Default" instead of an empty
+  "Unknown" control. (ACP's top-level ``SessionModeState`` is a *different*
+  mechanism that Zed 1.7.2 does not bind that dropdown to -- config options are
+  what work across clients.)
+* **Streaming toggle** — an On/Off ``select`` option. (A boolean option would
+  be more natural, but Zed 1.7.2 renders only ``select`` options in its bottom
+  bar -- a boolean shows as "Unknown" -- so every control here is a select.) We
+  deliberately expose only this safe setting; we do **not** expose a
+  yolo/approval-bypass toggle (permissions must stay client-driven).
+
+All accessors are best-effort and degrade to "nothing to offer" on error.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Optional, Tuple
+
+from acp.schema import (
+    SessionConfigOptionSelect,
+    SessionConfigSelectOption,
+)
+
+logger = logging.getLogger(__name__)
+
+# Config-option ids. ``MODEL_OPTION_ID`` is public because ``agent.py`` keys
+# its "rebind the live model" behaviour off it.
+MODEL_OPTION_ID = "model"
+MODE_OPTION_ID = "mode"
+_STREAMING_ID = "enable_streaming"
+_STREAMING_ON = "on"
+_STREAMING_OFF = "off"
+
+# Code Puppy has exactly one operating mode. We still advertise it as a
+# category="mode" select so the client's mode dropdown shows "Default" rather
+# than an empty "Unknown" control. (Model selection is the separate
+# category="model" option; ACP clients bind each dropdown to its category.)
+_DEFAULT_MODE_ID = "default"
+
+
+def _mode_option() -> SessionConfigOptionSelect:
+    """Advertise Code Puppy's single "Default" mode as a category=mode select.
+
+    There is nothing to switch between, but a one-item option keeps the
+    client's mode dropdown meaningful instead of blank.
+    """
+    return SessionConfigOptionSelect(
+        id=MODE_OPTION_ID,
+        name="Mode",
+        category="mode",
+        type="select",
+        current_value=_DEFAULT_MODE_ID,
+        options=[
+            SessionConfigSelectOption(
+                value=_DEFAULT_MODE_ID,
+                name="Default",
+                description="Standard Code Puppy session",
+            )
+        ],
+    )
+
+
+def _model_choices() -> Tuple[List[str], Optional[str]]:
+    """Return ``(available_model_names, current_selection)`` from config.
+
+    ``current`` is coerced into the available list so a picker always has a
+    valid selection. Returns ``([], None)`` when there are no models to offer.
+    """
+    from code_puppy.command_line.model_picker_completion import load_model_names
+    from code_puppy.config import get_global_model_name
+
+    names = list(load_model_names() or [])
+    if not names:
+        return [], None
+    current = get_global_model_name()
+    return names, (current if current in names else names[0])
+
+
+def _model_option() -> Optional[SessionConfigOptionSelect]:
+    """Build the model picker as a ``category="model"`` select option.
+
+    Returns ``None`` when there are no models to offer.
+    """
+    names, current = _model_choices()
+    if not names or current is None:
+        return None
+    return SessionConfigOptionSelect(
+        id=MODEL_OPTION_ID,
+        name="Model",
+        category="model",
+        type="select",
+        current_value=current,
+        options=[SessionConfigSelectOption(value=n, name=n) for n in names],
+    )
+
+
+def set_model(model_id: str) -> bool:
+    """Switch the active model. Returns ``True`` on success."""
+    try:
+        from code_puppy.config import set_model_name
+
+        set_model_name(model_id)
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("ACP: set_model failed", exc_info=True)
+        return False
+
+
+def config_options() -> List[Any]:
+    """Build the config-option list for a session (model picker + streaming).
+
+    Order matters for presentation: the model picker leads. Either entry is
+    omitted if it can't be built, so a config hiccup never sinks the session.
+    """
+    opts: List[Any] = []
+    try:
+        model_opt = _model_option()
+        if model_opt is not None:
+            opts.append(model_opt)
+    except Exception:  # noqa: BLE001
+        logger.debug("ACP: could not build model option", exc_info=True)
+    try:
+        opts.append(_mode_option())
+    except Exception:  # noqa: BLE001
+        logger.debug("ACP: could not build mode option", exc_info=True)
+    try:
+        from code_puppy.config import get_enable_streaming
+
+        # A select (On/Off), not a boolean: Zed 1.7.2 only renders select-type
+        # config options in its bottom bar; a boolean shows as "Unknown".
+        opts.append(
+            SessionConfigOptionSelect(
+                id=_STREAMING_ID,
+                name="Streaming responses",
+                type="select",
+                current_value=_STREAMING_ON
+                if get_enable_streaming()
+                else _STREAMING_OFF,
+                options=[
+                    SessionConfigSelectOption(value=_STREAMING_ON, name="On"),
+                    SessionConfigSelectOption(value=_STREAMING_OFF, name="Off"),
+                ],
+                description="Stream model output token-by-token.",
+            )
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("ACP: could not build streaming option", exc_info=True)
+    return opts
+
+
+def apply_config_option(config_id: str, value: Any) -> List[Any]:
+    """Apply a config-option change and return the refreshed option list."""
+    try:
+        if config_id == MODEL_OPTION_ID:
+            set_model(str(value))
+        elif config_id == _STREAMING_ID:
+            from code_puppy.config import set_config_value
+
+            set_config_value("enable_streaming", "true" if _as_bool(value) else "false")
+    except Exception:  # noqa: BLE001
+        logger.debug("ACP: apply_config_option failed", exc_info=True)
+    return config_options()
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in ("1", "true", "yes", "on")

--- a/code_puppy/plugins/acp/state.py
+++ b/code_puppy/plugins/acp/state.py
@@ -1,0 +1,137 @@
+"""Run context for the active ACP connection.
+
+Code Puppy's approval and I/O seams live at its *edges* (the
+``run_shell_command`` hook, the ``tools.common`` approval backend, and the
+``tools.io_backends`` filesystem/command backends). Those are plain module
+functions with no reference to the live ACP connection, so this module is the
+small, explicit bridge between them and the running agent.
+
+Two kinds of state live here:
+
+* **Connection-scoped** — the ``AgentSideConnection`` handle + its event loop.
+  There is exactly one connection per process (set once, on connect), so these
+  are plain module globals.
+* **Run-scoped** — the id of the session whose prompt is currently running, the
+  stack of in-flight tool calls (so permission dialogs and updates correlate to
+  the tool that triggered them), and whether any assistant text has streamed.
+  A single ACP connection multiplexes *multiple* sessions, and the SDK
+  dispatches each ``session/prompt`` as its own task, so two prompts can be in
+  flight at once. Run-scoped state therefore lives in a **``ContextVar``** — set
+  in ``begin_run`` before the run task is spawned, so each prompt task (and the
+  tool coroutines/threads it copies its context into) sees its *own* run, never
+  a sibling's. The var holds a shared mutable dict so a mutation made deep in
+  the run (e.g. ``note_streamed_text`` from a streamed delta) is visible back in
+  the prompt coroutine's ``finally`` that reads it.
+
+Keeping this here — rather than smuggled through globals or reached via the
+agent object — keeps the coupling visible and testable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import uuid
+from typing import Any, Dict, List, Optional, Tuple
+
+_CONNECTION: Any = None
+_LOOP: Optional[asyncio.AbstractEventLoop] = None
+
+# Per-run state, isolated per prompt task via a ContextVar. ``None`` means "no
+# run active in this context". The value is a mutable dict:
+#   {"session_id": str, "streamed": bool, "tool_stack": List[(name, id)]}
+# so writes made in child tasks/threads (which copy this context) are visible in
+# the prompt coroutine that created the run.
+_RUN: contextvars.ContextVar[Optional[Dict[str, Any]]] = contextvars.ContextVar(
+    "acp_run", default=None
+)
+
+
+# ---- Connection lifecycle -------------------------------------------------
+def set_connection(connection: Any, loop: Optional[asyncio.AbstractEventLoop]) -> None:
+    """Register (or clear, with ``None``) the live connection + its loop."""
+    global _CONNECTION, _LOOP
+    _CONNECTION = connection
+    _LOOP = loop
+
+
+def get_connection() -> Any:
+    """Return the ``AgentSideConnection``, or ``None`` when not in ACP mode."""
+    return _CONNECTION
+
+
+def get_loop() -> Optional[asyncio.AbstractEventLoop]:
+    """Return the ACP event loop, or ``None`` when not in ACP mode."""
+    return _LOOP
+
+
+# ---- Per-run context ------------------------------------------------------
+def begin_run(session_id: str) -> None:
+    """Mark ``session_id`` as the run whose events/permissions we handle.
+
+    Sets a fresh run-state dict in the current context. Call this in the prompt
+    coroutine *before* spawning the run task, so the task (and every tool
+    coroutine/thread that copies the context) shares this exact dict.
+    """
+    _RUN.set(
+        {
+            "session_id": session_id,
+            "streamed": False,
+            "tool_stack": [],
+        }
+    )
+
+
+def end_run() -> None:
+    """Detach after a run; late events/permissions in this context are dropped."""
+    _RUN.set(None)
+
+
+def get_active_session_id() -> Optional[str]:
+    """The session id of the in-flight run in this context, or ``None``."""
+    run = _RUN.get()
+    return run["session_id"] if run else None
+
+
+# ---- Streamed-text tracking (final-result fallback) -----------------------
+def note_streamed_text() -> None:
+    """Record that at least one assistant text delta streamed this run."""
+    run = _RUN.get()
+    if run is not None:
+        run["streamed"] = True
+
+
+def streamed_text() -> bool:
+    """Whether any assistant text streamed during the active run."""
+    run = _RUN.get()
+    return bool(run and run["streamed"])
+
+
+# ---- Tool-call correlation ------------------------------------------------
+def push_tool_call(tool_name: str) -> str:
+    """Open a tool call, returning a fresh id to report to the client."""
+    tool_call_id = f"tc_{uuid.uuid4().hex[:12]}"
+    run = _RUN.get()
+    if run is not None:
+        run["tool_stack"].append((tool_name, tool_call_id))
+    return tool_call_id
+
+
+def pop_tool_call(tool_name: str) -> Optional[str]:
+    """Close the most recent open call for ``tool_name`` and return its id."""
+    run = _RUN.get()
+    if run is None:
+        return None
+    stack: List[Tuple[str, str]] = run["tool_stack"]
+    for i in range(len(stack) - 1, -1, -1):
+        if stack[i][0] == tool_name:
+            return stack.pop(i)[1]
+    return None
+
+
+def current_tool_call() -> Optional[Tuple[str, str]]:
+    """Return the most recent open ``(tool_name, tool_call_id)``, or ``None``."""
+    run = _RUN.get()
+    if not run or not run["tool_stack"]:
+        return None
+    return run["tool_stack"][-1]

--- a/code_puppy/tools/command_runner.py
+++ b/code_puppy/tools/command_runner.py
@@ -1179,9 +1179,68 @@ async def _execute_shell_command(
     # This is reference-counted: listener starts on first command, stops on last
     _acquire_keyboard_context()
     try:
+        # When a command executor backend is installed (e.g. an editor host
+        # running commands in its own terminal), delegate execution to it.
+        # This runs on the event loop, so we can await the host directly.
+        from code_puppy.tools.io_backends import get_command_executor
+
+        executor = get_command_executor()
+        if executor is not None:
+            return await _execute_via_backend(
+                executor, command, cwd, timeout, group_id, silent
+            )
         return await _run_command_inner(command, cwd, timeout, group_id, silent=silent)
     finally:
         _release_keyboard_context()
+
+
+async def _execute_via_backend(
+    executor,
+    command: str,
+    cwd: str | None,
+    timeout: int,
+    group_id: str,
+    silent: bool,
+) -> ShellCommandOutput:
+    """Run a command through an installed ``CommandExecutor`` backend.
+
+    Streams the host's combined output to the UI as shell lines (so the run
+    still looks live inside Code Puppy) and maps the result to the standard
+    ``ShellCommandOutput``. Failures fall back to a structured error rather
+    than raising, matching ``_run_command_inner``.
+    """
+    start = time.perf_counter()
+    try:
+        result = await executor.run(command, cwd, timeout)
+    except Exception as e:
+        if not silent:
+            emit_error(traceback.format_exc(), message_group=group_id)
+        return ShellCommandOutput(
+            success=False,
+            command=command,
+            error=f"Error executing command {str(e)}",
+            stdout=None,
+            stderr=None,
+            exit_code=-1,
+            execution_time=time.perf_counter() - start,
+            timeout=False,
+        )
+
+    output = result.output or ""
+    if output and not silent:
+        bus = get_message_bus()
+        for line in output.splitlines():
+            bus.emit_shell_line(line)
+    truncated = "\n".join(_truncate_line(line) for line in output.split("\n")[-256:])
+    return ShellCommandOutput(
+        success=(result.exit_code == 0 and not result.timed_out),
+        command=command,
+        stdout=truncated or None,
+        stderr=None,
+        exit_code=result.exit_code,
+        execution_time=time.perf_counter() - start,
+        timeout=result.timed_out,
+    )
 
 
 def _run_command_sync(

--- a/code_puppy/tools/common.py
+++ b/code_puppy/tools/common.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import fnmatch
 import hashlib
 import os
@@ -73,6 +74,101 @@ def _deny_noninteractive_approval(title: str) -> tuple[bool, None]:
     """Fail closed when approval is requested without an interactive stdin."""
     emit_warning(f"Approval for '{title}' rejected: stdin is not interactive.")
     return False, None
+
+
+# =============================================================================
+# Pluggable approval backend
+# =============================================================================
+#
+# By default, user approval is collected via an interactive stdin prompt
+# (see ``get_user_approval`` / ``get_user_approval_async``). Frontends that
+# have no stdin to prompt on -- a GUI, a web UI, or an editor speaking the
+# Agent Client Protocol -- would otherwise fail closed (auto-deny) via
+# ``_deny_noninteractive_approval`` above.
+#
+# An embedder can instead register an approval *backend*: a callable that
+# renders the request in its own UI and returns the user's decision. When a
+# backend is registered it takes precedence over the stdin prompt in BOTH the
+# sync and async approval paths. The backend is a plain synchronous callable
+# (an async backend would have to bridge two event loops); the async path
+# runs it in a worker thread so it never blocks the running loop.
+
+ApprovalBackend = Callable[[str, str, Optional[str]], Tuple[bool, Optional[str]]]
+_APPROVAL_BACKEND: Optional[ApprovalBackend] = None
+
+
+def set_approval_backend(backend: Optional[ApprovalBackend]) -> None:
+    """Install (or clear, with ``None``) the approval backend.
+
+    ``backend(title, message, preview) -> (approved, feedback)``. When set, it
+    replaces the interactive stdin prompt for every approval request, so a
+    non-terminal frontend can gate file/shell operations in its own UI.
+    """
+    global _APPROVAL_BACKEND
+    _APPROVAL_BACKEND = backend
+
+
+def get_approval_backend() -> Optional[ApprovalBackend]:
+    """Return the installed approval backend, or ``None`` for stdin prompting."""
+    return _APPROVAL_BACKEND
+
+
+def _approval_message_text(content) -> str:
+    """Flatten Rich ``Text``/``str`` approval content to plain text."""
+    plain = getattr(content, "plain", None)
+    return plain if isinstance(plain, str) else str(content)
+
+
+# =============================================================================
+# Active working directory (async-safe base for relative path resolution)
+# =============================================================================
+#
+# Tools resolve relative paths against a base directory. By default that base is
+# the process CWD (``os.getcwd()``). An embedder that runs Code Puppy against a
+# workspace it did not ``cd`` into -- e.g. an editor speaking the Agent Client
+# Protocol, where each session carries its own ``cwd`` -- can override the base
+# *without mutating process-global state* (``os.chdir`` would corrupt the SDK's
+# own I/O, subprocesses, and any concurrent session).
+#
+# This uses a ``ContextVar`` so the override is isolated per asyncio task and
+# propagates into sync tools (pydantic-ai runs them via anyio ``to_thread``,
+# which copies the context to the worker thread). ``None`` means "use os.getcwd".
+
+_WORKING_DIR: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "code_puppy_working_dir", default=None
+)
+
+
+def set_working_directory(path: Optional[str]) -> contextvars.Token:
+    """Override the base dir for relative path resolution in this context.
+
+    Returns a token; pass it to :func:`reset_working_directory` to restore.
+    """
+    return _WORKING_DIR.set(path)
+
+
+def reset_working_directory(token: contextvars.Token) -> None:
+    """Restore the working directory to its value before ``set``."""
+    _WORKING_DIR.reset(token)
+
+
+def get_working_directory() -> str:
+    """The active base dir for relative paths (override, else process CWD)."""
+    return _WORKING_DIR.get() or os.getcwd()
+
+
+def resolve_path(file_path: str) -> str:
+    """Absolutize ``file_path`` against the active working directory.
+
+    Expands ``~`` and joins relative paths onto :func:`get_working_directory`
+    (absolute inputs pass through unchanged). Use this instead of
+    ``os.path.abspath(os.path.expanduser(...))`` in tools so an embedder's
+    per-session cwd is honored without a process-global ``os.chdir``.
+    """
+    expanded = os.path.expanduser(file_path)
+    if os.path.isabs(expanded):
+        return os.path.abspath(expanded)
+    return os.path.abspath(os.path.join(get_working_directory(), expanded))
 
 
 # Syntax highlighting imports for "syntax" diff mode
@@ -1139,6 +1235,10 @@ def _get_user_approval_impl(
 
     from code_puppy.tools.command_runner import set_awaiting_user_input
 
+    backend = get_approval_backend()
+    if backend is not None:
+        return backend(title, _approval_message_text(content), preview)
+
     if not _stdin_supports_interactive_approval():
         return _deny_noninteractive_approval(title)
 
@@ -1330,6 +1430,13 @@ async def _get_user_approval_async_impl(
 ) -> tuple[bool, str | None]:
     """Inner implementation of get_user_approval_async (lock-free)."""
     from code_puppy.tools.command_runner import set_awaiting_user_input
+
+    backend = get_approval_backend()
+    if backend is not None:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, backend, title, _approval_message_text(content), preview
+        )
 
     if not _stdin_supports_interactive_approval():
         return _deny_noninteractive_approval(title)
@@ -1538,6 +1645,37 @@ def atomic_write_text(
             os.close(dir_fd)
     except (OSError, AttributeError):
         pass  # directory fsync unsupported -- file content is still durable
+
+
+def write_project_file(
+    file_path: str, content: str, *, encoding: str = "utf-8"
+) -> None:
+    """Write a *workspace* file the agent is editing, honoring the I/O backend.
+
+    Use this (not ``atomic_write_text``) for files the agent creates or edits on
+    the user's behalf. When a ``FileSystemBackend`` is installed (e.g. an editor
+    host), the write is delegated to it so the change lands in the host's diff
+    UI; otherwise it falls back to the local atomic write.
+
+    ``encoding`` applies only to the local path -- a backend host owns its own
+    on-disk encoding (the Agent Client Protocol, for instance, is UTF-8 only),
+    so a non-default encoding cannot be honored through a backend.
+
+    Internal writes (config, session state, agent metadata) intentionally keep
+    calling ``atomic_write_text`` directly -- they are machine-local and must
+    never be rerouted to an editor workspace.
+    """
+    from code_puppy.tools.io_backends import get_filesystem_backend
+
+    backend = get_filesystem_backend()
+    if backend is not None:
+        if encoding.lower() not in ("utf-8", "utf8"):
+            raise ValueError(
+                f"filesystem backend writes are UTF-8 only; got encoding={encoding!r}"
+            )
+        backend.write_text_file(resolve_path(file_path), content)
+        return
+    atomic_write_text(file_path, content, encoding=encoding)
 
 
 def _find_best_window(

--- a/code_puppy/tools/file_modifications.py
+++ b/code_puppy/tools/file_modifications.py
@@ -33,8 +33,9 @@ from code_puppy.messaging import (  # Structured messaging types
 )
 from code_puppy.tools.common import (
     _find_best_window,
-    atomic_write_text,
     generate_group_id,
+    resolve_path,
+    write_project_file,
 )
 
 
@@ -220,7 +221,7 @@ def _delete_snippet_from_file(
     message_group: str | None = None,
 ) -> Dict[str, Any]:
     UndoManager().record_change(file_path, "delete_snippet")
-    file_path = os.path.abspath(file_path)
+    file_path = resolve_path(file_path)
     diff_text = ""
     try:
         if not os.path.exists(file_path) or not os.path.isfile(file_path):
@@ -251,7 +252,7 @@ def _delete_snippet_from_file(
                 n=get_diff_context_lines(),
             )
         )
-        atomic_write_text(file_path, modified)
+        write_project_file(file_path, modified)
         return {
             "success": True,
             "path": file_path,
@@ -271,7 +272,7 @@ def _replace_in_file(
 ) -> Dict[str, Any]:
     UndoManager().record_change(path, "replace_in_file")
     """Robust replacement engine with explicit edge‑case reporting."""
-    file_path = os.path.abspath(path)
+    file_path = resolve_path(path)
     diff_text = ""
     try:
         if not os.path.exists(file_path) or not os.path.isfile(file_path):
@@ -346,7 +347,7 @@ def _replace_in_file(
                 n=get_diff_context_lines(),
             )
         )
-        atomic_write_text(file_path, modified)
+        write_project_file(file_path, modified)
         return {
             "success": True,
             "path": file_path,
@@ -366,7 +367,7 @@ def _write_to_file(
     message_group: str | None = None,
 ) -> Dict[str, Any]:
     UndoManager().record_change(path, "write_to_file")
-    file_path = os.path.abspath(path)
+    file_path = resolve_path(path)
 
     try:
         exists = os.path.exists(file_path)
@@ -403,8 +404,14 @@ def _write_to_file(
         )
         diff_text = "".join(diff_lines)
 
-        os.makedirs(os.path.dirname(file_path) or ".", exist_ok=True)
-        atomic_write_text(file_path, content)
+        # Only create local directories when writing locally; when a filesystem
+        # backend owns the write (e.g. a remote editor host), the host manages
+        # its own directory creation and a local mkdir would be a phantom.
+        from code_puppy.tools.io_backends import get_filesystem_backend
+
+        if get_filesystem_backend() is None:
+            os.makedirs(os.path.dirname(file_path) or ".", exist_ok=True)
+        write_project_file(file_path, content)
 
         action = "overwritten" if exists else "created"
         return {
@@ -540,7 +547,7 @@ def _edit_file(
     The function auto-detects the payload type and routes to the appropriate internal helper.
     """
     # Extract file_path from payload
-    file_path = os.path.abspath(payload.file_path)
+    file_path = resolve_path(payload.file_path)
 
     # Use provided group_id or generate one if not provided
     if group_id is None:
@@ -601,7 +608,7 @@ def _delete_file(
     context: RunContext, file_path: str, message_group: str | None = None
 ) -> Dict[str, Any]:
     UndoManager().record_change(file_path, "delete_file")
-    file_path = os.path.abspath(file_path)
+    file_path = resolve_path(file_path)
 
     # Use the plugin system for permission handling with operation data
     from code_puppy.callbacks import on_file_permission

--- a/code_puppy/tools/file_modifications.py
+++ b/code_puppy/tools/file_modifications.py
@@ -37,6 +37,7 @@ from code_puppy.tools.common import (
     resolve_path,
     write_project_file,
 )
+from code_puppy.tools import fs_access
 
 
 def _create_rejection_response(file_path: str) -> Dict[str, Any]:
@@ -224,10 +225,9 @@ def _delete_snippet_from_file(
     file_path = resolve_path(file_path)
     diff_text = ""
     try:
-        if not os.path.exists(file_path) or not os.path.isfile(file_path):
+        if not fs_access.exists(file_path) or not fs_access.is_file(file_path):
             return {"error": f"File '{file_path}' does not exist.", "diff": diff_text}
-        with open(file_path, "r", encoding="utf-8", errors="surrogateescape") as f:
-            original = f.read()
+        original = fs_access.read_text(file_path)
         # Sanitize any surrogate characters from reading
         try:
             original = original.encode("utf-8", errors="surrogatepass").decode(
@@ -275,11 +275,10 @@ def _replace_in_file(
     file_path = resolve_path(path)
     diff_text = ""
     try:
-        if not os.path.exists(file_path) or not os.path.isfile(file_path):
+        if not fs_access.exists(file_path) or not fs_access.is_file(file_path):
             return {"error": f"File '{file_path}' does not exist.", "diff": diff_text}
 
-        with open(file_path, "r", encoding="utf-8", errors="surrogateescape") as f:
-            original = f.read()
+        original = fs_access.read_text(file_path)
 
         # Sanitize any surrogate characters from reading
         try:
@@ -370,7 +369,7 @@ def _write_to_file(
     file_path = resolve_path(path)
 
     try:
-        exists = os.path.exists(file_path)
+        exists = fs_access.exists(file_path)
         if exists and not overwrite:
             return {
                 "success": False,
@@ -383,8 +382,7 @@ def _write_to_file(
         from code_puppy.config import get_diff_context_lines
 
         if exists:
-            with open(file_path, "r", encoding="utf-8", errors="surrogateescape") as f:
-                old_content = f.read()
+            old_content = fs_access.read_text(file_path)
             try:
                 old_content = old_content.encode(
                     "utf-8", errors="surrogatepass"
@@ -405,12 +403,9 @@ def _write_to_file(
         diff_text = "".join(diff_lines)
 
         # Only create local directories when writing locally; when a filesystem
-        # backend owns the write (e.g. a remote editor host), the host manages
-        # its own directory creation and a local mkdir would be a phantom.
-        from code_puppy.tools.io_backends import get_filesystem_backend
-
-        if get_filesystem_backend() is None:
-            os.makedirs(os.path.dirname(file_path) or ".", exist_ok=True)
+        # backend owns the write it manages its own topology (the ACP host, for
+        # instance, creates parents on the local disk it shares).
+        fs_access.make_dirs(os.path.dirname(file_path) or ".")
         write_project_file(file_path, content)
 
         action = "overwritten" if exists else "created"
@@ -568,7 +563,7 @@ def _edit_file(
                 context, file_path, replacements_dict, message_group=group_id
             )
         elif isinstance(payload, ContentPayload):
-            file_exists = os.path.exists(file_path)
+            file_exists = fs_access.exists(file_path)
             if file_exists and not payload.overwrite:
                 return {
                     "success": False,
@@ -625,10 +620,10 @@ def _delete_file(
         return _create_rejection_response(file_path)
 
     try:
-        if not os.path.exists(file_path) or not os.path.isfile(file_path):
+        if not fs_access.exists(file_path) or not fs_access.is_file(file_path):
             return {"error": f"File '{file_path}' does not exist."}
 
-        os.remove(file_path)
+        fs_access.delete_file(file_path)
         try:
             emit_success(f"Deleted file: {file_path}", message_group=message_group)
         except Exception:

--- a/code_puppy/tools/file_operations.py
+++ b/code_puppy/tools/file_operations.py
@@ -20,6 +20,7 @@ from code_puppy.messaging import (  # New structured messaging types
     GrepResultMessage,
     get_message_bus,
 )
+from code_puppy.tools.common import resolve_path
 
 
 # Pydantic models for tool return types
@@ -154,7 +155,7 @@ def _list_files(
     import sys
 
     results = []
-    directory = os.path.abspath(os.path.expanduser(directory))
+    directory = resolve_path(directory)
 
     # Plain text output for LLM consumption
     output_lines = []
@@ -464,7 +465,40 @@ def _read_file(
     start_line: int | None = None,
     num_lines: int | None = None,
 ) -> ReadFileOutput:
-    file_path = os.path.abspath(os.path.expanduser(file_path))
+    file_path = resolve_path(file_path)
+
+    # When a filesystem backend is installed (e.g. an editor host), read
+    # through it so we see unsaved buffers and the host's view of the file.
+    # The backend owns existence/permission semantics, so we skip the local
+    # disk checks on this path.
+    from code_puppy.tools.io_backends import get_filesystem_backend
+
+    backend = get_filesystem_backend()
+    if backend is not None:
+        if start_line is not None and start_line < 1:
+            error_msg = "start_line must be >= 1 (1-based indexing)"
+            return ReadFileOutput(content=error_msg, num_tokens=0, error=error_msg)
+        if num_lines is not None and num_lines < 1:
+            error_msg = "num_lines must be >= 1"
+            return ReadFileOutput(content=error_msg, num_tokens=0, error=error_msg)
+        # Push the slice down to the host (ACP fs/read supports line+limit) so a
+        # chunked read doesn't drag the whole file across the wire. Matches the
+        # local path: only slice when BOTH bounds are given.
+        want_slice = start_line is not None and num_lines is not None
+        try:
+            if want_slice:
+                raw = backend.read_text_file(
+                    file_path, line=start_line, limit=num_lines
+                )
+            else:
+                raw = backend.read_text_file(file_path)
+        except FileNotFoundError:
+            error_msg = f"File {file_path} does not exist"
+            return ReadFileOutput(content=error_msg, num_tokens=0, error=error_msg)
+        except Exception as e:
+            message = f"An error occurred trying to read the file: {e}"
+            return ReadFileOutput(content=message, num_tokens=0, error=message)
+        return _finalize_read_output(file_path, raw, start_line, num_lines)
 
     if not os.path.exists(file_path):
         error_msg = f"File {file_path} does not exist"
@@ -497,54 +531,7 @@ def _read_file(
                 # Read the entire file
                 content = f.read()
 
-            # Sanitize the content to remove any surrogate characters that could
-            # cause issues when the content is later serialized or displayed
-            # This re-encodes with surrogatepass then decodes with replace to
-            # convert lone surrogates to replacement characters
-            try:
-                content = content.encode("utf-8", errors="surrogatepass").decode(
-                    "utf-8", errors="replace"
-                )
-            except (UnicodeEncodeError, UnicodeDecodeError):
-                # If that fails, do a more aggressive cleanup
-                content = "".join(
-                    char if ord(char) < 0xD800 or ord(char) > 0xDFFF else "\ufffd"
-                    for char in content
-                )
-
-            # Simple approximation: ~4 characters per token
-            num_tokens = len(content) // 4
-            if num_tokens > 10000:
-                return ReadFileOutput(
-                    content=None,
-                    error="The file is massive, greater than 10,000 tokens which is dangerous to read entirely. Please read this file in chunks.",
-                    num_tokens=0,
-                )
-
-            # Count total lines for the message
-            total_lines = content.count("\n") + (
-                1 if content and not content.endswith("\n") else 0
-            )
-
-            # Emit structured message for the UI
-            # Only include start_line/num_lines if they are valid positive integers
-            emit_start_line = (
-                start_line if start_line is not None and start_line >= 1 else None
-            )
-            emit_num_lines = (
-                num_lines if num_lines is not None and num_lines >= 1 else None
-            )
-            file_content_msg = FileContentMessage(
-                path=file_path,
-                content=content,
-                start_line=emit_start_line,
-                num_lines=emit_num_lines,
-                total_lines=total_lines,
-                num_tokens=num_tokens,
-            )
-            get_message_bus().emit(file_content_msg)
-
-        return ReadFileOutput(content=content, num_tokens=num_tokens)
+        return _finalize_read_output(file_path, content, start_line, num_lines)
     except FileNotFoundError:
         error_msg = "FILE NOT FOUND"
         return ReadFileOutput(content=error_msg, num_tokens=0, error=error_msg)
@@ -554,6 +541,56 @@ def _read_file(
     except Exception as e:
         message = f"An error occurred trying to read the file: {e}"
         return ReadFileOutput(content=message, num_tokens=0, error=message)
+
+
+def _finalize_read_output(
+    file_path: str,
+    content: str,
+    start_line: int | None,
+    num_lines: int | None,
+) -> ReadFileOutput:
+    """Sanitize/guard/emit for a just-read file body and build the output.
+
+    Shared by the local (disk) and backend (host) read paths so both apply the
+    identical surrogate sanitization, 10k-token guard, and UI emission.
+    """
+    # Sanitize the content to remove any surrogate characters that could cause
+    # issues when the content is later serialized or displayed.
+    try:
+        content = content.encode("utf-8", errors="surrogatepass").decode(
+            "utf-8", errors="replace"
+        )
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        content = "".join(
+            char if ord(char) < 0xD800 or ord(char) > 0xDFFF else "\ufffd"
+            for char in content
+        )
+
+    # Simple approximation: ~4 characters per token
+    num_tokens = len(content) // 4
+    if num_tokens > 10000:
+        return ReadFileOutput(
+            content=None,
+            error="The file is massive, greater than 10,000 tokens which is dangerous to read entirely. Please read this file in chunks.",
+            num_tokens=0,
+        )
+
+    total_lines = content.count("\n") + (
+        1 if content and not content.endswith("\n") else 0
+    )
+    emit_start_line = start_line if start_line is not None and start_line >= 1 else None
+    emit_num_lines = num_lines if num_lines is not None and num_lines >= 1 else None
+    get_message_bus().emit(
+        FileContentMessage(
+            path=file_path,
+            content=content,
+            start_line=emit_start_line,
+            num_lines=emit_num_lines,
+            total_lines=total_lines,
+            num_tokens=num_tokens,
+        )
+    )
+    return ReadFileOutput(content=content, num_tokens=num_tokens)
 
 
 def _sanitize_string(text: str) -> str:
@@ -676,7 +713,7 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
     # Sanitize search string to handle any surrogates from copy-paste
     search_string = _sanitize_string(search_string)
 
-    directory = os.path.abspath(os.path.expanduser(directory))
+    directory = resolve_path(directory)
     matches: List[MatchInfo] = []
     error_message: str | None = None
 

--- a/code_puppy/tools/file_operations.py
+++ b/code_puppy/tools/file_operations.py
@@ -1,6 +1,7 @@
 # file_operations.py
 
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -21,6 +22,7 @@ from code_puppy.messaging import (  # New structured messaging types
     get_message_bus,
 )
 from code_puppy.tools.common import resolve_path
+from code_puppy.tools import fs_access
 
 
 # Pydantic models for tool return types
@@ -149,6 +151,58 @@ def would_match_directory(pattern: str, directory: str) -> bool:
     return False
 
 
+def _list_entries_via_backend(directory: str, recursive: bool) -> List["ListedFile"]:
+    """Build ``ListedFile`` results from the installed filesystem backend.
+
+    Composes the listing from ``fs_access.walk`` / ``list_dir`` so it reflects
+    the backend's single coherent filesystem (the same source ``read_file`` and
+    ``grep`` see), rather than the local ripgrep path used when no backend is
+    installed. Honors the same ignore rules as the local path.
+    """
+    from code_puppy.tools.common import should_ignore_dir_path, should_ignore_path
+
+    results: List[ListedFile] = []
+
+    def _rel(full: str) -> str:
+        if full.startswith(directory):
+            return full[len(directory) :].lstrip(os.sep)
+        return full
+
+    if recursive:
+        for full, entry in fs_access.walk(
+            directory,
+            skip_dir=should_ignore_dir_path,
+            skip_file=should_ignore_path,
+        ):
+            rel = _rel(full)
+            if not rel:
+                continue
+            results.append(
+                ListedFile(
+                    path=rel,
+                    type="directory" if entry.is_dir else "file",
+                    size=0 if entry.is_dir else entry.size,
+                    full_path=full,
+                    depth=rel.count(os.sep),
+                )
+            )
+    else:
+        for entry in sorted(fs_access.list_dir(directory), key=lambda e: e.name):
+            # Match the local non-recursive path: hide dot-directories.
+            if entry.is_dir and entry.name.startswith("."):
+                continue
+            results.append(
+                ListedFile(
+                    path=entry.name,
+                    type="directory" if entry.is_dir else "file",
+                    size=0 if entry.is_dir else entry.size,
+                    full_path=os.path.join(directory, entry.name),
+                    depth=0,
+                )
+            )
+    return results
+
+
 def _list_files(
     context: RunContext, directory: str = ".", recursive: bool = True
 ) -> ListFileOutput:
@@ -161,10 +215,10 @@ def _list_files(
     output_lines = []
     output_lines.append(f"DIRECTORY LISTING: {directory} (recursive={recursive})")
 
-    if not os.path.exists(directory):
+    if not fs_access.exists(directory):
         error_msg = f"Error: Directory '{directory}' does not exist"
         return ListFileOutput(content=error_msg, error=error_msg)
-    if not os.path.isdir(directory):
+    if not fs_access.is_dir(directory):
         error_msg = f"Error: '{directory}' is not a directory"
         return ListFileOutput(content=error_msg, error=error_msg)
 
@@ -177,7 +231,22 @@ def _list_files(
             )
             recursive = False
 
-    # Create a temporary ignore file with our ignore patterns
+    # When a filesystem backend is installed it owns the whole FS surface, so
+    # we compose the listing from it (fs_access.walk / list_dir) instead of
+    # shelling out to the local ripgrep -- keeping every operation coherent.
+    from code_puppy.tools.io_backends import get_filesystem_backend
+
+    _use_backend = get_filesystem_backend() is not None
+    if _use_backend:
+        try:
+            results = _list_entries_via_backend(directory, recursive)
+        except Exception as e:
+            # A backend raising (TOCTOU race, host error) must degrade to a
+            # tool error, never crash the tool -- parity with the local path.
+            error_msg = f"Error: Error during list files operation: {e}"
+            return ListFileOutput(content=error_msg, error=error_msg)
+
+    # Create a temporary ignore file with our ignore patterns (local rg path)
     ignore_file = None
     try:
         # Find ripgrep executable - first check system PATH, then virtual environment
@@ -193,13 +262,13 @@ def _list_files(
                     rg_path = candidate
                     break
 
-        if not rg_path and recursive:
+        if not rg_path and recursive and not _use_backend:
             # Only need ripgrep for recursive listings
             error_msg = "Error: ripgrep (rg) not found. Please install ripgrep to use this tool."
             return ListFileOutput(content=error_msg, error=error_msg)
 
         # Only use ripgrep for recursive listings
-        if recursive:
+        if recursive and not _use_backend:
             # Build command for ripgrep --files
             cmd = [rg_path, "--files"]
 
@@ -308,7 +377,7 @@ def _list_files(
 
         # In non-recursive mode, we also need to explicitly list immediate entries
         # ripgrep's --files option only returns files; we add directories and files ourselves
-        if not recursive:
+        if not recursive and not _use_backend:
             try:
                 entries = os.listdir(directory)
                 for entry in sorted(entries):
@@ -656,6 +725,25 @@ def _strip_quote_pair(token: str) -> str:
     return token
 
 
+def _tokenize_flag_string(search_string: str) -> list[str] | None:
+    """Tokenize a flag-mode grep string (non-POSIX). ``None`` on unmatched quote.
+
+    Shared by the local ripgrep arg builder and the backend matcher so both
+    interpret ``-i --type py 'class Limits'`` identically. Non-POSIX so regex
+    escapes and Windows paths (``\\b``, ``C:\\Users``) are never mangled; one
+    surrounding quote pair is stripped per token.
+    """
+    import shlex
+
+    lexer = shlex.shlex(search_string, posix=False)
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    try:
+        return [_strip_quote_pair(part) for part in lexer]
+    except ValueError:
+        return None
+
+
 def _build_grep_args(search_string: str) -> tuple[list[str], str | None]:
     """Convert ``search_string`` into ripgrep arguments, identically on all OSes.
 
@@ -674,17 +762,11 @@ def _build_grep_args(search_string: str) -> tuple[list[str], str | None]:
     Returns ``(args, error)``. ``error`` is set when an unsupported
     output-format flag is requested.
     """
-    import shlex
-
     if not search_string.startswith("-"):
         return ["-e", search_string], None
 
-    lexer = shlex.shlex(search_string, posix=False)
-    lexer.whitespace_split = True
-    lexer.commenters = ""
-    try:
-        tokens = [_strip_quote_pair(part) for part in lexer]
-    except ValueError:
+    tokens = _tokenize_flag_string(search_string)
+    if tokens is None:
         # Unmatched quote: refuse to guess at shell-like structure and
         # treat the whole string as a literal pattern.
         return ["-e", search_string], None
@@ -701,6 +783,238 @@ def _build_grep_args(search_string: str) -> tuple[list[str], str | None]:
     return tokens, None
 
 
+# ripgrep --type name -> file extensions, for the backend grep path. Covers the
+# common types; unknown types raise a clear error rather than silently matching
+# nothing (ripgrep itself owns the full list on the local path).
+_RG_TYPE_EXTS: dict[str, set[str]] = {
+    "py": {".py", ".pyi", ".pyw"},
+    "js": {".js", ".jsx", ".mjs", ".cjs", ".vue"},
+    "ts": {".ts", ".tsx", ".mts", ".cts"},
+    "rust": {".rs"},
+    "go": {".go"},
+    "java": {".java"},
+    "kotlin": {".kt", ".kts"},
+    "c": {".c", ".h"},
+    "cpp": {".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx"},
+    "cs": {".cs"},
+    "rb": {".rb"},
+    "php": {".php"},
+    "swift": {".swift"},
+    "html": {".html", ".htm"},
+    "css": {".css", ".scss", ".sass", ".less"},
+    "json": {".json"},
+    "yaml": {".yaml", ".yml"},
+    "toml": {".toml"},
+    "md": {".md", ".markdown"},
+    "sh": {".sh", ".bash", ".zsh"},
+    "txt": {".txt"},
+    "xml": {".xml"},
+    "sql": {".sql"},
+}
+
+_BACKEND_GREP_SUPPORTED = "-i, -s, -w, -F, --type/-t, -e, or a plain pattern"
+
+
+def _build_backend_matcher(
+    search_string: str,
+) -> tuple["re.Pattern | None", "set[str] | None", str | None]:
+    """Parse ``search_string`` into ``(regex, allowed_exts, error)`` for backend grep.
+
+    Mirrors the local ripgrep flag modes as far as Python ``re`` can:
+
+    * plain pattern (no leading ``-``) -> regex, verbatim
+    * ``-i`` / ``--ignore-case`` -> ``re.IGNORECASE``
+    * ``-s`` / ``--case-sensitive`` -> case-sensitive (default)
+    * ``-w`` / ``--word-regexp`` -> wrap in ``\\b(?:...)\\b``
+    * ``-F`` / ``--fixed-strings`` -> ``re.escape`` (literal match)
+    * ``--type``/``-t`` NAME -> restrict to that type's extensions
+    * ``-e``/``--regexp`` PAT -> explicit pattern
+
+    Any other flag returns a clear error instead of the old behavior (compiling
+    the flag text as a literal regex, which silently matched nothing).
+    ``allowed_exts`` is ``None`` for "all files".
+    """
+    flags = 0
+    fixed = False
+    word = False
+    exts: set[str] | None = None
+    pattern: str | None = None
+
+    if not search_string.startswith("-"):
+        pattern = search_string
+    else:
+        tokens = _tokenize_flag_string(search_string)
+        if tokens is None:
+            pattern = search_string  # unmatched quote -> treat as literal
+        else:
+            i = 0
+            while i < len(tokens):
+                tok = tokens[i]
+                key, eq, inline = tok.partition("=")
+
+                def _value() -> str | None:
+                    nonlocal i
+                    if eq:
+                        return inline
+                    if i + 1 < len(tokens):
+                        i += 1
+                        return tokens[i]
+                    return None
+
+                if key in _INCOMPATIBLE_RG_FLAGS:
+                    return (
+                        None,
+                        None,
+                        (
+                            f"ripgrep flag '{key}' changes output format and is not "
+                            f"supported by backend grep. Supported: {_BACKEND_GREP_SUPPORTED}."
+                        ),
+                    )
+                if key in ("-i", "--ignore-case"):
+                    flags |= re.IGNORECASE
+                elif key in ("-s", "--case-sensitive"):
+                    flags &= ~re.IGNORECASE
+                elif key in ("-w", "--word-regexp"):
+                    word = True
+                elif key in ("-F", "--fixed-strings"):
+                    fixed = True
+                elif key in ("-t", "--type"):
+                    name = _value()
+                    mapped = _RG_TYPE_EXTS.get(name or "")
+                    if mapped is None:
+                        return (
+                            None,
+                            None,
+                            (
+                                f"--type '{name}' is not supported by backend grep "
+                                f"(known: {', '.join(sorted(_RG_TYPE_EXTS))})"
+                            ),
+                        )
+                    exts = (exts or set()) | mapped
+                elif key in ("-e", "--regexp"):
+                    pattern = _value()
+                elif key.startswith("-"):
+                    return (
+                        None,
+                        None,
+                        (
+                            f"grep flag '{key}' is not supported by backend grep. "
+                            f"Supported: {_BACKEND_GREP_SUPPORTED}."
+                        ),
+                    )
+                else:
+                    pattern = tok  # positional -> the pattern
+                i += 1
+
+    if not pattern:
+        return None, None, "no search pattern provided"
+    if fixed:
+        pattern = re.escape(pattern)
+    if word:
+        pattern = r"\b(?:" + pattern + r")\b"
+    try:
+        return re.compile(pattern, flags), exts, None
+    except re.error as exc:
+        return None, None, f"invalid search pattern: {exc}"
+
+
+def _emit_grep_result(
+    search_string: str,
+    directory: str,
+    matches: List["MatchInfo"],
+    error_message: str | None,
+) -> "GrepOutput":
+    """Emit the structured grep result to the UI and return the tool output.
+
+    Shared by the local (ripgrep) and backend (composed) grep paths so the UI
+    behavior is identical regardless of where the search actually ran.
+    """
+    from code_puppy.config import get_grep_output_verbose
+
+    grep_matches = [
+        GrepMatch(
+            file_path=m.file_path or "",
+            line_number=m.line_number or 1,
+            line_content=m.line_content or "",
+        )
+        for m in matches
+    ]
+    unique_files = len(set(m.file_path for m in matches)) if matches else 0
+    grep_result_msg = GrepResultMessage(
+        search_term=search_string,
+        directory=directory,
+        matches=grep_matches,
+        total_matches=len(matches),
+        files_searched=unique_files,
+        verbose=get_grep_output_verbose(),
+    )
+    get_message_bus().emit(grep_result_msg)
+    return GrepOutput(matches=matches, error=error_message)
+
+
+def _grep_via_backend(directory: str, search_string: str) -> "GrepOutput":
+    """Search through the installed filesystem backend (no local ripgrep).
+
+    Walks the backend's filesystem and matches each file's text, so grep sees
+    exactly what ``read_file`` and ``list_files`` see -- including, for an
+    editor host, unsaved buffers. Flag mode is honored to the extent Python
+    ``re`` allows: ``-i`` (ignore case), ``-s`` (case sensitive), ``-w`` (word),
+    ``-F`` (fixed string), ``--type``/``-t`` (restrict extensions), and
+    ``-e`` (explicit pattern). Unsupported flags return a clear error rather
+    than silently matching nothing. Files larger than the local path's 5 MB
+    cap and binary files (NUL in the first chunk) are skipped, matching
+    ripgrep's defaults.
+    """
+    from code_puppy.tools.common import should_ignore_dir_path, should_ignore_path
+
+    # Report a missing/non-directory target as an error, matching the local
+    # ripgrep path (rather than silently returning zero matches for a typo'd
+    # directory). ``walk`` itself tolerates a bad root by yielding nothing.
+    if not fs_access.is_dir(directory):
+        error_msg = (
+            f"Error: Directory '{directory}' does not exist"
+            if not fs_access.exists(directory)
+            else f"Error: '{directory}' is not a directory"
+        )
+        return _emit_grep_result(search_string, directory, [], error_msg)
+
+    pattern, allowed_exts, error = _build_backend_matcher(search_string)
+    if error is not None:
+        return _emit_grep_result(search_string, directory, [], error)
+
+    max_filesize = 5 * 1024 * 1024  # mirror ripgrep --max-filesize 5M
+    matches: List[MatchInfo] = []
+    for full, entry in fs_access.walk(
+        directory, skip_dir=should_ignore_dir_path, skip_file=should_ignore_path
+    ):
+        if entry.is_dir:
+            continue
+        if allowed_exts is not None and os.path.splitext(full)[1] not in allowed_exts:
+            continue
+        if entry.size and entry.size > max_filesize:
+            continue
+        try:
+            text = fs_access.read_text(full)
+        except Exception:
+            # Unreadable/hostile file: skip it, never abort the whole search.
+            continue
+        if "\x00" in text[:8192]:  # cheap binary sniff, like ripgrep
+            continue
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if pattern.search(line):
+                matches.append(
+                    MatchInfo(
+                        file_path=full,
+                        line_number=line_number,
+                        line_content=_sanitize_string(line.strip()),
+                    )
+                )
+                # Cap total matches to mirror the local path's 50-match limit.
+                if len(matches) >= 50:
+                    return _emit_grep_result(search_string, directory, matches, None)
+    return _emit_grep_result(search_string, directory, matches, None)
+
+
 def _grep(context: RunContext, search_string: str, directory: str = ".") -> GrepOutput:
     import json
     import os
@@ -708,12 +1022,18 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
     import subprocess
     import sys
 
-    from code_puppy.config import get_grep_output_verbose
-
     # Sanitize search string to handle any surrogates from copy-paste
     search_string = _sanitize_string(search_string)
 
     directory = resolve_path(directory)
+
+    # When a filesystem backend is installed, search through it (walk + read)
+    # so grep sees the same coherent filesystem as read_file / list_files.
+    from code_puppy.tools.io_backends import get_filesystem_backend
+
+    if get_filesystem_backend() is not None:
+        return _grep_via_backend(directory, search_string)
+
     matches: List[MatchInfo] = []
     error_message: str | None = None
 
@@ -846,30 +1166,7 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
             os.unlink(ignore_file)
 
     # Build structured GrepMatch objects for the UI
-    grep_matches = [
-        GrepMatch(
-            file_path=m.file_path or "",
-            line_number=m.line_number or 1,
-            line_content=m.line_content or "",
-        )
-        for m in matches
-    ]
-
-    # Count unique files searched (approximation based on matches)
-    unique_files = len(set(m.file_path for m in matches)) if matches else 0
-
-    # Emit structured message for the UI (only once, at the end)
-    grep_result_msg = GrepResultMessage(
-        search_term=search_string,
-        directory=directory,
-        matches=grep_matches,
-        total_matches=len(matches),
-        files_searched=unique_files,
-        verbose=get_grep_output_verbose(),
-    )
-    get_message_bus().emit(grep_result_msg)
-
-    return GrepOutput(matches=matches, error=error_message)
+    return _emit_grep_result(search_string, directory, matches, error_message)
 
 
 def register_list_files(agent):

--- a/code_puppy/tools/fs_access.py
+++ b/code_puppy/tools/fs_access.py
@@ -1,0 +1,229 @@
+"""Filesystem access facade: one dispatch point for backend-or-local I/O.
+
+Every filesystem *metadata*, *mutation*, and *traversal* operation the agent's
+file tools perform goes through here. When a
+:class:`~code_puppy.tools.io_backends.FileSystemBackend` is installed these
+delegate to it; otherwise they run against the local disk exactly as before.
+
+Centralizing the "backend or local?" decision keeps it in one place (instead of
+scattering ``get_filesystem_backend()`` checks across every tool) and, crucially,
+guarantees the agent sees a *single coherent filesystem*: with a backend
+installed, ``list_files``, ``grep``, existence checks, deletes, and mkdir all
+resolve against the same source as ``read_file`` / ``write_to_file``. Recursive
+listing and content search are *composed* here from ``list_dir`` + text reads
+(see :func:`walk`), so the backend contract stays small.
+
+Content reads/writes for *workspace* files also honor the backend, but their
+call sites already live in ``file_operations`` / ``common`` where local
+encoding/atomic-write details matter; this module owns the metadata + traversal
+surface and the backend-aware read used by :func:`walk`.
+
+All paths passed in must be absolute (callers resolve via
+``common.resolve_path``); the local branch here does not re-resolve.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Callable, Iterator, List, Optional, Tuple
+
+from code_puppy.tools.io_backends import DirEntry, get_filesystem_backend
+
+
+# ---------------------------------------------------------------------------
+# Metadata
+# ---------------------------------------------------------------------------
+def exists(path: str) -> bool:
+    backend = get_filesystem_backend()
+    if backend is not None:
+        return backend.exists(path)
+    return os.path.exists(path)
+
+
+def is_file(path: str) -> bool:
+    backend = get_filesystem_backend()
+    if backend is not None:
+        return backend.is_file(path)
+    return os.path.isfile(path)
+
+
+def is_dir(path: str) -> bool:
+    backend = get_filesystem_backend()
+    if backend is not None:
+        return backend.is_dir(path)
+    return os.path.isdir(path)
+
+
+def list_dir(path: str) -> List[DirEntry]:
+    """List the immediate children of ``path`` (one level).
+
+    Raises ``FileNotFoundError`` / ``NotADirectoryError`` consistently across
+    backend and local paths.
+    """
+    backend = get_filesystem_backend()
+    if backend is not None:
+        return backend.list_dir(path)
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+    if not os.path.isdir(path):
+        raise NotADirectoryError(path)
+    entries: List[DirEntry] = []
+    for name in os.listdir(path):
+        full = os.path.join(path, name)
+        try:
+            if os.path.isdir(full):
+                entries.append(DirEntry(name=name, is_dir=True, size=0))
+            elif os.path.isfile(full):
+                entries.append(DirEntry(name=name, is_dir=False, size=_safe_size(full)))
+        except OSError:
+            continue
+    return entries
+
+
+def _safe_size(path: str) -> int:
+    try:
+        return os.path.getsize(path)
+    except OSError:
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Content (backend-aware read; used by traversal/grep and by callers that want
+# to honor unsaved host buffers)
+# ---------------------------------------------------------------------------
+def read_text(
+    path: str, line: Optional[int] = None, limit: Optional[int] = None
+) -> str:
+    """Read text of ``path`` through the backend, else local disk.
+
+    ``line`` (1-based) + ``limit`` request a slice; both ``None`` = whole file.
+    Local reads use ``surrogateescape`` so invalid-UTF-8 files never crash the
+    tool (matching the existing tool behavior).
+    """
+    backend = get_filesystem_backend()
+    if backend is not None:
+        return backend.read_text_file(path, line=line, limit=limit)
+    with open(path, "r", encoding="utf-8", errors="surrogateescape") as f:
+        if line is None or limit is None:
+            return f.read()
+        # 1-based line slice, mirroring the backend contract.
+        out: List[str] = []
+        for i, row in enumerate(f, start=1):
+            if i < line:
+                continue
+            if i >= line + limit:
+                break
+            out.append(row)
+        return "".join(out)
+
+
+def write_text(path: str, content: str) -> None:
+    """Write ``content`` (UTF-8 text) to ``path`` through the backend, else local.
+
+    This is the low-level facade write used by machinery that must stay coherent
+    with the active filesystem (e.g. undo). Tool-facing writes go through
+    ``common.write_project_file`` for diffing/messaging, which itself honors the
+    backend; this is the raw equivalent.
+    """
+    backend = get_filesystem_backend()
+    if backend is not None:
+        backend.write_text_file(path, content)
+        return
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+# ---------------------------------------------------------------------------
+# Mutation
+# ---------------------------------------------------------------------------
+def delete_file(path: str) -> None:
+    backend = get_filesystem_backend()
+    if backend is not None:
+        backend.delete_file(path)
+        return
+    os.remove(path)
+
+
+def make_dirs(path: str) -> None:
+    """Create ``path`` and parents (idempotent). No-op for the empty string."""
+    if not path:
+        return
+    backend = get_filesystem_backend()
+    if backend is not None:
+        backend.make_dirs(path)
+        return
+    os.makedirs(path, exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Traversal (composed from list_dir; backend-agnostic)
+# ---------------------------------------------------------------------------
+# Depth backstop for hostile/buggy backends whose list_dir forms an infinite
+# chain of *distinct* paths (so the visited-set can't catch it). Real source
+# trees are nowhere near this deep; ripgrep (the local path) is likewise bounded.
+MAX_WALK_DEPTH = 1000
+
+
+def walk(
+    root: str,
+    *,
+    skip_dir: Optional[Callable[[str], bool]] = None,
+    skip_file: Optional[Callable[[str], bool]] = None,
+) -> Iterator[Tuple[str, DirEntry]]:
+    """Yield ``(full_path, DirEntry)`` under ``root`` (pre-order) via ``list_dir``.
+
+    Directories are yielded before their contents. ``skip_dir(full_path)`` /
+    ``skip_file(full_path)`` (when given) prune entries -- a pruned directory is
+    not descended into. This is the single traversal used by both recursive
+    ``list_files`` and ``grep`` when a backend is installed, so their view is
+    identical to every other operation.
+
+    Implemented **iteratively** with an explicit stack so a legitimately deep
+    tree cannot overflow the interpreter stack. Cycles are broken two ways:
+    a visited-set keyed on the resolved real path (catches symlink / same-path
+    loops), plus a ``MAX_WALK_DEPTH`` backstop for a hostile backend that
+    invents an unbounded chain of distinct paths. A ``list_dir`` that raises
+    (missing/permission/not-a-dir) is skipped, never fatal.
+    """
+    visited: set[str] = set()
+    # Stack of iterators-of-(full_path, entry); each level is one directory.
+    stack: list[Iterator[Tuple[str, DirEntry]]] = [_walk_level(root, visited)]
+    while stack:
+        if len(stack) > MAX_WALK_DEPTH:
+            stack.pop()  # too deep: stop descending this branch, keep going
+            continue
+        try:
+            full, entry = next(stack[-1])
+        except StopIteration:
+            stack.pop()
+            continue
+        if entry.is_dir:
+            if skip_dir is not None and skip_dir(full):
+                continue
+            yield full, entry
+            stack.append(_walk_level(full, visited))
+        else:
+            if skip_file is not None and skip_file(full):
+                continue
+            yield full, entry
+
+
+def _walk_level(directory: str, visited: set[str]) -> Iterator[Tuple[str, DirEntry]]:
+    """Yield the immediate children of ``directory`` (sorted), skipping revisits.
+
+    Records the directory's real path in ``visited`` and yields nothing if it
+    was already seen -- the cycle guard shared across the whole walk.
+    """
+    try:
+        key = os.path.realpath(directory)
+    except OSError:
+        key = directory
+    if key in visited:
+        return
+    visited.add(key)
+    try:
+        entries = list_dir(directory)
+    except (FileNotFoundError, NotADirectoryError, OSError):
+        return
+    for entry in sorted(entries, key=lambda e: e.name):
+        yield os.path.join(directory, entry.name), entry

--- a/code_puppy/tools/io_backends.py
+++ b/code_puppy/tools/io_backends.py
@@ -1,0 +1,101 @@
+"""Pluggable I/O backends for Code Puppy's tool layer.
+
+By default Code Puppy's file and shell tools do I/O directly against the local
+machine (``open()`` / ``atomic_write_text`` / ``subprocess``). An embedder that
+hosts Code Puppy inside another environment -- an IDE, a sandbox, or an editor
+speaking the Agent Client Protocol -- may want that I/O routed through *its*
+channels instead, so edits land in the host's diff UI, reads see the host's
+unsaved buffers, and commands run in the host's terminal.
+
+These registries are the seam for that. They mirror ``set_approval_backend`` in
+``tools.common``: a single process-wide slot, ``None`` by default (pure local
+behavior), swapped in by the embedder. The tool layer checks the slot and
+delegates when a backend is present, otherwise runs locally.
+
+Two independent backends:
+
+* ``FileSystemBackend`` — **synchronous** (file tools run in Code Puppy's tool
+  threadpool, off any event loop). Covers *workspace* file reads/writes, i.e.
+  the agent editing project files; internal writes (config, session state)
+  deliberately do not go through it.
+* ``CommandExecutor`` — **asynchronous** (the shell tool awaits it on the event
+  loop). Runs one shell command and returns its combined output + exit code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Protocol, runtime_checkable
+
+
+# =============================================================================
+# Filesystem backend (workspace file I/O)
+# =============================================================================
+@runtime_checkable
+class FileSystemBackend(Protocol):
+    """Host-provided read/write for workspace files. Synchronous."""
+
+    def read_text_file(
+        self, path: str, line: Optional[int] = None, limit: Optional[int] = None
+    ) -> str:
+        """Return text of ``path`` (may reflect unsaved host edits).
+
+        ``line`` (1-based) + ``limit`` request a slice so hosts can avoid
+        shipping an entire large file for a chunked read; both ``None`` means
+        the full file.
+        """
+
+    def write_text_file(self, path: str, content: str) -> None:
+        """Write ``content`` to ``path`` through the host."""
+
+
+_FS_BACKEND: Optional[FileSystemBackend] = None
+
+
+def set_filesystem_backend(backend: Optional[FileSystemBackend]) -> None:
+    """Install (or clear, with ``None``) the workspace filesystem backend."""
+    global _FS_BACKEND
+    _FS_BACKEND = backend
+
+
+def get_filesystem_backend() -> Optional[FileSystemBackend]:
+    """Return the installed filesystem backend, or ``None`` for local I/O."""
+    return _FS_BACKEND
+
+
+# =============================================================================
+# Command executor (shell)
+# =============================================================================
+@dataclass
+class ExecResult:
+    """Outcome of running one command through a ``CommandExecutor``.
+
+    ``output`` is the combined stdout+stderr stream (host terminals typically
+    interleave them, matching Code Puppy's own streaming shell behavior).
+    """
+
+    exit_code: int
+    output: str
+    timed_out: bool = False
+
+
+@runtime_checkable
+class CommandExecutor(Protocol):
+    """Host-provided shell execution. Asynchronous (awaited on the loop)."""
+
+    async def run(self, command: str, cwd: Optional[str], timeout: int) -> ExecResult:
+        """Run ``command`` (a shell string) and return its result."""
+
+
+_CMD_EXECUTOR: Optional[CommandExecutor] = None
+
+
+def set_command_executor(executor: Optional[CommandExecutor]) -> None:
+    """Install (or clear, with ``None``) the shell command executor."""
+    global _CMD_EXECUTOR
+    _CMD_EXECUTOR = executor
+
+
+def get_command_executor() -> Optional[CommandExecutor]:
+    """Return the installed command executor, or ``None`` for local subprocess."""
+    return _CMD_EXECUTOR

--- a/code_puppy/tools/io_backends.py
+++ b/code_puppy/tools/io_backends.py
@@ -14,27 +14,87 @@ delegates when a backend is present, otherwise runs locally.
 
 Two independent backends:
 
-* ``FileSystemBackend`` — **synchronous** (file tools run in Code Puppy's tool
-  threadpool, off any event loop). Covers *workspace* file reads/writes, i.e.
-  the agent editing project files; internal writes (config, session state)
-  deliberately do not go through it.
-* ``CommandExecutor`` — **asynchronous** (the shell tool awaits it on the event
+* ``FileSystemBackend`` -- **synchronous** (file tools run in Code Puppy's tool
+  threadpool, off any event loop). When installed it owns the *entire* file
+  surface the agent's tools touch, so there is exactly one filesystem the agent
+  sees (no reading from the host while listing the local disk). See the
+  protocol docstring for the operation set and the path/error/encoding
+  contracts a backend must honor.
+* ``CommandExecutor`` -- **asynchronous** (the shell tool awaits it on the event
   loop). Runs one shell command and returns its combined output + exit code.
+
+Design note -- why the FileSystemBackend covers the *whole* surface
+------------------------------------------------------------------
+An earlier iteration only routed text read/write through the backend and left
+``list_files`` / existence / delete on the local disk. That produced a
+split-brain filesystem: a backend could serve ``read_file`` from a host buffer
+while ``list_files`` reported the local disk -- coherent *only* when the host
+happens to be the local disk (as it is for an editor on the same machine), and
+incoherent for any remote/sandbox/virtual backend. So the backend owns every
+operation the file tools perform. Recursive listing and content search are
+*composed* by the core from ``list_dir`` + ``read_text_file`` when a backend is
+installed, which keeps the backend contract small while remaining coherent; the
+fast local ripgrep path is retained only for the no-backend (default) case.
+
+A backend that legitimately shares the local disk (e.g. the ACP editor host,
+which overlays only *content* -- unsaved buffers) is free to implement the
+metadata/topology operations against the local disk in its adapter. That
+"serve topology locally" choice belongs in the adapter, which *knows* its host
+shares the disk -- never baked into this general seam.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Protocol, runtime_checkable
+from typing import List, Optional, Protocol, runtime_checkable
 
 
 # =============================================================================
 # Filesystem backend (workspace file I/O)
 # =============================================================================
+@dataclass(frozen=True)
+class DirEntry:
+    """One entry in a directory listing.
+
+    ``name`` is the bare entry name (no path), ``is_dir`` distinguishes files
+    from directories, and ``size`` is the file size in bytes (0 for
+    directories, or when the backend cannot cheaply determine it).
+    """
+
+    name: str
+    is_dir: bool
+    size: int = 0
+
+
 @runtime_checkable
 class FileSystemBackend(Protocol):
-    """Host-provided read/write for workspace files. Synchronous."""
+    """Host-provided filesystem for the agent's workspace tools. Synchronous.
 
+    When a backend is installed it owns **every** filesystem operation the
+    agent's file tools perform, so the agent sees a single coherent filesystem.
+    Recursive listing and content search (grep) are composed by the core from
+    ``list_dir`` + ``read_text_file``; a backend does not implement those
+    directly.
+
+    Contracts every method must honor
+    ---------------------------------
+    * **Paths** are always absolute and already normalized by the core
+      (``code_puppy.tools.common.resolve_path``) before the backend is called.
+      A backend never has to resolve relative paths or a working directory.
+    * **Errors**: raise ``FileNotFoundError`` when a required path is missing,
+      ``NotADirectoryError`` when a directory op targets a file (and vice
+      versa), and ``OSError`` / ``ValueError`` for anything else. The core maps
+      these onto tool error messages uniformly, so a backend should not invent
+      its own error return values.
+    * **Encoding**: text is UTF-8. A backend need not honor other encodings
+      (the core rejects non-UTF-8 writes before reaching the backend).
+
+    Internal writes (config, session state, agent metadata) deliberately do
+    **not** go through a backend -- they are machine-local and must never be
+    rerouted into an editor workspace.
+    """
+
+    # --- content -----------------------------------------------------------
     def read_text_file(
         self, path: str, line: Optional[int] = None, limit: Optional[int] = None
     ) -> str:
@@ -42,11 +102,36 @@ class FileSystemBackend(Protocol):
 
         ``line`` (1-based) + ``limit`` request a slice so hosts can avoid
         shipping an entire large file for a chunked read; both ``None`` means
-        the full file.
+        the full file. Raises ``FileNotFoundError`` if ``path`` does not exist.
         """
 
     def write_text_file(self, path: str, content: str) -> None:
-        """Write ``content`` to ``path`` through the host."""
+        """Write ``content`` (UTF-8 text) to ``path`` through the host."""
+
+    # --- metadata / topology ----------------------------------------------
+    def exists(self, path: str) -> bool:
+        """Return whether ``path`` exists (file or directory)."""
+
+    def is_file(self, path: str) -> bool:
+        """Return whether ``path`` exists and is a regular file."""
+
+    def is_dir(self, path: str) -> bool:
+        """Return whether ``path`` exists and is a directory."""
+
+    def list_dir(self, path: str) -> List[DirEntry]:
+        """List the immediate children of directory ``path`` (one level).
+
+        Raises ``FileNotFoundError`` if ``path`` does not exist and
+        ``NotADirectoryError`` if it is not a directory.
+        """
+
+    # --- mutation ----------------------------------------------------------
+    def delete_file(self, path: str) -> None:
+        """Delete the file at ``path``. Raises ``FileNotFoundError`` if absent."""
+
+    def make_dirs(self, path: str) -> None:
+        """Create directory ``path`` and any parents (idempotent, like
+        ``os.makedirs(path, exist_ok=True)``)."""
 
 
 _FS_BACKEND: Optional[FileSystemBackend] = None

--- a/code_puppy/undo_manager.py
+++ b/code_puppy/undo_manager.py
@@ -1,4 +1,3 @@
-import os
 from typing import Optional, List
 from dataclasses import dataclass
 
@@ -24,11 +23,17 @@ class UndoManager:
             self.history: List[FileChange] = []
 
     def record_change(self, file_path: str, action: str):
+        # Route through the filesystem facade + resolve the path so undo stays
+        # coherent with whatever filesystem the tools actually wrote to (local
+        # disk by default, or an installed backend such as an editor host).
+        from code_puppy.tools import fs_access
+        from code_puppy.tools.common import resolve_path
+
+        file_path = resolve_path(file_path)
         original_content = None
-        if os.path.exists(file_path):
+        if fs_access.exists(file_path):
             try:
-                with open(file_path, "r", encoding="utf-8") as f:
-                    original_content = f.read()
+                original_content = fs_access.read_text(file_path)
             except Exception:
                 pass  # Ignore binary files or unreadable files for now
         self.history.append(
@@ -48,15 +53,16 @@ class UndoManager:
             return "No more actions to undo."
 
         try:
+            from code_puppy.tools import fs_access
+
             if change.original_content is None:
                 # File was created, so we delete it
-                if os.path.exists(change.file_path):
-                    os.remove(change.file_path)
+                if fs_access.exists(change.file_path):
+                    fs_access.delete_file(change.file_path)
                 return f"Undid {change.action}: deleted {change.file_path}"
             else:
                 # File was modified or deleted, restore original content
-                with open(change.file_path, "w", encoding="utf-8") as f:
-                    f.write(change.original_content)
+                fs_access.write_text(change.file_path, change.original_content)
                 return f"Undid {change.action}: restored {change.file_path}"
         except Exception as e:
             return f"Failed to undo {change.action} on {change.file_path}: {e}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "azure-identity>=1.15.0",
     "anthropic==0.79.0",
     "boto3>=1.43.9",
+    "agent-client-protocol>=0.11.0,<0.12",
 ]
 dev-dependencies = [
     "pytest>=8.3.4",

--- a/tests/test_acp_plugin.py
+++ b/tests/test_acp_plugin.py
@@ -701,6 +701,208 @@ async def test_fs_backend_read_bridges_worker_thread():
 
 
 # --------------------------------------------------------------------------- #
+# I/O delegation — terminal error/edge paths + bridge guards
+# --------------------------------------------------------------------------- #
+class _TerminalConn(FakeConnection):
+    """FakeConnection with configurable terminal behavior for edge paths."""
+
+    def __init__(
+        self,
+        *,
+        terminal_id="term1",
+        wait_exit_code=0,
+        hang=False,
+        out_exit_code=0,
+        kill_raises=False,
+        release_raises=False,
+        output_raises=False,
+    ):
+        super().__init__()
+        self._terminal_id = terminal_id
+        self._wait_exit_code = wait_exit_code
+        self._hang = hang
+        self._out_exit_code = out_exit_code
+        self._kill_raises = kill_raises
+        self._release_raises = release_raises
+        self._output_raises = output_raises
+        self.killed = False
+
+    async def create_terminal(self, command, session_id, args=None, cwd=None, **_):
+        self.created = (command, args, cwd)
+        return CreateTerminalResponse(terminal_id=self._terminal_id)
+
+    async def wait_for_terminal_exit(self, session_id, terminal_id, **_):
+        if self._hang:
+            await asyncio.sleep(10)
+        if self._wait_exit_code is None:
+            return SimpleNamespace()  # no exit_code attr -> triggers fallback
+        return WaitForTerminalExitResponse(exit_code=self._wait_exit_code)
+
+    async def terminal_output(self, session_id, terminal_id, **_):
+        if self._output_raises:
+            raise RuntimeError("output boom")
+        status = (
+            TerminalExitStatus(exit_code=self._out_exit_code)
+            if self._out_exit_code is not None
+            else None
+        )
+        return TerminalOutputResponse(
+            output="OUT\n", exit_status=status, truncated=False
+        )
+
+    async def kill_terminal(self, session_id, terminal_id, **_):
+        self.killed = True
+        if self._kill_raises:
+            raise RuntimeError("kill boom")
+
+    async def release_terminal(self, session_id, terminal_id, **_):
+        self.released = True
+        if self._release_raises:
+            raise RuntimeError("release boom")
+
+
+async def _run_cmd(conn, command="echo x", cwd="/tmp", timeout=60):
+    state.set_connection(conn, asyncio.get_event_loop())
+    state.begin_run("s1")
+    try:
+        return await io_delegation.DelegatedCommandExecutor().run(command, cwd, timeout)
+    finally:
+        state.end_run()
+        state.set_connection(None, None)
+
+
+@pytest.mark.asyncio
+async def test_command_timeout_kills_and_reports_minus_one():
+    conn = _TerminalConn(hang=True, out_exit_code=None)
+    result = await _run_cmd(conn, timeout=0)
+    assert result.timed_out is True
+    assert result.exit_code == -1  # no exit status available after a timeout
+    assert conn.killed is True
+    assert conn.released is True  # released in finally, always
+
+
+@pytest.mark.asyncio
+async def test_command_exit_status_fallback_when_wait_has_no_code():
+    # wait_for_terminal_exit returns no exit_code -> fall back to terminal_output.
+    conn = _TerminalConn(wait_exit_code=None, out_exit_code=7)
+    result = await _run_cmd(conn)
+    assert result.exit_code == 7
+    assert result.timed_out is False
+
+
+@pytest.mark.asyncio
+async def test_command_missing_terminal_id_raises():
+    conn = _TerminalConn(terminal_id="")
+    with pytest.raises(RuntimeError, match="terminalId"):
+        await _run_cmd(conn)
+
+
+@pytest.mark.asyncio
+async def test_command_no_connection_raises():
+    state.set_connection(None, None)
+    with pytest.raises(RuntimeError, match="no active connection"):
+        await io_delegation.DelegatedCommandExecutor().run("echo x", "/tmp", 60)
+
+
+@pytest.mark.asyncio
+async def test_command_no_session_raises():
+    conn = _TerminalConn()
+    state.set_connection(conn, asyncio.get_event_loop())
+    state.end_run()  # ensure no active session
+    try:
+        with pytest.raises(RuntimeError, match="outside a session"):
+            await io_delegation.DelegatedCommandExecutor().run("echo x", "/tmp", 60)
+    finally:
+        state.set_connection(None, None)
+
+
+@pytest.mark.asyncio
+async def test_command_kill_and_release_errors_are_swallowed():
+    # A timeout path where both kill and release raise must NOT surface an error.
+    conn = _TerminalConn(
+        hang=True, out_exit_code=None, kill_raises=True, release_raises=True
+    )
+    result = await _run_cmd(conn, timeout=0)  # should not raise
+    assert result.timed_out is True
+    assert conn.killed is True
+
+
+@pytest.mark.asyncio
+async def test_command_releases_terminal_even_when_output_raises():
+    conn = _TerminalConn(output_raises=True)
+    with pytest.raises(RuntimeError, match="output boom"):
+        await _run_cmd(conn)
+    assert conn.released is True  # finally still released it
+
+
+@pytest.mark.asyncio
+async def test_fs_backend_write_bridges_to_client():
+    conn = FakeConnection()
+    state.set_connection(conn, asyncio.get_event_loop())
+    state.begin_run("s1")
+    try:
+        backend = io_delegation.DelegatedFileSystemBackend()
+        await asyncio.to_thread(backend.write_text_file, "/proj/w.py", "DATA\n")
+    finally:
+        state.end_run()
+        state.set_connection(None, None)
+    assert ("/proj/w.py", "DATA\n") in conn.writes
+
+
+@pytest.mark.asyncio
+async def test_fs_backend_bridge_no_connection_raises():
+    state.set_connection(None, None)
+    backend = io_delegation.DelegatedFileSystemBackend()
+    with pytest.raises(RuntimeError, match="no active connection"):
+        await asyncio.to_thread(backend.read_text_file, "/proj/a.py")
+
+
+@pytest.mark.asyncio
+async def test_fs_backend_bridge_no_session_raises():
+    # Connection present but no active session -> the fs bridge must refuse.
+    conn = FakeConnection()
+    state.set_connection(conn, asyncio.get_event_loop())
+    state.end_run()
+    try:
+        backend = io_delegation.DelegatedFileSystemBackend()
+        with pytest.raises(RuntimeError, match="outside a session"):
+            await asyncio.to_thread(backend.read_text_file, "/proj/a.py")
+    finally:
+        state.set_connection(None, None)
+
+
+def test_shell_invocation_windows(monkeypatch):
+    monkeypatch.setattr(io_delegation.sys, "platform", "win32")
+    assert io_delegation.shell_invocation("echo x") == ("cmd", ["/c", "echo x"])
+
+
+def test_shell_invocation_posix(monkeypatch):
+    monkeypatch.setattr(io_delegation.sys, "platform", "linux")
+    assert io_delegation.shell_invocation("echo x") == ("/bin/sh", ["-c", "echo x"])
+
+
+def test_acp_backend_make_dirs_empty_is_noop():
+    # Empty path must be a no-op (guards against makedirs('') raising).
+    io_delegation.DelegatedFileSystemBackend().make_dirs("")
+
+
+@pytest.mark.asyncio
+async def test_fs_backend_bridge_deadlock_guard():
+    # Calling a bridged method while ON the ACP loop must refuse, not deadlock.
+    conn = FakeConnection()
+    loop = asyncio.get_event_loop()
+    state.set_connection(conn, loop)
+    state.begin_run("s1")
+    try:
+        backend = io_delegation.DelegatedFileSystemBackend()
+        with pytest.raises(RuntimeError, match="deadlock"):
+            backend.read_text_file("/proj/a.py")  # sync call, on the loop thread
+    finally:
+        state.end_run()
+        state.set_connection(None, None)
+
+
+# --------------------------------------------------------------------------- #
 # Gap-closing features: fork / persistence / extra-dirs / commands / images /
 # mcp / models / config options
 # --------------------------------------------------------------------------- #

--- a/tests/test_acp_plugin.py
+++ b/tests/test_acp_plugin.py
@@ -1,0 +1,1328 @@
+"""Tests for the ACP (ACP native agent) plugin, built on the official SDK.
+
+The plugin implements the ``acp`` SDK's ``Agent`` interface, so these tests
+drive ``CodePuppyAgent`` directly and assert on the SDK model objects it emits
+through a fake ``AgentSideConnection``. No real stdio is bound.
+
+Coverage:
+  * capability negotiation + client-cap parsing
+  * prompt content-block flattening (incl. embedded resources)
+  * agent lifecycle: initialize / new_session / prompt (stream + fallback) /
+    cancel / list_sessions / close_session / unknown-session error
+  * tool-call event bridging + correlation (via run-context ``state``)
+  * permission delegation (file approval backend + shell hook)
+  * I/O delegation core seams + client-backed fs/terminal backends
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any, List, Optional, Tuple
+
+import pytest
+import pytest_asyncio
+
+from acp.schema import (
+    AllowedOutcome,
+    ClientCapabilities,
+    CreateTerminalResponse,
+    DeniedOutcome,
+    FileSystemCapabilities,
+    ReadTextFileResponse,
+    RequestPermissionResponse,
+    TerminalExitStatus,
+    TerminalOutputResponse,
+    WaitForTerminalExitResponse,
+)
+
+from code_puppy.plugins.acp import (
+    bridge as bridge_mod,
+    capabilities,
+    content,
+    io_delegation,
+    permissions,
+    state,
+)
+from code_puppy.plugins.acp.agent import CodePuppyAgent
+
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+class FakeConnection:
+    """Stands in for the SDK's ``AgentSideConnection`` (client handle)."""
+
+    def __init__(self, permission_outcome: Any = None) -> None:
+        self.updates: List[Tuple[str, Any]] = []
+        self.perm_requests: List[Any] = []
+        self.writes: List[Tuple[str, str]] = []
+        self.released = False
+        self.created: Optional[Tuple[str, list, Any]] = None
+        self._permission_outcome = permission_outcome
+
+    async def session_update(self, session_id: str, update: Any) -> None:
+        self.updates.append((session_id, update))
+
+    async def request_permission(self, options, session_id, tool_call):
+        self.perm_requests.append((session_id, tool_call))
+        return RequestPermissionResponse(outcome=self._permission_outcome)
+
+    async def read_text_file(self, path, session_id, **_):
+        return ReadTextFileResponse(content=f"contents of {path}")
+
+    async def write_text_file(self, content, path, session_id, **_):
+        self.writes.append((path, content))
+
+    async def create_terminal(self, command, session_id, args=None, cwd=None, **_):
+        self.created = (command, args, cwd)
+        return CreateTerminalResponse(terminal_id="term1")
+
+    async def wait_for_terminal_exit(self, session_id, terminal_id, **_):
+        return WaitForTerminalExitResponse(exit_code=0)
+
+    async def terminal_output(self, session_id, terminal_id, **_):
+        return TerminalOutputResponse(
+            output="hi there\n",
+            exit_status=TerminalExitStatus(exit_code=0),
+            truncated=False,
+        )
+
+    async def kill_terminal(self, session_id, terminal_id, **_):
+        return None
+
+    async def release_terminal(self, session_id, terminal_id, **_):
+        self.released = True
+        return None
+
+
+class FakeAgent:
+    """Minimal ``BaseAgent`` stand-in that streams via the real hooks."""
+
+    def __init__(self, stream: bool) -> None:
+        self._message_history: List[Any] = []
+        self._stream = stream
+
+    def get_message_history(self) -> List[Any]:
+        return self._message_history
+
+    def set_message_history(self, history: List[Any]) -> None:
+        self._message_history = list(history)
+
+    async def run_with_mcp(self, prompt: str, **_: Any) -> Any:
+        if self._stream:
+            from code_puppy import callbacks
+
+            delta = SimpleNamespace(content_delta="Hello ")
+            await callbacks.on_stream_event(
+                "part_delta", {"delta_type": "TextPartDelta", "delta": delta}
+            )
+        usage = SimpleNamespace(input_tokens=12, output_tokens=8, total_tokens=20)
+        return SimpleNamespace(output="Hello puppy", usage=lambda: usage)
+
+
+def _update_types(conn: FakeConnection) -> List[str]:
+    return [getattr(u, "session_update", None) for _, u in conn.updates]
+
+
+@pytest_asyncio.fixture
+async def wired_agent(monkeypatch):
+    """A ``CodePuppyAgent`` connected to a fake connection, with cleanup.
+
+    Async so ``on_connect`` runs *inside* the test's event loop — exactly like
+    production (the SDK calls it from within ``run_agent``), so
+    ``asyncio.get_running_loop()`` succeeds.
+    """
+    monkeypatch.setattr(
+        "code_puppy.agents.agent_manager.get_current_agent_name", lambda: "code-puppy"
+    )
+    monkeypatch.setattr(
+        "code_puppy.agents.agent_manager.load_agent",
+        lambda name: FakeAgent(stream=True),
+    )
+    conn = FakeConnection()
+    agent = CodePuppyAgent()
+    agent.on_connect(conn)
+    yield agent, conn
+    permissions.uninstall()
+    io_delegation.uninstall()
+    state.set_connection(None, None)
+
+
+# --------------------------------------------------------------------------- #
+# Capabilities
+# --------------------------------------------------------------------------- #
+def test_agent_capabilities_shape():
+    caps = capabilities.agent_capabilities()
+    assert caps.load_session is True
+    assert caps.prompt_capabilities.embedded_context is True
+    assert caps.prompt_capabilities.image is True
+    # list/close/fork/resume/additional_directories all advertised via markers.
+    assert caps.session_capabilities.list is not None
+    assert caps.session_capabilities.close is not None
+    assert caps.session_capabilities.fork is not None
+    assert caps.session_capabilities.resume is not None
+    assert caps.session_capabilities.additional_directories is not None
+
+
+def test_client_io_caps_parsing():
+    assert capabilities.client_io_caps(None) == (False, False, False)
+    caps = ClientCapabilities(
+        fs=FileSystemCapabilities(read_text_file=True, write_text_file=False),
+        terminal=True,
+    )
+    assert capabilities.client_io_caps(caps) == (True, False, True)
+
+
+# --------------------------------------------------------------------------- #
+# Content flattening
+# --------------------------------------------------------------------------- #
+def test_flatten_prompt_text_and_embedded_resource():
+    from acp.helpers import embedded_text_resource, resource_block, text_block
+
+    blocks = [
+        text_block("do the thing"),
+        resource_block(embedded_text_resource("file:///a.py", "print(1)")),
+        SimpleNamespace(type="resource_link", uri="file:///b.py", name="b.py"),
+    ]
+    out = content.flatten_prompt(blocks)
+    assert "do the thing" in out
+    assert "print(1)" in out
+    assert "file:///a.py" in out
+    assert "b.py" in out
+
+
+def test_flatten_prompt_empty():
+    assert content.flatten_prompt([]) == ""
+
+
+# --------------------------------------------------------------------------- #
+# Agent lifecycle
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_initialize_returns_versioned_capabilities(wired_agent):
+    agent, _ = wired_agent
+    resp = await agent.initialize(protocol_version=1, client_capabilities=None)
+    assert resp.protocol_version == 1
+    assert resp.agent_info.name == "code-puppy"
+    assert resp.agent_capabilities.load_session is True
+
+
+@pytest.mark.asyncio
+async def test_new_session_and_prompt_streams(wired_agent):
+    agent, conn = wired_agent
+    new = await agent.new_session(cwd="/tmp")
+    assert new.session_id in agent._sessions
+    assert agent._sessions[new.session_id].cwd == "/tmp"
+
+    resp = await agent.prompt([SimpleNamespace(type="text", text="hi")], new.session_id)
+    assert resp.stop_reason == "end_turn"
+    # Exactly one agent_message_chunk from streaming; no duplicate final chunk.
+    assert _update_types(conn).count("agent_message_chunk") == 1
+
+
+@pytest.mark.asyncio
+async def test_prompt_absorbs_history_for_memory_and_persistence(monkeypatch):
+    """A completed turn must fold result.all_messages() back into the agent.
+
+    The shared runtime does not do this on the normal path -- the caller must,
+    like cli_runner does. Without it the agent forgets every turn and
+    persistence saves only the user's prompt (no assistant reply), which is
+    what made ACP sessions reload with no history and no memory.
+    """
+    from pydantic_ai.messages import (
+        ModelRequest,
+        ModelResponse,
+        TextPart,
+        UserPromptPart,
+    )
+
+    monkeypatch.setattr(
+        "code_puppy.agents.agent_manager.get_current_agent_name", lambda: "code-puppy"
+    )
+
+    class MemAgent:
+        def __init__(self):
+            self._h = []
+
+        def get_message_history(self):
+            return self._h
+
+        def set_message_history(self, h):
+            self._h = list(h)
+
+        def estimate_tokens_for_message(self, _m):
+            return 1
+
+        async def run_with_mcp(self, prompt, **_):
+            new = list(self._h) + [
+                ModelRequest(parts=[UserPromptPart(content=prompt)]),
+                ModelResponse(parts=[TextPart(content=f"reply:{prompt}")]),
+            ]
+            return SimpleNamespace(
+                all_messages=lambda: new, usage=lambda: None, output="reply"
+            )
+
+    monkeypatch.setattr(
+        "code_puppy.agents.agent_manager.load_agent", lambda name: MemAgent()
+    )
+    conn = FakeConnection()
+    agent = CodePuppyAgent()
+    agent.on_connect(conn)
+    try:
+        new = await agent.new_session(cwd="/tmp")
+        sid = new.session_id
+        await agent.prompt([SimpleNamespace(type="text", text="one")], sid)
+        # Turn 1 folded request + response into the agent's memory.
+        assert len(agent._sessions[sid].agent.get_message_history()) == 2
+        await agent.prompt([SimpleNamespace(type="text", text="two")], sid)
+        # Turn 2 remembered turn 1 (grew, didn't reset).
+        assert len(agent._sessions[sid].agent.get_message_history()) == 4
+    finally:
+        permissions.uninstall()
+        io_delegation.uninstall()
+        state.set_connection(None, None)
+
+
+@pytest.mark.asyncio
+async def test_stream_part_start_content_not_dropped(wired_agent):
+    """The opening chunk (carried on part_start) must reach the client.
+
+    pydantic-ai often front-loads the first token(s) into the PartStartEvent's
+    ``part.content`` rather than the first delta. Forwarding only part_delta
+    truncates the start of every message (the reported bug). Start + deltas are
+    disjoint, so both are emitted and reconstruct the full text.
+    """
+    from code_puppy.plugins.acp.bridge import EventBridge
+
+    agent, conn = wired_agent
+    state.begin_run("sess_stream")
+    try:
+        bridge = EventBridge()
+        await bridge._on_stream_event(
+            "part_start",
+            {
+                "index": 0,
+                "part_type": "TextPart",
+                "part": SimpleNamespace(content="Hello "),
+            },
+        )
+        await bridge._on_stream_event(
+            "part_delta",
+            {
+                "index": 0,
+                "delta_type": "TextPartDelta",
+                "delta": SimpleNamespace(content_delta="world"),
+            },
+        )
+    finally:
+        state.end_run()
+    texts = [
+        getattr(getattr(u, "content", None), "text", None)
+        for _, u in conn.updates
+        if getattr(u, "session_update", None) == "agent_message_chunk"
+    ]
+    assert "".join(t for t in texts if t) == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_prompt_reports_token_usage(wired_agent):
+    agent, _ = wired_agent
+    new = await agent.new_session(cwd="/tmp")
+    resp = await agent.prompt([SimpleNamespace(type="text", text="hi")], new.session_id)
+    assert resp.usage is not None
+    assert resp.usage.input_tokens == 12
+    assert resp.usage.output_tokens == 8
+    assert resp.usage.total_tokens == 20
+
+
+@pytest.mark.asyncio
+async def test_prompt_final_fallback_when_no_stream(monkeypatch):
+    monkeypatch.setattr(
+        "code_puppy.agents.agent_manager.get_current_agent_name", lambda: "code-puppy"
+    )
+    monkeypatch.setattr(
+        "code_puppy.agents.agent_manager.load_agent",
+        lambda name: FakeAgent(stream=False),
+    )
+    conn = FakeConnection()
+    agent = CodePuppyAgent()
+    agent.on_connect(conn)
+    try:
+        new = await agent.new_session(cwd="/tmp")
+        await agent.prompt([SimpleNamespace(type="text", text="hi")], new.session_id)
+        chunks = [
+            u
+            for sid, u in conn.updates
+            if getattr(u, "session_update", None) == "agent_message_chunk"
+        ]
+        assert len(chunks) == 1
+        assert chunks[0].content.text == "Hello puppy"
+    finally:
+        permissions.uninstall()
+        io_delegation.uninstall()
+        state.set_connection(None, None)
+
+
+@pytest.mark.asyncio
+async def test_prompt_unknown_session_raises(wired_agent):
+    agent, _ = wired_agent
+    with pytest.raises(ValueError):
+        await agent.prompt([], "nope")
+
+
+@pytest.mark.asyncio
+async def test_list_and_close_session(wired_agent):
+    agent, _ = wired_agent
+    a = await agent.new_session(cwd="/one")
+    b = await agent.new_session(cwd="/two")
+    listed = await agent.list_sessions()
+    ids = {s.session_id for s in listed.sessions}
+    assert {a.session_id, b.session_id} <= ids
+
+    await agent.close_session(a.session_id)
+    assert a.session_id not in agent._sessions
+
+
+@pytest.mark.asyncio
+async def test_cancel_stops_run(monkeypatch):
+    monkeypatch.setattr(
+        "code_puppy.agents.agent_manager.get_current_agent_name", lambda: "code-puppy"
+    )
+
+    class SlowAgent:
+        _message_history: list = []
+
+        async def run_with_mcp(self, prompt, **_):
+            await asyncio.sleep(30)
+            return SimpleNamespace(output="never")
+
+    monkeypatch.setattr(
+        "code_puppy.agents.agent_manager.load_agent", lambda name: SlowAgent()
+    )
+    conn = FakeConnection()
+    agent = CodePuppyAgent()
+    agent.on_connect(conn)
+    try:
+        new = await agent.new_session(cwd="/tmp")
+        task = asyncio.ensure_future(
+            agent.prompt([SimpleNamespace(type="text", text="go")], new.session_id)
+        )
+        await asyncio.sleep(0.05)
+        await agent.cancel(new.session_id)
+        resp = await task
+        assert resp.stop_reason == "cancelled"
+    finally:
+        permissions.uninstall()
+        io_delegation.uninstall()
+        state.set_connection(None, None)
+
+
+# --------------------------------------------------------------------------- #
+# Event bridge — tool-call correlation
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_tool_call_kind_locations_and_correlation():
+    conn = FakeConnection()
+    state.set_connection(conn, asyncio.get_event_loop())
+    state.begin_run("s1")
+    bridge = bridge_mod.EventBridge()
+    try:
+        await bridge._on_pre_tool_call("edit_file", {"file_path": "foo.py"})
+        _, start = conn.updates[-1]
+        assert start.session_update == "tool_call"
+        assert start.kind == "edit"
+        assert start.title == "Edit foo.py"
+        assert start.locations[0].path.endswith("foo.py")
+
+        name, tool_call_id = state.current_tool_call()
+        assert name == "edit_file"
+        assert start.tool_call_id == tool_call_id
+
+        await bridge._on_post_tool_call(
+            "edit_file", {}, {"success": True, "diff": "- old\n+ new\n"}, 1.0
+        )
+        _, done = conn.updates[-1]
+        assert done.session_update == "tool_call_update"
+        assert done.status == "completed"
+        assert done.tool_call_id == tool_call_id
+        # Unified diff surfaced as an inline content block.
+        assert done.content and "old" in done.content[0].content.text
+        assert state.current_tool_call() is None
+    finally:
+        state.end_run()
+        state.set_connection(None, None)
+
+
+# --------------------------------------------------------------------------- #
+# Approval-backend seam (core: tools.common)
+# --------------------------------------------------------------------------- #
+def test_approval_backend_sync_overrides_stdin():
+    from code_puppy.tools import common
+
+    seen = []
+
+    def backend(title, message, preview):
+        seen.append((title, message, preview))
+        return True, None
+
+    common.set_approval_backend(backend)
+    try:
+        approved, feedback = common.get_user_approval("Op", "do it?", preview="diff")
+    finally:
+        common.set_approval_backend(None)
+
+    assert approved is True and feedback is None
+    assert seen == [("Op", "do it?", "diff")]
+
+
+@pytest.mark.asyncio
+async def test_approval_backend_async_runs_in_executor():
+    from code_puppy.tools import common
+
+    def backend(title, message, preview):
+        return False, None
+
+    common.set_approval_backend(backend)
+    try:
+        approved, _ = await common.get_user_approval_async("Op", "do it?")
+    finally:
+        common.set_approval_backend(None)
+    assert approved is False
+
+
+# --------------------------------------------------------------------------- #
+# Permission delegation to the client
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_ask_client_allow_and_deny():
+    loop = asyncio.get_event_loop()
+
+    allow = FakeConnection(AllowedOutcome(option_id="allow_once", outcome="selected"))
+    state.set_connection(allow, loop)
+    state.begin_run("s1")
+    try:
+        assert await permissions._ask_client("s1", "t") is True
+    finally:
+        state.end_run()
+
+    deny = FakeConnection(DeniedOutcome(outcome="cancelled"))
+    state.set_connection(deny, loop)
+    state.begin_run("s1")
+    try:
+        assert await permissions._ask_client("s1", "t") is False
+    finally:
+        state.end_run()
+        state.set_connection(None, None)
+
+
+@pytest.mark.asyncio
+async def test_shell_hook_gates_through_client(monkeypatch):
+    # The client-dialog edge only applies in non-yolo mode (yolo defaults ON).
+    monkeypatch.setattr("code_puppy.config.get_yolo_mode", lambda: False)
+    loop = asyncio.get_event_loop()
+
+    deny = FakeConnection(DeniedOutcome(outcome="cancelled"))
+    state.set_connection(deny, loop)
+    state.begin_run("s1")
+    try:
+        blocked = await permissions._on_run_shell_command(None, "rm -rf /", None, 60)
+    finally:
+        state.end_run()
+    assert blocked["blocked"] is True
+
+    allow = FakeConnection(AllowedOutcome(option_id="allow_once", outcome="selected"))
+    state.set_connection(allow, loop)
+    state.begin_run("s1")
+    try:
+        ok = await permissions._on_run_shell_command(None, "ls", None, 60)
+    finally:
+        state.end_run()
+        state.set_connection(None, None)
+    assert ok is None
+
+
+@pytest.mark.asyncio
+async def test_shell_hook_yolo_mode_does_not_prompt(monkeypatch):
+    """In yolo mode the shell hook auto-allows without a client dialog.
+
+    Matches the file-permission edge (which skips its prompt in yolo mode), so
+    ACP + yolo doesn't silently auto-approve writes yet prompt for every shell.
+    """
+    monkeypatch.setattr("code_puppy.config.get_yolo_mode", lambda: True)
+    # A connection that would DENY if asked -- proves we never ask.
+    deny = FakeConnection(DeniedOutcome(outcome="cancelled"))
+    state.set_connection(deny, asyncio.get_event_loop())
+    state.begin_run("s1")
+    try:
+        result = await permissions._on_run_shell_command(None, "rm -rf /", None, 60)
+    finally:
+        state.end_run()
+        state.set_connection(None, None)
+    assert result is None  # allowed
+    assert deny.perm_requests == []  # dialog never shown
+
+
+@pytest.mark.asyncio
+async def test_shell_hook_inert_without_connection():
+    assert await permissions._on_run_shell_command(None, "ls", None, 60) is None
+
+
+@pytest.mark.asyncio
+async def test_file_approval_bridges_worker_thread_to_client():
+    """Sync approval backend (from a tool thread) reaches the client via the ACP loop
+    and gets an answer — the deadlock-prone path.
+    """
+    loop = asyncio.get_event_loop()
+    conn = FakeConnection(AllowedOutcome(option_id="allow_once", outcome="selected"))
+    state.set_connection(conn, loop)
+    state.begin_run("s1")
+    try:
+        approved, feedback = await asyncio.to_thread(
+            permissions._approval_backend, "Edit foo.py", "write?", "diff"
+        )
+    finally:
+        state.end_run()
+        state.set_connection(None, None)
+    assert approved is True and feedback is None
+    assert conn.perm_requests
+
+
+# --------------------------------------------------------------------------- #
+# I/O delegation — core seams
+# --------------------------------------------------------------------------- #
+def test_write_project_file_delegates_then_falls_back(tmp_path):
+    from code_puppy.tools import common, io_backends
+
+    writes = []
+
+    class _FS:
+        def read_text_file(self, path, line=None, limit=None):
+            return ""
+
+        def write_text_file(self, path, content):
+            writes.append((path, content))
+
+    io_backends.set_filesystem_backend(_FS())
+    try:
+        common.write_project_file("/somewhere/x.txt", "delegated")
+    finally:
+        io_backends.set_filesystem_backend(None)
+    assert writes == [("/somewhere/x.txt", "delegated")]
+
+    local = tmp_path / "y.txt"
+    common.write_project_file(str(local), "local")
+    assert local.read_text() == "local"
+
+
+def test_read_file_uses_backend_with_slicing():
+    from code_puppy.tools import io_backends
+    from code_puppy.tools.file_operations import _read_file
+
+    class _FS:
+        def read_text_file(self, path, line=None, limit=None):
+            lines = ["line1\n", "line2\n", "line3\n"]
+            if line is not None and limit is not None:
+                return "".join(lines[line - 1 : line - 1 + limit])
+            return "".join(lines)
+
+        def write_text_file(self, path, content):
+            pass
+
+    io_backends.set_filesystem_backend(_FS())
+    try:
+        full = _read_file(None, "/virtual/foo.py")
+        sliced = _read_file(None, "/virtual/foo.py", start_line=2, num_lines=1)
+    finally:
+        io_backends.set_filesystem_backend(None)
+
+    assert "line2" in full.content
+    assert sliced.content.strip() == "line2"
+
+
+# --------------------------------------------------------------------------- #
+# I/O delegation — client-delegated backends (capability-gated)
+# --------------------------------------------------------------------------- #
+def test_io_delegation_install_is_capability_gated():
+    from code_puppy.tools import io_backends
+
+    io_delegation.install(ClientCapabilities())
+    assert io_backends.get_filesystem_backend() is None
+    assert io_backends.get_command_executor() is None
+
+    io_delegation.install(
+        ClientCapabilities(
+            fs=FileSystemCapabilities(read_text_file=True, write_text_file=True)
+        )
+    )
+    assert io_backends.get_filesystem_backend() is not None
+    assert io_backends.get_command_executor() is None
+
+    io_delegation.install(ClientCapabilities(terminal=True))
+    assert io_backends.get_command_executor() is not None
+
+    io_delegation.uninstall()
+    assert io_backends.get_filesystem_backend() is None
+    assert io_backends.get_command_executor() is None
+
+
+@pytest.mark.asyncio
+async def test_command_executor_runs_through_terminal():
+    conn = FakeConnection()
+    state.set_connection(conn, asyncio.get_event_loop())
+    state.begin_run("s1")
+    try:
+        result = await io_delegation.DelegatedCommandExecutor().run(
+            "echo hi", "/tmp", 60
+        )
+    finally:
+        state.end_run()
+        state.set_connection(None, None)
+
+    assert result.exit_code == 0
+    assert "hi there" in result.output
+    assert result.timed_out is False
+    assert conn.released is True
+    assert conn.created[1] in (["-c", "echo hi"], ["/c", "echo hi"])
+
+
+@pytest.mark.asyncio
+async def test_fs_backend_read_bridges_worker_thread():
+    conn = FakeConnection()
+    state.set_connection(conn, asyncio.get_event_loop())
+    state.begin_run("s1")
+    try:
+        backend = io_delegation.DelegatedFileSystemBackend()
+        content_out = await asyncio.to_thread(backend.read_text_file, "/proj/a.py")
+    finally:
+        state.end_run()
+        state.set_connection(None, None)
+    assert content_out == "contents of /proj/a.py"
+
+
+# --------------------------------------------------------------------------- #
+# Gap-closing features: fork / persistence / extra-dirs / commands / images /
+# mcp / models / config options
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_fork_session_copies_history(wired_agent):
+    agent, _ = wired_agent
+    src = await agent.new_session(cwd="/tmp")
+    agent._sessions[src.session_id].agent.set_message_history(["turn-1", "turn-2"])
+    forked = await agent.fork_session(cwd="/tmp", session_id=src.session_id)
+    assert forked.session_id != src.session_id
+    assert agent._sessions[forked.session_id].agent.get_message_history() == [
+        "turn-1",
+        "turn-2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_load_session_rehydrates_history(wired_agent, monkeypatch):
+    agent, _ = wired_agent
+    monkeypatch.setattr(
+        "code_puppy.plugins.acp.persistence.load_history",
+        lambda sid: ["persisted-a", "persisted-b"],
+    )
+    await agent.load_session(cwd="/tmp", session_id="sess_restored")
+    hist = agent._sessions["sess_restored"].agent.get_message_history()
+    assert hist == ["persisted-a", "persisted-b"]
+
+
+@pytest.mark.asyncio
+async def test_load_session_replays_history_to_client(wired_agent, monkeypatch):
+    """session/load must stream the conversation back so the client rebuilds it.
+
+    Rehydrating the agent's memory is not enough: without replayed
+    ``session/update`` notifications the client shows (and may discard) an
+    empty thread -- the reported "click a session, it disappears, no history".
+    """
+    from pydantic_ai.messages import (
+        ModelRequest,
+        ModelResponse,
+        TextPart,
+        UserPromptPart,
+    )
+
+    agent, conn = wired_agent
+    history = [
+        ModelRequest(parts=[UserPromptPart(content="hello")]),
+        ModelResponse(parts=[TextPart(content="hi there")]),
+    ]
+    monkeypatch.setattr(
+        "code_puppy.plugins.acp.persistence.load_history", lambda sid: history
+    )
+    await agent.load_session(cwd="/tmp", session_id="sess_replay")
+    kinds = [getattr(u, "session_update", None) for _, u in conn.updates]
+    assert "user_message_chunk" in kinds
+    assert "agent_message_chunk" in kinds
+    # Ordering: the user turn is replayed before the agent's reply.
+    assert kinds.index("user_message_chunk") < kinds.index("agent_message_chunk")
+
+
+@pytest.mark.asyncio
+async def test_additional_directories_reported(wired_agent):
+    agent, _ = wired_agent
+    await agent.new_session(cwd="/root", additional_directories=["/extra"])
+    listed = await agent.list_sessions()
+    assert any(s.additional_directories == ["/extra"] for s in listed.sessions)
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_includes_persisted_after_restart(wired_agent, monkeypatch):
+    """A session persisted by a prior process must still be listable + revivable.
+
+    Simulates the reported bug: nothing live in ``_sessions`` (fresh process),
+    but a session pickled to disk. ``list_sessions`` must surface it (with the
+    required ``cwd``) so the client's picker can revive it.
+    """
+    from code_puppy.plugins.acp import persistence
+
+    agent, _ = wired_agent
+    monkeypatch.setattr(
+        persistence,
+        "list_persisted",
+        lambda: [
+            persistence.PersistedSession(
+                session_id="sess_ghost",
+                cwd="/proj",
+                additional_directories=["/extra"],
+                updated_at="2026-01-01T00:00:00",
+            )
+        ],
+    )
+    listed = await agent.list_sessions()
+    ghost = next(s for s in listed.sessions if s.session_id == "sess_ghost")
+    assert ghost.cwd == "/proj"
+    assert ghost.additional_directories == ["/extra"]
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_live_wins_over_persisted(wired_agent, monkeypatch):
+    """A live session and its on-disk copy must dedupe to a single entry."""
+    from code_puppy.plugins.acp import persistence
+
+    agent, _ = wired_agent
+    live = await agent.new_session(cwd="/live")
+    monkeypatch.setattr(
+        persistence,
+        "list_persisted",
+        lambda: [
+            persistence.PersistedSession(session_id=live.session_id, cwd="/stale")
+        ],
+    )
+    listed = await agent.list_sessions()
+    matches = [s for s in listed.sessions if s.session_id == live.session_id]
+    assert len(matches) == 1
+    assert matches[0].cwd == "/live"
+
+
+@pytest.mark.asyncio
+async def test_close_session_deletes_persisted(wired_agent, monkeypatch):
+    """Closing a session tombstones its disk copy so it can't resurrect."""
+    from code_puppy.plugins.acp import persistence
+
+    agent, _ = wired_agent
+    deleted: list = []
+    monkeypatch.setattr(persistence, "delete", lambda sid: deleted.append(sid))
+    new = await agent.new_session(cwd="/tmp")
+    await agent.close_session(new.session_id)
+    assert deleted == [new.session_id]
+
+
+def test_persistence_roundtrip_lists_and_deletes(tmp_path):
+    """``list_persisted`` finds real sessions; ``delete`` removes them.
+
+    Fully hermetic and deterministic: the on-disk state (pickle + ACP sidecar)
+    is written directly into an injected ``base_dir``, so this exercises the
+    code under test (glob sidecars, require the pickle, parse, delete) without
+    depending on the ``session_storage`` save path, the process environment, or
+    any global location -- it can neither be perturbed by nor perturb other
+    tests.
+    """
+    import json
+    import pickle
+
+    from code_puppy.plugins.acp import persistence
+
+    # A complete session: pickle + sidecar (what list_persisted keys on).
+    (tmp_path / "sess_x.pkl").write_bytes(pickle.dumps(["turn-1"]))
+    (tmp_path / "sess_x_acp.json").write_text(
+        json.dumps(
+            {
+                "session_id": "sess_x",
+                "cwd": "/work",
+                "additional_directories": ["/aux"],
+                "updated_at": "2026-01-01T00:00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    records = persistence.list_persisted(base_dir=tmp_path)
+    assert len(records) == 1
+    assert records[0].session_id == "sess_x"
+    assert records[0].cwd == "/work"
+    assert records[0].additional_directories == ["/aux"]
+
+    # A sidecar whose pickle vanished is skipped -- nothing left to rehydrate.
+    (tmp_path / "sess_orphan_acp.json").write_text(
+        json.dumps({"session_id": "sess_orphan", "cwd": "/o"}), encoding="utf-8"
+    )
+    assert {r.session_id for r in persistence.list_persisted(base_dir=tmp_path)} == {
+        "sess_x"
+    }
+
+    persistence.delete("sess_x", base_dir=tmp_path)
+    assert persistence.list_persisted(base_dir=tmp_path) == []
+
+
+def test_persistence_save_writes_listable_session(tmp_path):
+    """``save`` writes a pickle + sidecar that ``list_persisted`` then surfaces.
+
+    Covers the write path end-to-end against an injected ``base_dir`` (no
+    globals). Kept separate from the list/delete unit test so a failure points
+    at the right half.
+    """
+    from code_puppy.plugins.acp import persistence
+
+    class _Agent:
+        def get_message_history(self):
+            return ["turn-1"]
+
+    persistence.save(
+        "sess_saved",
+        _Agent(),
+        cwd="/work",
+        additional_directories=["/aux"],
+        base_dir=tmp_path,
+    )
+    assert (tmp_path / "sess_saved.pkl").exists()
+    assert (tmp_path / "sess_saved_acp.json").exists()
+    records = persistence.list_persisted(base_dir=tmp_path)
+    assert [r.session_id for r in records] == ["sess_saved"]
+    assert records[0].cwd == "/work"
+
+
+@pytest.mark.asyncio
+async def test_slash_command_handled_not_modelled(wired_agent, monkeypatch):
+    """A handled command (handler returns True) is routed, not sent to the model."""
+    agent, conn = wired_agent
+    new = await agent.new_session(cwd="/tmp")
+
+    calls = {}
+
+    def fake_handle(cmd):
+        calls["cmd"] = cmd
+        return True  # handled; nothing to feed the model
+
+    monkeypatch.setattr(
+        "code_puppy.command_line.command_handler.handle_command", fake_handle
+    )
+    resp = await agent.prompt(
+        [SimpleNamespace(type="text", text="/help")], new.session_id
+    )
+    assert resp.stop_reason == "end_turn"
+    assert calls["cmd"] == "/help"
+    texts = [
+        u.content.text
+        for _, u in conn.updates
+        if getattr(u, "session_update", None) == "agent_message_chunk"
+    ]
+    # The command ran; the model did NOT (the streaming FakeAgent would have
+    # emitted "Hello "). A confirmation chunk stands in for the command output.
+    assert not any("Hello" in t for t in texts)
+    assert any("Ran" in t for t in texts)
+
+
+@pytest.mark.asyncio
+async def test_slash_command_string_result_runs_model(wired_agent, monkeypatch):
+    """A command that returns a string expands into a prompt run by the model.
+
+    Custom/markdown commands return their expanded text (like ``cli_runner``'s
+    string command result), which must be fed to the agent -- not displayed as
+    if it were the answer.
+    """
+    agent, _ = wired_agent
+    new = await agent.new_session(cwd="/tmp")
+
+    calls = {}
+
+    def fake_handle(cmd):
+        calls["cmd"] = cmd
+        return "expanded prompt for the model"
+
+    monkeypatch.setattr(
+        "code_puppy.command_line.command_handler.handle_command", fake_handle
+    )
+
+    captured = {}
+
+    async def echo_run(prompt, **_):
+        captured["prompt"] = prompt
+        return SimpleNamespace(
+            output="modelled reply", usage=lambda: None, all_messages=lambda: []
+        )
+
+    agent._sessions[new.session_id].agent.run_with_mcp = echo_run
+    resp = await agent.prompt(
+        [SimpleNamespace(type="text", text="/plan feature")], new.session_id
+    )
+    assert resp.stop_reason == "end_turn"
+    assert calls["cmd"] == "/plan feature"
+    # The expanded string was fed to the model, not displayed verbatim.
+    assert captured["prompt"] == "expanded prompt for the model"
+
+
+@pytest.mark.asyncio
+async def test_slash_command_sentinel_not_modelled(wired_agent, monkeypatch):
+    """A ``__SENTINEL__`` string (TUI-only) must not be modelled over ACP."""
+    agent, _ = wired_agent
+    new = await agent.new_session(cwd="/tmp")
+
+    monkeypatch.setattr(
+        "code_puppy.command_line.command_handler.handle_command",
+        lambda cmd: "__AUTOSAVE_LOAD__",
+    )
+
+    modelled = {"called": False}
+
+    async def guard_run(prompt, **_):
+        modelled["called"] = True
+        return SimpleNamespace(output="x", usage=lambda: None, all_messages=lambda: [])
+
+    agent._sessions[new.session_id].agent.run_with_mcp = guard_run
+    resp = await agent.prompt(
+        [SimpleNamespace(type="text", text="/load")], new.session_id
+    )
+    assert resp.stop_reason == "end_turn"
+    assert modelled["called"] is False
+
+
+def test_image_block_becomes_attachment():
+    import base64
+
+    png = base64.b64encode(b"\x89PNG fake").decode()
+    parsed = content.parse_prompt(
+        [
+            SimpleNamespace(type="text", text="look"),
+            SimpleNamespace(type="image", data=png, mime_type="image/png", uri=None),
+        ]
+    )
+    assert parsed.text == "look"
+    assert len(parsed.attachments) == 1
+    assert parsed.attachments[0].media_type == "image/png"
+
+
+def test_mcp_config_attach_stdio():
+    from code_puppy.plugins.acp import mcp_config
+
+    class _Agent:
+        _mcp_servers: list = []
+
+    agent = _Agent()
+    spec = SimpleNamespace(
+        name="fs", command="mcp-fs", args=["--root", "/x"], env=None, url=None
+    )
+    mcp_config.attach(agent, [spec])
+    assert len(agent._mcp_servers) == 1
+
+
+@pytest.mark.asyncio
+async def test_set_config_option_toggles_streaming(wired_agent, monkeypatch):
+    agent, _ = wired_agent
+    written = {}
+    monkeypatch.setattr(
+        "code_puppy.config.set_config_value",
+        lambda k, v: written.__setitem__(k, v),
+    )
+    monkeypatch.setattr("code_puppy.config.get_enable_streaming", lambda: False)
+    new = await agent.new_session(cwd="/tmp")
+    # Streaming is an On/Off select (Zed only renders selects), so the value is
+    # the string "off", not a bool.
+    resp = await agent.set_config_option("enable_streaming", new.session_id, "off")
+    assert written["enable_streaming"] == "false"
+    assert resp.config_options is not None
+    streaming = next(o for o in resp.config_options if o.id == "enable_streaming")
+    assert streaming.type == "select"
+    assert [o.value for o in streaming.options] == ["on", "off"]
+
+
+@pytest.mark.asyncio
+async def test_set_config_model_rebinds_model(wired_agent, monkeypatch):
+    """Switching the 'model' config option rebinds the agent, keeping history."""
+    agent, _ = wired_agent
+    picked = {}
+    monkeypatch.setattr(
+        "code_puppy.command_line.model_picker_completion.load_model_names",
+        lambda: ["gpt-9"],
+    )
+    monkeypatch.setattr(
+        "code_puppy.config.set_model_name", lambda m: picked.__setitem__("m", m)
+    )
+    new = await agent.new_session(cwd="/tmp")
+    agent._sessions[new.session_id].agent.set_message_history(["keep-me"])
+    await agent.set_config_option("model", new.session_id, "gpt-9")
+    assert picked["m"] == "gpt-9"
+    # History carried across the model rebind.
+    assert agent._sessions[new.session_id].agent.get_message_history() == ["keep-me"]
+
+
+@pytest.mark.asyncio
+async def test_set_session_mode_is_noop(wired_agent, monkeypatch):
+    """session/set_mode never switches models (Code Puppy has no modes)."""
+    agent, _ = wired_agent
+    called = {}
+    monkeypatch.setattr(
+        "code_puppy.config.set_model_name", lambda m: called.__setitem__("m", m)
+    )
+    new = await agent.new_session(cwd="/tmp")
+    await agent.set_session_mode("anything", new.session_id)
+    assert called == {}
+
+
+def test_config_options_expose_model_select(monkeypatch):
+    """The model picker is a category='model', type='select' config option."""
+    from code_puppy.plugins.acp import session_config
+
+    monkeypatch.setattr(
+        "code_puppy.command_line.model_picker_completion.load_model_names",
+        lambda: ["alpha", "beta"],
+    )
+    monkeypatch.setattr("code_puppy.config.get_global_model_name", lambda: "beta")
+    opts = session_config.config_options()
+    model_opt = next(o for o in opts if o.id == "model")
+    assert model_opt.category == "model"
+    assert model_opt.type == "select"
+    assert [o.value for o in model_opt.options] == ["alpha", "beta"]
+    assert model_opt.current_value == "beta"
+    # A current model outside the list falls back to the first offered.
+    monkeypatch.setattr("code_puppy.config.get_global_model_name", lambda: "gone")
+    opts2 = session_config.config_options()
+    assert next(o for o in opts2 if o.id == "model").current_value == "alpha"
+
+
+def test_mode_state_is_single_default():
+    """We advertise one 'default' mode as a category=mode select (not blank)."""
+    from code_puppy.plugins.acp import session_config
+
+    opts = session_config.config_options()
+    mode_opt = next(o for o in opts if o.id == "mode")
+    assert mode_opt.category == "mode"
+    assert mode_opt.type == "select"
+    assert mode_opt.current_value == "default"
+    assert [o.value for o in mode_opt.options] == ["default"]
+
+
+@pytest.mark.asyncio
+async def test_interactive_tool_blocked_over_acp():
+    """ask_user_question can't run headless; the bridge blocks it (steering the
+    model to ask in plain text) without opening a dangling tool-call entry.
+    """
+    conn = FakeConnection()
+    state.set_connection(conn, asyncio.get_event_loop())
+    state.begin_run("s1")
+    bridge = bridge_mod.EventBridge()
+    try:
+        result = await bridge._on_pre_tool_call("ask_user_question", {})
+        assert isinstance(result, dict) and result["blocked"] is True
+        assert "text response" in result["error_message"]
+        # No tool_call update emitted and nothing pushed onto the stack.
+        assert conn.updates == []
+        assert state.current_tool_call() is None
+    finally:
+        state.end_run()
+        state.set_connection(None, None)
+
+
+# --------------------------------------------------------------------------- #
+# Run-context isolation (concurrent prompts on one connection)
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_run_context_is_task_isolated():
+    """Two concurrent runs in separate tasks must not see each other's session.
+
+    The SDK dispatches each ``session/prompt`` as its own task, so a shared
+    module global would let one run clobber the other's active session id. The
+    ``ContextVar`` keeps each run's state in its own task context.
+    """
+    seen = {}
+
+    async def run(name):
+        state.begin_run(name)
+        await asyncio.sleep(0)  # yield so the sibling task interleaves here
+        seen[name] = state.get_active_session_id()
+        state.end_run()
+
+    await asyncio.gather(run("A"), run("B"))
+    assert seen == {"A": "A", "B": "B"}
+
+
+@pytest.mark.asyncio
+async def test_run_context_shared_with_child_task():
+    """A mutation made in a spawned child task is visible in the parent run.
+
+    ``note_streamed_text`` fires deep inside the run task, while the streamed
+    fallback is read back in the prompt coroutine's ``finally``; the run state
+    is a shared mutable so that write propagates despite the task boundary.
+    """
+    state.begin_run("s")
+    try:
+
+        async def child():
+            state.note_streamed_text()
+
+        await asyncio.ensure_future(child())
+        assert state.streamed_text() is True
+    finally:
+        state.end_run()
+
+
+def test_bridge_unregister_removes_callbacks():
+    """``EventBridge.unregister`` leaves the callback registry as it found it."""
+    from code_puppy import callbacks
+
+    phases = ("stream_event", "pre_tool_call", "post_tool_call")
+    before = {p: callbacks.count_callbacks(p) for p in phases}
+    bridge = bridge_mod.EventBridge()
+    bridge.register()
+    assert all(callbacks.count_callbacks(p) == before[p] + 1 for p in phases)
+    bridge.unregister()
+    assert {p: callbacks.count_callbacks(p) for p in phases} == before
+
+
+# --------------------------------------------------------------------------- #
+# CR follow-ups: core seams + hardened behaviors
+# --------------------------------------------------------------------------- #
+def test_resolve_path_honors_working_directory_contextvar():
+    from code_puppy.tools import common
+
+    token = common.set_working_directory("/work/base")
+    try:
+        # Relative paths resolve against the override; absolute pass through.
+        assert common.resolve_path("foo/bar.py") == "/work/base/foo/bar.py"
+        assert common.resolve_path("/abs/x.py") == "/abs/x.py"
+    finally:
+        common.reset_working_directory(token)
+    # After reset, no override -> falls back to process cwd.
+    import os as _os
+
+    assert common.resolve_path("rel.py") == _os.path.join(_os.getcwd(), "rel.py")
+
+
+def test_write_project_file_rejects_non_utf8_over_backend():
+    from code_puppy.tools import common, io_backends
+
+    class _FS:
+        def read_text_file(self, path, line=None, limit=None):
+            return ""
+
+        def write_text_file(self, path, content):
+            pass
+
+    io_backends.set_filesystem_backend(_FS())
+    try:
+        with pytest.raises(ValueError):
+            common.write_project_file("/x.txt", "hi", encoding="latin-1")
+    finally:
+        io_backends.set_filesystem_backend(None)
+
+
+def test_approval_backend_precedence_sync():
+    from code_puppy.tools import common
+
+    calls = []
+
+    def backend(title, message, preview):
+        calls.append((title, message, preview))
+        return True, None
+
+    common.set_approval_backend(backend)
+    try:
+        approved, feedback = common._get_user_approval_impl("Edit x.py", "body", None)
+    finally:
+        common.set_approval_backend(None)
+    assert approved is True and feedback is None
+    assert calls and calls[0][0] == "Edit x.py"
+
+
+@pytest.mark.asyncio
+async def test_approval_backend_precedence_async():
+    from code_puppy.tools import common
+
+    def backend(title, message, preview):
+        return False, None
+
+    common.set_approval_backend(backend)
+    try:
+        approved, _ = await common._get_user_approval_async_impl(
+            "Run: rm", "body", None
+        )
+    finally:
+        common.set_approval_backend(None)
+    assert approved is False
+
+
+@pytest.mark.asyncio
+async def test_execute_via_backend_maps_result():
+    from code_puppy.tools import command_runner, io_backends
+
+    class _Exec:
+        async def run(self, command, cwd, timeout):
+            return io_backends.ExecResult(exit_code=0, output="hello\nworld")
+
+    io_backends.set_command_executor(_Exec())
+    try:
+        out = await command_runner._execute_via_backend(
+            _Exec(), "echo hi", None, 60, "grp", True
+        )
+    finally:
+        io_backends.set_command_executor(None)
+    assert out.success is True
+    assert out.exit_code == 0
+    assert "world" in out.stdout
+
+
+@pytest.mark.asyncio
+async def test_set_config_model_reattaches_mcp(wired_agent, monkeypatch):
+    agent, _ = wired_agent
+    monkeypatch.setattr(
+        "code_puppy.command_line.model_picker_completion.load_model_names",
+        lambda: ["gpt-9"],
+    )
+    monkeypatch.setattr("code_puppy.config.set_model_name", lambda m: None)
+    reattached = {}
+    monkeypatch.setattr(
+        "code_puppy.plugins.acp.mcp_config.attach",
+        lambda ag, specs: reattached.update(specs=specs),
+    )
+    new = await agent.new_session(cwd="/tmp")
+    agent._sessions[new.session_id].mcp_specs = [SimpleNamespace(name="fs")]
+    await agent.set_config_option("model", new.session_id, "gpt-9")
+    assert "specs" in reattached and reattached["specs"][0].name == "fs"
+
+
+@pytest.mark.asyncio
+async def test_fork_unknown_session_raises(wired_agent):
+    agent, _ = wired_agent
+    with pytest.raises(ValueError):
+        await agent.fork_session(cwd="/tmp", session_id="does-not-exist")
+
+
+@pytest.mark.asyncio
+async def test_refusal_sends_error_notice(wired_agent, monkeypatch):
+    agent, conn = wired_agent
+    new = await agent.new_session(cwd="/tmp")
+
+    async def boom(*a, **k):
+        raise RuntimeError("kaboom")
+
+    agent._sessions[new.session_id].agent.run_with_mcp = boom
+    resp = await agent.prompt([SimpleNamespace(type="text", text="hi")], new.session_id)
+    assert resp.stop_reason == "refusal"
+    texts = [
+        u.content.text
+        for _, u in conn.updates
+        if getattr(u, "session_update", None) == "agent_message_chunk"
+    ]
+    assert any("failed" in t for t in texts)

--- a/tests/tools/test_atomic_write.py
+++ b/tests/tools/test_atomic_write.py
@@ -100,7 +100,7 @@ def test_write_to_file_returns_error_dict_on_atomic_failure(tmp_path, monkeypatc
     def boom(*args, **kwargs):
         raise OSError("simulated atomic write failure")
 
-    monkeypatch.setattr(fmod, "atomic_write_text", boom)
+    monkeypatch.setattr(fmod, "write_project_file", boom)
 
     p = tmp_path / "out.txt"
     result = fmod._write_to_file(None, str(p), "some content", overwrite=True)

--- a/tests/tools/test_fs_backend.py
+++ b/tests/tools/test_fs_backend.py
@@ -1,0 +1,552 @@
+"""Reference in-memory FileSystemBackend + contract/coherence tests.
+
+The in-memory backend here is the canonical *reference implementation* of
+``code_puppy.tools.io_backends.FileSystemBackend``: it is not the local disk and
+not ACP, so it proves the seam stands on its own -- any host that implements the
+protocol gets a single coherent filesystem across every file tool.
+
+Two layers of tests:
+
+* **contract** -- each protocol method behaves + raises per the documented
+  contract, exercised through the ``fs_access`` facade so the dispatch is real.
+* **coherence** -- with the backend installed, metadata / listing / traversal
+  agree with content (the property whose absence was the old "split-brain" bug).
+"""
+
+from __future__ import annotations
+
+import os
+import posixpath
+import sys
+from typing import Dict, List, Optional
+
+import pytest
+
+from code_puppy.tools import fs_access
+from code_puppy.tools.io_backends import (
+    DirEntry,
+    FileSystemBackend,
+    get_filesystem_backend,
+    set_filesystem_backend,
+)
+
+
+class InMemoryFileSystemBackend:
+    """A dict-backed filesystem. Paths are absolute, POSIX-style keys.
+
+    Directories are implicit (any prefix of a file path). This is deliberately
+    tiny -- it exists to demonstrate the contract, not to be efficient.
+    """
+
+    def __init__(self, files: Optional[Dict[str, str]] = None) -> None:
+        self._files: Dict[str, str] = dict(files or {})
+
+    # --- content ---
+    def read_text_file(
+        self, path: str, line: Optional[int] = None, limit: Optional[int] = None
+    ) -> str:
+        if path not in self._files:
+            raise FileNotFoundError(path)
+        text = self._files[path]
+        if line is None or limit is None:
+            return text
+        rows = text.splitlines(keepends=True)
+        return "".join(rows[line - 1 : line - 1 + limit])
+
+    def write_text_file(self, path: str, content: str) -> None:
+        self._files[path] = content
+
+    # --- metadata ---
+    def exists(self, path: str) -> bool:
+        return self.is_file(path) or self.is_dir(path)
+
+    def is_file(self, path: str) -> bool:
+        return path in self._files
+
+    def is_dir(self, path: str) -> bool:
+        prefix = path.rstrip("/") + "/"
+        return any(f.startswith(prefix) for f in self._files)
+
+    def list_dir(self, path: str) -> List[DirEntry]:
+        if self.is_file(path):
+            raise NotADirectoryError(path)
+        prefix = path.rstrip("/") + "/"
+        if not self.is_dir(path):
+            raise FileNotFoundError(path)
+        names_seen = set()
+        entries: List[DirEntry] = []
+        for f, content in self._files.items():
+            if not f.startswith(prefix):
+                continue
+            rest = f[len(prefix) :]
+            head, sep, _tail = rest.partition("/")
+            if head in names_seen:
+                continue
+            names_seen.add(head)
+            if sep:  # there was a "/", so head is a subdirectory
+                entries.append(DirEntry(name=head, is_dir=True, size=0))
+            else:
+                entries.append(
+                    DirEntry(name=head, is_dir=False, size=len(content.encode()))
+                )
+        return entries
+
+    # --- mutation ---
+    def delete_file(self, path: str) -> None:
+        if path not in self._files:
+            raise FileNotFoundError(path)
+        del self._files[path]
+
+    def make_dirs(self, path: str) -> None:
+        # Directories are implicit; nothing to materialize.
+        return None
+
+
+@pytest.fixture
+def backend():
+    fs = InMemoryFileSystemBackend(
+        {
+            "/ws/a.py": "print('a')\nx = 1\n",
+            "/ws/pkg/b.py": "import os\nNEEDLE = 42\n",
+            "/ws/pkg/c.txt": "no match here\n",
+        }
+    )
+    set_filesystem_backend(fs)
+    try:
+        yield fs
+    finally:
+        set_filesystem_backend(None)
+
+
+def test_reference_backend_satisfies_protocol(backend):
+    # runtime_checkable structural check + it is actually installed.
+    assert isinstance(backend, FileSystemBackend)
+    assert get_filesystem_backend() is backend
+
+
+# --- contract (through the facade) ------------------------------------------
+def test_read_whole_and_slice(backend):
+    assert fs_access.read_text("/ws/a.py") == "print('a')\nx = 1\n"
+    assert fs_access.read_text("/ws/a.py", line=2, limit=1) == "x = 1\n"
+
+
+def test_metadata(backend):
+    assert fs_access.exists("/ws/a.py")
+    assert fs_access.is_file("/ws/a.py")
+    assert not fs_access.is_dir("/ws/a.py")
+    assert fs_access.is_dir("/ws/pkg")
+    assert not fs_access.exists("/ws/nope.py")
+
+
+def test_list_dir_one_level(backend):
+    names = {e.name: e.is_dir for e in fs_access.list_dir("/ws")}
+    assert names == {"a.py": False, "pkg": True}
+
+
+def test_missing_read_raises_file_not_found(backend):
+    with pytest.raises(FileNotFoundError):
+        fs_access.read_text("/ws/ghost.py")
+
+
+def test_list_dir_errors(backend):
+    with pytest.raises(FileNotFoundError):
+        fs_access.list_dir("/ws/ghost")
+    with pytest.raises(NotADirectoryError):
+        fs_access.list_dir("/ws/a.py")
+
+
+def test_delete_and_make_dirs(backend):
+    fs_access.delete_file("/ws/pkg/c.txt")
+    assert not fs_access.exists("/ws/pkg/c.txt")
+    with pytest.raises(FileNotFoundError):
+        fs_access.delete_file("/ws/pkg/c.txt")
+    fs_access.make_dirs("/ws/new")  # idempotent no-op for this backend
+
+
+# --- coherence (the anti-split-brain property) ------------------------------
+def test_walk_sees_every_file_no_local_disk(backend):
+    found = {full for full, entry in fs_access.walk("/ws") if not entry.is_dir}
+    assert found == {"/ws/a.py", "/ws/pkg/b.py", "/ws/pkg/c.txt"}
+
+
+def test_write_is_immediately_visible_to_metadata_list_and_walk(backend):
+    # Write through the backend, then confirm EVERY other operation agrees --
+    # this is exactly what split-brain (list local, read host) got wrong.
+    backend.write_text_file("/ws/pkg/new.py", "value = 'created'\n")
+
+    assert fs_access.exists("/ws/pkg/new.py")
+    assert fs_access.is_file("/ws/pkg/new.py")
+    assert "new.py" in {e.name for e in fs_access.list_dir("/ws/pkg")}
+    walked = {full for full, e in fs_access.walk("/ws") if not e.is_dir}
+    assert "/ws/pkg/new.py" in walked
+    assert fs_access.read_text("/ws/pkg/new.py") == "value = 'created'\n"
+
+
+def test_walk_prune_skips_directory(backend):
+    walked = {
+        full
+        for full, e in fs_access.walk("/ws", skip_dir=lambda p: p.endswith("/pkg"))
+        if not e.is_dir
+    }
+    assert walked == {"/ws/a.py"}  # pkg pruned entirely
+
+
+def test_paths_are_posix_join(backend):
+    # sanity: facade uses os.path.join; on POSIX CI this equals posixpath.
+    assert posixpath.join("/ws", "a.py") == "/ws/a.py"
+
+
+# --- tool-level coherence: the real list_files / grep tools ------------------
+def test_list_files_tool_uses_backend(backend):
+    """``_list_files`` composes its listing from the backend, not local disk."""
+    from code_puppy.tools.file_operations import _list_files
+
+    out = _list_files(None, "/ws", recursive=True)
+    assert out.error is None
+    # Every backend file shows up; nothing from the real local disk leaks in.
+    assert "a.py" in out.content
+    assert "b.py" in out.content
+    assert "pkg" in out.content
+    assert "c.txt" in out.content
+
+
+def test_grep_tool_searches_backend(backend):
+    """``_grep`` searches the backend's files (walk + read), not local ripgrep."""
+    from code_puppy.tools.file_operations import _grep
+
+    out = _grep(None, "NEEDLE", "/ws")
+    assert out.error is None
+    hits = {(m.file_path, m.line_content) for m in out.matches}
+    assert ("/ws/pkg/b.py", "NEEDLE = 42") in hits
+    # c.txt has no match -> not present
+    assert all(m.file_path != "/ws/pkg/c.txt" for m in out.matches)
+
+
+def test_created_file_is_listable_and_greppable(backend):
+    """End-to-end anti-split-brain: write via backend, then the *tools* agree."""
+    from code_puppy.tools.file_operations import _grep, _list_files
+
+    backend.write_text_file("/ws/pkg/fresh.py", "MARKER = 'x'\n")
+
+    listing = _list_files(None, "/ws", recursive=True)
+    assert "fresh.py" in listing.content
+
+    grep_out = _grep(None, "MARKER", "/ws")
+    assert any(m.file_path == "/ws/pkg/fresh.py" for m in grep_out.matches)
+
+
+# --- backend grep flag-mode parity ------------------------------------------
+def test_grep_ignore_case_flag(backend):
+    from code_puppy.tools.file_operations import _grep
+
+    # 'needle' lower-case only matches NEEDLE with -i.
+    assert _grep(None, "needle", "/ws").matches == []
+    hits = _grep(None, "-i needle", "/ws").matches
+    assert any(m.file_path == "/ws/pkg/b.py" for m in hits)
+
+
+def test_grep_fixed_string_flag(backend):
+    from code_puppy.tools.file_operations import _grep
+
+    backend.write_text_file("/ws/dots.py", "a=b.c.d\naXbYcZd\n")
+    # As regex, 'b.c.d' matches 'aXbYcZd'? No -- but 'b.c.d' regex matches
+    # 'b.c.d' literally too. Use -F to force literal: only the real 'b.c.d'.
+    literal = _grep(None, "-F b.c.d", "/ws").matches
+    assert {m.line_content for m in literal} == {"a=b.c.d"}
+
+
+def test_grep_word_flag(backend):
+    from code_puppy.tools.file_operations import _grep
+
+    backend.write_text_file("/ws/w.py", "cat\ncategory\nscatter\n")
+    words = {m.line_content for m in _grep(None, "-w cat", "/ws").matches}
+    assert words == {"cat"}
+
+
+def test_grep_type_filter(backend):
+    from code_puppy.tools.file_operations import _grep
+
+    # b.py and c.txt both contain 'no match'? Put a common token in both.
+    backend.write_text_file("/ws/pkg/b.py", "import os\nTOKEN = 42\n")
+    backend.write_text_file("/ws/pkg/c.txt", "TOKEN in text\n")
+    py_only = _grep(None, "--type py TOKEN", "/ws").matches
+    assert {m.file_path for m in py_only} == {"/ws/pkg/b.py"}
+
+
+def test_grep_unsupported_flag_errors_loudly(backend):
+    from code_puppy.tools.file_operations import _grep
+
+    out = _grep(None, "-z foo", "/ws")
+    assert out.matches == []
+    assert out.error is not None and "-z" in out.error
+
+
+def test_grep_unknown_type_errors(backend):
+    from code_puppy.tools.file_operations import _grep
+
+    out = _grep(None, "--type cobol foo", "/ws")
+    assert out.matches == []
+    assert out.error is not None and "cobol" in out.error
+
+
+def test_grep_nonexistent_directory_errors(backend):
+    """A missing directory reports an error, not zero silent matches.
+
+    Parity with the local ripgrep path (which errors on a bad directory) so a
+    typo'd path isn't mistaken for "searched, found nothing".
+    """
+    from code_puppy.tools.file_operations import _grep
+
+    out = _grep(None, "NEEDLE", "/ws/does_not_exist")
+    assert out.matches == []
+    assert out.error is not None and "does not exist" in out.error
+
+
+def test_grep_skips_binary_files(backend):
+    from code_puppy.tools.file_operations import _grep
+
+    backend.write_text_file("/ws/bin.dat", "MARK\x00MARK\n")
+    out = _grep(None, "MARK", "/ws")
+    assert all(m.file_path != "/ws/bin.dat" for m in out.matches)
+
+
+# --- adversarial: hostile / degenerate backends -----------------------------
+class _CyclicBackend:
+    """list_dir always returns one subdir -> an infinite chain of distinct paths."""
+
+    def read_text_file(self, p, line=None, limit=None):
+        return ""
+
+    def write_text_file(self, p, c):
+        pass
+
+    def exists(self, p):
+        return True
+
+    def is_file(self, p):
+        return False
+
+    def is_dir(self, p):
+        return True
+
+    def list_dir(self, p):
+        return [DirEntry("sub", True, 0)]
+
+    def delete_file(self, p):
+        pass
+
+    def make_dirs(self, p):
+        pass
+
+
+class _DeepBackend(_CyclicBackend):
+    def __init__(self, depth):
+        self.depth = depth
+
+    def is_dir(self, p):
+        return p.count("/") <= self.depth
+
+    def list_dir(self, p):
+        return [DirEntry("d", True, 0)] if p.count("/") < self.depth else []
+
+
+def test_walk_survives_cyclic_backend():
+    """A cyclic list_dir must not blow the stack (no OS ELOOP to save us)."""
+    from code_puppy.tools import fs_access
+
+    set_filesystem_backend(_CyclicBackend())
+    old = sys.getrecursionlimit()
+    sys.setrecursionlimit(400)
+    try:
+        n = sum(1 for _ in fs_access.walk("/r"))
+        assert n <= fs_access.MAX_WALK_DEPTH  # capped, not infinite / crashed
+    finally:
+        sys.setrecursionlimit(old)
+        set_filesystem_backend(None)
+
+
+def test_walk_survives_deep_tree():
+    """A legitimately very deep tree must not overflow the recursive stack."""
+    from code_puppy.tools import fs_access
+
+    set_filesystem_backend(_DeepBackend(5000))
+    old = sys.getrecursionlimit()
+    sys.setrecursionlimit(400)
+    try:
+        n = sum(1 for _ in fs_access.walk("/r"))
+        assert n == fs_access.MAX_WALK_DEPTH
+    finally:
+        sys.setrecursionlimit(old)
+        set_filesystem_backend(None)
+
+
+def test_list_files_degrades_when_backend_raises():
+    """A backend raising must become a tool error, never a crash."""
+    from code_puppy.tools.file_operations import _list_files
+
+    class _Boom:
+        def read_text_file(self, p, line=None, limit=None):
+            return ""
+
+        def write_text_file(self, p, c):
+            pass
+
+        def exists(self, p):
+            return True
+
+        def is_file(self, p):
+            return False
+
+        def is_dir(self, p):
+            return True
+
+        def list_dir(self, p):
+            raise RuntimeError("host exploded")
+
+        def delete_file(self, p):
+            pass
+
+        def make_dirs(self, p):
+            pass
+
+    set_filesystem_backend(_Boom())
+    try:
+        out = _list_files(None, "/ws", recursive=False)
+        assert out.error is not None and "host exploded" in out.error
+    finally:
+        set_filesystem_backend(None)
+
+
+def test_grep_skips_unreadable_file(backend):
+    """One file whose read raises must not abort the whole search."""
+    from code_puppy.tools.file_operations import _grep
+
+    real_read = backend.read_text_file
+
+    def flaky(path, line=None, limit=None):
+        if path == "/ws/pkg/b.py":
+            raise RuntimeError("cannot read this one")
+        return real_read(path, line, limit)
+
+    backend.read_text_file = flaky
+    backend.write_text_file("/ws/ok.py", "FINDME = 1\n")
+    out = _grep(None, "FINDME", "/ws")
+    assert any(m.file_path == "/ws/ok.py" for m in out.matches)
+    assert out.error is None
+
+
+# --- gap A: the facade's LOCAL (no-backend) branches ------------------------
+def test_facade_local_disk_roundtrip(tmp_path):
+    """With no backend, the facade operates on real local disk."""
+    from code_puppy.tools import fs_access
+
+    assert get_filesystem_backend() is None
+    d = tmp_path / "proj"
+    fs_access.make_dirs(str(d / "pkg"))
+    assert fs_access.is_dir(str(d / "pkg"))
+    f = d / "pkg" / "m.py"
+    fs_access.write_text(str(f), "l1\nl2\nl3\n")
+    assert fs_access.exists(str(f)) and fs_access.is_file(str(f))
+    # whole-file + slice reads via the local branch
+    assert fs_access.read_text(str(f)) == "l1\nl2\nl3\n"
+    assert fs_access.read_text(str(f), line=2, limit=1) == "l2\n"
+    names = {e.name for e in fs_access.list_dir(str(d / "pkg"))}
+    assert names == {"m.py"}
+    fs_access.delete_file(str(f))
+    assert not fs_access.exists(str(f))
+
+
+def test_facade_local_list_dir_errors(tmp_path):
+    from code_puppy.tools import fs_access
+
+    with pytest.raises(FileNotFoundError):
+        fs_access.list_dir(str(tmp_path / "nope"))
+    f = tmp_path / "a.txt"
+    f.write_text("x")
+    with pytest.raises(NotADirectoryError):
+        fs_access.list_dir(str(f))
+
+
+def test_facade_local_walk_and_symlink_cycle(tmp_path):
+    """Local walk traverses real disk and survives a real symlink cycle."""
+    from code_puppy.tools import fs_access
+
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "f.py").write_text("hi\n")
+    files = {full for full, e in fs_access.walk(str(tmp_path)) if not e.is_dir}
+    assert str(tmp_path / "a" / "f.py") in files
+    try:
+        os.symlink(str(tmp_path), str(tmp_path / "a" / "loop"))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable")
+    # Must terminate (visited-set on realpath breaks the cycle).
+    n = sum(1 for _ in fs_access.walk(str(tmp_path)))
+    assert n < 1000
+
+
+# --- gap B: the ACP adapter's topology methods (pure local os) --------------
+def test_acp_backend_topology(tmp_path):
+    from code_puppy.plugins.acp.io_delegation import DelegatedFileSystemBackend
+
+    be = DelegatedFileSystemBackend()
+    be.make_dirs(str(tmp_path / "sub"))
+    assert be.is_dir(str(tmp_path / "sub"))
+    f = tmp_path / "sub" / "x.txt"
+    f.write_text("data")
+    (tmp_path / "sub" / "nested").mkdir()  # a directory entry too
+    assert be.exists(str(f)) and be.is_file(str(f)) and not be.is_dir(str(f))
+    entries = {e.name: (e.is_dir, e.size) for e in be.list_dir(str(tmp_path / "sub"))}
+    assert entries == {"x.txt": (False, 4), "nested": (True, 0)}
+    be.delete_file(str(f))
+    assert not be.exists(str(f))
+
+
+def test_acp_backend_list_dir_errors(tmp_path):
+    from code_puppy.plugins.acp.io_delegation import DelegatedFileSystemBackend
+
+    be = DelegatedFileSystemBackend()
+    with pytest.raises(FileNotFoundError):
+        be.list_dir(str(tmp_path / "ghost"))
+    f = tmp_path / "f"
+    f.write_text("x")
+    with pytest.raises(NotADirectoryError):
+        be.list_dir(str(f))
+
+
+# --- gap C: file-mod tools + undo, WITH a backend installed -----------------
+def test_file_mod_tools_hit_backend(backend):
+    from code_puppy.tools.file_modifications import (
+        _delete_file,
+        delete_snippet_from_file,
+        replace_in_file,
+        write_to_file,
+    )
+
+    write_to_file(None, "/ws/pkg/new.py", "V = 1\nKEEP = 2\n", True)
+    assert backend.is_file("/ws/pkg/new.py")
+    assert backend.read_text_file("/ws/pkg/new.py") == "V = 1\nKEEP = 2\n"
+    # write must NOT have touched the real local disk
+    assert not os.path.exists("/ws/pkg/new.py")
+
+    replace_in_file(None, "/ws/pkg/new.py", [{"old_str": "V = 1", "new_str": "V = 9"}])
+    assert "V = 9" in backend.read_text_file("/ws/pkg/new.py")
+
+    delete_snippet_from_file(None, "/ws/pkg/new.py", "KEEP = 2\n")
+    assert "KEEP" not in backend.read_text_file("/ws/pkg/new.py")
+
+    _delete_file(None, "/ws/pkg/c.txt")
+    assert not backend.exists("/ws/pkg/c.txt")
+
+
+def test_undo_is_backend_coherent(backend):
+    """Undo must snapshot/restore through the backend, not local disk."""
+    from code_puppy.tools.file_modifications import write_to_file
+    from code_puppy.undo_manager import UndoManager
+
+    UndoManager()._instance.history.clear()
+    write_to_file(None, "/ws/created.py", "NEW = 1\n", True)
+    assert backend.is_file("/ws/created.py")
+    msg = UndoManager().undo_last()
+    # created file -> undo deletes it FROM THE BACKEND
+    assert "deleted" in msg
+    assert not backend.exists("/ws/created.py")

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,18 @@ revision = 3
 requires-python = ">=3.11, <3.15"
 
 [[package]]
+name = "agent-client-protocol"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/93/396d02c91b387b2678f23081869ca47bd495fc6c78789022c683180cf5f1/agent_client_protocol-0.11.0.tar.gz", hash = "sha256:8920a3b27bdcc852fd7c73066f47ab53257dbfbe57b505e20a40c69f80a5391c", size = 87402 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/48/a1367dded7765f5489f9840389949d5aeac53a73aeb1b4e6c0ab61e1617a/agent_client_protocol-0.11.0-py3-none-any.whl", hash = "sha256:2d8570cd4911f8af9fbab4808f7b05f09204a756f346c7409ecdcae3f37cdb2f", size = 68089 },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -303,6 +315,7 @@ name = "code-puppy"
 version = "0.0.615"
 source = { editable = "." }
 dependencies = [
+    { name = "agent-client-protocol" },
     { name = "anthropic" },
     { name = "azure-identity" },
     { name = "boto3" },
@@ -344,6 +357,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "agent-client-protocol", specifier = ">=0.11.0,<0.12" },
     { name = "anthropic", specifier = "==0.79.0" },
     { name = "azure-identity", specifier = ">=1.15.0" },
     { name = "boto3", specifier = ">=1.43.9" },


### PR DESCRIPTION
> **This is a proposal — opening as a draft to get your take on the approach before polishing.** Happy to split it, reshape the API, or adjust naming/scope. Nothing here is precious.

## What & why

Makes Code Puppy a **native agent inside any Agent Client Protocol (ACP) host** (Zed and other editors) via `code-puppy --acp`, and generalizes the tool layer's I/O into host-agnostic seams so a host can back Code Puppy's file and shell operations with no ACP-specific assumptions leaking into core.

**Two commits:**

1. **`feat(plugins): native ACP agent`** — a self-contained `code_puppy/plugins/acp/` plugin implementing the ACP SDK's `Agent` interface: capability negotiation, prompt content-block parsing (incl. images), the full session lifecycle (initialize / new / load / resume / fork / list / close / prompt / cancel / set_model / set_config_option), event bridging (streamed message + thought chunks, tool calls with kind/locations/inline diffs), client-authoritative permissions, and capability-gated I/O delegation to the host's `fs/*` + `terminal/*`. Rides existing callback hooks — no edits to `command_line/` or the CLI runner.

2. **`refactor(tools): make FileSystemBackend own the whole FS surface`** — the pluggable I/O seam the ACP plugin needs, designed to stand on its own (below).

## Session lifecycle correctness

The session lifecycle was hardened end-to-end against a real Zed client. Four behaviors that a persisted, multi-turn, restartable ACP agent must get right — all covered by tests:

- **Survives restart.** `session/list` merges live in-memory sessions with those persisted on disk (deduped, live wins), and `fork` falls back to persisted history — so sessions stay listable and revivable after the `--acp` process restarts. `close` tombstones the persisted copy so a deliberate close doesn't resurrect.
- **Remembers turns.** After each turn, `prompt()` folds `result.all_messages()` back into the agent (exactly as `cli_runner` does). Without this the shared runtime never writes the turn back, so the agent forgets everything and persistence saves only the user's prompt — never the reply.
- **Rebuilds the thread on open.** `load`/`resume` replay the rehydrated history to the client as ordered `session/update` chunks (user / agent / thinking / past tool calls), so the client reconstructs the conversation instead of showing — and discarding — an empty thread.
- **No truncation.** The stream bridge forwards a part's *initial* content (`PartStartEvent`), not just deltas, so messages aren't chopped at the front when the model front-loads the opening tokens.

A per-session `cwd` is honored via a `ContextVar` + `resolve_path()` (no process-global `os.chdir`, so concurrent sessions don't corrupt each other), and off-main-thread SIGINT wiring is skipped (signal handlers are main-thread-only in CPython) so the ACP server thread doesn't crash on startup.

## The FileSystemBackend seam

When a host backend is installed it owns **every** filesystem operation the agent's tools perform, so the agent sees one coherent filesystem — nothing about ACP is assumed in core.

Rationale for owning the whole surface: if only text read/write were routed through a backend and `list_files` / existence / delete / mkdir / grep stayed on local disk, you'd get a **split-brain filesystem** — `read_file` could serve a host buffer while `list_files` reports local disk. Coherent only when the host *is* the local disk; incoherent for any remote/sandbox/virtual backend. So the backend owns every operation; recursive listing and grep are *composed* by core from `list_dir` + `read_text_file`, keeping the backend contract small.

- **`io_backends.py`** — `FileSystemBackend` (`read`/`write` + `exists`/`is_file`/`is_dir`/`list_dir`/`delete_file`/`make_dirs`, with a `DirEntry` type) and `CommandExecutor`, both `None` by default (local I/O), with documented path (always absolute), error (`FileNotFoundError`/`OSError`), and UTF-8 contracts.
- **`fs_access.py`** (new) — a single dispatch facade ("backend or local disk?") for metadata, mutation, read/write, and the recursive `walk` that `list_files`/`grep` compose from. One place to make the decision (DRY); coherence guaranteed by construction.
- **tools** — `list_files`, `grep`, existence, read, delete, mkdir, and undo route through the facade. **The fast local ripgrep path is retained verbatim for the default (no-backend) case — zero behavior change for a normal install.**
- **ACP adapter** — serves *topology* (list/exists/delete/mkdir) from local disk (its host shares the disk) and *content* from the client. That "topology is local" choice lives in the adapter that legitimately knows its host shares the disk — never baked into the general seam.

### Robustness

- `walk` is iterative (deep trees can't overflow the stack); cycles broken by a realpath visited-set plus a `MAX_WALK_DEPTH` backstop for a backend returning an infinite chain of distinct paths.
- backend `list_files` degrades to a tool error instead of crashing if a backend raises; grep skips unreadable files instead of aborting.

## Testing

- **Default (no-backend) path unchanged** — existing file-op/list/grep/read/mod suites pass untouched.
- `tests/tools/test_fs_backend.py`: a reference in-memory backend (proves the seam is host-agnostic) + contract, coherence (write → immediately listable *and* greppable), tool-level, grep flag-mode, and adversarial (cyclic / deep / raising backend) cases.
- `tests/test_acp_plugin.py`: capability negotiation, prompt parsing, full session lifecycle, **list-across-restart, multi-turn memory, load/resume replay, streaming start-chunk**, tool-call bridging, permission delegation, and delegated fs/terminal backends incl. terminal edge paths.
- Full suite green.

## Notes for reviewers

- Rebased on latest `main`; the only merge point is `_runtime.py`, where the ACP off-main-thread SIGINT guard meets `main`'s pure-keybinding Ctrl+C handling (both preserved).
- `backend grep` uses Python `re` where the local path uses Rust regex — common patterns are identical; exotic features (lookaround/backrefs) differ. `--type` covers ~24 common types and errors clearly on unknown ones.
- Happy to land the seam refactor separately from the ACP plugin if you'd rather review them independently.
