### PR TITLE
Warn instead of silently falling back on unknown agent

### DIFF
--- a/code_puppy/agents/agent_manager.py
+++ b/code_puppy/agents/agent_manager.py
@@ -515,6 +515,13 @@ def get_current_agent() -> BaseAgent:
     return _CURRENT_AGENT
 
 
+def get_registered_agent_names() -> list[str]:
+    """Return the names of all registered agents (after discovery), cheaply."""
+    message_group_id = str(uuid.uuid4())
+    _discover_agents(message_group_id=message_group_id)
+    return list(_AGENT_REGISTRY.keys())
+
+
 def load_agent(agent_name: str) -> BaseAgent:
     """Load an agent configuration by name.
 
@@ -525,7 +532,7 @@ def load_agent(agent_name: str) -> BaseAgent:
         The agent configuration instance.
 
     Raises:
-        ValueError: If the agent is not found.
+        ValueError: If the agent is not found and no fallback is available.
     """
     # Generate a message group ID for agent loading
     message_group_id = str(uuid.uuid4())
@@ -534,6 +541,11 @@ def load_agent(agent_name: str) -> BaseAgent:
     if agent_name not in _AGENT_REGISTRY:
         # Fallback to code-puppy if agent not found
         if "code-puppy" in _AGENT_REGISTRY:
+            emit_warning(
+                f"Requested agent '{agent_name}' isn't available; falling back to "
+                f"the default 'code-puppy' agent.",
+                message_group=message_group_id,
+            )
             agent_name = "code-puppy"
         else:
             raise ValueError(

--- a/code_puppy/tools/agent_tools.py
+++ b/code_puppy/tools/agent_tools.py
@@ -207,6 +207,8 @@ class AgentInvokeOutput(BaseModel):
     agent_name: str
     session_id: str | None = None
     model_name: str | None = None
+    requested_agent_name: str | None = None
+    fell_back: bool = False
     error: str | None = None
 
 

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -49,7 +49,14 @@ async def _invoke_agent_impl(
     emit_response_message: bool = True,
 ) -> AgentInvokeOutput:
     """Invoke a sub-agent, optionally suppressing its standard response message."""
-    from code_puppy.agents.agent_manager import load_agent
+    from code_puppy.agents.agent_manager import (
+        get_registered_agent_names,
+        load_agent,
+    )
+
+    requested_agent_name = agent_name
+    actual_agent_name = requested_agent_name
+    fell_back = False
 
     # Validate user-provided session_id if given
     if session_id is not None:
@@ -65,6 +72,12 @@ async def _invoke_agent_impl(
                 model_name=model_name,
                 error=str(e),
             )
+
+    # Mirror load_agent() fallback behavior exactly:
+    # fallback only happens when requested agent is missing AND code-puppy exists.
+    registered = get_registered_agent_names()
+    fell_back = requested_agent_name not in registered and "code-puppy" in registered
+    actual_agent_name = "code-puppy" if fell_back else requested_agent_name
 
     # Generate a group ID for this tool execution
     group_id = generate_group_id("invoke_agent", agent_name)
@@ -105,7 +118,7 @@ async def _invoke_agent_impl(
     bus = get_message_bus()
     bus.emit(
         SubAgentInvocationMessage(
-            agent_name=agent_name,
+            agent_name=actual_agent_name,
             session_id=session_id,
             prompt=prompt,
             is_new_session=is_new_session,
@@ -288,7 +301,7 @@ async def _invoke_agent_impl(
                 stream_handler = partial(subagent_stream_handler, session_id=session_id)
 
             # Wrap the agent run in subagent context for tracking
-            with subagent_context(agent_name):
+            with subagent_context(actual_agent_name):
                 run_ctxs = on_agent_run_context(
                     agent_config, temp_agent, group_id, mcp_servers
                 )
@@ -328,6 +341,21 @@ async def _invoke_agent_impl(
             # Extract the response from the result
             response = result.output
 
+            if fell_back:
+                notice = (
+                    "[invoke_agent notice] The requested sub-agent "
+                    f"'{requested_agent_name}' is not installed/available, so "
+                    "this task was routed to the default 'code-puppy' agent "
+                    "instead. Before using this result, tell the user that "
+                    f"'{requested_agent_name}' doesn't exist, and offer to either "
+                    "(a) install/create it (e.g. via the agent marketplace or "
+                    "agent-creator) or (b) continue with a different existing "
+                    "agent. Do not attribute this output to "
+                    f"'{requested_agent_name}'.\n\n"
+                    "--- code-puppy output below ---\n\n"
+                )
+                response = f"{notice}{response}"
+
             # Update the session history with the new messages from this interaction
             # The result contains all_messages which includes the full conversation
             updated_history = result.all_messages()
@@ -336,7 +364,7 @@ async def _invoke_agent_impl(
             _save_session_history(
                 session_id=session_id,
                 message_history=updated_history,
-                agent_name=agent_name,
+                agent_name=actual_agent_name,
                 initial_prompt=prompt if is_new_session else None,
             )
 
@@ -347,7 +375,7 @@ async def _invoke_agent_impl(
             if emit_response_message and not (is_high_mode and streamed_text):
                 bus.emit(
                     SubAgentResponseMessage(
-                        agent_name=agent_name,
+                        agent_name=actual_agent_name,
                         session_id=session_id,
                         response=response,
                         message_count=len(updated_history),
@@ -356,23 +384,38 @@ async def _invoke_agent_impl(
 
             # Emit clean completion summary
             emit_success(
-                f"✓ {agent_name} completed successfully", message_group=group_id
+                f"\u2713 {actual_agent_name} completed successfully",
+                message_group=group_id,
             )
 
             return AgentInvokeOutput(
                 response=response,
-                agent_name=agent_name,
+                agent_name=actual_agent_name,
                 session_id=session_id,
                 model_name=effective_model_name,
+                requested_agent_name=requested_agent_name if fell_back else None,
+                fell_back=fell_back,
             )
 
     except Exception as e:
         # Emit clean failure summary
-        emit_error(f"✗ {agent_name} failed: {str(e)}", message_group=group_id)
+        emit_error(
+            f"{actual_agent_name} failed: {str(e)}",
+            message_group=group_id,
+        )
 
         # Full traceback for debugging
-        error_msg = f"Error invoking agent '{agent_name}': {traceback.format_exc()}"
+        error_msg = (
+            f"Error invoking agent '{actual_agent_name}': {traceback.format_exc()}"
+        )
         emit_error(error_msg, message_group=group_id)
+
+        if fell_back:
+            error_msg = (
+                "(requested agent "
+                f"'{requested_agent_name}' not found; ran 'code-puppy' instead) "
+                f"{error_msg}"
+            )
 
         # Save whatever progress the agent made before crashing. The history
         # processor keeps ``agent_config._message_history`` in sync with each
@@ -385,7 +428,7 @@ async def _invoke_agent_impl(
                 _save_session_history(
                     session_id=session_id,
                     message_history=partial_history,
-                    agent_name=agent_name,
+                    agent_name=actual_agent_name,
                     initial_prompt=prompt if is_new_session else None,
                 )
                 emit_info(
@@ -398,9 +441,11 @@ async def _invoke_agent_impl(
 
         return AgentInvokeOutput(
             response=None,
-            agent_name=agent_name,
+            agent_name=actual_agent_name,
             session_id=session_id,
             model_name=effective_model_name,
+            requested_agent_name=requested_agent_name if fell_back else None,
+            fell_back=fell_back,
             error=error_msg,
         )
 

--- a/tests/agents/test_agent_manager_basics.py
+++ b/tests/agents/test_agent_manager_basics.py
@@ -14,6 +14,7 @@ from code_puppy.agents.agent_manager import (
     _save_session_data,
     get_available_agents,
     get_current_agent,
+    get_registered_agent_names,
     get_terminal_session_id,
     load_agent,
     refresh_agents,
@@ -108,6 +109,19 @@ class TestAgentManagerBasics:
             assert isinstance(display_name, str)
             assert len(agent_name) > 0
             assert len(display_name) > 0
+
+    @patch("code_puppy.agents.agent_manager._discover_agents")
+    def test_get_registered_agent_names_returns_registry_keys(self, mock_discover):
+        """Helper should trigger discovery and return registered names."""
+        mock_discover.return_value = None
+        with patch(
+            "code_puppy.agents.agent_manager._AGENT_REGISTRY",
+            {"code-puppy": MockAgent, "reviewer": MockAgent},
+        ):
+            names = get_registered_agent_names()
+
+        mock_discover.assert_called_once()
+        assert set(names) == {"code-puppy", "reviewer"}
 
     def test_get_terminal_session_id(self):
         """Test that terminal session ID generation works."""
@@ -303,39 +317,34 @@ class TestAgentManagerBasics:
             with pytest.raises(ValueError, match="not found and no fallback"):
                 load_agent("nonexistent-agent")
 
-    @patch("code_puppy.agents.agent_manager.discover_json_agents")
-    @patch("pkgutil.iter_modules")
-    @patch("importlib.import_module")
-    def test_load_agent_fallback_to_code_puppy(
-        self, mock_import, mock_iter_modules, mock_json_agents
-    ):
+    @patch("code_puppy.agents.agent_manager.emit_warning")
+    @patch("code_puppy.agents.agent_manager._discover_agents")
+    def test_load_agent_fallback_to_code_puppy(self, mock_discover, mock_emit_warning):
         """Test fallback to code-puppy agent when requested agent not found."""
 
-        # Setup registry with only code-puppy
         class CodePuppyAgent(MockAgent):
             def __init__(self):
                 super().__init__()
                 self._name = "code-puppy"
 
-        mock_iter_modules.return_value = [("code_puppy.agents", "code_puppy", True)]
+        with patch(
+            "code_puppy.agents.agent_manager._AGENT_REGISTRY",
+            {"code-puppy": CodePuppyAgent},
+        ):
+            # Try to load non-existent agent
+            agent = load_agent("nonexistent-agent")
 
-        mock_module = MagicMock()
-        mock_module.CodePuppyAgent = CodePuppyAgent
+            # Should fallback to code-puppy and emit warning
+            assert agent is not None
+            assert agent.name == "code-puppy"
+            mock_emit_warning.assert_called_once()
+            assert "nonexistent-agent" in mock_emit_warning.call_args[0][0]
 
-        def mock_import_side_effect(module_name):
-            if "code_puppy" in module_name:
-                return mock_module
-            return MagicMock()
-
-        mock_import.side_effect = mock_import_side_effect
-        mock_json_agents.return_value = {}
-
-        # Try to load non-existent agent
-        agent = load_agent("nonexistent-agent")
-
-        # Should fallback to code-puppy
-        assert agent is not None
-        assert agent.name == "code-puppy"
+            # Known agent should not emit this fallback warning
+            mock_emit_warning.reset_mock()
+            known_agent = load_agent("code-puppy")
+            assert known_agent.name == "code-puppy"
+            mock_emit_warning.assert_not_called()
 
     def test_refresh_agents(self):
         """Test refreshing agent discovery."""

--- a/tests/agents/test_agent_manager_errors.py
+++ b/tests/agents/test_agent_manager_errors.py
@@ -72,8 +72,9 @@ class TestAgentManagerErrors:
             ):
                 load_agent("agent@#$%^&*()")
 
+    @patch("code_puppy.agents.agent_manager.emit_warning")
     @patch("code_puppy.agents.agent_manager._discover_agents")
-    def test_load_agent_fallback_behavior(self, mock_discover):
+    def test_load_agent_fallback_behavior(self, mock_discover, mock_emit_warning):
         """Test load_agent fallback to code-puppy when requested agent not found."""
         mock_discover.return_value = None
 
@@ -89,6 +90,15 @@ class TestAgentManagerErrors:
             result = load_agent("nonexistent-agent")
             assert result is not None
             mock_agent_class.assert_called_once()
+            mock_emit_warning.assert_called_once()
+            warning_text = mock_emit_warning.call_args[0][0]
+            assert "nonexistent-agent" in warning_text
+            assert "list_agents" not in warning_text
+
+            # Known agent should not emit fallback warning
+            mock_emit_warning.reset_mock()
+            load_agent("code-puppy")
+            mock_emit_warning.assert_not_called()
 
     @patch("code_puppy.agents.agent_manager._discover_agents")
     def test_load_agent_no_fallback_available(self, mock_discover):

--- a/tests/agents/test_agent_manager_full_coverage.py
+++ b/tests/agents/test_agent_manager_full_coverage.py
@@ -841,13 +841,24 @@ class TestSetCurrentAgent:
 class TestLoadAgent:
     """Tests for load_agent."""
 
+    @patch("code_puppy.agents.agent_manager.emit_warning")
     @patch("code_puppy.agents.agent_manager._discover_agents")
-    def test_fallback_to_code_puppy(self, mock_discover):
+    def test_fallback_to_code_puppy(self, mock_discover, mock_emit_warning):
         from code_puppy.agents.agent_code_puppy import CodePuppyAgent
 
         am._AGENT_REGISTRY["code-puppy"] = CodePuppyAgent
         agent = am.load_agent("nonexistent")
         assert agent.name == "code-puppy"
+        mock_emit_warning.assert_called_once()
+        warning_text = mock_emit_warning.call_args[0][0]
+        assert "nonexistent" in warning_text
+        assert "list_agents" not in warning_text
+
+        # Known agent should not emit fallback warning
+        mock_emit_warning.reset_mock()
+        known_agent = am.load_agent("code-puppy")
+        assert known_agent.name == "code-puppy"
+        mock_emit_warning.assert_not_called()
 
     @patch("code_puppy.agents.agent_manager._discover_agents")
     def test_no_fallback_raises(self, mock_discover):

--- a/tests/test_agent_tools_coverage.py
+++ b/tests/test_agent_tools_coverage.py
@@ -28,6 +28,16 @@ from code_puppy.tools.agent_tools import (
 )
 
 
+@pytest.fixture(autouse=True)
+def patch_registered_agent_names_default():
+    """Keep invoke-agent tests deterministic unless a test overrides it."""
+    with patch(
+        "code_puppy.agents.agent_manager.get_registered_agent_names",
+        return_value=["code-puppy", "test-agent", "reviewer", "qa-expert"],
+    ):
+        yield
+
+
 class TestGetSubagentSessionsDir:
     """Test suite for _get_subagent_sessions_dir function."""
 
@@ -180,6 +190,8 @@ class TestPydanticModels:
             )
             assert output.session_id is None
             assert output.model_name is None
+            assert output.requested_agent_name is None
+            assert output.fell_back is False
             assert output.error is None
 
         def test_serialization(self):
@@ -195,6 +207,8 @@ class TestPydanticModels:
             assert data["agent_name"] == "greeter"
             assert data["session_id"] == "session-123"
             assert data["model_name"] == "test-model"
+            assert data["requested_agent_name"] is None
+            assert data["fell_back"] is False
 
 
 class TestRegisterListAgentsExecution:
@@ -402,6 +416,7 @@ class TestRegisterInvokeAgentExecution:
         mock_context = MagicMock()
 
         mock_agent_config = MagicMock()
+        mock_agent_config.name = "test-agent"
         mock_agent_config.get_model_name.return_value = "nonexistent-model"
 
         with (
@@ -448,6 +463,475 @@ class TestRegisterInvokeAgentExecution:
             assert mock_emit_error.called
 
     @pytest.mark.asyncio
+    async def test_invoke_agent_reports_fallback_to_calling_agent(self):
+        """Missing sub-agent should surface fallback details in output payload."""
+        import contextvars
+
+        invoke_agent = self._get_registered_invoke_agent()
+        mock_context = MagicMock()
+
+        mock_agent_config = MagicMock()
+
+        @contextmanager
+        def temporary_override(_model_name):
+            yield
+
+        mock_agent_config.name = "code-puppy"
+        mock_agent_config.temporary_model_name_override.side_effect = temporary_override
+        mock_agent_config.get_model_name.return_value = "default-model"
+        mock_agent_config.get_full_system_prompt.return_value = "Test instructions"
+        mock_agent_config.get_available_tools.return_value = ["list_files"]
+
+        mock_result = MagicMock()
+        mock_result.output = "subagent response"
+        mock_result.all_messages.return_value = ["updated-history"]
+
+        mock_temp_agent = MagicMock()
+        mock_temp_agent.run = AsyncMock(return_value=mock_result)
+
+        fake_browser_var = contextvars.ContextVar("fake_browser")
+        browser_token = fake_browser_var.set("browser-session")
+
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.subagent_invocation.generate_group_id",
+                    return_value="test-group",
+                )
+            )
+            mock_bus = stack.enter_context(
+                patch("code_puppy.tools.subagent_invocation.get_message_bus")
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.subagent_invocation.get_session_context",
+                    return_value="parent",
+                )
+            )
+            stack.enter_context(
+                patch("code_puppy.tools.subagent_invocation.set_session_context")
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.agents.agent_manager.get_registered_agent_names",
+                    return_value=["code-puppy", "reviewer"],
+                )
+            )
+            stack.enter_context(patch("code_puppy.tools.subagent_invocation.emit_info"))
+            mock_emit_success = stack.enter_context(
+                patch("code_puppy.tools.subagent_invocation.emit_success")
+            )
+            mock_save_history = stack.enter_context(
+                patch("code_puppy.tools.subagent_invocation._save_session_history")
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.agents.agent_manager.load_agent",
+                    return_value=mock_agent_config,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.model_factory.ModelFactory.load_config",
+                    return_value={"default-model": {}},
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.model_factory.ModelFactory.get_model",
+                    return_value=MagicMock(),
+                )
+            )
+            stack.enter_context(
+                patch("code_puppy.model_factory.make_model_settings", return_value={})
+            )
+            stack.enter_context(
+                patch("code_puppy.agents._builder.load_puppy_rules", return_value=None)
+            )
+            mock_prepare = stack.enter_context(
+                patch("code_puppy.model_utils.prepare_prompt_for_model")
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.agents._builder.autostart_bound_servers_async",
+                    new=AsyncMock(),
+                )
+            )
+            stack.enter_context(
+                patch("code_puppy.config.get_value", return_value="true")
+            )
+            stack.enter_context(
+                patch("code_puppy.config.get_output_level", return_value="medium")
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.agents._compaction.make_history_processor",
+                    return_value=lambda messages: messages,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.subagent_invocation.Agent",
+                    return_value=mock_temp_agent,
+                )
+            )
+            stack.enter_context(patch("code_puppy.tools.register_tools_for_agent"))
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.subagent_invocation.on_wrap_pydantic_agent",
+                    side_effect=lambda _cfg, agent, **_kwargs: agent,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.subagent_invocation.on_agent_run_context",
+                    return_value=[],
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.subagent_invocation._load_session_history",
+                    return_value=[],
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.subagent_invocation._generate_session_hash_suffix",
+                    return_value="abc123",
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.subagent_invocation.get_message_limit",
+                    return_value=50,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.browser.browser_manager.set_browser_session",
+                    return_value=browser_token,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.browser.browser_manager._browser_session_var",
+                    fake_browser_var,
+                )
+            )
+
+            mock_bus.return_value.emit = MagicMock()
+            mock_prepare.return_value = MagicMock(
+                instructions="prepared instructions", user_prompt="prepared prompt"
+            )
+
+            result = await invoke_agent(
+                mock_context,
+                agent_name="architect",
+                prompt="Hello",
+            )
+
+        assert result.agent_name == "code-puppy"
+        assert result.requested_agent_name == "architect"
+        assert result.fell_back is True
+        assert result.response.startswith("[invoke_agent notice]")
+        assert "architect" in result.response
+        assert "--- code-puppy output below ---" in result.response
+        assert result.response.endswith("subagent response")
+
+        assert mock_emit_success.call_count == 1
+        assert (
+            "code-puppy completed successfully" in mock_emit_success.call_args.args[0]
+        )
+        assert mock_save_history.call_count == 1
+        assert mock_save_history.call_args.kwargs["agent_name"] == "code-puppy"
+
+        emitted_messages = [
+            call.args[0] for call in mock_bus.return_value.emit.call_args_list
+        ]
+        assert emitted_messages[0].agent_name == "code-puppy"
+        assert emitted_messages[-1].agent_name == "code-puppy"
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_fallback_error_prefixes_requested_agent(self):
+        """Fallback failures should include requested-agent context in the error."""
+        invoke_agent = self._get_registered_invoke_agent()
+        mock_context = MagicMock()
+
+        mock_agent_config = MagicMock()
+        mock_agent_config.name = "code-puppy"
+        mock_agent_config.get_model_name.return_value = "missing-model"
+
+        with (
+            patch(
+                "code_puppy.tools.subagent_invocation.generate_group_id",
+                return_value="test-group",
+            ),
+            patch("code_puppy.tools.subagent_invocation.get_message_bus") as mock_bus,
+            patch(
+                "code_puppy.tools.subagent_invocation.get_session_context",
+                return_value="parent",
+            ),
+            patch("code_puppy.tools.subagent_invocation.set_session_context"),
+            patch(
+                "code_puppy.agents.agent_manager.get_registered_agent_names",
+                return_value=["code-puppy", "reviewer"],
+            ),
+            patch("code_puppy.tools.subagent_invocation.emit_error"),
+            patch(
+                "code_puppy.agents.agent_manager.load_agent",
+                return_value=mock_agent_config,
+            ),
+            patch(
+                "code_puppy.model_factory.ModelFactory.load_config",
+                return_value={},
+            ),
+            patch(
+                "code_puppy.tools.subagent_invocation._load_session_history",
+                return_value=[],
+            ),
+            patch(
+                "code_puppy.tools.subagent_invocation._generate_session_hash_suffix",
+                return_value="abc123",
+            ),
+        ):
+            mock_bus.return_value.emit = MagicMock()
+            result = await invoke_agent(
+                mock_context,
+                agent_name="architect",
+                prompt="Hello",
+                session_id=None,
+            )
+
+        assert result.response is None
+        assert result.agent_name == "code-puppy"
+        assert result.requested_agent_name == "architect"
+        assert result.fell_back is True
+        assert result.error.startswith(
+            "(requested agent 'architect' not found; ran 'code-puppy' instead)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_missing_requested_and_missing_code_puppy_no_fallback(
+        self,
+    ):
+        """When no fallback agent exists, do not claim fallback attribution."""
+        invoke_agent = self._get_registered_invoke_agent()
+        mock_context = MagicMock()
+
+        with (
+            patch(
+                "code_puppy.tools.subagent_invocation.generate_group_id",
+                return_value="test-group",
+            ),
+            patch("code_puppy.tools.subagent_invocation.get_message_bus") as mock_bus,
+            patch(
+                "code_puppy.tools.subagent_invocation.get_session_context",
+                return_value="parent",
+            ),
+            patch("code_puppy.tools.subagent_invocation.set_session_context"),
+            patch(
+                "code_puppy.agents.agent_manager.get_registered_agent_names",
+                return_value=["reviewer", "qa-expert"],
+            ),
+            patch(
+                "code_puppy.agents.agent_manager.load_agent",
+                side_effect=ValueError(
+                    "Agent 'architect' not found and no fallback available"
+                ),
+            ),
+            patch("code_puppy.tools.subagent_invocation.emit_error"),
+            patch(
+                "code_puppy.tools.subagent_invocation._load_session_history",
+                return_value=[],
+            ),
+            patch(
+                "code_puppy.tools.subagent_invocation._generate_session_hash_suffix",
+                return_value="abc123",
+            ),
+        ):
+            mock_bus.return_value.emit = MagicMock()
+            result = await invoke_agent(
+                mock_context,
+                agent_name="architect",
+                prompt="Hello",
+                session_id=None,
+            )
+
+        assert result.response is None
+        assert result.fell_back is False
+        assert result.requested_agent_name is None
+        assert result.error is not None
+        assert "not found and no fallback available" in result.error
+        assert "ran 'code-puppy' instead" not in result.error
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_keeps_response_untouched_when_no_fallback(self):
+        """Valid sub-agent call should not inject fallback metadata or notice."""
+        import contextvars
+
+        invoke_agent = self._get_registered_invoke_agent()
+        mock_context = MagicMock()
+
+        mock_agent_config = MagicMock()
+
+        @contextmanager
+        def temporary_override(_model_name):
+            yield
+
+        mock_agent_config.name = "reviewer"
+        mock_agent_config.temporary_model_name_override.side_effect = temporary_override
+        mock_agent_config.get_model_name.return_value = "default-model"
+        mock_agent_config.get_full_system_prompt.return_value = "Test instructions"
+        mock_agent_config.get_available_tools.return_value = ["list_files"]
+
+        mock_result = MagicMock()
+        mock_result.output = "clean response"
+        mock_result.all_messages.return_value = ["updated-history"]
+
+        mock_temp_agent = MagicMock()
+        mock_temp_agent.run = AsyncMock(return_value=mock_result)
+
+        fake_browser_var = contextvars.ContextVar("fake_browser")
+        browser_token = fake_browser_var.set("browser-session")
+
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.subagent_invocation.generate_group_id",
+                    return_value="test-group",
+                )
+            )
+            mock_bus = stack.enter_context(
+                patch("code_puppy.tools.subagent_invocation.get_message_bus")
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.subagent_invocation.get_session_context",
+                    return_value="parent",
+                )
+            )
+            stack.enter_context(
+                patch("code_puppy.tools.subagent_invocation.set_session_context")
+            )
+            stack.enter_context(patch("code_puppy.tools.subagent_invocation.emit_info"))
+            stack.enter_context(
+                patch("code_puppy.tools.subagent_invocation.emit_success")
+            )
+            stack.enter_context(
+                patch("code_puppy.tools.subagent_invocation._save_session_history")
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.agents.agent_manager.load_agent",
+                    return_value=mock_agent_config,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.model_factory.ModelFactory.load_config",
+                    return_value={"default-model": {}},
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.model_factory.ModelFactory.get_model",
+                    return_value=MagicMock(),
+                )
+            )
+            stack.enter_context(
+                patch("code_puppy.model_factory.make_model_settings", return_value={})
+            )
+            stack.enter_context(
+                patch("code_puppy.agents._builder.load_puppy_rules", return_value=None)
+            )
+            mock_prepare = stack.enter_context(
+                patch("code_puppy.model_utils.prepare_prompt_for_model")
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.agents._builder.autostart_bound_servers_async",
+                    new=AsyncMock(),
+                )
+            )
+            stack.enter_context(
+                patch("code_puppy.config.get_value", return_value="true")
+            )
+            stack.enter_context(
+                patch("code_puppy.config.get_output_level", return_value="medium")
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.agents._compaction.make_history_processor",
+                    return_value=lambda messages: messages,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.subagent_invocation.Agent",
+                    return_value=mock_temp_agent,
+                )
+            )
+            stack.enter_context(patch("code_puppy.tools.register_tools_for_agent"))
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.subagent_invocation.on_wrap_pydantic_agent",
+                    side_effect=lambda _cfg, agent, **_kwargs: agent,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.subagent_invocation.on_agent_run_context",
+                    return_value=[],
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.subagent_invocation._load_session_history",
+                    return_value=[],
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.subagent_invocation._generate_session_hash_suffix",
+                    return_value="abc123",
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.subagent_invocation.get_message_limit",
+                    return_value=50,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.browser.browser_manager.set_browser_session",
+                    return_value=browser_token,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "code_puppy.tools.browser.browser_manager._browser_session_var",
+                    fake_browser_var,
+                )
+            )
+
+            mock_bus.return_value.emit = MagicMock()
+            mock_prepare.return_value = MagicMock(
+                instructions="prepared instructions", user_prompt="prepared prompt"
+            )
+
+            result = await invoke_agent(
+                mock_context,
+                agent_name="reviewer",
+                prompt="Hello",
+            )
+
+        assert result.agent_name == "reviewer"
+        assert result.requested_agent_name is None
+        assert result.fell_back is False
+        assert result.response == "clean response"
+
+    @pytest.mark.asyncio
     async def test_invoke_agent_with_model_uses_override_for_runtime(self):
         """A supplied model_name should drive all model-specific run setup."""
         invoke_agent = self._get_registered_invoke_agent_with_model()
