### PR TITLE
feat(callbacks): let run_shell_command hooks rewrite the command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ and skills (`<CWD>/.code_puppy/skills/`).
 | `agent_run_start` | Before agent task | `(agent_name, model_name, session_id=None) -> None` |
 | `agent_run_end` | After agent run | `(agent_name, model_name, session_id=None, success=True, error=None, response_text=None, metadata=None) -> None` |
 | `load_prompt` | System prompt assembly | `() -> str \| None` |
-| `run_shell_command` | Before shell exec | `(context, command, cwd=None, timeout=60) -> dict \| None` (return `{"blocked": True}` to block) |
+| `run_shell_command` | Before shell exec | `(context, command, cwd=None, timeout=60) -> dict \| None` (return `{"blocked": True}` to block, `{"rewrite": "<new cmd>"}` to transparently transform) |
 | `file_permission` | Before file op | `(context, file_path, operation, ...) -> bool` |
 | `pre_tool_call` | Before tool executes | `(tool_name, tool_args, context=None) -> Any` |
 | `post_tool_call` | After tool finishes | `(tool_name, tool_args, result, duration_ms, context=None) -> Any` |

--- a/code_puppy/tools/command_runner.py
+++ b/code_puppy/tools/command_runner.py
@@ -1096,6 +1096,23 @@ async def run_shell_command(
                 execution_time=None,
             )
 
+    # Apply any command rewrites requested by callbacks.
+    # A callback can return {"rewrite": "<new command>"} to transparently
+    # transform the command before execution (e.g. inject a git trailer,
+    # redact a secret, prepend a corporate proxy). Rewrites are applied in
+    # callback registration order; each one sees whatever the previous ones
+    # produced. A visible info line surfaces the change so users always know
+    # what actually ran -- rewriting must never be sneaky.
+    for result in callback_results:
+        if result and isinstance(result, dict) and "rewrite" in result:
+            new_command = result["rewrite"]
+            if not isinstance(new_command, str) or not new_command.strip():
+                continue  # ignore empty / non-string rewrites defensively
+            if new_command != command:
+                reason = result.get("rewrite_reason", "plugin")
+                emit_info(f"[dim]\U0001f527 command rewritten by {reason}[/dim]")
+                command = new_command
+
     # Handle background execution - runs command detached and returns immediately
     # This happens BEFORE user confirmation since we don't wait for the command
     if background:

--- a/tests/tools/test_command_runner_full_coverage.py
+++ b/tests/tools/test_command_runner_full_coverage.py
@@ -545,6 +545,115 @@ class TestRunShellCommand:
         assert "nope" in result.error
 
     @pytest.mark.asyncio
