### PR TITLE
feat(plugins): lock_builtin_plugins deployment lock

### DIFF
--- a/code_puppy/plugins/config.py
+++ b/code_puppy/plugins/config.py
@@ -12,11 +12,42 @@ from __future__ import annotations
 
 import json
 import logging
+from pathlib import Path
 from typing import Set
 
 from code_puppy.config import get_value, set_value
 
 logger = logging.getLogger(__name__)
+
+# Hidden config key. When truthy, builtin plugins cannot be disabled and are
+# hidden from the /plugins menu. A general-purpose deployment lock: managed
+# distributions (corporate forks, kiosk installs) can flip it to protect the
+# shipped plugin set from being switched off by end users.
+LOCK_BUILTIN_KEY = "lock_builtin_plugins"
+
+
+def get_lock_builtin_plugins() -> bool:
+    """Whether builtin plugins are locked (un-disableable + hidden)."""
+    raw = get_value(LOCK_BUILTIN_KEY)
+    if raw is None:
+        return False
+    return str(raw).strip().lower() in ("1", "true", "yes", "on")
+
+
+def set_lock_builtin_plugins(locked: bool) -> None:
+    """Set the builtin-plugin lock. Idempotent at the config layer."""
+    set_value(LOCK_BUILTIN_KEY, "true" if locked else "false")
+
+
+def is_builtin_plugin(plugin_name: str) -> bool:
+    """True if *plugin_name* is a builtin (shipped in code_puppy/plugins/).
+
+    Filesystem ground-truth so the check is independent of plugin load order.
+    """
+    import code_puppy.plugins as plugins_pkg
+
+    plugin_dir = Path(plugins_pkg.__file__).parent / plugin_name
+    return plugin_dir.is_dir() and (plugin_dir / "register_callbacks.py").exists()
 
 
 def get_disabled_plugins() -> Set[str]:
@@ -44,8 +75,19 @@ def set_plugin_disabled(plugin_name: str, disabled: bool) -> bool:
     """Disable or re-enable a plugin by name.
 
     Returns ``True`` if the state changed, ``False`` if it was already in the
-    requested state.
+    requested state (or if the change was refused).
+
+    When the builtin lock is active, requests to *disable* a builtin plugin
+    are refused outright — re-enabling is always allowed so the lock can
+    never strand a builtin in the disabled set.
     """
+    if disabled and get_lock_builtin_plugins() and is_builtin_plugin(plugin_name):
+        logger.warning(
+            f"Refusing to disable builtin plugin '{plugin_name}': "
+            f"builtin plugins are locked ({LOCK_BUILTIN_KEY})."
+        )
+        return False
+
     disabled_plugins = get_disabled_plugins()
 
     if disabled:

--- a/code_puppy/plugins/plugin_list/plugins_menu.py
+++ b/code_puppy/plugins/plugin_list/plugins_menu.py
@@ -88,6 +88,8 @@ class PluginsMenu:
         self.plugins: List[_PluginEntry] = []
         self.disabled: set[str] = set()
         self.project_dir: Optional[str] = None
+        self.lock_builtin: bool = False
+        self.hidden_builtin_count: int = 0
 
         # Trust popup state. While ``trust_target`` is set, the modal is
         # visible, ALL list keybindings are filter-disabled (so typing the
@@ -144,16 +146,26 @@ class PluginsMenu:
             get_project_plugins_directory,
         )
         from code_puppy.plugins.config import get_disabled_plugins
+        from code_puppy.plugins.config import (
+            get_lock_builtin_plugins,
+        )
 
         loaded = get_loaded_plugins()
         self.disabled = get_disabled_plugins()
+        self.lock_builtin = get_lock_builtin_plugins()
 
         project_dir = get_project_plugins_directory()
         self.project_dir = project_dir.as_posix() if project_dir else None
 
         entries: List[_PluginEntry] = []
+        self.hidden_builtin_count = 0
         for tier in ("builtin", "user", "project"):
             for name in sorted(loaded.get(tier, [])):
+                # When locked, builtins are managed/protected — hide them so
+                # they can't be toggled (the config layer refuses anyway).
+                if self.lock_builtin and tier == "builtin":
+                    self.hidden_builtin_count += 1
+                    continue
                 entries.append(_PluginEntry(name, tier))
 
         # Project plugins held back by the trust gate — shown so Enter can
