### PR TITLE
Add ChatGPT GPT-5.6 OAuth models

### DIFF
--- a/code_puppy/plugins/chatgpt_oauth/utils.py
+++ b/code_puppy/plugins/chatgpt_oauth/utils.py
@@ -344,6 +344,10 @@ def exchange_code_for_tokens(
 # These are the known models that work with ChatGPT OAuth tokens
 # Based on codex-rs CLI and shell-scripts/codex-call.sh
 DEFAULT_CODEX_MODELS = [
+    "gpt-5.6",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
     "gpt-5.5",
     "gpt-5.4",
     "gpt-5.3-instant",
@@ -357,6 +361,10 @@ DEFAULT_CODEX_MODELS = [
 # doesn't return them (e.g. newly launched, not yet in the API catalogue).
 # These are merged into whatever the endpoint returns.
 REQUIRED_CODEX_MODELS = [
+    "gpt-5.6",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
     "gpt-5.5",
     "gpt-5.4",
     "gpt-5.3-instant",
@@ -366,9 +374,21 @@ REQUIRED_CODEX_MODELS = [
 # Per-model context length overrides (tokens).
 # Models not listed here use CHATGPT_OAUTH_CONFIG["default_context_length"] (272,000).
 CODEX_MODEL_CONTEXT_LENGTHS = {
+    "gpt-5.6": 1050000,
+    "gpt-5.6-sol": 1050000,
+    "gpt-5.6-terra": 1050000,
+    "gpt-5.6-luna": 1050000,
     "gpt-5.3-codex-spark": 131000,
     "gpt-5.3-instant": 192000,
 }
+
+
+def _supports_xhigh_reasoning(model_name: str) -> bool:
+    """Return whether a ChatGPT OAuth model supports xhigh reasoning."""
+    normalized_model_name = model_name.lower()
+    return "codex" in normalized_model_name or normalized_model_name.startswith(
+        ("gpt-5.4", "gpt-5.5", "gpt-5.6")
+    )
 
 
 def _ensure_required_models(models: List[str]) -> List[str]:
@@ -482,11 +502,7 @@ def add_models_to_extra_config(models: List[str]) -> bool:
 
             # xhigh reasoning is supported by codex models and GPT-5.4+ variants.
             # Older non-codex GPT-5.x models like gpt-5.2 stay capped at "high".
-            normalized_model_name = model_name.lower()
-            supports_xhigh_reasoning = (
-                "codex" in normalized_model_name
-                or normalized_model_name.startswith(("gpt-5.4", "gpt-5.5"))
-            )
+            supports_xhigh_reasoning = _supports_xhigh_reasoning(model_name)
 
             chatgpt_models[prefixed] = {
                 "type": "chatgpt_oauth",

--- a/tests/plugins/test_chatgpt_oauth_integration.py
+++ b/tests/plugins/test_chatgpt_oauth_integration.py
@@ -88,6 +88,10 @@ class TestModelManagement:
 
         result = add_models_to_extra_config(
             [
+                "gpt-5.6",
+                "gpt-5.6-sol",
+                "gpt-5.6-terra",
+                "gpt-5.6-luna",
                 "gpt-5.5",
                 "gpt-5.2",
                 "gpt-5.2-codex",
@@ -96,9 +100,18 @@ class TestModelManagement:
 
         assert result is True
         models = json.loads(models_file.read_text())
+        assert "chatgpt-gpt-5.6" in models
+        assert "chatgpt-gpt-5.6-sol" in models
+        assert "chatgpt-gpt-5.6-terra" in models
+        assert "chatgpt-gpt-5.6-luna" in models
         assert "chatgpt-gpt-5.5" in models
         assert "chatgpt-gpt-5.2" in models
         assert "chatgpt-gpt-5.2-codex" in models
+        assert models["chatgpt-gpt-5.6"]["context_length"] == 1050000
+        assert models["chatgpt-gpt-5.6-sol"]["context_length"] == 1050000
+        assert models["chatgpt-gpt-5.6-terra"]["context_length"] == 1050000
+        assert models["chatgpt-gpt-5.6-luna"]["context_length"] == 1050000
+        assert models["chatgpt-gpt-5.6"]["supports_xhigh_reasoning"] is True
         assert models["chatgpt-gpt-5.5"]["supports_xhigh_reasoning"] is True
 
     @patch("code_puppy.plugins.chatgpt_oauth.utils.get_chatgpt_models_path")
@@ -177,6 +190,10 @@ class TestModelManagement:
         models = fetch_chatgpt_models("test_token", "test_account")
 
         # Required models are prepended if not in API response
+        assert "gpt-5.6" in models
+        assert "gpt-5.6-sol" in models
+        assert "gpt-5.6-terra" in models
+        assert "gpt-5.6-luna" in models
         assert "gpt-5.5" in models
         assert "gpt-5.4" in models
         assert "gpt-5.3-instant" in models

--- a/tests/plugins/test_chatgpt_oauth_utils.py
+++ b/tests/plugins/test_chatgpt_oauth_utils.py
@@ -1082,11 +1082,27 @@ class TestAddModelsToConfig:
         mock_load.return_value = {}
         mock_save.return_value = True
 
-        result = add_models_to_extra_config(["gpt-5.5", "gpt-5.4"])
+        result = add_models_to_extra_config(
+            [
+                "gpt-5.6",
+                "gpt-5.6-sol",
+                "gpt-5.6-terra",
+                "gpt-5.6-luna",
+                "gpt-5.5",
+                "gpt-5.4",
+            ]
+        )
 
         assert result is True
         saved_config = mock_save.call_args[0][0]
-        for model_name in ("chatgpt-gpt-5.5", "chatgpt-gpt-5.4"):
+        for model_name in (
+            "chatgpt-gpt-5.6",
+            "chatgpt-gpt-5.6-sol",
+            "chatgpt-gpt-5.6-terra",
+            "chatgpt-gpt-5.6-luna",
+            "chatgpt-gpt-5.5",
+            "chatgpt-gpt-5.4",
+        ):
             model_config = saved_config[model_name]
             assert model_config["supported_settings"] == [
                 "reasoning_effort",


### PR DESCRIPTION
## Summary
- add GPT-5.6, GPT-5.6 Sol, GPT-5.6 Terra, and GPT-5.6 Luna to the ChatGPT OAuth default and required model lists
- set GPT-5.6 ChatGPT OAuth context windows to 1,050,000 tokens based on the model docs
- keep GPT-5.6 variants eligible for xhigh reasoning via a shared helper
- update ChatGPT OAuth model management tests

## Tests
- All checks passed!
- ........................................................................ [ 73%]
..........................                                               [100%]
98 passed in 0.19s