### PR TITLE
Theme the theme picker TUI

### DIFF
--- a/code_puppy/plugins/theme/picker.py
+++ b/code_puppy/plugins/theme/picker.py
@@ -211,26 +211,32 @@ def _format_menu(selected_index: int) -> FormattedText:
     page_start = page * THEMES_PER_PAGE
     page_end = min(page_start + THEMES_PER_PAGE, len(MENU))
     lines: list[tuple[str, str]] = [
-        ("bold cyan", "Pick a Theme"),
-        ("fg:ansibrightblack", f"  Page {page + 1}/{_total_pages()}"),
+        ("class:tui.header", "Pick a Theme"),
+        ("class:tui.muted", f"  Page {page + 1}/{_total_pages()}"),
         ("", "\n\n"),
     ]
     for i in range(page_start, page_end):
         _, theme = MENU[i]
         prefix = "> " if i == selected_index else "  "
-        style = "fg:ansigreen bold" if i == selected_index else ""
+        style = "class:tui.selected" if i == selected_index else "class:tui.body"
         line = f"{prefix}{i + 1}. {theme['icon']} {theme['label']}"
         lines.append((style, line))
         lines.append(("", "\n"))
-        lines.append(("fg:ansigray", f"     {theme['blurb']}"))
+        lines.append(("class:tui.muted", f"     {theme['blurb']}"))
         lines.append(("", "\n\n"))
 
     lines.append(("", "\n"))
-    lines.append(
-        (
-            "fg:ansicyan",
-            "Up/Down Navigate  |  PgUp/PgDn Page\nEnter Apply  |  Esc / Ctrl-C Cancel",
-        )
+    lines.extend(
+        [
+            ("class:tui.help-key", "Up/Down"),
+            ("class:tui.help", " Navigate  |  "),
+            ("class:tui.help-key", "PgUp/PgDn"),
+            ("class:tui.help", " Page\n"),
+            ("class:tui.help-key", "Enter"),
+            ("class:tui.help", " Apply  |  "),
+            ("class:tui.help-key", "Esc / Ctrl-C"),
+            ("class:tui.help", " Cancel"),
+        ]
     )
     return FormattedText(lines)
 

--- a/tests/plugins/test_theme_plugin.py
+++ b/tests/plugins/test_theme_plugin.py
@@ -293,6 +293,20 @@ class TestThemePickerPagination:
         assert "Ocean" not in rendered
         assert "Deep Black" not in rendered
 
+    def test_menu_uses_semantic_roles_for_chrome(self):
+        fragments = list(_format_menu(0))
+        styles = {style for style, _ in fragments}
+
+        assert {
+            "class:tui.header",
+            "class:tui.muted",
+            "class:tui.selected",
+            "class:tui.body",
+            "class:tui.help",
+            "class:tui.help-key",
+        } <= styles
+        assert not any("ansi" in style for style in styles)
+
     def test_page_navigation_clamps_at_catalog_edges(self):
         assert _move_page(2, 1) == 7
         assert _move_page(7, -1) == 2


### PR DESCRIPTION
Closes #574

Migrates this TUI to the centralized semantic `class:tui.*` palette while preserving its existing layout and interactions.

Validation is recorded on parent issue #552: full suite 12005 passed, 81 skipped, 1 xpassed; Ruff, formatting, and visual light/dark audits pass.