### PR TITLE
fix(retry): retry gateway 502s wrapped in ExceptionGroup instead of crashing

### DIFF
--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -113,6 +113,8 @@ _RETRYABLE_SNIPPETS = (
     "rate limited",
     "overloaded",
     "service unavailable",
+    "bad gateway",
+    "gateway timeout",
     "server had an error processing your request",
     "retry your request",
     "internal server error",
@@ -194,6 +196,16 @@ def _is_retryable_one(exc: BaseException) -> bool:
         return _matches_retryable_snippet(msg)
 
     if OpenAIAPIError is not None and isinstance(exc, OpenAIAPIError):
+        # 5xx gateway/server errors (502/503/504) and 429 rate limits are
+        # transient regardless of message wording. The OpenAI SDK exposes the
+        # HTTP status on APIStatusError subclasses; APIConnectionError /
+        # APITimeoutError have no status_code and are already covered by the
+        # transport-exception branch above. This mirrors the ModelHTTPError and
+        # Anthropic branches so an OpenAI-compatible 502 gets the same slow
+        # 1-2-3 retry instead of a raw REPL traceback.
+        status_code = getattr(exc, "status_code", None)
+        if status_code == 429 or (isinstance(status_code, int) and status_code >= 500):
+            return True
         if _matches_retryable_snippet(msg):
             return True
         body = getattr(exc, "body", None)
@@ -255,16 +267,54 @@ def _is_retryable_one(exc: BaseException) -> bool:
     return False
 
 
+def _group_members(exc: BaseException) -> tuple:
+    """Return an ExceptionGroup's sub-exceptions, or ``()`` for a plain error.
+
+    Guards against the 3.10 fallback where ``BaseExceptionGroup`` aliases
+    ``Exception`` -- there we'd otherwise treat *every* exception as a group.
+    On 3.11+ (and 3.10 with the backport) real groups expose ``.exceptions``.
+    """
+    if BaseExceptionGroup is Exception:  # 3.10 without exceptiongroup backport
+        return ()
+    if isinstance(exc, BaseExceptionGroup):
+        return tuple(exc.exceptions)
+    return ()
+
+
 def should_retry_streaming(exc: Exception) -> bool:
     """Decide whether ``exc`` (or anything it wraps) is a transient hiccup.
 
     Walks the ``__cause__`` / ``__context__`` chain so wrapper exception types
     like :class:`pydantic_ai.exceptions.ModelAPIError` -- which hide the
     real httpx/anthropic transport error in ``__cause__`` -- still get
-    classified correctly. Returns ``True`` if *any* link in the chain is
-    transient.
+    classified correctly.
+
+    Also descends into :class:`ExceptionGroup` members. pydantic-ai runs the
+    model stream inside an anyio task group, so a transient provider error
+    (e.g. ``anthropic.APIStatusError`` HTTP 502 from a gateway) reaches us
+    wrapped in an ``ExceptionGroup`` -- which is why ``run_agent_task`` catches
+    it with ``except*``. The linear cause walker alone can't see inside
+    ``.exceptions``, so a retryable 5xx used to look opaque and crash the REPL
+    with a full traceback instead of getting the slow 1-2-3 retry.
+
+    Returns ``True`` if *any* reachable exception is transient. Cycle-safe via
+    an ``id`` set; the per-chain depth cap of :func:`_walk_cause_chain` is
+    preserved (group membership is a separate traversal axis).
     """
-    return any(_is_retryable_one(e) for e in _walk_cause_chain(exc))
+    seen: set[int] = set()
+    stack: list[BaseException] = [exc]
+    while stack:
+        node = stack.pop()
+        if node is None or id(node) in seen:
+            continue
+        for link in _walk_cause_chain(node):
+            if id(link) in seen:
+                continue
+            seen.add(id(link))
+            if _is_retryable_one(link):
+                return True
+            stack.extend(_group_members(link))
+    return False
 
 
 def streaming_retry(

--- a/tests/agents/test_streaming_retry.py
+++ b/tests/agents/test_streaming_retry.py
@@ -433,3 +433,110 @@ class TestWrappedTransientErrors:
         # If this assertion ever flips, the cap moved -- intentional or not,
         # the change deserves to be looked at deliberately.
         assert not should_retry_streaming_exception(chain[0])
+
+
+def _make_anthropic_502() -> "BaseException":
+    """Reproduce the production 502: a Google-gateway HTML error page bubbled
+    up by the Anthropic SDK as APIStatusError(status_code=502).
+
+    The message is a giant HTML blob (``[HTTP 502] <!DOCTYPE html>...``) that
+    matches NO retry snippet -- the only reliable signal is ``status_code``.
+    """
+    from anthropic import APIStatusError
+
+    err = APIStatusError.__new__(APIStatusError)
+    err.status_code = 502
+    err.body = {"message": "[HTTP 502] <!DOCTYPE html> ... 502. That's an error."}
+    err.message = "[HTTP 502] <!DOCTYPE html> ... 502. That's an error."
+    return err
+
+
+class TestExceptionGroupUnwrapping:
+    """Regression coverage for the real-world 502 crash.
+
+    pydantic-ai streams the model response inside an anyio task group, so a
+    transient provider error (e.g. anthropic.APIStatusError HTTP 502 from a
+    gateway) reaches ``run_agent_task`` wrapped in an ExceptionGroup -- which
+    is why that code path uses ``except*``. The classifier used to only walk
+    ``__cause__``/``__context__`` and never descended into ``.exceptions``, so
+    a perfectly retryable 5xx looked opaque and crashed the REPL with a
+    60-line traceback instead of getting the slow 1-2-3 retry.
+    """
+
+    def test_bare_anthropic_502_is_retryable(self):
+        # Sanity: even outside a group, an HTML-body 502 must retry purely on
+        # status_code (its message matches no snippet).
+        assert should_retry_streaming_exception(_make_anthropic_502())
+
+    def test_exception_group_wrapping_502_is_retryable(self):
+        # The exact production shape: ExceptionGroup([APIStatusError(502)]).
+        group = ExceptionGroup(
+            "unhandled errors in a TaskGroup", [_make_anthropic_502()]
+        )
+        assert should_retry_streaming_exception(group)
+
+    def test_nested_exception_groups_are_retryable(self):
+        # anyio can nest groups when tasks spawn sub-tasks. Descend all the way.
+        inner = ExceptionGroup("inner", [_make_anthropic_502()])
+        outer = ExceptionGroup("outer", [ValueError("noise"), inner])
+        assert should_retry_streaming_exception(outer)
+
+    def test_exception_group_member_via_cause_chain(self):
+        # A group member that hides its transient origin in __cause__ must still
+        # be caught -- we walk each member's cause chain, not just the member.
+        wrapper = RuntimeError("opaque wrapper")
+        wrapper.__cause__ = httpx.ConnectError("dropped socket")
+        group = ExceptionGroup("grp", [ValueError("noise"), wrapper])
+        assert should_retry_streaming_exception(group)
+
+    def test_exception_group_of_only_non_transient_is_not_retryable(self):
+        # Belt-and-braces: a group of genuine bugs must NOT be retried.
+        group = ExceptionGroup("grp", [ValueError("bug"), TypeError("also bug")])
+        assert not should_retry_streaming_exception(group)
+
+    def test_exception_group_is_cycle_safe(self):
+        # A member whose cause points back at a sibling must still terminate.
+        a = ValueError("a")
+        b = httpx.ConnectError("transient")
+        a.__cause__ = b
+        b.__cause__ = a
+        group = ExceptionGroup("grp", [a])
+        assert should_retry_streaming_exception(group)
+
+
+class TestOpenAIStatusCodeRetry:
+    """The OpenAI branch must retry 5xx/429 on status_code alone.
+
+    Mirrors the Anthropic and ModelHTTPError branches. An OpenAI-compatible
+    gateway 502 whose body is an HTML error page matches no snippet -- the only
+    reliable signal is the HTTP status the SDK exposes on APIStatusError.
+    """
+
+    def _make_openai_status_error(self, status_code: int, message: str | None = None):
+        try:
+            from openai import APIStatusError
+        except ImportError:  # pragma: no cover
+            pytest.skip("openai is not installed in this test environment")
+        if message is None:
+            message = "<!DOCTYPE html> 502 Bad Gateway"
+        err = APIStatusError.__new__(APIStatusError)
+        err.status_code = status_code
+        err.body = {"message": message}
+        err.message = message
+        return err
+
+    @pytest.mark.parametrize("status_code", [500, 502, 503, 504, 429])
+    def test_transient_status_codes_retry(self, status_code):
+        assert should_retry_streaming_exception(
+            self._make_openai_status_error(status_code)
+        )
+
+    @pytest.mark.parametrize("status_code", [400, 401, 403, 404, 422])
+    def test_client_errors_do_not_retry(self, status_code):
+        # A snippet-free client-error body -- status_code is the only signal,
+        # and 4xx (other than 429) must NOT retry.
+        assert not should_retry_streaming_exception(
+            self._make_openai_status_error(
+                status_code, message="invalid request payload"
+            )
+        )


### PR DESCRIPTION
## Problem

A gateway **502** during a streaming request currently barfs a ~60-line traceback into the REPL instead of doing the graceful slow 1-2-3 retry we already do for streaming connection breaks.

Real-world repro (from a `custom_anthropic` model pointed at `puppy-backend`): the gateway returns a Google `502 Server Error` HTML page, which the Anthropic SDK raises mid-stream as `anthropic.APIStatusError(status_code=502)`.

## Root cause

`_is_retryable_one` **already** classifies `anthropic.APIStatusError` with `status_code >= 500` as retryable. But pydantic-ai runs the model stream inside an **anyio task group**, so the error reaches `run_agent_task` wrapped in an `ExceptionGroup` (that's why that frame uses `except*`).

`should_retry_streaming` only walked the `__cause__` / `__context__` chain — it **never descended into `ExceptionGroup.exceptions`**. So the group looked like an unrecognized type → not retryable → crash.

## Fix

- `should_retry_streaming` now also traverses `ExceptionGroup` members (handles nesting, walks each member's cause chain, cycle-safe via an `id` set). The per-chain depth cap of `_walk_cause_chain` is preserved — group membership is a separate traversal axis, so the existing depth-cap tripwire test stays valid.
- The **OpenAI branch** of `_is_retryable_one` now retries on `status_code == 429` or `>= 500`, mirroring the Anthropic and `ModelHTTPError` branches. HTML-body 5xx errors match no snippet, so `status_code` is the only reliable signal — this closes the same gap for OpenAI-compatible gateways.
- Added `"bad gateway"` / `"gateway timeout"` to `_RETRYABLE_SNIPPETS` as belt-and-braces.

## Tests

- `TestExceptionGroupUnwrapping`: bare 502, `ExceptionGroup([502])` (the exact prod shape), nested groups, group member via cause chain, cycle-safety, and a non-transient group that must NOT retry.
- `TestOpenAIStatusCodeRetry`: 500/502/503/504/429 retry; 400/401/403/404/422 do not.

All 70 tests in `tests/agents/test_streaming_retry*.py` pass; `ruff check` + `ruff format` clean.