@@ -459,6 +943,7 @@ class TestRegisterInvokeAgentExecution:
         def temporary_override(model_name):
             yield
 
+        mock_agent_config.name = "test-agent"
         mock_agent_config.temporary_model_name_override.side_effect = temporary_override
         mock_agent_config.get_model_name.return_value = "override-model"
         mock_agent_config.get_full_system_prompt.return_value = "Test instructions"
@@ -610,6 +1095,7 @@ class TestRegisterInvokeAgentExecution:
         def temporary_override(model_name):
             yield
 
+        mock_agent_config.name = "test-agent"
         mock_agent_config.temporary_model_name_override.side_effect = temporary_override
         mock_agent_config.get_model_name.return_value = "missing-model"
 
@@ -666,6 +1152,7 @@ class TestRegisterInvokeAgentExecution:
         mock_context = MagicMock()
 
         mock_agent_config = MagicMock()
+        mock_agent_config.name = "test-agent"
         mock_agent_config.get_model_name.return_value = "test-model"
         mock_agent_config.get_system_prompt.return_value = "Test"
 
@@ -744,6 +1231,7 @@ class TestInvokeAgentPartialSessionSaveOnCrash:
 
     def _make_agent_config(self, partial_history):
         cfg = MagicMock()
+        cfg.name = "test-agent"
         cfg.get_model_name.return_value = "test-model"
         cfg.get_system_prompt.return_value = "Test"
         cfg.get_message_history.return_value = partial_history


