### PR TITLE
fix: assorted robustness fixes (Windows encoding, pid guard, MCP config guard, configurable shell timeout)

### DIFF
--- a/code_puppy/agents/agent_manager.py
+++ b/code_puppy/agents/agent_manager.py
@@ -71,8 +71,11 @@ def _is_process_alive(pid: int) -> bool:
         pid: Process ID to check
 
     Returns:
-        bool: True if process likely exists, False otherwise
+        bool: True if process likely exists, False otherwise.
     """
+    if pid <= 0:
+        return False
+
     try:
         if os.name == "nt":
             # Windows: use OpenProcess to probe liveness safely
@@ -182,8 +185,31 @@ def _save_session_data(sessions: dict[str, str]) -> None:
         with open(temp_file, "w", encoding="utf-8") as f:
             json.dump(cleaned_sessions, f, indent=2)
 
-        # Atomic rename (works on all platforms)
-        temp_file.replace(session_file)
+        # Atomic rename; on Windows replace() is best-effort if target exists
+        try:
+            temp_file.replace(session_file)
+        except Exception:
+            try:
+                if session_file.exists():
+                    session_file.unlink(
+                        missing_ok=True
+                    )  # Python 3.8+: ignore if missing
+            except Exception:
+                pass
+            try:
+                temp_file.replace(session_file)
+            except Exception:
+                # As a last resort, copy contents
+                try:
+                    with (
+                        open(temp_file, "r", encoding="utf-8") as rf,
+                        open(session_file, "w", encoding="utf-8") as wf,
+                    ):
+                        wf.write(rf.read())
+                    temp_file.unlink(missing_ok=True)
+                except Exception:
+                    # Give up silently; session persistence isn't critical
+                    pass
 
     except (IOError, OSError):
         # File permission issues, etc. - just continue without persistence

--- a/code_puppy/agents/agent_manager.py
+++ b/code_puppy/agents/agent_manager.py
@@ -73,7 +73,12 @@ def _is_process_alive(pid: int) -> bool:
     Returns:
         bool: True if process likely exists, False otherwise.
     """
-    if pid <= 0:
+    try:
+        process_id = int(pid)
+    except (TypeError, ValueError, OverflowError):
+        return False
+
+    if process_id <= 0:
         return False
 
     try:
@@ -91,7 +96,7 @@ def _is_process_alive(pid: int) -> bool:
             ]
             kernel32.OpenProcess.restype = wintypes.HANDLE
             handle = kernel32.OpenProcess(
-                PROCESS_QUERY_LIMITED_INFORMATION, False, int(pid)
+                PROCESS_QUERY_LIMITED_INFORMATION, False, process_id
             )
             if handle:
                 kernel32.CloseHandle(handle)
@@ -104,7 +109,7 @@ def _is_process_alive(pid: int) -> bool:
             return False
         else:
             # Unix-like: signal 0 does not deliver a signal but checks existence
-            os.kill(int(pid), 0)
+            os.kill(process_id, 0)
             return True
     except PermissionError:
         # No permission to signal -> process exists

--- a/code_puppy/agents/json_agent.py
+++ b/code_puppy/agents/json_agent.py
@@ -209,7 +209,7 @@ class JSONAgent(BaseAgent):
             return override
 
         result = self._config.get("model")
-        if result is None:
+        if result is None or (isinstance(result, str) and not result.strip()):
             result = super().get_model_name()
         return result
 

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -1419,6 +1419,25 @@ def get_message_limit(default: int = 1000) -> int:
         return default
 
 
