### PR TITLE
feat(ask_user_question): support clipboard paste in the Other option

### DIFF
--- a/code_puppy/tools/ask_user_question/tui_loop.py
+++ b/code_puppy/tools/ask_user_question/tui_loop.py
@@ -16,6 +16,7 @@ from prompt_toolkit import Application
 from prompt_toolkit.application import run_in_terminal
 from prompt_toolkit.formatted_text import ANSI, FormattedText
 from prompt_toolkit.key_binding import KeyBindings, KeyPressEvent
+from prompt_toolkit.keys import Keys
 from prompt_toolkit.layout import Layout, VSplit, Window
 from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.layout.dimension import Dimension
@@ -270,6 +271,38 @@ async def run_question_tui(
             if char and len(char) == 1 and ord(char) >= 32:
                 state.other_text_buffer += char
                 event.app.invalidate()
+
+    @kb.add(Keys.BracketedPaste)
+    def handle_paste(event: KeyPressEvent) -> None:
+        """Support clipboard paste into the 'Other' text buffer.
+
+        The terminal delivers the whole pasted payload in ``event.data`` when
+        bracketed paste is enabled (prompt_toolkit's ``Application`` turns
+        this on by default). We only accept paste while the user is typing
+        into the 'Other' option -- pasting outside text-entry mode would be
+        meaningless and is silently ignored.
+
+        Control characters are stripped so a stray newline / tab from the
+        clipboard cannot submit the form or break the layout. Newlines and
+        tabs are collapsed to a single space to keep the single-line input
+        readable.
+        """
+        state.reset_activity_timer()
+        if not state.entering_other_text:
+            return
+        pasted = event.data or ""
+        if not pasted:
+            return
+        cleaned_chars: list[str] = []
+        for ch in pasted:
+            if ch in ("\n", "\r", "\t"):
+                cleaned_chars.append(" ")
+            elif ch.isprintable():
+                cleaned_chars.append(ch)
+        cleaned = "".join(cleaned_chars)
+        if cleaned:
+            state.other_text_buffer += cleaned
+            event.app.invalidate()
 
     @kb.add("backspace")
     def handle_backspace(event: KeyPressEvent) -> None:

--- a/tests/tools/test_ask_user_question/test_tui_loop.py
+++ b/tests/tools/test_ask_user_question/test_tui_loop.py
@@ -543,6 +543,80 @@ class TestKeyHandlers:
         await _run_with_handler_callback(state, action)
 
     @pytest.mark.asyncio
+    async def test_paste_in_other_mode_appends_full_string(self):
+        """Bracketed paste dumps the full clipboard payload into the buffer."""
+        state = _make_state()
+        state.entering_other_text = True
+        state.other_text_buffer = "prefix-"
+
+        def action(kb, app):
+            e = _make_event()
+            e.app = app
+            e.data = "https://example.com/some/path?x=1&y=2"
+            _find_handler(kb, "<bracketed-paste>")(e)
+            assert (
+                state.other_text_buffer
+                == "prefix-https://example.com/some/path?x=1&y=2"
+            )
+            _find_handler(kb, "escape")(e)
+            _find_handler(kb, "c-c")(e)
+
+        await _run_with_handler_callback(state, action)
+
+    @pytest.mark.asyncio
+    async def test_paste_strips_control_chars_and_collapses_whitespace(self):
+        """Newlines/tabs become spaces; other control chars are dropped."""
+        state = _make_state()
+        state.entering_other_text = True
+        state.other_text_buffer = ""
+
+        def action(kb, app):
+            e = _make_event()
+            e.app = app
+            # Contains newline, tab, carriage return, and a bell (0x07)
+            e.data = "hello\nworld\there\r\x07end"
+            _find_handler(kb, "<bracketed-paste>")(e)
+            assert state.other_text_buffer == "hello world here end"
+            _find_handler(kb, "escape")(e)
+            _find_handler(kb, "c-c")(e)
+
+        await _run_with_handler_callback(state, action)
+
+    @pytest.mark.asyncio
+    async def test_paste_ignored_outside_other_mode(self):
+        """Pasting while browsing options is a no-op (no unintended input)."""
+        state = _make_state()
+        # entering_other_text intentionally False
+
+        def action(kb, app):
+            e = _make_event()
+            e.app = app
+            e.data = "should be ignored"
+            _find_handler(kb, "<bracketed-paste>")(e)
+            assert state.other_text_buffer == ""
+            _find_handler(kb, "c-c")(e)
+
+        await _run_with_handler_callback(state, action)
+
+    @pytest.mark.asyncio
+    async def test_paste_empty_payload_is_noop(self):
+        """Empty/whitespace-only paste doesn't mutate the buffer."""
+        state = _make_state()
+        state.entering_other_text = True
+        state.other_text_buffer = "keep-me"
+
+        def action(kb, app):
+            e = _make_event()
+            e.app = app
+            e.data = ""
+            _find_handler(kb, "<bracketed-paste>")(e)
+            assert state.other_text_buffer == "keep-me"
+            _find_handler(kb, "escape")(e)
+            _find_handler(kb, "c-c")(e)
+
+        await _run_with_handler_callback(state, action)
+
+    @pytest.mark.asyncio
     async def test_backspace_in_other_mode(self):
         state = _make_state()
         state.entering_other_text = True


### PR DESCRIPTION
# Support clipboard paste in the "Other" option of `ask_user_question`

##  The problem

When the `ask_user_question` TUI shows a question with the auto-added **"Other"** option and the user selects it to type free-form input (e.g. a URL, file path, or anything longer than a few chars), **paste is silently dropped**. Every character has to be re-typed by hand.

Root cause: the text-entry keybinding is `@kb.add("<any>")`, which only fires per single keypress. Terminals deliver clipboard content as a single bracketed-paste event (`Keys.BracketedPaste`), and there was no handler for it — so the whole payload was ignored.

##  The fix

Add a dedicated `@kb.add(Keys.BracketedPaste)` handler in `tui_loop.py` that:

1. **Only accepts paste inside `Other` text-entry mode** — pasting while browsing options is a deliberate no-op so nothing weird happens.
2. **Collapses `\n`, `\r`, `\t` to a single space** — the input is single-line, and a stray newline in the clipboard should not accidentally submit the form.
3. **Strips other non-printable control chars** — belt-and-suspenders against layout corruption or escape-sequence injection from clipboard content.
4. **Appends the cleaned payload to `other_text_buffer`** and invalidates the app for a repaint.

Bracketed paste is enabled by default in prompt_toolkit's `Application`, so no other wiring is needed.

##  Tests

Four new tests in `tests/tools/test_ask_user_question/test_tui_loop.py`:

- `test_paste_in_other_mode_appends_full_string` — pastes a URL, verifies the whole string lands in the buffer.
- `test_paste_strips_control_chars_and_collapses_whitespace` — pastes `"hello\nworld\there\r\x07end"`, verifies it becomes `"hello world here end"`.
- `test_paste_ignored_outside_other_mode` — paste while browsing options is a no-op.
- `test_paste_empty_payload_is_noop` — empty paste doesn't clobber the buffer.

All 40 tests in `test_tui_loop.py` pass; `ruff check` and `ruff format --check` are clean.

##  UX before/after

**Before:** User selects Other → tries `Cmd+V` a URL → nothing happens → grumbles → retypes it → typos → repeat.

**After:** User selects Other → `Cmd+V` → whole URL lands instantly. Newlines and tabs from the clipboard get sanitized to spaces so the layout stays intact.

##  Scope / non-goals

- Only touches the `Other` text-entry mode. Nothing else in the TUI behaviour changes.
- Doesn't add multi-line input support (that's a bigger UX decision — this PR keeps `Other` single-line and just makes paste work).
- Doesn't change the `<any>` handler for individual keystrokes.