### PR DESCRIPTION
## TL;DR
Invoking an agent that doesn't exist currently *looks* like it works — you silently get `code-puppy` wearing the missing agent's name tag, and nobody is told. This PR keeps the graceful fallback but makes it **honest**: it warns, it re-labels the run truthfully, and — most importantly — it hands a structured "that agent doesn't exist, I used code-puppy instead" signal *back to the calling agent* so it can explain the situation to the user and offer to install-or-switch.

## The bug
`load_agent()` maps any unrecognized agent name to `code-puppy` without a peep, and `invoke_agent` then echoes the *requested* name back as if it ran:

```python
if agent_name not in _AGENT_REGISTRY:
    if "code-puppy" in _AGENT_REGISTRY:
        agent_name = "code-puppy"   # silent swap
    ...
```

### Repro
```python
invoke_agent(agent_name="architect", prompt="review this design")
# 'architect' was deleted/renamed — you still get a happy response,
# labeled as 'architect', actually produced by code-puppy. No signal anywhere.
```

### Why it hurts
- **Typos and stale references pass as success** — a renamed/removed agent keeps "working," so nobody notices the reference rotted.
- **Mislabeled output erodes trust** — the reply is attributed to the agent you asked for, not the one that actually ran.
- **A debugging black hole** — nothing in logs, events, history, or the tool result says a substitution happened.
- **The prior "use `list_agents()`" warning talked past the user** — that's a tool only the LLM can call; it's useless advice to a human.

