### PR TITLE
Theme the ask-user-question TUI

### DIFF
--- a/code_puppy/tools/ask_user_question/renderers.py
+++ b/code_puppy/tools/ask_user_question/renderers.py
@@ -117,10 +117,11 @@ def _render_question_panel_unsafe(
     # Question text
     if question.multi_select:
         console.print(
-            f"{pad}[bold]? {safe_question}[/bold] [dim](select multiple)[/dim]"
+            f"{pad}[{colors.question}]? {safe_question}[/{colors.question}] "
+            f"[{colors.question_hint}](select multiple)[/{colors.question_hint}]"
         )
     else:
-        console.print(f"{pad}[bold]? {safe_question}[/bold]")
+        console.print(f"{pad}[{colors.question}]? {safe_question}[/{colors.question}]")
     console.print()
 
     # Render options

--- a/code_puppy/tools/ask_user_question/theme.py
+++ b/code_puppy/tools/ask_user_question/theme.py
@@ -55,50 +55,36 @@ def _apply_config_overrides(default: _T, config_map: Mapping[str, str]) -> _T:
 class TUIColors(NamedTuple):
     """Color scheme for the ask_user_question TUI."""
 
-    # Header and title colors
-    header_bold: str = "bold cyan"
-    header_dim: str = "fg:ansicyan dim"
+    # Compatibility field names; values are shared prompt-toolkit semantic roles.
+    header_bold: str = "class:tui.header"
+    header_dim: str = "class:tui.help"
 
-    # Cursor and selection colors
-    cursor_active: str = "fg:ansigreen bold"
-    cursor_inactive: str = "fg:ansiwhite"
-    selected: str = "fg:ansicyan"
-    selected_check: str = "fg:ansigreen"
+    cursor_active: str = "class:tui.success"
+    cursor_inactive: str = "class:tui.body"
+    selected: str = "class:tui.selected"
+    selected_check: str = "class:tui.success"
 
-    # Text colors
-    text_normal: str = ""
-    text_dim: str = "fg:ansiwhite dim"
-    text_warning: str = "fg:ansiyellow bold"
+    text_normal: str = "class:tui.body"
+    text_dim: str = "class:tui.muted"
+    text_warning: str = "class:tui.warning"
 
-    # Help text colors
-    help_key: str = "fg:ansigreen"
-    help_text: str = "fg:ansiwhite dim"
+    help_key: str = "class:tui.help-key"
+    help_text: str = "class:tui.help"
 
-    # Error colors
-    error: str = "fg:ansired"
+    error: str = "class:tui.error"
 
 
 # Create defaults after class definitions
 _DEFAULT_TUI = TUIColors()
 
-# Mapping of configurable TUI color fields to config keys
-_TUI_CONFIG_MAP: dict[str, str] = {
-    "header_bold": "tui_header_color",
-    "cursor_active": "tui_cursor_color",
-    "selected": "tui_selected_color",
-}
-
 
 def get_tui_colors() -> TUIColors:
-    """Get the current TUI color scheme.
+    """Return shared semantic roles for prompt-toolkit rendering.
 
-    Loads colors from code-puppy's configuration system for custom theming.
-    Falls back to defaults for any missing config values.
-
-    Returns:
-        TUIColors instance with the current theme.
+    The active theme resolves these classes centrally. Legacy per-tool color
+    configuration must not override that shared palette.
     """
-    return _apply_config_overrides(_DEFAULT_TUI, _TUI_CONFIG_MAP)
+    return _DEFAULT_TUI
 
 
 # Rich console color mappings for the right panel
@@ -107,29 +93,29 @@ class RichColors(NamedTuple):
 
     # Header colors (Rich markup format)
     header: str = "bold cyan"
-    progress: str = "dim"
+    progress: str = "italic"
 
     # Question text
     question: str = "bold"
-    question_hint: str = "dim"
+    question_hint: str = "italic"
 
     # Option colors
     cursor: str = "green bold"
     selected: str = "cyan"
     normal: str = ""
-    description: str = "dim"
+    description: str = "italic"
 
     # Input field
     input_label: str = "bold yellow"
     input_text: str = "green"
-    input_hint: str = "dim"
+    input_hint: str = "italic"
 
     # Help overlay
     help_border: str = "bold cyan"
     help_title: str = "bold cyan"
     help_section: str = "bold"
     help_key: str = "green"
-    help_close: str = "dim"
+    help_close: str = "italic"
 
     # Timeout warning
     timeout_warning: str = "bold yellow"
@@ -137,19 +123,21 @@ class RichColors(NamedTuple):
 
 _DEFAULT_RICH = RichColors()
 
-# Mapping of configurable Rich color fields to config keys
-_RICH_CONFIG_MAP: dict[str, str] = {
-    "header": "tui_rich_header_color",
-    "cursor": "tui_rich_cursor_color",
-}
-
 
 def get_rich_colors() -> RichColors:
-    """Get Rich console colors for the question panel.
+    """Return Rich styles backed by the shared prompt-toolkit palette."""
+    from code_puppy.plugins.theme.prompt_toolkit_theme import get_style_rules
 
-    Falls back to defaults for any missing config values.
+    muted_rule = get_style_rules().get("tui.muted", "").removeprefix("fg:")
+    if not muted_rule:
+        return _DEFAULT_RICH
+    muted = muted_rule.split(maxsplit=1)[0]
 
-    Returns:
-        RichColors instance with current theme.
-    """
-    return _apply_config_overrides(_DEFAULT_RICH, _RICH_CONFIG_MAP)
+    muted_style = f"{muted} italic"
+    return _DEFAULT_RICH._replace(
+        progress=muted_style,
+        question_hint=muted_style,
+        description=muted_style,
+        input_hint=muted_style,
+        help_close=muted_style,
+    )

--- a/code_puppy/tools/ask_user_question/tui_loop.py
+++ b/code_puppy/tools/ask_user_question/tui_loop.py
@@ -358,19 +358,21 @@ async def run_question_tui(
             [
                 ("", "\n"),
                 ("", pad),
-                (tui_colors.header_dim, f"{ARROW_LEFT}{ARROW_RIGHT} Switch question"),
+                (tui_colors.help_key, f"{ARROW_LEFT}{ARROW_RIGHT}"),
+                (tui_colors.help_text, " Switch question"),
                 ("", "\n"),
                 ("", pad),
-                (tui_colors.header_dim, f"{ARROW_UP}{ARROW_DOWN} Navigate options"),
+                (tui_colors.help_key, f"{ARROW_UP}{ARROW_DOWN}"),
+                (tui_colors.help_text, " Navigate options"),
                 ("", "\n"),
                 ("", "\n"),
                 ("", pad),
                 (tui_colors.help_key, "Ctrl+S"),
-                (tui_colors.header_dim, " Submit"),
+                (tui_colors.help_text, " Submit"),
                 ("", "\n"),
                 ("", pad),
                 (tui_colors.help_key, "Tab"),
-                (tui_colors.header_dim, " Peek behind"),
+                (tui_colors.help_text, " Peek behind"),
             ]
         )
 

--- a/tests/tools/test_ask_user_question/test_theme.py
+++ b/tests/tools/test_ask_user_question/test_theme.py
@@ -17,18 +17,19 @@ class TestTUIColors:
 
     def test_defaults(self):
         c = TUIColors()
-        assert c.header_bold == "bold cyan"
-        assert c.header_dim == "fg:ansicyan dim"
-        assert c.cursor_active == "fg:ansigreen bold"
-        assert c.cursor_inactive == "fg:ansiwhite"
-        assert c.selected == "fg:ansicyan"
-        assert c.selected_check == "fg:ansigreen"
-        assert c.text_normal == ""
-        assert c.text_dim == "fg:ansiwhite dim"
-        assert c.text_warning == "fg:ansiyellow bold"
-        assert c.help_key == "fg:ansigreen"
-        assert c.help_text == "fg:ansiwhite dim"
-        assert c.error == "fg:ansired"
+        assert c.header_bold == "class:tui.header"
+        assert c.header_dim == "class:tui.help"
+        assert c.cursor_active == "class:tui.success"
+        assert c.cursor_inactive == "class:tui.body"
+        assert c.selected == "class:tui.selected"
+        assert c.selected_check == "class:tui.success"
+        assert c.text_normal == "class:tui.body"
+        assert c.text_dim == "class:tui.muted"
+        assert c.text_warning == "class:tui.warning"
+        assert c.help_key == "class:tui.help-key"
+        assert c.help_text == "class:tui.help"
+        assert c.error == "class:tui.error"
+        assert all(style.startswith("class:tui.") for style in c)
 
 
 class TestRichColors:
@@ -37,18 +38,18 @@ class TestRichColors:
     def test_defaults(self):
         c = RichColors()
         assert c.header == "bold cyan"
-        assert c.progress == "dim"
+        assert c.progress == "italic"
         assert c.cursor == "green bold"
         assert c.selected == "cyan"
-        assert c.description == "dim"
+        assert c.description == "italic"
         assert c.input_label == "bold yellow"
         assert c.input_text == "green"
-        assert c.input_hint == "dim"
+        assert c.input_hint == "italic"
         assert c.help_border == "bold cyan"
         assert c.help_title == "bold cyan"
         assert c.help_section == "bold"
         assert c.help_key == "green"
-        assert c.help_close == "dim"
+        assert c.help_close == "italic"
         assert c.timeout_warning == "bold yellow"
 
 
@@ -131,18 +132,15 @@ class TestGetTuiColors:
             result = get_tui_colors()
         assert isinstance(result, TUIColors)
 
-    def test_applies_overrides(self):
-        def fake_config(key):
-            if key == "tui_header_color":
-                return "magenta"
-            return None
-
+    def test_legacy_overrides_do_not_bypass_shared_theme(self):
         with patch(
             "code_puppy.tools.ask_user_question.theme._get_config_value",
-            side_effect=fake_config,
-        ):
+            return_value="magenta",
+        ) as get_config:
             result = get_tui_colors()
-        assert result.header_bold == "magenta"
+
+        assert result == TUIColors()
+        get_config.assert_not_called()
 
 
 class TestGetRichColors:
@@ -154,15 +152,13 @@ class TestGetRichColors:
             result = get_rich_colors()
         assert isinstance(result, RichColors)
 
-    def test_applies_overrides(self):
-        def fake_config(key):
-            if key == "tui_rich_header_color":
-                return "yellow"
-            return None
-
+    def test_uses_shared_muted_color_in_rich_panel(self):
         with patch(
-            "code_puppy.tools.ask_user_question.theme._get_config_value",
-            side_effect=fake_config,
+            "code_puppy.plugins.theme.prompt_toolkit_theme.get_style_rules",
+            return_value={"tui.muted": "fg:#586e75"},
         ):
             result = get_rich_colors()
-        assert result.header == "yellow"
+
+        assert result.description == "#586e75 italic"
+        assert result.progress == "#586e75 italic"
+        assert result.header == RichColors().header


### PR DESCRIPTION
Closes #575

Migrates this TUI to the centralized semantic `class:tui.*` palette while preserving its existing layout and interactions.

Validation is recorded on parent issue #552: full suite 12005 passed, 81 skipped, 1 xpassed; Ruff, formatting, and visual light/dark audits pass.