+    async def test_rewrite_from_callback_replaces_command(self):
+        """A callback that returns {"rewrite": ...} transforms the command.
+
+        Proves the new hook contract: infrastructure for plugins that want
+        to transparently transform commands (secret redaction, proxy
+        injection, attribution trailers) instead of merely blocking them.
+        """
+        from code_puppy.tools.command_runner import run_shell_command
+
+        ctx = MagicMock(spec=RunContext)
+        rewrite_result = {"rewrite": "echo rewritten", "rewrite_reason": "unit test"}
+        mock_output = MagicMock()
+        mock_output.success = True
+
+        with patch(
+            "code_puppy.callbacks.on_run_shell_command",
+            new_callable=AsyncMock,
+            return_value=[rewrite_result],
+        ):
+            with patch("code_puppy.config.get_yolo_mode", return_value=True):
+                with patch(
+                    "code_puppy.tools.command_runner.is_subagent",
+                    return_value=False,
+                ):
+                    with patch(
+                        "code_puppy.tools.command_runner._execute_shell_command",
+                        new_callable=AsyncMock,
+                        return_value=mock_output,
+                    ) as mock_exec:
+                        with patch("code_puppy.tools.command_runner.emit_info"):
+                            result = await run_shell_command(
+                                ctx, "echo original", timeout=10
+                            )
+
+        assert result.success is True
+        # The rewritten command is what actually got executed.
+        executed = mock_exec.call_args.kwargs["command"]
+        assert executed == "echo rewritten", (
+            f"expected rewritten command to be executed, got {executed!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_rewrite_ignored_when_same_as_original(self):
+        """A no-op rewrite should not emit the visible info notice."""
+        from code_puppy.tools.command_runner import run_shell_command
+
+        ctx = MagicMock(spec=RunContext)
+        noop_result = {"rewrite": "echo same"}
+        mock_output = MagicMock()
+        mock_output.success = True
+
+        with patch(
+            "code_puppy.callbacks.on_run_shell_command",
+            new_callable=AsyncMock,
+            return_value=[noop_result],
+        ):
+            with patch("code_puppy.config.get_yolo_mode", return_value=True):
+                with patch(
+                    "code_puppy.tools.command_runner.is_subagent",
+                    return_value=False,
+                ):
+                    with patch(
+                        "code_puppy.tools.command_runner._execute_shell_command",
+                        new_callable=AsyncMock,
+                        return_value=mock_output,
+                    ):
+                        with patch(
+                            "code_puppy.tools.command_runner.emit_info"
+                        ) as mock_info:
+                            await run_shell_command(ctx, "echo same", timeout=10)
+
+        # No 'command rewritten' notice should fire when the string is identical.
+        for call in mock_info.call_args_list:
+            args = call.args or ()
+            payload = args[0] if args else ""
+            assert "command rewritten" not in str(payload)
+
+    @pytest.mark.asyncio
+    async def test_rewrite_ignored_for_empty_or_non_string(self):
+        """Defensively skip empty / non-string rewrite payloads."""
+        from code_puppy.tools.command_runner import run_shell_command
+
+        ctx = MagicMock(spec=RunContext)
+        bad_results = [{"rewrite": ""}, {"rewrite": None}, {"rewrite": 42}]
+        mock_output = MagicMock()
+        mock_output.success = True
+
+        with patch(
+            "code_puppy.callbacks.on_run_shell_command",
+            new_callable=AsyncMock,
+            return_value=bad_results,
+        ):
+            with patch("code_puppy.config.get_yolo_mode", return_value=True):
+                with patch(
+                    "code_puppy.tools.command_runner.is_subagent",
+                    return_value=False,
+                ):
+                    with patch(
+                        "code_puppy.tools.command_runner._execute_shell_command",
+                        new_callable=AsyncMock,
+                        return_value=mock_output,
+                    ) as mock_exec:
+                        with patch("code_puppy.tools.command_runner.emit_info"):
+                            await run_shell_command(ctx, "echo keep", timeout=10)
+
+        # Original command flows through unmutated.
+        assert mock_exec.call_args.kwargs["command"] == "echo keep"
+
+    @pytest.mark.asyncio
     async def test_yolo_mode_executes(self):
         from code_puppy.tools.command_runner import run_shell_command
 


### PR DESCRIPTION
## Summary

Small, backward-compatible extension of the existing `run_shell_command` callback contract: a callback can now return `{"rewrite": "<new command>"}` to transparently transform a shell command before execution, in addition to the existing `{"blocked": True}` allow / block semantics.

This PR ships **infrastructure only** — no policy. Following review feedback on the earlier version, the opinionated `git_coauthor` plugin has been pulled out entirely and will live as a user / marketplace plugin instead of a builtin.

## What changed

**`code_puppy/tools/command_runner.py`** — ~15 lines. After the existing block-check loop, iterate callback results and apply `result["rewrite"]` (in registration order, only when non-empty and different from the current command). Each applied rewrite fires a visible `emit_info` line so users always see what actually ran — rewriting is never sneaky.

**`AGENTS.md`** — one line. Document the new `rewrite` key alongside `blocked` in the `run_shell_command` hook row.

**`tests/tools/test_command_runner_full_coverage.py`** — three new cases in `TestRunShellCommand`:
- `test_rewrite_from_callback_replaces_command` — happy path: rewrite is applied and the transformed command is what `_execute_shell_command` sees.
- `test_rewrite_ignored_when_same_as_original` — no `command rewritten` notice fires when the rewrite string equals the original (no false-positive UI noise).
- `test_rewrite_ignored_for_empty_or_non_string` — defensive: empty strings, `None`, and non-string payloads are ignored so a broken plugin can't wipe out the user's command.

## Backward compatibility

- Callbacks returning `None` → unchanged behavior (allow).
- Callbacks returning `{"blocked": True, ...}` → unchanged behavior (block).
- Callbacks returning anything else → unchanged behavior (ignored), unless they explicitly include a `"rewrite"` key with a non-empty string.

Verified by running the full pre-existing shell-command test suite:

```
259 passed, 2 skipped
```

across `test_command_runner_full_coverage`, `test_command_runner_extended`, `test_shell_safety`, `test_shell_safety_callbacks`, `test_destructive_command_detector`, `test_shell_passthrough`, and `test_shell_line_crlf`.

`ruff check` + `ruff format` clean.

## What this unlocks

Plugins that need to *transform* a command instead of merely blocking it — a class that isn't possible on the current contract:

- **Secret redaction** — strip API keys / tokens accidentally included in a command before it runs.
- **Corporate proxy / mirror injection** — prepend `HTTPS_PROXY=…` or rewrite `pip install` to point at an internal index.
- **Path fixup** — canonicalize relative paths that would otherwise depend on the shell's `pwd`.
- **Attribution trailers** on `git commit` — the opinionated case that motivated this work, now correctly living outside core.

## Context

This is the slimmed-down version of the original PR (which shipped both the hook extension **and** a `git_coauthor` builtin plugin). Per the reviewer's feedback — opinionated attribution defaults belong outside core, and community/marketplace plugins are the right home for them — the plugin has been removed from this PR entirely. Only the enabling infrastructure remains.