## The fix — surface the fallback at every layer
1. **Clear console warning** (reworded, no end-user tool instructions), still naming the requested agent.
2. **Truthful attribution.** On fallback, the *actual* runner (`code-puppy`) is used in the invocation event, response message, session history, and success line — no more crediting a non-existent agent.
3. **Structured signal to the caller.** `AgentInvokeOutput` gains two backward-compatible fields:
   - `requested_agent_name: str | None = None`
   - `fell_back: bool = False`
4. **In-band notice for the calling agent.** On fallback, the response is prepended with an `[invoke_agent notice]` telling the calling LLM to inform the user that the requested agent doesn't exist and offer to (a) install/create it or (b) switch to a different existing agent — and not to attribute the output to the missing agent.
5. **Error-path parity.** If the fallback run errors, the error is prefixed with `(requested agent '<name>' not found; ran 'code-puppy' instead) …`.

### Deterministic detection (no guessing)
Fallback is computed to mirror `load_agent()` exactly:

```python
registered = get_registered_agent_names()
fell_back = (requested_agent_name not in registered) and ("code-puppy" in registered)
actual_agent_name = "code-puppy" if fell_back else requested_agent_name
```

A new lightweight `get_registered_agent_names()` helper returns registry names without instantiating agents. When the requested agent is missing **and** there's no `code-puppy` fallback, `load_agent()` still raises `"not found and no fallback available"` and nothing falsely claims code-puppy ran.

