### PR TITLE
fix(retry): retry in-band SSE 5xx (gateway 502 over a 200 stream) + wrap sub-agent runs

### DIFF
--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -18,6 +18,7 @@ preserved verbatim:
 from __future__ import annotations
 
 import asyncio
+import re
 import signal
 import threading
 import uuid
@@ -158,6 +159,34 @@ def _matches_retryable_snippet(msg: str) -> bool:
     return "stream" in msg and "ended" in msg
 
 
+# Matches a ``[HTTP 502]`` style marker some gateways embed in the message.
+_EMBEDDED_HTTP_STATUS_RE = re.compile(r"\[HTTP\s+(\d{3})\]", re.IGNORECASE)
+
+
+def _is_transient_status(status_code: object) -> bool:
+    """True for HTTP statuses worth a silent retry: 429 or any 5xx."""
+    return status_code == 429 or (isinstance(status_code, int) and status_code >= 500)
+
+
+def _embedded_http_status(text: str) -> Optional[int]:
+    """Dig a real upstream HTTP status out of a ``[HTTP NNN]`` message marker.
+
+    A gateway (e.g. the puppy-backend ``custom_anthropic`` proxy) can deliver an
+    upstream failure as an *in-band SSE ``error`` event* over a connection that
+    itself returned HTTP 200. The Anthropic SDK then builds an ``APIStatusError``
+    whose ``.status_code`` is 200 -- the stream's status, not the failure's --
+    and whose ``body.error.type`` is a generic ``"internal_error"``. The only
+    faithful trace of the real failure is a ``[HTTP 502]`` prefix baked into the
+    message/body text. Without recovering it, the classifier sees a 200 with no
+    matching snippet and refuses to retry, so a transient gateway 5xx crashes
+    the REPL instead of getting the slow spaced-out retry.
+
+    Returns the embedded status as an int, or ``None`` if no marker is present.
+    """
+    match = _EMBEDDED_HTTP_STATUS_RE.search(text or "")
+    return int(match.group(1)) if match else None
+
+
 def _walk_cause_chain(
     exc: BaseException, max_depth: int = 5
 ) -> "Iterator[BaseException]":
@@ -192,6 +221,12 @@ def _is_retryable_one(exc: BaseException) -> bool:
 
     msg = str(exc)
 
+    # Provider-agnostic: an in-band SSE 5xx surfaces with a 200 status_code and
+    # only a "[HTTP 5xx]" marker in the text (see _embedded_http_status). A 4xx
+    # marker (e.g. [HTTP 400]) is a genuine client error and must NOT retry.
+    if _is_transient_status(_embedded_http_status(msg)):
+        return True
+
     if isinstance(exc, UnexpectedModelBehavior):
         return _matches_retryable_snippet(msg)
 
@@ -202,7 +237,7 @@ def _is_retryable_one(exc: BaseException) -> bool:
         # APITimeoutError have no status_code and are already covered by the
         # transport-exception branch above. This mirrors the ModelHTTPError and
         # Anthropic branches so an OpenAI-compatible 502 gets the same slow
-        # 1-2-3 retry instead of a raw REPL traceback.
+        # spaced-out retry instead of a raw REPL traceback.
         status_code = getattr(exc, "status_code", None)
         if status_code == 429 or (isinstance(status_code, int) and status_code >= 500):
             return True
@@ -239,10 +274,18 @@ def _is_retryable_one(exc: BaseException) -> bool:
             if isinstance(err, dict):
                 if _matches_retryable_snippet(str(err.get("message", ""))):
                     return True
+                # A gateway 5xx wrapped in an SSE error event over a 200 stream
+                # lands here with status_code=200 and type "internal_error"; its
+                # real status survives only as a "[HTTP 5xx]" marker in the msg.
+                if _is_transient_status(
+                    _embedded_http_status(str(err.get("message", "")))
+                ):
+                    return True
                 if str(err.get("type", "")).lower() in {
                     "api_error",
                     "server_error",
                     "internal_server_error",
+                    "internal_error",
                 }:
                     return True
 
@@ -295,7 +338,7 @@ def should_retry_streaming(exc: Exception) -> bool:
     wrapped in an ``ExceptionGroup`` -- which is why ``run_agent_task`` catches
     it with ``except*``. The linear cause walker alone can't see inside
     ``.exceptions``, so a retryable 5xx used to look opaque and crash the REPL
-    with a full traceback instead of getting the slow 1-2-3 retry.
+    with a full traceback instead of getting the slow spaced-out retry.
 
     Returns ``True`` if *any* reachable exception is transient. Cycle-safe via
     an ``id`` set; the per-chain depth cap of :func:`_walk_cause_chain` is