+def get_command_timeout_seconds() -> int:
+    """
+    Returns the user-configured absolute timeout for shell commands in seconds.
+    This is the maximum time any single command can run before being terminated.
+    Defaults to 270 seconds if unset or misconfigured.
+    Valid range: 60-900 seconds. Values outside this range default to 270.
+    Configurable by 'command_timeout_seconds' key.
+    """
+    val = get_value("command_timeout_seconds")
+    try:
+        timeout = int(val) if val else 270
+        # Enforce bounds: min 60, max 900, default 270 if outside bounds
+        if timeout < 60 or timeout > 900:
+            return 270
+        return timeout
+    except (ValueError, TypeError):
+        return 270
+
+
 def save_command_to_history(command: str):
     """Save a command to the history file with an ISO format timestamp.
 

--- a/code_puppy/mcp_/manager.py
+++ b/code_puppy/mcp_/manager.py
@@ -174,6 +174,17 @@ class MCPManager:
 
             for name, conf in configs.items():
                 try:
+                    # The config loader is the single chokepoint for wrapper-key
+                    # normalization (it accepts both mcp_servers and mcpServers
+                    # and never returns wrapper keys as server names). Sync only
+                    # guards against per-entry garbage.
+                    if not isinstance(conf, dict):
+                        logger.warning(
+                            "Skipping MCP server '%s': config must be a dictionary",
+                            name,
+                        )
+                        continue
+
                     # Create ServerConfig from the loaded configuration
                     server_config = ServerConfig(
                         id=conf.get("id", ""),  # Empty ID will be auto-generated

--- a/code_puppy/tools/agent_tools.py
+++ b/code_puppy/tools/agent_tools.py
@@ -147,7 +147,7 @@ def _save_session_history(
     elif txt_path.exists():
         # Update message count on subsequent saves
         try:
-            with open(txt_path, "r") as f:
+            with open(txt_path, "r", encoding="utf-8") as f:
                 metadata = json.load(f)
             metadata["message_count"] = len(message_history)
             metadata["last_updated"] = datetime.now().isoformat()

--- a/code_puppy/tools/command_runner.py
+++ b/code_puppy/tools/command_runner.py
@@ -669,7 +669,10 @@ def run_shell_command_streaming(
     start_time = time.time()
     last_output_time = [start_time]
 
-    ABSOLUTE_TIMEOUT_SECONDS = 270
+    # Get the user-configured absolute timeout for shell commands
+    from code_puppy.config import get_command_timeout_seconds
+
+    ABSOLUTE_TIMEOUT_SECONDS = get_command_timeout_seconds()
 
     stdout_lines = []
     stderr_lines = []

--- a/code_puppy/tools/common.py
+++ b/code_puppy/tools/common.py
@@ -1425,10 +1425,17 @@ async def _get_user_approval_async_impl(
             confirmed = False
             emit_info("")
             emit_info(f"Tell {puppy_name} what to change:")
-            user_feedback = Prompt.ask(
-                "[bold green]➤[/bold green]",
-                default="",
-            ).strip()
+            # Rich's Prompt.ask reads stdin -- suspend the key listener
+            # so it doesn't fight us for keystrokes. Without this, the
+            # key-listener thread eats roughly half the user's keypresses
+            # and the feedback box appears "broken."
+            from code_puppy.agents._key_listeners import suspended_key_listener
+
+            with suspended_key_listener():
+                user_feedback = Prompt.ask(
+                    "[bold green]➤[/bold green]",
+                    default="",
+                ).strip()
 
             if not user_feedback:
                 user_feedback = None


### PR DESCRIPTION
## What

Six small, independent fixes:

| Area | Fix |
|---|---|
| `agents/json_agent.py` | Treat empty-string `"model": ""` as unset -> fall back to the global model instead of trying to load a model literally named `''` |
| `tools/agent_tools.py` | `open(..., encoding='utf-8')` for session metadata — Windows defaults to cp1252 and chokes on emoji |
| `agents/agent_manager.py` | `_is_process_alive`: guard `pid <= 0` (negative/zero pids probe process groups or throw). `_save_session_data`: Windows-safe atomic rename — `Path.replace()` can fail when the target exists on Windows; retry after unlink, last-resort content copy |
| `mcp_/manager.py` | Skip non-dict server config entries during sync instead of crashing on hand-edited `mcp_servers.json` garbage |
| `tools/common.py` | Suspend the key listener around the interactive-feedback `Prompt.ask` — the listener thread was eating ~half the user's keystrokes, making the feedback box look broken |
| `tools/command_runner.py` + `config.py` | The hardcoded 270s absolute shell timeout becomes configurable via `command_timeout_seconds` (bounded 60-900, default 270) — long builds/test suites routinely blow the fixed cap |

## Notes

- Each fix is independent; happy to split if any needs discussion.
- Ruff clean (check + format) under this repo's config; `test_json_agents` (13) and file-tool suites pass locally.
- An earlier revision included a `skills_menu` safe_input change — dropped, main already has it.