### PR TITLE
Theme the plugin manager TUI

### DIFF
--- a/code_puppy/plugins/plugin_list/plugins_menu_render.py
+++ b/code_puppy/plugins/plugin_list/plugins_menu_render.py
@@ -76,7 +76,7 @@ def render_list(menu: "PluginsMenu") -> Fragments:
     if menu.lock_builtin and menu.hidden_builtin_count:
         lines.append(
             (
-                "fg:ansibrightblack",
+                "class:tui.muted",
                 f"  {menu.hidden_builtin_count} builtin plugins are "
                 f"managed and hidden.",
             )
@@ -85,9 +85,9 @@ def render_list(menu: "PluginsMenu") -> Fragments:
 
     if not menu.plugins:
         if menu.lock_builtin and menu.hidden_builtin_count:
-            lines.append(("fg:ansiyellow", "  No user or project plugins loaded."))
+            lines.append(("class:tui.warning", "  No user or project plugins loaded."))
         else:
-            lines.append(("fg:ansiyellow", "  No plugins loaded."))
+            lines.append(("class:tui.warning", "  No plugins loaded."))
         lines.append(("", "\n"))
         _render_hints(lines)
         return lines
@@ -104,26 +104,28 @@ def render_list(menu: "PluginsMenu") -> Fragments:
 
         if entry.status == "loaded":
             icon = "x" if is_disabled else "+"
-            icon_style = "fg:ansired" if is_disabled else "fg:ansigreen"
+            icon_style = "class:tui.error" if is_disabled else "class:tui.success"
         else:
             # Trust-gated project plugin: discovered but never imported.
             icon = "!"
-            icon_style = "fg:ansired" if entry.status == "error" else "fg:ansiyellow"
+            icon_style = (
+                "class:tui.error" if entry.status == "error" else "class:tui.warning"
+            )
         prefix = " > " if is_selected else "   "
 
         if is_selected:
-            lines.append(("bold", prefix))
-            lines.append((icon_style + " bold", icon))
-            lines.append(("bold", f" {entry.name}"))
+            lines.append(("class:tui.selected", prefix))
+            lines.append(("class:tui.selected", icon))
+            lines.append(("class:tui.selected", f" {entry.name}"))
         else:
             lines.append(("", prefix))
             lines.append((icon_style, icon))
-            lines.append(("fg:ansibrightblack", f" {entry.name}"))
+            lines.append(("class:tui.muted", f" {entry.name}"))
 
         lines.append(("", "\n"))
 
     lines.append(("", "\n"))
-    lines.append(("fg:ansibrightblack", f" Page {menu.current_page + 1}/{total_pages}"))
+    lines.append(("class:tui.muted", f" Page {menu.current_page + 1}/{total_pages}"))
     lines.append(("", "\n"))
 
     _render_hints(lines)
@@ -135,12 +137,12 @@ def _render_hints(lines: Fragments) -> None:
     # across both split-pane inspectors. See _build_key_bindings docstring
     # for the full mental model.
     hints: List[Tuple[str, str, str]] = [
-        ("fg:ansibrightblack", "  up/down or j/k ", "Navigate"),
-        ("fg:ansibrightblack", "  PgUp/PgDn      ", "Page"),
-        ("fg:ansibrightblack", "  g / G          ", "First / Last"),
-        ("fg:ansibrightblack", "  h/l or \u2190/\u2192    ", "Scroll details"),
-        ("fg:ansigreen", "  Enter          ", "Toggle / Enable"),
-        ("fg:ansired", "  q / Esc        ", "Exit"),
+        ("class:tui.help-key", "  up/down or j/k ", "Navigate"),
+        ("class:tui.help-key", "  PgUp/PgDn      ", "Page"),
+        ("class:tui.help-key", "  g / G          ", "First / Last"),
+        ("class:tui.help-key", "  h/l or \u2190/\u2192    ", "Scroll details"),
+        ("class:tui.help-key", "  Enter          ", "Toggle / Enable"),
+        ("class:tui.help-key", "  q / Esc        ", "Exit"),
     ]
     lines.append(("", "\n"))
     for i, (style, key_text, label) in enumerate(hints):
@@ -156,23 +158,23 @@ def _render_hints(lines: Fragments) -> None:
 # ``{name}`` is substituted with the plugin name in the hint text.
 _GATE_STATUS_DETAILS = {
     "untrusted": (
-        "fg:ansiyellow bold",
+        "class:tui.warning",
         "Not enabled (project plugins are disabled by default)",
         "Press Enter to review its files and enable it.",
     ),
     "changed": (
-        "fg:ansiyellow bold",
+        "class:tui.warning",
         "Changed since you accepted it",
         "Its files were modified after you trusted it, so trust was "
         "revoked. Press Enter to re-review and re-enable.",
     ),
     "disabled": (
-        "fg:ansired bold",
+        "class:tui.error",
         "Disabled (trusted, but not loaded)",
         "Press Enter to load it.",
     ),
     "error": (
-        "fg:ansired bold",
+        "class:tui.error",
         "Failed to load",
         "Check the logs, then press Enter to retry.",
     ),
@@ -183,15 +185,13 @@ def _render_gate_status(lines: Fragments, menu: "PluginsMenu", entry) -> None:
     """Status + hint for a project plugin that was never imported."""
     style, label, hint = _GATE_STATUS_DETAILS.get(
         entry.status,
-        ("fg:ansiyellow bold", entry.status, "See '/plugins list' for details."),
+        ("class:tui.warning", entry.status, "See '/plugins list' for details."),
     )
     lines.append(("bold", "  Status: "))
     lines.append((style, label))
     lines.append(("", "\n"))
     inner = max(20, menu._detail_cols - 4)
-    _append_wrapped(
-        lines, "fg:ansibrightblack", "  ", hint.format(name=entry.name), inner
-    )
+    _append_wrapped(lines, "class:tui.muted", "  ", hint.format(name=entry.name), inner)
     lines.append(("", "\n"))
 
 
@@ -217,9 +217,7 @@ def render_trust_modal(menu: "PluginsMenu") -> Fragments:
         if entry.status == "changed"
         else "has never been enabled for this project"
     )
-    _append_wrapped(
-        lines, "fg:ansiyellow bold", " ", f"'{entry.name}' {reason}.", inner
-    )
+    _append_wrapped(lines, "class:tui.warning", " ", f"'{entry.name}' {reason}.", inner)
     lines.append(("", "\n"))
     _append_wrapped(
         lines,
@@ -239,12 +237,12 @@ def render_trust_modal(menu: "PluginsMenu") -> Fragments:
         listing = plugin_file_listing(Path(menu.project_dir) / entry.name, limit=8)
         for row in listing.splitlines():
             for piece in wrap_text(row.strip(), inner - 2):
-                lines.append(("fg:ansicyan", f"   {piece}"))
+                lines.append(("class:tui.header", f"   {piece}"))
                 lines.append(("", "\n"))
         lines.append(("", "\n"))
 
     if menu.trust_error:
-        _append_wrapped(lines, "fg:ansired bold", " ", menu.trust_error, inner)
+        _append_wrapped(lines, "class:tui.error", " ", menu.trust_error, inner)
         lines.append(("", "\n"))
 
     _append_wrapped(
@@ -260,18 +258,18 @@ def render_trust_modal(menu: "PluginsMenu") -> Fragments:
 def render_detail(menu: "PluginsMenu") -> Fragments:
     lines: Fragments = []
 
-    lines.append(("dim cyan", " PLUGIN DETAILS"))
+    lines.append(("class:tui.title dim", " PLUGIN DETAILS"))
     lines.append(("", "\n\n"))
 
     # Outcome of the most recent enable/activate action, if any.
     if menu.trust_feedback:
         inner = max(20, menu._detail_cols - 4)
-        _append_wrapped(lines, "fg:ansigreen", "  ", menu.trust_feedback, inner)
+        _append_wrapped(lines, "class:tui.success", "  ", menu.trust_feedback, inner)
         lines.append(("", "\n"))
 
     entry = menu._current()
     if not entry:
-        lines.append(("fg:ansiyellow", "  No plugin selected."))
+        lines.append(("class:tui.warning", "  No plugin selected."))
         return lines
 
     from code_puppy.plugins.plugin_list import plugin_meta
@@ -298,7 +296,7 @@ def render_detail(menu: "PluginsMenu") -> Fragments:
         lines.append(("bold", "  Project:"))
         lines.append(("", "\n"))
         inner = max(20, menu._detail_cols - 6)
-        _append_wrapped(lines, "fg:ansibrightblack", "    ", menu.project_dir, inner)
+        _append_wrapped(lines, "class:tui.muted", "    ", menu.project_dir, inner)
         lines.append(("", "\n"))
 
     if entry.status != "loaded":
@@ -309,20 +307,18 @@ def render_detail(menu: "PluginsMenu") -> Fragments:
             lines.append(("bold", "  Path:"))
             lines.append(("", "\n"))
             inner = max(20, menu._detail_cols - 6)
-            _append_wrapped(lines, "fg:ansibrightblack", "    ", path, inner)
+            _append_wrapped(lines, "class:tui.muted", "    ", path, inner)
         return lines
 
     lines.append(("bold", "  Status: "))
     if is_disabled:
-        lines.append(("fg:ansired bold", "Disabled"))
+        lines.append(("class:tui.error", "Disabled"))
         lines.append(("", "\n"))
-        lines.append(
-            ("fg:ansibrightblack", "  Callbacks are skipped at dispatch time.")
-        )
+        lines.append(("class:tui.muted", "  Callbacks are skipped at dispatch time."))
     else:
-        lines.append(("fg:ansigreen bold", "Enabled"))
+        lines.append(("class:tui.success", "Enabled"))
         lines.append(("", "\n"))
-        lines.append(("fg:ansibrightblack", "  All callbacks are active."))
+        lines.append(("class:tui.muted", "  All callbacks are active."))
     lines.append(("", "\n\n"))
 
     _render_contributions(lines, menu, entry)
@@ -332,10 +328,10 @@ def render_detail(menu: "PluginsMenu") -> Fragments:
     lines.append(("", "\n"))
     if hooks:
         for hook in hooks:
-            lines.append(("fg:ansicyan", f"    • {hook}"))
+            lines.append(("class:tui.header", f"    • {hook}"))
             lines.append(("", "\n"))
     else:
-        lines.append(("fg:ansibrightblack", "    (none registered)"))
+        lines.append(("class:tui.muted", "    (none registered)"))
         lines.append(("", "\n"))
     lines.append(("", "\n"))
 
@@ -345,7 +341,7 @@ def render_detail(menu: "PluginsMenu") -> Fragments:
         lines.append(("bold", "  Path:"))
         lines.append(("", "\n"))
         inner = max(20, menu._detail_cols - 6)  # -4 indent, -2 frame border
-        _append_wrapped(lines, "fg:ansibrightblack", "    ", path, inner)
+        _append_wrapped(lines, "class:tui.muted", "    ", path, inner)
         lines.append(("", "\n"))
 
     if menu._changed:
@@ -356,7 +352,7 @@ def render_detail(menu: "PluginsMenu") -> Fragments:
         inner = max(20, menu._detail_cols - 4)  # -2 indent, -2 frame border
         _append_wrapped(
             lines,
-            "fg:ansiyellow bold",
+            "class:tui.warning",
             "  ",
             "Restart Code Puppy for changes to take effect.",
             inner,
@@ -407,13 +403,13 @@ def _render_contributions(
         items = contributions.get(key)
         if not items:
             continue
-        lines.append(("fg:ansimagenta", f"    {label}:"))
+        lines.append(("class:tui.title", f"    {label}:"))
         lines.append(("", "\n"))
         for item in items:
             pieces = wrap_text(str(item), inner)
             for idx, piece in enumerate(pieces):
                 prefix = bullet_prefix if idx == 0 else cont_prefix
-                lines.append(("fg:ansicyan", f"{prefix}{piece}"))
+                lines.append(("class:tui.header", f"{prefix}{piece}"))
                 lines.append(("", "\n"))
     lines.append(("", "\n"))
 


### PR DESCRIPTION
Closes #570

Migrates this TUI to the centralized semantic `class:tui.*` palette while preserving its existing layout and interactions.

Validation is recorded on parent issue #552: full suite 12005 passed, 81 skipped, 1 xpassed; Ruff, formatting, and visual light/dark audits pass.