## Backward compatibility
- New pydantic fields default to `None`/`False`.
- `AgentInvokeOutput.agent_name` now reflects the **actual** runner; the originally requested name is preserved in `requested_agent_name` whenever `fell_back` is `True`. Callers that need the requested value should read that field.

## Scope & safety
- **No warning spam.** The not-found branch only fires on genuine explicit misses; agent discovery/description enumeration iterates the registry directly and never calls `load_agent`.
- Registry membership check runs only after `session_id` validation, so bad-session early-returns don't pay discovery cost.

## Tests
Extended the three `load_agent` fallback tests plus `tests/test_agent_tools_coverage.py`:
- reworded warning contains the requested name and no longer mentions `list_agents`;
- `get_registered_agent_names()` discovery/behavior;
- fallback **success**: `fell_back=True`, `requested_agent_name=<bogus>`, `agent_name="code-puppy"`, response starts with `[invoke_agent notice]`, and events/history/success use the actual runner;
- fallback **error**: `fell_back=True` with the `(requested agent … ran 'code-puppy' instead)` prefix;
- **no-fallback-available**: `fell_back=False`, `requested_agent_name=None`, real "no fallback available" error, no false code-puppy claim;
- **non-fallback**: `fell_back=False`, response untouched.

```
uv run pytest tests/agents/test_agent_manager_basics.py \
              tests/agents/test_agent_manager_errors.py \
              tests/agents/test_agent_manager_full_coverage.py \
              tests/test_agent_tools_coverage.py -q
# 150 passed
```

## Out of scope (noted for later)
Repeated invalid requests for the same name will each warn; a small dedupe/rate-limit by agent name would be a clean follow-up, intentionally left out to keep this focused.

---