@@ -165,6 +177,10 @@ class PluginsMenu:
                 entries.append(_PluginEntry(name, "project", statuses[name]))
 
         self.plugins = entries
+
+        # Keep selection in range if the list shrank.
+        if self.selected_idx >= len(self.plugins):
+            self.selected_idx = max(0, len(self.plugins) - 1)
 
     def _current(self) -> Optional[_PluginEntry]:
         if 0 <= self.selected_idx < len(self.plugins):
@@ -197,9 +213,10 @@ class PluginsMenu:
         from code_puppy.plugins.config import set_plugin_disabled
 
         is_disabled = entry.name in self.disabled
-        set_plugin_disabled(entry.name, not is_disabled)
-        self._changed = True
-        self.detail_scroll = 0
+        changed = set_plugin_disabled(entry.name, not is_disabled)
+        if changed:
+            self._changed = True
+            self.detail_scroll = 0
         self._refresh_data()
         self.update_display()
 
@@ -247,6 +264,16 @@ class PluginsMenu:
         self._refresh_data()
         self._close_trust_modal()
         return False
+
+    # -- render compatibility ---------------------------------------------
+
+    def _render_list(self) -> Fragments:
+        """Return rendered list fragments for existing tests/callers."""
+        return render_list(self)
+
+    def _render_detail(self) -> Fragments:
+        """Return rendered detail fragments for existing tests/callers."""
+        return render_detail(self)
 
     # -- display update ----------------------------------------------------
 

--- a/code_puppy/plugins/plugin_list/plugins_menu_render.py
+++ b/code_puppy/plugins/plugin_list/plugins_menu_render.py
@@ -73,8 +73,21 @@ def render_list(menu: "PluginsMenu") -> Fragments:
     lines.append(("bold", " Plugins"))
     lines.append(("", "\n\n"))
 
+    if menu.lock_builtin and menu.hidden_builtin_count:
+        lines.append(
+            (
+                "fg:ansibrightblack",
+                f"  {menu.hidden_builtin_count} builtin plugins are "
+                f"managed and hidden.",
+            )
+        )
+        lines.append(("", "\n\n"))
+
     if not menu.plugins:
-        lines.append(("fg:ansiyellow", "  No plugins loaded."))
+        if menu.lock_builtin and menu.hidden_builtin_count:
+            lines.append(("fg:ansiyellow", "  No user or project plugins loaded."))
+        else:
+            lines.append(("fg:ansiyellow", "  No plugins loaded."))
         lines.append(("", "\n"))
         _render_hints(lines)
         return lines

