### PR TITLE
feat(mcp): support trust-gated project-level MCP server configs

### DIFF
--- a/code_puppy/command_line/mcp/handler.py
+++ b/code_puppy/command_line/mcp/handler.py
@@ -29,6 +29,7 @@ from .start_command import StartCommand
 from .status_command import StatusCommand
 from .stop_all_command import StopAllCommand
 from .stop_command import StopCommand
+from .trust_command import TrustCommand
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -68,6 +69,7 @@ class MCPCommandHandler(MCPCommandBase):
             "install": InstallCommand(),
             "silence-warning": SilenceWarningCommand(),
             "unsilence-warning": UnsilenceWarningCommand(),
+            "trust": TrustCommand(),
             "help": HelpCommand(),
         }
 

--- a/code_puppy/command_line/mcp/help_command.py
+++ b/code_puppy/command_line/mcp/help_command.py
@@ -110,6 +110,12 @@ class HelpCommand(MCPCommandBase):
                 + Text(" Restore the 'registered but not bound' warning")
             )
             help_lines.append(
+                Text("/mcp trust", style="cyan")
+                + Text(
+                    " [accept|revoke]  Trust this repo's .code_puppy/mcp_servers.json"
+                )
+            )
+            help_lines.append(
                 Text("/mcp help", style="cyan")
                 + Text("               Show this help message")
             )