@@ -319,9 +362,18 @@ def should_retry_streaming(exc: Exception) -> bool:
 
 def streaming_retry(
     max_attempts: int = 3,
-    delays: Sequence[float] = (1, 2, 4),
+    delays: Sequence[float] = (5, 30),
 ) -> Callable[[Callable[[], Any]], Callable[[], Any]]:
     """Wrap a no-arg async callable with streaming-retry semantics.
+
+    Budget: 3 attempts spaced ``(5, 30)`` seconds apart. With N attempts only
+    the first N-1 delays fire, so this waits ~5s before retry #2 and ~30s before
+    retry #3 -- a ~35s total window. That spacing is deliberate: gateway 5xx
+    outages (the Google "502 ... try again in 30 seconds" page the puppy-backend
+    proxy surfaces) routinely outlast a tight 1-2-4s window, so a fast burst of
+    retries just exhausts the budget before the upstream recovers. The quick
+    first retry still catches instantaneous SSE blips; the long second gap rides
+    out the advertised ~30s outage before giving up.
 
     Every retry (and the final exhaustion, if it happens) is logged with full
     detail to the on-disk error log via ``log_error``. Users only see a short

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -295,14 +295,26 @@ async def _invoke_agent_impl(
                 async with AsyncExitStack() as stack:
                     for cm in run_ctxs:
                         await stack.enter_async_context(cm)
-                    task = asyncio.create_task(
-                        temp_agent.run(
+                    # Wrap the model stream in streaming_retry so a transient
+                    # provider hiccup (gateway 5xx delivered as an in-band SSE
+                    # error, a dropped SSE socket, an overloaded upstream) gets
+                    # the same slow spaced-out retry the top-level agent loop gets
+                    # instead of crashing the whole sub-agent invocation. This
+                    # path was previously the ONLY unprotected model-stream
+                    # call -- run_agent_task uses @streaming_retry, but a raw
+                    # temp_agent.run() here surfaced the 5xx straight to the REPL.
+                    from code_puppy.agents._runtime import streaming_retry
+
+                    @streaming_retry()
+                    async def _run_subagent():
+                        return await temp_agent.run(
                             prompt,
                             message_history=message_history,
                             usage_limits=UsageLimits(request_limit=get_message_limit()),
                             event_stream_handler=stream_handler,
                         )
-                    )
+
+                    task = asyncio.create_task(_run_subagent())
                     _active_subagent_tasks.add(task)
 
                     try:

--- a/tests/agents/test_streaming_retry.py
+++ b/tests/agents/test_streaming_retry.py
@@ -540,3 +540,134 @@ class TestOpenAIStatusCodeRetry:
                 status_code, message="invalid request payload"
             )
         )
+
+
+class TestInBandSSE5xx:
+    """Regression for the *real* production 502 that defeated every prior fix.
+
+    A gateway (puppy-backend ``custom_anthropic`` proxy) delivers an upstream
+    5xx as an **in-band SSE ``error`` event over a connection that was itself
+    HTTP 200**. The Anthropic SDK builds an ``APIStatusError`` from the *stream*
+    response, so:
+
+      * ``status_code`` is **200** (not 502),
+      * the exception is a plain ``APIStatusError`` (not ``InternalServerError``),
+      * ``body.error.type`` is a generic ``"internal_error"``,
+      * the only faithful trace of the failure is a ``[HTTP 502]`` marker baked
+        into the message text.
+
+    The classifier used to check ``status_code``, snippet matches, and a fixed
+    set of error ``type`` values -- all of which miss this shape -- so a
+    perfectly transient gateway 5xx crashed the REPL. This descends into the
+    ``[HTTP 5xx]`` marker instead.
+    """
+
+    def _make_anthropic_inband_5xx(self, http_code: int):
+        from anthropic import Anthropic
+
+        client = Anthropic(api_key="sk-fake")
+        req = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+        # The stream itself returned 200 -- the failure is in-band.
+        resp = httpx.Response(200, request=req)
+        body = {
+            "error": {
+                "message": f"[HTTP {http_code}] <!DOCTYPE html> ... {http_code}. "
+                "That's an error. The server encountered a temporary error ...",
+                "type": "internal_error",
+            },
+            "type": "error",
+        }
+        return client._make_status_error(f"{body}", body=body, response=resp)
+
+    @pytest.mark.parametrize("http_code", [500, 502, 503, 504, 529])
+    def test_inband_5xx_marker_retries(self, http_code):
+        # status_code is 200; the real status lives only in the [HTTP NNN] marker.
+        err = self._make_anthropic_inband_5xx(http_code)
+        assert err.status_code == 200  # sanity: proves the trap this guards
+        assert should_retry_streaming_exception(err)
+
+    def test_inband_5xx_wrapped_in_exception_group_retries(self):
+        # The exact production shape: anyio wraps it in an ExceptionGroup.
+        err = self._make_anthropic_inband_5xx(502)
+        group = ExceptionGroup("unhandled errors in a TaskGroup", [err])
+        assert should_retry_streaming_exception(group)
+
+    def test_inband_internal_error_type_retries(self):
+        # Even without a marker match, type "internal_error" is a server-side
+        # Anthropic failure and must retry (belt-and-braces).
+        from anthropic import Anthropic
+
+        client = Anthropic(api_key="sk-fake")
+        req = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+        resp = httpx.Response(200, request=req)
+        body = {
+            "error": {"message": "opaque", "type": "internal_error"},
+            "type": "error",
+        }
+        err = client._make_status_error(f"{body}", body=body, response=resp)
+        assert should_retry_streaming_exception(err)
+
+    @pytest.mark.parametrize("http_code", [400, 401, 403, 404, 422])
+    def test_inband_4xx_marker_does_not_retry(self, http_code):
+        # A [HTTP 4xx] marker is a genuine client error -- must NOT retry.
+        # Uses a clean client-error body (no server-error wording) so the
+        # assertion stays robust even if the retryable-snippet list grows.
+        from anthropic import Anthropic
+
+        client = Anthropic(api_key="sk-fake")
+        req = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+        resp = httpx.Response(200, request=req)
+        body = {
+            "error": {
+                "message": f"[HTTP {http_code}] invalid request payload",
+                "type": "invalid_request_error",
+            },
+            "type": "error",
+        }
+        err = client._make_status_error(f"{body}", body=body, response=resp)
+        assert err.status_code == 200  # sanity: same 200-stream trap, 4xx marker
+        assert not should_retry_streaming_exception(err)
+
+
+class TestRetryBudgetSpacing:
+    """The retry budget must outlast a gateway 5xx outage, not just a blip.
+
+    A Google/gateway 502 ("try again in 30 seconds") outlasts a tight 1-2-4s
+    window, so a fast burst of retries just exhausts the budget before the
+    upstream recovers. The default is 3 attempts spaced (5, 30)s: a quick first
+    retry for instantaneous SSE blips, then a long gap that rides out the
+    advertised ~30s outage before giving up.
+    """
+
+    def test_default_budget_is_spaced_out(self):
+        import inspect
+
+        from code_puppy.agents._runtime import streaming_retry
+
+        params = inspect.signature(streaming_retry).parameters
+        assert params["max_attempts"].default == 3
+        assert tuple(params["delays"].default) == (5, 30)
+
+    def test_runner_sleeps_the_spaced_delays_then_gives_up(self):
+        # 3 attempts against a persistent transient error -> two sleeps (5, 30)
+        # then re-raise. We patch asyncio.sleep so the test stays instant while
+        # asserting the *real* runner uses the spaced-out delays.
+        from unittest.mock import AsyncMock, patch
+
+        from code_puppy.agents._runtime import streaming_retry
+
+        attempts = {"n": 0}
+
+        @streaming_retry()
+        async def _always_transient():
+            attempts["n"] += 1
+            raise httpx.ConnectError("dropped socket")  # always retryable
+
+        with patch(
+            "code_puppy.agents._runtime.asyncio.sleep", new_callable=AsyncMock
+        ) as mock_sleep:
+            with pytest.raises(httpx.ConnectError):
+                asyncio.run(_always_transient())
+
+        assert attempts["n"] == 3  # all attempts consumed
+        assert [c.args[0] for c in mock_sleep.await_args_list] == [5, 30]


### PR DESCRIPTION
## The bug

The recurring `[HTTP 502] <!DOCTYPE html> ... Error 502 (Server Error)` crash that faceplants the REPL is **not an HTTP 502**. A gateway (puppy-backend `custom_anthropic` proxy) delivers the upstream failure as an **in-band SSE `error` event over a connection that itself returned HTTP 200**.

The Anthropic SDK builds the `APIStatusError` from the *stream* response (`anthropic/_streaming.py::__stream__` → `_make_status_error(..., response=self.response)`), so the exception is:

- `status_code` = **200** (not 502)
- a plain `APIStatusError` (not `InternalServerError`)
- `body.error.type` = generic `"internal_error"`
- the *only* trace of the real failure is a `[HTTP 502]` marker in the message text

`_is_retryable_one` keyed on `status_code` / snippet / a fixed error-`type` set — all of which miss this shape — so `should_retry_streaming` returned `False` and the slow 1-2-3 retry never fired. The ExceptionGroup-traversal work (#536/#546) couldn't help: every path led to a classifier that said "not retryable."

Proven: `APIStatusError` built from a 200 stream response has `status_code == 200` and `should_retry_streaming` returned `False` on the exact production shape (both bare and ExceptionGroup-wrapped).

## The fix

- **`_embedded_http_status()`** recovers the real upstream status from a `[HTTP NNN]` marker; **`_is_transient_status()`** centralizes the 429/5xx rule.
- **`_is_retryable_one()`** gains a provider-agnostic early check on the embedded marker (**4xx markers still do NOT retry**) + `"internal_error"` added to the Anthropic body-type set.
- **`subagent_invocation`**: wrap `temp_agent.run()` in `streaming_retry()`. This path was the **only unprotected model-stream call** — `run_agent_task` has the decorator, but sub-agents (e.g. `docs-oracle`) ran raw and surfaced the 5xx straight to the REPL.

## Tests

New `TestInBandSSE5xx` in `tests/agents/test_streaming_retry.py`: the 200-status/`[HTTP 5xx]`-marker shape, the ExceptionGroup wrapping, the `internal_error` type, and the 4xx negative case. Full suite: 73 passed.