--- a/tests/plugins/test_builtin_plugin_lock.py
+++ b/tests/plugins/test_builtin_plugin_lock.py
@@ -1,0 +1,126 @@
+"""Tests for the builtin-plugin lock (hidden ``lock_builtin_plugins`` key).
+
+When the lock is active:
+  * disabling a builtin plugin is refused at the config layer
+  * re-enabling a builtin is always allowed (never strand one disabled)
+  * user/project plugins remain freely toggleable
+  * the /plugins menu hides builtins and shows a managed-count note
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from code_puppy.plugins import config as pc
+from code_puppy.plugins.plugin_list.plugins_menu import PluginsMenu
+
+_FAKE_LOADED = {
+    "builtin": ["plugin_list", "agent_skills", "emoji_filter"],
+    "user": ["convo_namer"],
+    "project": [],
+}
+
+
+# ── config layer ────────────────────────────────────────────────
+
+
+def test_is_builtin_plugin_filesystem_truth():
+    assert pc.is_builtin_plugin("plugin_list")  # ships in code_puppy/plugins/
+    assert not pc.is_builtin_plugin("convo_namer")  # user-tier name
+    assert not pc.is_builtin_plugin("does_not_exist")
+
+
+def test_lock_defaults_off():
+    assert pc.get_lock_builtin_plugins() is False
+
+
+def test_lock_roundtrip():
+    pc.set_lock_builtin_plugins(True)
+    assert pc.get_lock_builtin_plugins() is True
+    pc.set_lock_builtin_plugins(False)
+    assert pc.get_lock_builtin_plugins() is False
+
+
+def test_builtin_disablable_when_unlocked():
+    pc.set_lock_builtin_plugins(False)
+    assert pc.set_plugin_disabled("plugin_list", True) is True
+    assert "plugin_list" in pc.get_disabled_plugins()
+
+
+def test_builtin_disable_refused_when_locked():
+    pc.set_lock_builtin_plugins(True)
+    assert pc.set_plugin_disabled("plugin_list", True) is False
+    assert "plugin_list" not in pc.get_disabled_plugins()
+
+
+def test_user_plugin_disablable_when_locked():
+    pc.set_lock_builtin_plugins(True)
+    assert pc.set_plugin_disabled("convo_namer", True) is True
+    assert "convo_namer" in pc.get_disabled_plugins()
+
+
+def test_builtin_reenable_always_allowed_when_locked():
+    # A builtin somehow already in the disabled set must be recoverable.
+    from code_puppy.config import set_value
+
+    set_value("disabled_plugins", json.dumps(["plugin_list"]))
+    pc.set_lock_builtin_plugins(True)
+    assert pc.set_plugin_disabled("plugin_list", False) is True
+    assert "plugin_list" not in pc.get_disabled_plugins()
+
+
+# ── menu layer ──────────────────────────────────────────────────
+
+
+def test_menu_shows_all_when_unlocked():
+    pc.set_lock_builtin_plugins(False)
+    with patch("code_puppy.plugins.get_loaded_plugins", return_value=_FAKE_LOADED):
+        menu = PluginsMenu()
+    tiers = {e.tier for e in menu.plugins}
+    assert "builtin" in tiers and "user" in tiers
+    assert menu.hidden_builtin_count == 0
+
+
+def test_menu_hides_builtins_when_locked():
+    pc.set_lock_builtin_plugins(True)
+    with patch("code_puppy.plugins.get_loaded_plugins", return_value=_FAKE_LOADED):
+        menu = PluginsMenu()
+    names = {e.name for e in menu.plugins}
+    assert names == {"convo_namer"}
+    assert all(e.tier != "builtin" for e in menu.plugins)
+    assert menu.hidden_builtin_count == 3
+
+
+def test_menu_renders_managed_note_when_locked():
+    pc.set_lock_builtin_plugins(True)
+    with patch("code_puppy.plugins.get_loaded_plugins", return_value=_FAKE_LOADED):
+        menu = PluginsMenu()
+        text = "".join(seg for _, seg in menu._render_list())
+    assert "3 builtin plugins are managed and hidden" in text
+
+
+def test_menu_toggle_does_not_flag_changed_on_refusal():
+    """Selecting a builtin (only possible if lock flips mid-session) and
+    toggling must not falsely set the restart-needed flag."""
+    pc.set_lock_builtin_plugins(False)
+    with patch("code_puppy.plugins.get_loaded_plugins", return_value=_FAKE_LOADED):
+        menu = PluginsMenu()
+        # Force selection onto a builtin, then lock and toggle.
+        builtin_idx = next(i for i, e in enumerate(menu.plugins) if e.tier == "builtin")
+        menu.selected_idx = builtin_idx
+        pc.set_lock_builtin_plugins(True)
+        menu._toggle_current()
+    assert menu._changed is False
+
+
+# ── idempotent set ──────────────────────────────────────────────
+
+
+def test_set_lock_builtin_plugins_is_idempotent():
+    pc.set_lock_builtin_plugins(False)
+    pc.set_lock_builtin_plugins(True)
+    assert pc.get_lock_builtin_plugins() is True
+    # Second call is a harmless no-op.
+    pc.set_lock_builtin_plugins(True)
+    assert pc.get_lock_builtin_plugins() is True


### PR DESCRIPTION
## What

A hidden config key: `lock_builtin_plugins`. When truthy:

- builtin plugins **cannot be disabled** — `set_plugin_disabled(name, True)` refuses at the config layer (re-enabling is always allowed, so nothing can get stranded in the disabled set)
- builtins are **hidden from the `/plugins` menu**, replaced by a one-line `N builtin plugins are managed and hidden.` notice; user/project plugins list normally

## Why

Managed distributions (corporate forks, kiosk-style installs) ship builtin plugins that need to stay on — policy/compliance filters, telemetry, etc. Today any user can flip them off in `/plugins`. This gives deployments a single switch to protect the shipped set while leaving user/project plugins fully self-service.

## Notes

- `is_builtin_plugin()` checks filesystem ground truth (subdir of `code_puppy/plugins/` containing `register_callbacks.py`) so it is independent of plugin load order.
- Off by default; zero behavior change unless the key is set.
- Tests: `tests/plugins/test_builtin_plugin_lock.py` (12 passing) covers config-layer refusal, menu hiding, toggle refusal, and idempotency.