### PR TITLE
Centralize prompt-toolkit semantic theme roles

### DIFF
--- a/code_puppy/command_line/prompt_toolkit_completion.py
+++ b/code_puppy/command_line/prompt_toolkit_completion.py
@@ -42,6 +42,7 @@ from code_puppy.command_line.model_picker_completion import (
 from code_puppy.command_line.pin_command_completion import PinCompleter, UnpinCompleter
 from code_puppy.command_line.skills_completion import SkillsCompleter
 from code_puppy.command_line.utils import list_directory
+from code_puppy.callbacks import on_prompt_text_color, on_prompt_toolkit_style
 from code_puppy.config import (
     COMMAND_HISTORY_FILE,
     get_config_keys,
@@ -173,7 +174,7 @@ class SetCompleter(Completer):
 class AttachmentPlaceholderProcessor(Processor):
     """Display friendly placeholders for recognised attachments."""
 
-    _PLACEHOLDER_STYLE = "class:attachment-placeholder"
+    _PLACEHOLDER_STYLE = "class:attachment-placeholder class:tui.title"
     # Skip expensive path detection for very long input (likely pasted content)
     _MAX_TEXT_LENGTH_FOR_REALTIME = 500
 
@@ -557,7 +558,6 @@ def _normalize_emoji_spacing(text: str) -> str:
 # palette remap (Level 3) restyles the prompt to the chosen theme.
 PROMPT_STYLES = {
     "puppy": "bold ansimagenta",
-    "owner": "bold ansiwhite",
     "agent": "bold ansiblue",
     "model": "bold ansicyan",
     "cwd": "bold ansigreen",
@@ -602,12 +602,15 @@ def get_prompt_with_active_model(base: str = ">>> "):
         cwd_display = cwd
     return FormattedText(
         [
-            ("class:puppy", f"{puppy}"),
+            ("class:puppy class:tui.header", f"{puppy}"),
             ("", " "),
-            ("class:agent", f"[{_normalize_emoji_spacing(agent_display)}] "),
-            ("class:model", model_display + " "),
-            ("class:cwd", "(" + str(cwd_display) + ") "),
-            ("class:arrow", str(base)),
+            (
+                "class:agent class:tui.label",
+                f"[{_normalize_emoji_spacing(agent_display)}] ",
+            ),
+            ("class:model class:tui.title", model_display + " "),
+            ("class:cwd class:tui.muted", "(" + str(cwd_display) + ") "),
+            ("class:arrow class:tui.help-key", str(base)),
         ]
     )
 
@@ -972,45 +975,29 @@ async def get_input_with_combined_completion(
     # NOTE: the style field must be a str — `None` crashes `to_formatted_text`.
     if isinstance(prompt_str, str):
         prompt_str = FormattedText([("", prompt_str)])
-    from code_puppy.callbacks import on_prompt_text_color
-
     prompt_text_color = on_prompt_text_color()
-    default_input_style = (
-        f"fg:{prompt_text_color}" if prompt_text_color else "fg:default"
-    )
-    style = Style.from_dict(
+    default_input_style = f"fg:{prompt_text_color}" if prompt_text_color else ""
+    local_style = Style.from_dict(
         {
-            # Explicitly color unclassified input text. Relying on the terminal's
-            # default foreground leaks white in terminals that ignore OSC 10.
+            # Keep the prompt useful without the theme plugin. With the plugin
+            # active, its semantic root supplies the palette underneath these
+            # structural rules while an explicit prompt-text override still wins.
             "": default_input_style,
-            # Keys must AVOID the 'class:' prefix – that prefix is used only when
-            # tagging tokens in `FormattedText`. See prompt_toolkit docs.
-            **PROMPT_STYLES,
-            "attachment-placeholder": "italic ansicyan",
-            # ── Completion menu (pi-inspired minimal look) ────────────────
-            # Drop the chunky default highlight bar. Use terminal-default bg
-            # so the menu blends, then `ansibrightblack` for a soft "dim"
-            # look that stays readable on both light and dark themes (since
-            # ANSI bright-black gets remapped to a mid-grey by most terms).
-            "completion-menu": "bg:default fg:ansibrightblack",
-            "completion-menu.completion": "bg:default fg:ansibrightblack",
-            # Selection highlight: use cyan to match the puppy/model banner
-            # colors (green is already the `cwd` color, and the bright-green
-            # bold variant was way too loud — Mike's eyeballs filed a complaint).
-            # `noreverse` is critical: prompt_toolkit's default for this class
-            # is `fg:#888888 bg:#ffffff reverse`, which would otherwise swap
-            # our fg/bg and paint a chunky cyan block behind the left column.
-            "completion-menu.completion.current": "noreverse bg:default fg:ansibrightcyan bold",
-            # `display_meta` is the right-hand path column — same dim treatment,
-            # italicized to differentiate it from the primary column.
-            "completion-menu.meta.completion": "bg:default fg:ansibrightblack italic",
-            "completion-menu.meta.completion.current": "bg:default fg:ansicyan italic",
-            # Scrollbar — keep it subtle so it doesn't reintroduce a bar.
-            "completion-menu.multi-column-meta": "bg:default",
-            "scrollbar.background": "bg:default",
-            "scrollbar.button": "bg:ansibrightblack",
+            "attachment-placeholder": "italic",
+            # Suppress prompt_toolkit's fixed white/grey/reverse completion
+            # presentation. Colors now inherit from the semantic theme root;
+            # only hierarchy and emphasis belong to this local component.
+            "completion-menu": "noreverse",
+            "completion-menu.completion": "noreverse",
+            "completion-menu.completion.current": "noreverse bold underline",
+            "completion-menu.meta.completion": "noreverse italic",
+            "completion-menu.meta.completion.current": "noreverse italic bold",
+            "completion-menu.multi-column-meta": "noreverse",
+            "scrollbar.background": "noreverse",
+            "scrollbar.button": "noreverse bold",
         }
     )
+    style = on_prompt_toolkit_style(local_style)
     text = await session.prompt_async(prompt_str, style=style)
     # NOTE: We used to call update_model_in_input(text) here to handle /model and /m
     # commands at the prompt level, but that prevented the command handler from running

--- a/code_puppy/plugins/theme/prompt_toolkit_theme.py
+++ b/code_puppy/plugins/theme/prompt_toolkit_theme.py
@@ -23,6 +23,36 @@ def _active_palette() -> dict[str, Any] | None:
     return palette
 
 
+def _relative_luminance(color: str) -> float:
+    """Return WCAG relative luminance for a ``#rrggbb`` color."""
+    channels = [int(color[index : index + 2], 16) / 255 for index in (1, 3, 5)]
+    linear = [
+        value / 12.92 if value <= 0.04045 else ((value + 0.055) / 1.055) ** 2.4
+        for value in channels
+    ]
+    return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
+
+
+def _contrast_ratio(first: str, second: str) -> float:
+    lighter, darker = sorted(
+        (_relative_luminance(first), _relative_luminance(second)), reverse=True
+    )
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def _muted_foreground(ansi: list[str], foreground: str, background: str) -> str:
+    """Choose the least-prominent candidate that still meets WCAG AA."""
+    candidates = (ansi[8], ansi[14], ansi[15], foreground)
+    readable = [
+        color for color in candidates if _contrast_ratio(color, background) >= 4.5
+    ]
+    return min(
+        readable,
+        key=lambda color: _contrast_ratio(color, background),
+        default=foreground,
+    )
+
+
 def get_style_rules() -> dict[str, str]:
     """Return semantic prompt-toolkit rules for the active theme."""
     palette = _active_palette()
@@ -32,9 +62,7 @@ def get_style_rules() -> dict[str, str]:
     ansi = palette["ansi"]
     foreground = palette.get("fg", ansi[7])
     background = palette.get("bg", ansi[0])
-    # Some light palettes reserve bright-black for their background. It is not
-    # a usable muted foreground in that case (Solarized base3, hello again).
-    muted = ansi[14] if ansi[8].lower() == background.lower() else ansi[8]
+    muted = _muted_foreground(ansi, foreground, background)
     return {
         "": f"fg:{foreground} bg:{background}",
         "tui": f"fg:{foreground} bg:{background}",
@@ -51,7 +79,24 @@ def get_style_rules() -> dict[str, str]:
         "tui.warning": f"fg:{ansi[11]} bold",
         "tui.error": f"fg:{ansi[9]} bold",
         "tui.input": f"fg:{foreground}",
-        "tui.input.focused": f"fg:{foreground} bg:{muted}",
+        "tui.input.focused": f"fg:{background} bg:{ansi[12]} bold noreverse",
+        # prompt_toolkit's defaults hard-code grey on white for completion
+        # menus. Root semantic rules cannot beat those more-specific selectors,
+        # so adapt the standard widget classes here as part of the shared theme.
+        "completion-menu": f"fg:{muted} bg:{background} noreverse",
+        "completion-menu.completion": f"fg:{muted} bg:{background} noreverse",
+        "completion-menu.completion.current": (
+            f"fg:{ansi[12]} bg:{background} bold noreverse"
+        ),
+        "completion-menu.meta.completion": (
+            f"fg:{muted} bg:{background} italic noreverse"
+        ),
+        "completion-menu.meta.completion.current": (
+            f"fg:{ansi[14]} bg:{background} italic noreverse"
+        ),
+        "completion-menu.multi-column-meta": f"bg:{background}",
+        "scrollbar.background": f"fg:{muted} bg:{background}",
+        "scrollbar.button": f"fg:{muted} bg:{background}",
     }
 
 

--- a/tests/plugins/test_prompt_toolkit_theme.py
+++ b/tests/plugins/test_prompt_toolkit_theme.py
@@ -1,0 +1,100 @@
+"""Contract tests for the theme plugin's central prompt-toolkit adapter."""
+
+from prompt_toolkit.styles import Style
+
+from code_puppy.plugins.theme.bundled_palettes import CATPPUCCIN_MOCHA, SOLARIZED_LIGHT
+from code_puppy.plugins.theme.prompt_toolkit_theme import (
+    _contrast_ratio,
+    get_style_rules,
+    merge_with_active_style,
+)
+
+
+_SEMANTIC_ROLES = {
+    "",
+    "tui",
+    "tui.header",
+    "tui.title",
+    "tui.body",
+    "tui.label",
+    "tui.muted",
+    "tui.border",
+    "tui.selected",
+    "tui.help",
+    "tui.help-key",
+    "tui.success",
+    "tui.warning",
+    "tui.error",
+    "tui.input",
+    "tui.input.focused",
+}
+
+_COMPLETION_ADAPTER_ROLES = {
+    "completion-menu",
+    "completion-menu.completion",
+    "completion-menu.completion.current",
+    "completion-menu.meta.completion",
+    "completion-menu.meta.completion.current",
+    "completion-menu.multi-column-meta",
+    "scrollbar.background",
+    "scrollbar.button",
+}
+
+
+def test_active_adapter_exposes_shared_semantic_roles(monkeypatch):
+    monkeypatch.setattr(
+        "code_puppy.plugins.theme.prompt_toolkit_theme._active_palette",
+        lambda: SOLARIZED_LIGHT,
+    )
+
+    rules = get_style_rules()
+    assert _SEMANTIC_ROLES <= rules.keys()
+    assert _COMPLETION_ADAPTER_ROLES <= rules.keys()
+    assert "#ffffff" not in repr(rules)
+    assert "#000000" not in repr(rules)
+
+
+def test_solarized_light_muted_text_does_not_use_its_background(monkeypatch):
+    monkeypatch.setattr(
+        "code_puppy.plugins.theme.prompt_toolkit_theme._active_palette",
+        lambda: SOLARIZED_LIGHT,
+    )
+
+    muted_rule = get_style_rules()["tui.muted"]
+
+    assert muted_rule == f"fg:{SOLARIZED_LIGHT['ansi'][14]}"
+    assert SOLARIZED_LIGHT["bg"] not in muted_rule
+
+
+def test_dark_theme_muted_text_meets_wcag_contrast(monkeypatch):
+    monkeypatch.setattr(
+        "code_puppy.plugins.theme.prompt_toolkit_theme._active_palette",
+        lambda: CATPPUCCIN_MOCHA,
+    )
+
+    muted = get_style_rules()["tui.muted"].removeprefix("fg:")
+
+    assert _contrast_ratio(muted, CATPPUCCIN_MOCHA["bg"]) >= 4.5
+    assert muted != CATPPUCCIN_MOCHA["ansi"][8]
+
+
+def test_menu_style_merges_over_semantic_base(monkeypatch):
+    monkeypatch.setattr(
+        "code_puppy.plugins.theme.prompt_toolkit_theme._active_palette",
+        lambda: SOLARIZED_LIGHT,
+    )
+    local_style = Style.from_dict(
+        {
+            "tui.header": "fg:#123456",
+            "menu-only": "italic",
+        }
+    )
+
+    merged = merge_with_active_style(local_style)
+
+    header = merged.get_attrs_for_style_str("class:tui.header")
+    body = merged.get_attrs_for_style_str("class:tui.body")
+    menu_only = merged.get_attrs_for_style_str("class:menu-only")
+    assert header.color == "123456"
+    assert body.color == SOLARIZED_LIGHT["fg"].lstrip("#")
+    assert menu_only.italic is True

--- a/tests/test_prompt_toolkit_completion.py
+++ b/tests/test_prompt_toolkit_completion.py
@@ -20,6 +20,7 @@ from code_puppy.command_line.prompt_toolkit_completion import (
     SetCompleter,
     _complete_or_cycle,
     get_input_with_combined_completion,
+    get_prompt_with_active_model,
 )
 
 # Skip some path-format sensitive tests on Windows where backslashes are expected
@@ -486,6 +487,71 @@ async def test_get_input_with_combined_completion_defaults(
     # The prompt layer now just returns the input as-is.
     assert result == "test input"
     mock_file_history.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("code_puppy.command_line.prompt_toolkit_completion._NoGhostLinesPromptSession")
+async def test_prompt_session_style_uses_central_theme_adapter(
+    mock_prompt_session_cls,
+):
+    mock_session = MagicMock()
+    mock_session.prompt_async = AsyncMock(return_value="themed input")
+    mock_prompt_session_cls.return_value = mock_session
+    themed_style = MagicMock(name="themed-style")
+
+    with (
+        patch(
+            "code_puppy.command_line.prompt_toolkit_completion.on_prompt_text_color",
+            return_value=None,
+        ),
+        patch(
+            "code_puppy.command_line.prompt_toolkit_completion.on_prompt_toolkit_style",
+            return_value=themed_style,
+        ) as mock_theme_adapter,
+    ):
+        await get_input_with_combined_completion()
+
+    local_style = mock_theme_adapter.call_args.args[0]
+    local_rules = dict(local_style.style_rules)
+    assert mock_session.prompt_async.call_args.kwargs["style"] is themed_style
+    assert "ansiwhite" not in repr(local_rules)
+    assert "ansibrightblack" not in repr(local_rules)
+    assert "#ffffff" not in repr(local_rules)
+    assert "#000000" not in repr(local_rules)
+    assert local_rules["completion-menu.completion.current"] == (
+        "noreverse bold underline"
+    )
+
+
+def test_meaningful_prompt_fragments_include_semantic_roles():
+    agent = MagicMock(display_name="Code Puppy")
+    agent.get_model_name.return_value = "test-model"
+
+    with (
+        patch(
+            "code_puppy.command_line.prompt_toolkit_completion.get_puppy_name",
+            return_value="Biscuit",
+        ),
+        patch(
+            "code_puppy.command_line.prompt_toolkit_completion.get_active_model",
+            return_value="test-model",
+        ),
+        patch(
+            "code_puppy.agents.agent_manager.get_current_agent",
+            return_value=agent,
+        ),
+    ):
+        prompt = get_prompt_with_active_model()
+
+    styles = [style for style, _text in prompt]
+    rendered = "".join(text for _style, text in prompt)
+    assert "class:puppy class:tui.header" in styles
+    assert "class:agent class:tui.label" in styles
+    assert "class:model class:tui.title" in styles
+    assert "class:cwd class:tui.muted" in styles
+    assert "class:arrow class:tui.help-key" in styles
+    assert rendered.startswith("Biscuit [Code Puppy] [test-model] ")
+    assert rendered.endswith(">>> ")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Refs #552

- defines the shared semantic TUI palette and contrast-aware muted role
- themes ordinary prompt and completion-menu rendering
- adds adapter, merge, light-theme, and dark-theme contract tests

Validation: full suite 12005 passed, 81 skipped, 1 xpassed; Ruff and git diff checks pass.