### PR TITLE
feat: add runtime --yolo CLI override

### DIFF
--- a/code_puppy/command_line/config_apply.py
+++ b/code_puppy/command_line/config_apply.py
@@ -58,10 +58,14 @@ def invalidate_post_write_caches(key: str) -> None:
     Called from both the slash-set path (:func:`apply_setting`) and the
     menu reset path so the two stay in lock-step.
 
-    Today only the ``model`` key has a cache that needs this treatment;
-    add new keys here as they grow caches.
+    Runtime CLI overrides are also cleared when their persisted setting is
+    explicitly changed, so an in-session ``/set`` always wins.
     """
-    if key == "model":
+    if key == "yolo_mode":
+        from code_puppy.config import set_cli_yolo_override
+
+        set_cli_yolo_override(None)
+    elif key == "model":
         from code_puppy.config import clear_model_cache, reset_session_model
 
         reset_session_model()
@@ -121,7 +125,12 @@ def apply_setting(
         warning = _restart_notice("DBOS configuration")
         requires_restart = True
 
-    set_config_value(key, normalized_value)
+    if key == "yolo_mode" and normalized_value.strip().lower() == "config":
+        # ``config`` only drops the process-local CLI override. The persisted
+        # value remains the source of truth once that override is gone.
+        normalized_value = ""
+    else:
+        set_config_value(key, normalized_value)
     invalidate_post_write_caches(key)
 
     reload_error: Optional[str] = None

--- a/code_puppy/command_line/config_commands.py
+++ b/code_puppy/command_line/config_commands.py
@@ -135,7 +135,10 @@ def handle_set_command(command: str) -> bool:
         if is_sensitive_key(key)
         else result.value_after
     )
-    emit_success(f'Set {key} = "{display}" in puppy.cfg!')
+    if key == "yolo_mode" and (value or "").strip().lower() == "config":
+        emit_success("Using YOLO mode from puppy.cfg; configuration unchanged.")
+    else:
+        emit_success(f'Set {key} = "{display}" in puppy.cfg!')
     # Restart notices (warning) and the reload-success/failure signal
     # are independent: a restart-required key like ``enable_dbos``
     # should still report whether the live agent reload happened. The

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -1193,18 +1193,29 @@ def initialize_command_history_file():
             )
 
 
-def get_yolo_mode():
-    """
-    Checks puppy.cfg for 'yolo_mode' (case-insensitive in value only).
-    Defaults to True if not set.
-    Allowed values for ON: 1, '1', 'true', 'yes', 'on' (all case-insensitive for value).
-    """
+_cli_yolo_override: Optional[bool] = None
+
+
+def set_cli_yolo_override(value: Optional[bool]) -> None:
+    """Set a process-local YOLO value supplied by the CLI."""
+    global _cli_yolo_override
+    _cli_yolo_override = value
+
+
+def get_cli_yolo_override() -> Optional[bool]:
+    """Return the process-local CLI override, if one was supplied."""
+    return _cli_yolo_override
+
+
+def get_yolo_mode() -> bool:
+    """Return effective YOLO mode using CLI > persisted config precedence."""
+    if _cli_yolo_override is not None:
+        return _cli_yolo_override
+
     true_vals = {"1", "true", "yes", "on"}
     cfg_val = get_value("yolo_mode")
     if cfg_val is not None:
-        if str(cfg_val).strip().lower() in true_vals:
-            return True
-        return False
+        return str(cfg_val).strip().lower() in true_vals
     return True
 
 

--- a/code_puppy/plugins/yolo_cli/__init__.py
+++ b/code_puppy/plugins/yolo_cli/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime-only CLI and session controls for YOLO mode."""

