### PR TITLE
Theme the /resume TUI

### DIFF
--- a/code_puppy/command_line/autosave_menu.py
+++ b/code_puppy/command_line/autosave_menu.py
@@ -191,17 +191,17 @@ def _render_menu_panel(
         lines.append(status_line)
     elif in_search_mode:
         lines.append(("", "\n"))
-        lines.append(("fg:ansiyellow", f"  Searching: '{search_buffer}'"))
+        lines.append(("class:tui.input.focused", f"  Searching: '{search_buffer}'"))
     elif search_text:
         lines.append(("", "\n"))
-        lines.append(("fg:ansiyellow", f"  Filter: '{search_text}'"))
+        lines.append(("class:tui.warning", f"  Filter: '{search_text}'"))
     lines.append(("", "\n\n"))
 
     if not entries:
         if search_text or in_search_mode:
-            lines.append(("fg:yellow", "  No sessions match your search."))
+            lines.append(("class:tui.warning", "  No sessions match your search."))
         else:
-            lines.append(("fg:yellow", "  No autosave sessions found."))
+            lines.append(("class:tui.warning", "  No autosave sessions found."))
         lines.append(("", "\n\n"))
         # Navigation hints (always show)
         lines.append(("", "\n"))
@@ -209,9 +209,9 @@ def _render_menu_panel(
         lines.append(("", "Navigate\n"))
         lines.append(("class:tui.muted", "  ←/→ "))
         lines.append(("", "Page\n"))
-        lines.append(("fg:green", "  Enter  "))
+        lines.append(("class:tui.help-key", "  Enter  "))
         lines.append(("", "Load\n"))
-        lines.append(("fg:ansibrightred", "  Ctrl+C "))
+        lines.append(("class:tui.help-key", "  Ctrl+C "))
         lines.append(("", "Cancel"))
         return lines
 
@@ -237,7 +237,7 @@ def _render_menu_panel(
 
         # Highlight selected item
         if is_selected:
-            lines.append(("class:tui.muted", f" > {label}"))
+            lines.append(("class:tui.selected", f" > {label}"))
         else:
             lines.append(("class:tui.muted", f"   {label}"))
 
@@ -246,22 +246,22 @@ def _render_menu_panel(
     # Navigation hints - change based on browse mode
     lines.append(("", "\n"))
     if browse_mode:
-        lines.append(("fg:ansicyan", "  ↑/↓ "))
+        lines.append(("class:tui.help-key", "  ↑/↓ "))
         lines.append(("", "Browse msgs\n"))
-        lines.append(("fg:ansiyellow", "  Esc "))
+        lines.append(("class:tui.help-key", "  Esc "))
         lines.append(("", "Exit browser\n"))
     else:
         lines.append(("class:tui.muted", "  ↑/↓ "))
         lines.append(("", "Navigate\n"))
         lines.append(("class:tui.muted", "  ←/→ "))
         lines.append(("", "Page\n"))
-        lines.append(("fg:ansicyan", "  e   "))
+        lines.append(("class:tui.help-key", "  e   "))
         lines.append(("", "Browse msgs\n"))
-        lines.append(("class:tui.muted", "  /   "))
+        lines.append(("class:tui.help-key", "  /   "))
         lines.append(("", "Search content\n"))
-    lines.append(("fg:green", "  Enter  "))
+    lines.append(("class:tui.help-key", "  Enter  "))
     lines.append(("", "Load\n"))
-    lines.append(("fg:ansibrightred", "  Ctrl+C "))
+    lines.append(("class:tui.help-key", "  Ctrl+C "))
     lines.append(("", "Cancel"))
 
     return lines
@@ -281,12 +281,12 @@ def _render_message_browser_panel(
     """
     lines = []
 
-    lines.append(("fg:ansicyan bold", " MESSAGE BROWSER"))
+    lines.append(("class:tui.header", " MESSAGE BROWSER"))
     lines.append(("", "\n\n"))
 
     total_messages = len(history)
     if total_messages == 0:
-        lines.append(("fg:yellow", "  No messages in this session."))
+        lines.append(("class:tui.warning", "  No messages in this session."))
         lines.append(("", "\n"))
         return lines
 
@@ -306,16 +306,16 @@ def _render_message_browser_panel(
 
     # Message position indicator
     display_num = message_idx + 1  # 1-based for display
-    lines.append(("bold", f"  Message {display_num} of {total_messages}"))
+    lines.append(("class:tui.label", f"  Message {display_num} of {total_messages}"))
     lines.append(("", "\n\n"))
 
     # Role indicator with icon and color
     if role == "user":
-        lines.append(("fg:ansicyan bold", "  🧑 USER"))
+        lines.append(("class:tui.title", "  \U0001f9d1 USER"))
     elif role == "tool":
-        lines.append(("fg:ansiyellow bold", "  TOOL"))
+        lines.append(("class:tui.warning", "  TOOL"))
     else:
-        lines.append(("fg:ansigreen bold", "  🤖 ASSISTANT"))
+        lines.append(("class:tui.success", "  \U0001f916 ASSISTANT"))
     lines.append(("", "\n"))
 
     # Separator line
@@ -328,7 +328,7 @@ def _render_message_browser_panel(
             # Tool messages are already formatted, don't pass through markdown
             # Use yellow color for tool output
             rendered = content
-            text_color = "fg:ansiyellow"
+            text_color = "class:tui.warning"
         else:
             # User and assistant messages should be rendered as markdown
             # Rich will handle the styling via ANSI codes
@@ -353,12 +353,12 @@ def _render_message_browser_panel(
             lines.append(("", "\n"))
 
     except Exception as e:
-        lines.append(("fg:red", f"  Error rendering message: {e}"))
+        lines.append(("class:tui.error", f"  Error rendering message: {e}"))
         lines.append(("", "\n"))
 
     # Navigation hint at bottom
     lines.append(("", "\n"))
-    lines.append(("class:tui.muted", "  ↑ older  ↓ newer  Esc exit"))
+    lines.append(("class:tui.help", "  ↑ older  ↓ newer  Esc exit"))
     lines.append(("", "\n"))
 
     return lines
@@ -372,14 +372,14 @@ def _render_preview_panel(base_dir: Path, entry: Optional[Tuple[str, dict]]) -> 
     lines.append(("", "\n\n"))
 
     if not entry:
-        lines.append(("fg:yellow", "  No session selected."))
+        lines.append(("class:tui.warning", "  No session selected."))
         lines.append(("", "\n"))
         return lines
 
     session_name, metadata = entry
 
     # Show metadata
-    lines.append(("bold", "  Session: "))
+    lines.append(("class:tui.label", "  Session: "))
     lines.append(("", session_name))
     lines.append(("", "\n"))
 
@@ -397,7 +397,7 @@ def _render_preview_panel(base_dir: Path, entry: Optional[Tuple[str, dict]]) -> 
     lines.append(("class:tui.muted", f"  Messages: {msg_count} • Tokens: {tokens:,}"))
     lines.append(("", "\n\n"))
 
-    lines.append(("bold", "  Last Message:"))
+    lines.append(("class:tui.label", "  Last Message:"))
     lines.append(("class:tui.muted", "  (press 'e' to browse full history)"))
     lines.append(("", "\n"))
 
@@ -427,7 +427,7 @@ def _render_preview_panel(base_dir: Path, entry: Optional[Tuple[str, dict]]) -> 
             lines.append(("", "\n"))
 
     except Exception as e:
-        lines.append(("fg:red", f"  Error loading preview: {e}"))
+        lines.append(("class:tui.error", f"  Error loading preview: {e}"))
         lines.append(("", "\n"))
 
     return lines
@@ -617,7 +617,7 @@ async def interactive_autosave_picker() -> Optional[str]:
              other search activity to crowd out.
         """
         if is_filtering[0]:
-            return ("fg:ansicyan bold", "  Filtering...")
+            return ("class:tui.input.focused", "  Filtering...")
         if in_search_mode[0] or search_text[0]:
             return None  # Let the renderer show the search/filter line.
         cached = content_index.count()


### PR DESCRIPTION
Closes #557

Migrates this TUI to the centralized semantic `class:tui.*` palette while preserving its existing layout and interactions.

Validation is recorded on parent issue #552: full suite 12005 passed, 81 skipped, 1 xpassed; Ruff, formatting, and visual light/dark audits pass.