--- a/code_puppy/command_line/mcp/trust_command.py
+++ b/code_puppy/command_line/mcp/trust_command.py
@@ -1,0 +1,213 @@
+"""``/mcp trust`` — accept, inspect, or revoke a project-level MCP config.
+
+Project MCP configs (``<CWD>/.code_puppy/mcp_servers.json``) can define
+``stdio`` servers that run arbitrary commands, so they are ignored until the
+user explicitly trusts them. This command drives that trust ceremony:
+
+* ``/mcp trust``            → preview the project config + servers, show status.
+* ``/mcp trust accept``     → record trust and re-sync the registry.
+* ``/mcp trust revoke``     → drop trust for this project.
+* ``/mcp trust status``     → just print the current trust status.
+
+Trust is content-hashed and stored user-side; see
+:mod:`code_puppy.mcp_.project_config`.
+"""
+
+import logging
+from typing import List, Optional
+
+from rich.text import Text
+
+from code_puppy.mcp_.project_config import (
+    CHANGED,
+    TRUSTED,
+    UNTRUSTED,
+    get_project_mcp_servers_file,
+    get_trust_status,
+    revoke_project_mcp,
+    trust_project_mcp,
+)
+from code_puppy.messaging import emit_error, emit_info
+
+from .base import MCPCommandBase
+
+logger = logging.getLogger(__name__)
+
+
+class TrustCommand(MCPCommandBase):
+    """Handle ``/mcp trust [accept|revoke|status]``."""
+
+    def execute(self, args: List[str], group_id: Optional[str] = None) -> None:
+        if group_id is None:
+            group_id = self.generate_group_id()
+
+        try:
+            import os
+
+            project_root = os.getcwd()
+            config_file = get_project_mcp_servers_file()
+
+            if config_file is None:
+                emit_info(
+                    Text.from_markup(
+                        "[yellow]No project MCP config found.[/yellow] Create "
+                        "[cyan].code_puppy/mcp_servers.json[/cyan] in this repo "
+                        "to define project-scoped MCP servers."
+                    ),
+                    message_group=group_id,
+                )
+                return
+
+            action = args[0].lower() if args else "preview"
+
+            if action == "revoke":
+                self._revoke(group_id)
+            elif action == "accept":
+                self._accept(config_file, group_id)
+            elif action in ("status", "preview", ""):
+                self._preview(project_root, config_file, group_id)
+            else:
+                emit_info(
+                    Text.from_markup(
+                        f"[yellow]Unknown '/mcp trust' action: {action}[/yellow]. "
+                        "Use [cyan]accept[/cyan], [cyan]revoke[/cyan], or "
+                        "[cyan]status[/cyan]."
+                    ),
+                    message_group=group_id,
+                )
+        except Exception as e:  # pragma: no cover - defensive
+            logger.error(f"Error handling /mcp trust: {e}")
+            emit_error(f"Error handling /mcp trust: {e}", message_group=group_id)
+
+    # ---- actions ------------------------------------------------------------
+
+    def _preview(self, project_root: str, config_file, group_id: str) -> None:
+        """Show the project config, its servers, and the trust status."""
+        from pathlib import Path
+
+        status = get_trust_status(Path(project_root), config_file)
+        lines = [
+            Text.from_markup(
+                f"[bold]Project MCP config:[/bold] [cyan]{config_file}[/cyan]"
+            ),
+            Text.from_markup(f"[bold]Trust status:[/bold] {_status_markup(status)}"),
+            Text(""),
+        ]
+
+        servers = self._safe_load_servers(config_file)
+        if servers:
+            lines.append(Text.from_markup("[bold]Declared servers:[/bold]"))
+            for name, conf in servers.items():
+                lines.append(_describe_server(name, conf))
+        else:
+            lines.append(
+                Text.from_markup("[dim](no servers declared, or file unreadable)[/dim]")
+            )
+        lines.append(Text(""))
+
+        if status == TRUSTED:
+            lines.append(
+                Text.from_markup(
+                    "[green]\u2713 Trusted.[/green] These servers are loaded. "
+                    "Run [cyan]/mcp trust revoke[/cyan] to disable them."
+                )
+            )
+        else:
+            verb = (
+                "changed since you trusted it" if status == CHANGED else "not trusted"
+            )
+            lines.append(
+                Text.from_markup(
+                    f"[yellow]\u26a0 This config is {verb}, so its servers are "
+                    "NOT loaded.[/yellow] These servers can run arbitrary "
+                    "commands. If you trust this repo, run "
+                    "[cyan]/mcp trust accept[/cyan]."
+                )
+            )
+        _emit_lines(lines, group_id)
+
+    def _accept(self, config_file, group_id: str) -> None:
+        if trust_project_mcp():
+            # Reflect the new trust immediately by re-syncing the registry.
+            try:
+                self.manager.sync_from_config()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Post-trust registry sync failed: %s", exc)
+            emit_info(
+                Text.from_markup(
+                    f"[green]\u2713 Trusted[/green] [cyan]{config_file}[/cyan]. "
+                    "Its servers are now available. Use [cyan]/mcp[/cyan] to see "
+                    "them and [cyan]/mcp start <name>[/cyan] to run one."
+                ),
+                message_group=group_id,
+            )
+        else:
+            emit_error(
+                f"Could not trust project MCP config {config_file} "
+                "(unreadable file or trust store write failure).",
+                message_group=group_id,
+            )
+
+    def _revoke(self, group_id: str) -> None:
+        if revoke_project_mcp():
+            emit_info(
+                Text.from_markup(
+                    "[green]\u2713 Revoked[/green] trust for this project's MCP "
+                    "config. Its servers will no longer load. Restart or re-sync "
+                    "to drop already-registered ones."
+                ),
+                message_group=group_id,
+            )
+        else:
+            emit_info(
+                Text.from_markup(
+                    "[dim]This project's MCP config wasn't trusted. "
+                    "Nothing to revoke.[/dim]"
+                ),
+                message_group=group_id,
+            )
+
+    # ---- helpers ------------------------------------------------------------
+
+    @staticmethod
+    def _safe_load_servers(config_file) -> dict:
+        """Parse the project config for display only; never raise."""
+        try:
+            from code_puppy.config import _parse_mcp_servers_mapping
+
+            return _parse_mcp_servers_mapping(config_file.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+
+
+def _status_markup(status: str) -> str:
+    return {
+        TRUSTED: "[green]trusted[/green]",
+        CHANGED: "[yellow]changed (re-accept needed)[/yellow]",
+        UNTRUSTED: "[yellow]untrusted[/yellow]",
+    }.get(status, status)
+
+
+def _describe_server(name: str, conf) -> Text:
+    """One-line description of a declared server, flagging arbitrary-command types."""
+    if not isinstance(conf, dict):
+        # Shorthand form: name -> url string.
+        return Text.from_markup(f"  \u2022 [cyan]{name}[/cyan]  [dim]{conf}[/dim]")
+    stype = conf.get("type", "sse")
+    if stype == "stdio" and conf.get("command"):
+        cmd = conf.get("command")
+        detail = f"[red]stdio[/red] \u2192 runs: [dim]{cmd}[/dim]"
+    elif conf.get("url"):
+        detail = f"[dim]{stype} \u2192 {conf.get('url')}[/dim]"
+    else:
+        detail = f"[dim]{stype}[/dim]"
+    return Text.from_markup(f"  \u2022 [cyan]{name}[/cyan]  {detail}")
+
+
+def _emit_lines(lines: List[Text], group_id: str) -> None:
+    final = Text()
+    for i, line in enumerate(lines):
+        if i > 0:
+            final.append("\n")
+        final.append_text(line)
+    emit_info(final, message_group=group_id)

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -412,23 +412,72 @@ def reset_value(key: str) -> None:
 
 
 # --- MODEL STICKY EXTENSION STARTS HERE ---
-def load_mcp_server_configs():
+def _parse_mcp_servers_mapping(raw_text: str) -> dict:
+    """Parse ``mcp_servers.json`` text into a ``{name: config}`` mapping.
+
+    Accepts either the ``mcp_servers`` (snake_case, canonical) or
+    ``mcpServers`` (camelCase, as used by some other MCP clients) wrapper key
+    so hand-copied configs Just Work. Raises ``ValueError`` / ``KeyError`` on
+    malformed input so callers can fail loudly and fall back to ``{}``.
+
+    This is the single chokepoint for wrapper-key normalization, shared by the
+    user-level loader below and the project-level loader in
+    :mod:`code_puppy.mcp_.project_config`.
     """
-    Loads the MCP server configurations from XDG_CONFIG_HOME/code_puppy/mcp_servers.json.
-    Returns a dict mapping names to their URL or config dict.
-    If file does not exist, returns an empty dict.
+    data = json.loads(raw_text)
+    if not isinstance(data, dict):
+        raise ValueError("MCP config root must be a JSON object")
+    servers = data.get("mcp_servers")
+    if servers is None:
+        servers = data.get("mcpServers")
+    if servers is None:
+        # Preserve historical KeyError-on-missing behavior for the canonical key.
+        raise KeyError("mcp_servers")
+    if not isinstance(servers, dict):
+        raise ValueError("'mcp_servers' must be a JSON object of name -> config")
+    return servers
+
+
+def load_mcp_server_configs():
+    """Load MCP server configs, merging user-level and trusted project-level.
+
+    Sources, in ascending order of precedence:
+
+    1. **User-level** \u2014 ``$XDG_CONFIG_HOME/code_puppy/mcp_servers.json``
+       (global, always trusted).
+    2. **Project-level** \u2014 ``<CWD>/.code_puppy/mcp_servers.json``, but ONLY
+       when the user has trusted it via ``/mcp trust``. Project MCP servers can
+       run arbitrary commands, so they are disabled until explicitly accepted;
+       see :mod:`code_puppy.mcp_.project_config`.
+
+    Project entries win on name collision, matching how project agents, skills,
+    and plugins override their user-level counterparts. Returns an empty dict
+    when nothing is configured.
     """
     from code_puppy.messaging.message_queue import emit_error
 
+    configs: dict = {}
+
+    # 1. User-level config (global, implicitly trusted).
     try:
-        if not pathlib.Path(MCP_SERVERS_FILE).exists():
-            return {}
-        with open(MCP_SERVERS_FILE, "r", encoding="utf-8") as f:
-            conf = json.loads(f.read())
-            return conf["mcp_servers"]
+        if pathlib.Path(MCP_SERVERS_FILE).exists():
+            with open(MCP_SERVERS_FILE, "r", encoding="utf-8") as f:
+                configs.update(_parse_mcp_servers_mapping(f.read()))
     except Exception as e:
         emit_error(f"Failed to load MCP servers - {str(e)}")
-        return {}
+
+    # 2. Project-level config (opt-in, trust-gated). A broken or untrusted
+    #    project file must never break user-level loading.
+    try:
+        from code_puppy.mcp_.project_config import load_project_mcp_server_configs
+
+        project_configs = load_project_mcp_server_configs()
+        if project_configs:
+            configs.update(project_configs)
+    except Exception as e:
+        emit_error(f"Failed to load project MCP servers - {str(e)}")
+
+    return configs
 
 
 def _default_model_from_models_json():

--- a/code_puppy/mcp_/project_config.py
+++ b/code_puppy/mcp_/project_config.py
@@ -1,0 +1,252 @@
+"""Project-level MCP server configuration discovery + trust gating.
+
+Code Puppy loads MCP server definitions from the user-level
+``$XDG_CONFIG_HOME/code_puppy/mcp_servers.json``. This module adds an
+*optional*, **trust-gated** project-level source at
+``<CWD>/.code_puppy/mcp_servers.json`` so a team can version-control the MCP
+servers their repo needs — mirroring the existing project-level discovery for
+agents, skills, and plugins.
+
+Why a trust gate?  A ``stdio`` MCP server runs an arbitrary command, and a
+project can also ship an agent (``.code_puppy/agents/*.json``) that declares an
+``auto_start`` binding to one of these servers. That combination is a
+code-execution vector the moment you open a freshly cloned repo. So, exactly
+like project *plugins* (see :mod:`code_puppy.plugins.trust`), project MCP
+configs are **disabled until the user explicitly trusts them** via
+``/mcp trust``.
+
+Trust model (identical philosophy to ``code_puppy/plugins/trust.py``):
+
+* Trust store lives **user-side** at ``~/.code_puppy/trusted_mcp.json`` — a repo
+  can never self-trust.
+* Trust is **content-addressed**: a SHA-256 of the project config file, scoped
+  to the resolved project path. Any edit to the file reverts it to "changed"
+  and demands re-acceptance (blocks silent-update attacks, same as direnv's
+  ``allow``).
+* **Fail closed**: an unreadable store, malformed JSON, or an unhashable file
+  all resolve to "not trusted" → the project config is silently ignored.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Trust store lives user-side so a repository can never self-trust. We hardcode
+# ``~/.code_puppy`` to match ``plugins/trust.py`` — the whole trust subsystem is
+# deliberately anchored to the legacy home dir, not the XDG config dir.
+TRUST_STORE_FILE = Path.home() / ".code_puppy" / "trusted_mcp.json"
+
+# Project-local MCP config path, relative to the current working directory.
+PROJECT_MCP_RELPATH = Path(".code_puppy") / "mcp_servers.json"
+
+_STORE_VERSION = 1
+
+# Trust statuses (mirrors plugins.trust for a consistent mental model).
+TRUSTED = "trusted"  # entry exists and hash matches current contents
+CHANGED = "changed"  # entry exists but contents differ since acceptance
+UNTRUSTED = "untrusted"  # no entry — user never accepted this config
+
+# Warn-once-per-session dedupe so a long-running session doesn't spam the same
+# "found an untrusted project MCP config" message on every registry sync.
+_WARNED: set[tuple[str, str]] = set()
+
+
+# ---------- discovery --------------------------------------------------------
+
+
+def get_project_mcp_servers_file(project_root: Optional[Path] = None) -> Optional[Path]:
+    """Return the project-local MCP config path if it exists, else ``None``.
+
+    Like :func:`code_puppy.config.get_project_agents_directory`, this never
+    creates anything — the team opts in by committing the file.
+    """
+    root = Path(project_root) if project_root is not None else Path.cwd()
+    candidate = root / PROJECT_MCP_RELPATH
+    try:
+        if candidate.is_file():
+            return candidate
+    except OSError:  # pragma: no cover - exotic filesystem errors
+        return None
+    return None
+
+
+# ---------- content hashing --------------------------------------------------
+
+
+def compute_mcp_file_hash(config_file: Path) -> Optional[str]:
+    """SHA-256 of the config file's bytes, or ``None`` if unreadable.
+
+    Callers must treat ``None`` as *not trusted* (fail closed).
+    """
+    try:
+        return hashlib.sha256(Path(config_file).read_bytes()).hexdigest()
+    except OSError as exc:
+        logger.warning("Could not hash project MCP config %s: %s", config_file, exc)
+        return None
+
+
+# ---------- trust store I/O --------------------------------------------------
+
+
+def _project_key(project_root: Path) -> str:
+    """Canonical store key for a project root (resolved absolute path)."""
+    return str(Path(project_root).resolve())
+
+
+def _load_store() -> dict:
+    """Read the trust store, returning an empty store on any problem."""
+    try:
+        if TRUST_STORE_FILE.is_file():
+            data = json.loads(TRUST_STORE_FILE.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and isinstance(data.get("projects"), dict):
+                return data
+            logger.warning(
+                "Malformed MCP trust store at %s — treating as empty",
+                TRUST_STORE_FILE,
+            )
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        logger.warning("Could not read MCP trust store %s: %s", TRUST_STORE_FILE, exc)
+    return {"version": _STORE_VERSION, "projects": {}}
+
+
+def _save_store(store: dict) -> bool:
+    """Persist the trust store. Returns ``False`` (and logs) on failure."""
+    try:
+        TRUST_STORE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        TRUST_STORE_FILE.write_text(
+            json.dumps(store, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        return True
+    except OSError as exc:
+        logger.error("Could not write MCP trust store %s: %s", TRUST_STORE_FILE, exc)
+        return False
+
+
+# ---------- trust queries / mutations ----------------------------------------
+
+
+def get_trust_status(project_root: Path, config_file: Path) -> str:
+    """Return :data:`TRUSTED`, :data:`CHANGED`, or :data:`UNTRUSTED`."""
+    store = _load_store()
+    entry = store["projects"].get(_project_key(project_root))
+    if not isinstance(entry, dict) or not entry.get("hash"):
+        return UNTRUSTED
+    current = compute_mcp_file_hash(config_file)
+    if current is not None and current == entry["hash"]:
+        return TRUSTED
+    return CHANGED
+
+
+def is_project_mcp_trusted(project_root: Optional[Path] = None) -> bool:
+    """True only when the current project's MCP config is trusted & unchanged."""
+    root = Path(project_root) if project_root is not None else Path.cwd()
+    config_file = get_project_mcp_servers_file(root)
+    if config_file is None:
+        return False
+    return get_trust_status(root, config_file) == TRUSTED
+
+
+def trust_project_mcp(project_root: Optional[Path] = None) -> bool:
+    """Record acceptance of the current project's MCP config at its hash.
+
+    Returns ``False`` if there's no project config or it can't be hashed.
+    """
+    root = Path(project_root) if project_root is not None else Path.cwd()
+    config_file = get_project_mcp_servers_file(root)
+    if config_file is None:
+        return False
+    config_hash = compute_mcp_file_hash(config_file)
+    if config_hash is None:
+        return False
+    store = _load_store()
+    store["projects"][_project_key(root)] = {
+        "hash": config_hash,
+        "accepted_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+    return _save_store(store)
+
+
+def revoke_project_mcp(project_root: Optional[Path] = None) -> bool:
+    """Remove trust for the current project. Returns True if an entry existed."""
+    root = Path(project_root) if project_root is not None else Path.cwd()
+    store = _load_store()
+    key = _project_key(root)
+    if key not in store["projects"]:
+        return False
+    del store["projects"][key]
+    return _save_store(store)
+
+
+# ---------- config loading ---------------------------------------------------
+
+
+def load_project_mcp_server_configs(
+    project_root: Optional[Path] = None,
+) -> Dict[str, dict]:
+    """Return the project's MCP server mapping, or ``{}`` when not usable.
+
+    Returns ``{}`` (and, for the untrusted/changed cases, emits a one-time
+    warning) when:
+
+    * there's no ``<CWD>/.code_puppy/mcp_servers.json``, or
+    * the user hasn't trusted it (or its contents changed since acceptance), or
+    * the file is malformed.
+
+    This function never raises — a broken project file must not be able to
+    break user-level MCP loading.
+    """
+    root = Path(project_root) if project_root is not None else Path.cwd()
+    config_file = get_project_mcp_servers_file(root)
+    if config_file is None:
+        return {}
+
+    status = get_trust_status(root, config_file)
+    if status != TRUSTED:
+        _warn_untrusted(root, config_file, status)
+        return {}
+
+    # Trusted: parse via the same chokepoint the user-level loader uses.
+    try:
+        from code_puppy.config import _parse_mcp_servers_mapping
+
+        return _parse_mcp_servers_mapping(config_file.read_text(encoding="utf-8"))
+    except Exception as exc:
+        from code_puppy.messaging.message_queue import emit_error
+
+        emit_error(f"Failed to load project MCP servers from {config_file}: {exc}")
+        return {}
+
+
+def _warn_untrusted(project_root: Path, config_file: Path, status: str) -> None:
+    """Emit a one-time, actionable warning about an unloaded project config."""
+    key = (_project_key(project_root), status)
+    if key in _WARNED:
+        return
+    _WARNED.add(key)
+
+    try:
+        from code_puppy.messaging.message_queue import emit_warning
+    except Exception:  # pragma: no cover - defensive
+        return
+
+    if status == CHANGED:
+        reason = "has changed since you trusted it"
+    else:
+        reason = "is not trusted yet"
+    emit_warning(
+        f"Project MCP config '{config_file}' {reason}; its servers are "
+        f"NOT loaded. Review it, then run '/mcp trust' to accept "
+        f"(project MCP servers can run arbitrary commands)."
+    )
+
+
+def _reset_warning_cache() -> None:
+    """Clear the warn-once cache. Test hook only."""
+    _WARNED.clear()

--- a/tests/mcp/test_project_config.py
+++ b/tests/mcp/test_project_config.py
@@ -1,0 +1,162 @@
+"""Tests for project-level, trust-gated MCP server configuration.
+
+Covers discovery of ``<CWD>/.code_puppy/mcp_servers.json``, the content-hash
+trust store, fail-closed behavior for untrusted/changed/malformed configs, and
+the merge precedence in :func:`code_puppy.config.load_mcp_server_configs`
+(project wins on name collision).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import code_puppy.config as cp_config
+from code_puppy.mcp_ import project_config as pc
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    """A tmp project dir (as CWD) with an isolated user-side trust store."""
+    monkeypatch.chdir(tmp_path)
+    trust_store = tmp_path / "home" / ".code_puppy" / "trusted_mcp.json"
+    monkeypatch.setattr(pc, "TRUST_STORE_FILE", trust_store)
+    pc._reset_warning_cache()
+    return tmp_path
+
+
+def _write_project_config(root: Path, servers: dict) -> Path:
+    cfg_dir = root / ".code_puppy"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    cfg = cfg_dir / "mcp_servers.json"
+    cfg.write_text(json.dumps({"mcp_servers": servers}))
+    return cfg
+
+
+# ---------- discovery --------------------------------------------------------
+
+
+def test_no_project_file_returns_none(project):
+    assert pc.get_project_mcp_servers_file() is None
+    assert pc.load_project_mcp_server_configs() == {}
+
+
+def test_discovers_existing_file(project):
+    cfg = _write_project_config(project, {"s1": "http://localhost"})
+    found = pc.get_project_mcp_servers_file()
+    assert found is not None
+    assert found.resolve() == cfg.resolve()
+
+
+# ---------- trust gating -----------------------------------------------------
+
+
+def test_untrusted_config_is_not_loaded(project):
+    _write_project_config(project, {"s1": {"type": "stdio", "command": "evil"}})
+    assert pc.is_project_mcp_trusted() is False
+    assert pc.load_project_mcp_server_configs() == {}
+
+
+def test_trusted_config_is_loaded(project):
+    _write_project_config(project, {"s1": {"type": "sse", "url": "http://x"}})
+    assert pc.trust_project_mcp() is True
+    assert pc.is_project_mcp_trusted() is True
+    assert pc.load_project_mcp_server_configs() == {
+        "s1": {"type": "sse", "url": "http://x"}
+    }
+
+
+def test_editing_a_trusted_config_reverts_to_changed(project):
+    cfg = _write_project_config(project, {"s1": {"type": "sse", "url": "http://x"}})
+    assert pc.trust_project_mcp() is True
+    assert pc.get_trust_status(project, cfg) == pc.TRUSTED
+
+    # Tamper with the file — trust must break (blocks silent-update attacks).
+    cfg.write_text(
+        json.dumps({"mcp_servers": {"s1": {"type": "stdio", "command": "x"}}})
+    )
+    assert pc.get_trust_status(project, cfg) == pc.CHANGED
+    assert pc.load_project_mcp_server_configs() == {}
+
+
+def test_revoke_roundtrip(project):
+    _write_project_config(project, {"s1": "http://localhost"})
+    assert pc.revoke_project_mcp() is False  # nothing trusted yet
+    assert pc.trust_project_mcp() is True
+    assert pc.revoke_project_mcp() is True
+    assert pc.is_project_mcp_trusted() is False
+
+
+def test_trust_with_no_config_is_noop(project):
+    assert pc.trust_project_mcp() is False
+
+
+def test_malformed_trusted_config_fails_closed(project):
+    cfg_dir = project / ".code_puppy"
+    cfg_dir.mkdir(parents=True)
+    cfg = cfg_dir / "mcp_servers.json"
+    cfg.write_text("{ not json ]")
+    # Trust the (malformed) file, then confirm loading swallows the error.
+    assert pc.trust_project_mcp() is True
+    assert pc.load_project_mcp_server_configs() == {}
+
+
+# ---------- merge precedence in the top-level loader -------------------------
+
+
+def test_loader_merges_project_over_user(project, monkeypatch):
+    # User-level config with two servers.
+    user_file = project / "user_mcp.json"
+    user_file.write_text(
+        json.dumps(
+            {
+                "mcp_servers": {
+                    "shared": {"type": "sse", "url": "user"},
+                    "user_only": "u",
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(cp_config, "MCP_SERVERS_FILE", str(user_file))
+
+    # Project-level config that overrides "shared" and adds "proj_only".
+    _write_project_config(
+        project,
+        {"shared": {"type": "sse", "url": "project"}, "proj_only": "p"},
+    )
+    assert pc.trust_project_mcp() is True
+
+    merged = cp_config.load_mcp_server_configs()
+    assert merged["user_only"] == "u"
+    assert merged["proj_only"] == "p"
+    # Project wins on name collision.
+    assert merged["shared"] == {"type": "sse", "url": "project"}
+
+
+def test_loader_ignores_untrusted_project(project, monkeypatch):
+    user_file = project / "user_mcp.json"
+    user_file.write_text(json.dumps({"mcp_servers": {"user_only": "u"}}))
+    monkeypatch.setattr(cp_config, "MCP_SERVERS_FILE", str(user_file))
+
+    _write_project_config(project, {"proj_only": {"type": "stdio", "command": "x"}})
+    # Not trusted → project servers absent, user servers still present.
+    merged = cp_config.load_mcp_server_configs()
+    assert merged == {"user_only": "u"}
+
+
+# ---------- parse helper -----------------------------------------------------
+
+
+def test_parse_accepts_camelcase_wrapper():
+    raw = json.dumps({"mcpServers": {"s1": "http://x"}})
+    assert cp_config._parse_mcp_servers_mapping(raw) == {"s1": "http://x"}
+
+
+def test_parse_rejects_non_object_root():
+    with pytest.raises(ValueError):
+        cp_config._parse_mcp_servers_mapping("[]")
+
+
+def test_parse_missing_wrapper_key_raises():
+    with pytest.raises(KeyError):
+        cp_config._parse_mcp_servers_mapping(json.dumps({"nope": {}}))


### PR DESCRIPTION
## What & why

Code Puppy only ever loaded MCP servers from the **user-level** `$XDG_CONFIG_HOME/code_puppy/mcp_servers.json`. There was **no project-level** support — even though agents, skills, and plugins all already discover from `<CWD>/.code_puppy/`. This PR closes that gap so a team can version-control the MCP servers their repo needs.

## The security angle (why it's trust-gated, not just merged)

Merely *loading* a server definition doesn't execute anything — servers start on explicit `/mcp start` or via `auto_start` bindings. But a project can **also** ship an agent (`.code_puppy/agents/*.json`) that declares an `auto_start` binding, and a `stdio` server runs an **arbitrary command**. That combo is a code-execution vector the moment you open a freshly cloned repo.

So, exactly like project **plugins**, project MCP configs are **disabled until the user explicitly trusts them**. The trust model is modeled directly on `code_puppy/plugins/trust.py`:

- Trust store lives **user-side** (`~/.code_puppy/trusted_mcp.json`) — a repo can never self-trust.
- Trust is **content-addressed** (SHA-256 of the config file, scoped to the resolved project path). Any edit reverts it to `changed` and demands re-acceptance (blocks silent-update attacks).
- **Fail closed**: unreadable store, malformed JSON, or an unhashable file → not trusted → ignored. A broken project file never breaks user-level loading.

## How it works

1. `code_puppy/config.load_mcp_server_configs()` now merges **user-level** + **trusted project-level** configs, with **project winning on name collision** (matching how project agents/skills/plugins override their user-level counterparts). This is the single chokepoint that feeds `MCPManager.sync_from_config()` → registry → `get_servers_for_agent()`, so nothing downstream had to change.
2. New `code_puppy/mcp_/project_config.py` — discovery + content-hash trust store.
3. New `_parse_mcp_servers_mapping()` shared parse helper (also now accepts the `mcpServers` camelCase wrapper key for hand-copied configs).
4. New `/mcp trust` command:
   - `/mcp trust` — preview the project config + declared servers (flagging `stdio` commands) and show trust status.
   - `/mcp trust accept` — record trust and re-sync the registry immediately.
   - `/mcp trust revoke` — drop trust for this project.
   - `/mcp trust status` — just print the status.

## Tests

13 new tests in `tests/mcp/test_project_config.py`: discovery, untrusted/changed/malformed fail-closed, trust/revoke roundtrip, tamper-detection, and the merge-precedence (project-over-user) behavior in the top-level loader. All existing `load_mcp_server_configs` tests still pass unchanged.

> Note: 2 failures in `tests/mcp/test_mcp_start_stop_commands.py` are **pre-existing** on clean `main` (verified via `git stash`) and unrelated to this change.

## Notes for reviewers

- Files stay well under the 600-line cap (project_config 252, trust_command 213, tests 162).
- No new dependencies; ruff clean & formatted.