--- a/code_puppy/plugins/yolo_cli/register_callbacks.py
+++ b/code_puppy/plugins/yolo_cli/register_callbacks.py
@@ -1,0 +1,41 @@
+"""Expose a runtime-only YOLO override through the CLI."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any, Optional
+
+from code_puppy.callbacks import register_callback
+from code_puppy.config import set_cli_yolo_override
+
+
+def _parse_bool(value: str) -> bool:
+    """Parse the explicit boolean syntax used by ``--yolo``."""
+    normalized = value.strip().lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    raise argparse.ArgumentTypeError("expected 'true' or 'false'")
+
+
+def _register_cli_args(parser: Any) -> None:
+    parser.add_argument(
+        "--yolo",
+        type=_parse_bool,
+        default=None,
+        metavar="{true,false}",
+        help=(
+            "Override YOLO mode for this run without changing puppy.cfg "
+            "(/set yolo_mode takes precedence)"
+        ),
+    )
+
+
+def _handle_cli_args(args: Any) -> Optional[dict]:
+    set_cli_yolo_override(getattr(args, "yolo", None))
+    return None
+
+
+register_callback("register_cli_args", _register_cli_args)
+register_callback("handle_cli_args", _handle_cli_args)

--- a/tests/command_line/test_yolo_set_override.py
+++ b/tests/command_line/test_yolo_set_override.py
@@ -1,0 +1,44 @@
+"""Precedence tests for persistent ``/set yolo_mode`` changes."""
+
+from unittest.mock import patch
+
+from code_puppy import config
+from code_puppy.command_line.config_apply import apply_setting
+from code_puppy.command_line.config_commands import handle_set_command
+
+
+def setup_function():
+    config.set_cli_yolo_override(None)
+
+
+def teardown_function():
+    config.set_cli_yolo_override(None)
+
+
+def test_persistent_yolo_write_supersedes_cli_override():
+    config.set_cli_yolo_override(False)
+
+    with patch("code_puppy.config.set_config_value") as set_config:
+        result = apply_setting("yolo_mode", "true", reload_agent=False)
+
+    assert result.ok is True
+    set_config.assert_called_once_with("yolo_mode", "true")
+    assert config.get_cli_yolo_override() is None
+
+
+def test_yolo_config_clears_cli_override_without_changing_persisted_value():
+    config.set_cli_yolo_override(False)
+
+    with (
+        patch("code_puppy.config.set_config_value") as set_value,
+        patch("code_puppy.config.reset_value") as reset_value,
+        patch("code_puppy.agents.get_current_agent") as current_agent,
+        patch("code_puppy.messaging.emit_success"),
+        patch("code_puppy.messaging.emit_info"),
+    ):
+        assert handle_set_command("/set yolo_mode config") is True
+
+    set_value.assert_not_called()
+    reset_value.assert_not_called()
+    current_agent.return_value.reload_code_generation_agent.assert_called_once()
+    assert config.get_cli_yolo_override() is None

--- a/tests/plugins/test_yolo_cli.py
+++ b/tests/plugins/test_yolo_cli.py
@@ -1,0 +1,58 @@
+"""Tests for the process-local ``--yolo`` override."""
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+
+from code_puppy import config
+from code_puppy.plugins.yolo_cli import register_callbacks as yolo_cli
+
+
+@pytest.fixture(autouse=True)
+def reset_cli_yolo_override():
+    config.set_cli_yolo_override(None)
+    yield
+    config.set_cli_yolo_override(None)
+
+
+def _parse(*arguments: str) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    yolo_cli._register_cli_args(parser)
+    return parser.parse_args(arguments)
+
+
+@pytest.mark.parametrize(("raw", "expected"), [("true", True), ("false", False)])
+def test_cli_flag_sets_runtime_override_without_writing_config(raw, expected):
+    args = _parse("--yolo", raw)
+
+    with patch("code_puppy.config.set_config_value") as set_config:
+        assert yolo_cli._handle_cli_args(args) is None
+
+    assert config.get_cli_yolo_override() is expected
+    set_config.assert_not_called()
+
+
+def test_omitted_cli_flag_does_not_override_persisted_config():
+    with patch("code_puppy.config.get_value", return_value="false"):
+        yolo_cli._handle_cli_args(_parse())
+        assert config.get_yolo_mode() is False
+
+
+@pytest.mark.parametrize("raw", ["yes", "1", "maybe", ""])
+def test_cli_flag_rejects_non_boolean_values(raw):
+    with pytest.raises(SystemExit) as exc_info:
+        _parse("--yolo", raw)
+
+    assert exc_info.value.code == 2
+
+
+@pytest.mark.parametrize(
+    ("persisted", "cli_value", "expected"),
+    [("false", True, True), ("true", False, False)],
+)
+def test_cli_override_takes_precedence_over_config(persisted, cli_value, expected):
+    config.set_cli_yolo_override(cli_value)
+
+    with patch("code_puppy.config.get_value", return_value=persisted):
+        assert config.get_yolo_mode() is expected


### PR DESCRIPTION
## Summary

- add `--yolo true|false` as a process-local startup override
- keep `puppy.cfg` unchanged when the CLI flag is used
- let persistent `/set yolo_mode true|false` changes supersede the startup override
- add `/set yolo_mode config` to discard the temporary override and return to the persisted setting without changing it

## Precedence

`/set yolo_mode` changes > `--yolo` startup override > `puppy.cfg` > existing default

## Implementation notes

The flag uses the existing built-in plugin CLI hooks, so no separate plugin installation is required. A narrow change in the shared config application path is necessary because registered `/set` commands are dispatched before plugin custom-command callbacks and there is no post-config-change hook.

## Testing

- user-tested interactively from this branch
- 86 focused config/plugin tests pass
- Ruff and formatting checks pass
- `git diff --check` passes

Closes #549
