### PR TITLE
Theme the /colors TUI

### DIFF
--- a/code_puppy/command_line/colors_menu.py
+++ b/code_puppy/command_line/colors_menu.py
@@ -270,21 +270,21 @@ async def _split_panel_selector(
         """Generate the selector menu text."""
         try:
             lines = []
-            lines.append(("bold cyan", title))
+            lines.append(("class:tui.header", title))
             lines.append(("", "\n\n"))
 
             if not choices:
-                lines.append(("fg:ansiyellow", "No choices available"))
+                lines.append(("class:tui.warning", "No choices available"))
                 lines.append(("", "\n"))
             else:
                 for i, choice in enumerate(choices):
                     # Skip separator lines for selection highlighting
                     if "───" in choice:
-                        lines.append(("fg:ansigray", f"  {choice}"))
+                        lines.append(("class:tui.muted", f"  {choice}"))
                         lines.append(("", "\n"))
                     elif i == selected_index[0]:
-                        lines.append(("fg:ansigreen", "▶ "))
-                        lines.append(("fg:ansigreen bold", choice))
+                        lines.append(("class:tui.selected", "▶ "))
+                        lines.append(("class:tui.selected", choice))
                         lines.append(("", "\n"))
                     else:
                         lines.append(("", "  "))
@@ -293,11 +293,11 @@ async def _split_panel_selector(
 
             lines.append(("", "\n"))
             lines.append(
-                ("fg:ansicyan", "↑↓ Navigate  │  Enter Select  │  Ctrl-C Cancel")
+                ("class:tui.help-key", "↑↓ Navigate  │  Enter Select  │  Ctrl-C Cancel")
             )
             return FormattedText(lines)
         except Exception as e:
-            return FormattedText([("fg:ansired", f"Error: {e}")])
+            return FormattedText([("class:tui.error", f"Error: {e}")])
 
     def get_right_panel_text():
         """Generate the preview panel text."""
@@ -305,7 +305,7 @@ async def _split_panel_selector(
             preview = get_preview()
             return preview
         except Exception as e:
-            return FormattedText([("fg:ansired", f"Preview error: {e}")])
+            return FormattedText([("class:tui.error", f"Preview error: {e}")])
 
     kb = KeyBindings()
 


### PR DESCRIPTION
Closes #559

Migrates this TUI to the centralized semantic `class:tui.*` palette while preserving its existing layout and interactions.

Validation is recorded on parent issue #552: full suite 12005 passed, 81 skipped, 1 xpassed; Ruff, formatting, and visual light/dark audits pass.