### PR TITLE
feat: support OAuth callback paste-back

### DIFF
--- a/code_puppy/plugins/chatgpt_oauth/oauth_flow.py
+++ b/code_puppy/plugins/chatgpt_oauth/oauth_flow.py
@@ -14,11 +14,14 @@ import requests
 
 from code_puppy.messaging import emit_error, emit_info, emit_success, emit_warning
 
+from ..oauth_pasteback import parse_oauth_callback_input, read_available_stdin_line
 from ..oauth_puppy_html import oauth_failure_html, oauth_success_html
 from .config import CHATGPT_OAUTH_CONFIG
 from .utils import (
+    OAuthContext,
     add_models_to_extra_config,
     assign_redirect_uri,
+    build_authorization_url,
     load_stored_tokens,
     parse_jwt_claims,
     prepare_oauth_context,
@@ -44,6 +47,94 @@ class AuthBundle:
     last_refresh: str
 
 
+def _exchange_code_for_auth_bundle(
+    *, code: str, context: OAuthContext, client_id: str
+) -> Tuple[AuthBundle, str]:
+    if not context.redirect_uri:
+        raise RuntimeError("Redirect URI missing from OAuth context")
+
+    data = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": context.redirect_uri,
+        "client_id": client_id,
+        "code_verifier": context.code_verifier,
+    }
+
+    response = requests.post(
+        CHATGPT_OAUTH_CONFIG["token_url"],
+        data=data,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        timeout=30,
+    )
+    response.raise_for_status()
+    payload = response.json()
+
+    id_token = payload.get("id_token", "")
+    access_token = payload.get("access_token", "")
+    refresh_token = payload.get("refresh_token", "")
+
+    id_token_claims = parse_jwt_claims(id_token) or {}
+    access_token_claims = parse_jwt_claims(access_token) or {}
+
+    auth_claims = id_token_claims.get("https://api.openai.com/auth") or {}
+    chatgpt_account_id = auth_claims.get("chatgpt_account_id", "")
+    organizations = auth_claims.get("organizations", [])
+    org_id = None
+    if organizations:
+        default_org = next(
+            (org for org in organizations if org.get("is_default")),
+            organizations[0],
+        )
+        org_id = default_org.get("id")
+    if not org_id:
+        org_id = id_token_claims.get("organization_id")
+
+    token_data = TokenData(
+        id_token=id_token,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        account_id=chatgpt_account_id,
+    )
+
+    last_refresh = (
+        datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+    )
+    bundle = AuthBundle(
+        api_key=token_data.access_token,
+        token_data=token_data,
+        last_refresh=last_refresh,
+    )
+
+    success_query = {
+        "id_token": token_data.id_token,
+        "access_token": token_data.access_token,
+        "refresh_token": token_data.refresh_token,
+        "org_id": org_id or "",
+        "plan_type": access_token_claims.get("chatgpt_plan_type"),
+        "platform_url": "https://platform.openai.com",
+    }
+    success_url = f"{URL_BASE}/success?{urllib.parse.urlencode(success_query)}"
+    return bundle, success_url
+
+
+def _save_auth_bundle(auth_bundle: AuthBundle) -> bool:
+    tokens = {
+        "id_token": auth_bundle.token_data.id_token,
+        "access_token": auth_bundle.token_data.access_token,
+        "refresh_token": auth_bundle.token_data.refresh_token,
+        "account_id": auth_bundle.token_data.account_id,
+        "last_refresh": auth_bundle.last_refresh,
+    }
+    if auth_bundle.api_key:
+        tokens["api_key"] = auth_bundle.api_key
+    return save_tokens(tokens)
+
+
+def _state_matches(context: OAuthContext, state: Optional[str]) -> bool:
+    return bool(state and state == context.state)
+
+
 class _OAuthServer(HTTPServer):
     def __init__(
         self,
@@ -59,6 +150,8 @@ class _OAuthServer(HTTPServer):
         self.client_id = client_id
         self.issuer = CHATGPT_OAUTH_CONFIG["issuer"]
         self.token_endpoint = CHATGPT_OAUTH_CONFIG["token_url"]
+        self.error: Optional[str] = None
+        self.received_event = threading.Event()
 
         # Create fresh OAuth context for this server instance
         context = prepare_oauth_context()
@@ -80,76 +173,9 @@ class _OAuthServer(HTTPServer):
         return f"{self.issuer}/oauth/authorize?" + urllib.parse.urlencode(params)
 
     def exchange_code(self, code: str) -> Tuple[AuthBundle, str]:
-        data = {
-            "grant_type": "authorization_code",
-            "code": code,
-            "redirect_uri": self.redirect_uri,
-            "client_id": self.client_id,
-            "code_verifier": self.context.code_verifier,
-        }
-
-        response = requests.post(
-            self.token_endpoint,
-            data=data,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            timeout=30,
+        return _exchange_code_for_auth_bundle(
+            code=code, context=self.context, client_id=self.client_id
         )
-        response.raise_for_status()
-        payload = response.json()
-
-        id_token = payload.get("id_token", "")
-        access_token = payload.get("access_token", "")
-        refresh_token = payload.get("refresh_token", "")
-
-        id_token_claims = parse_jwt_claims(id_token) or {}
-        access_token_claims = parse_jwt_claims(access_token) or {}
-
-        auth_claims = id_token_claims.get("https://api.openai.com/auth") or {}
-        chatgpt_account_id = auth_claims.get("chatgpt_account_id", "")
-        # Extract org_id from nested auth structure like ChatMock
-        organizations = auth_claims.get("organizations", [])
-        org_id = None
-        if organizations:
-            default_org = next(
-                (org for org in organizations if org.get("is_default")),
-                organizations[0],
-            )
-            org_id = default_org.get("id")
-        # Fallback to top-level org_id if still not found
-        if not org_id:
-            org_id = id_token_claims.get("organization_id")
-
-        token_data = TokenData(
-            id_token=id_token,
-            access_token=access_token,
-            refresh_token=refresh_token,
-            account_id=chatgpt_account_id,
-        )
-
-        # Instead of exchanging for an API key, just use the access_token directly
-        # This matches how ChatMock works - no token exchange, just OAuth tokens
-        api_key = token_data.access_token
-
-        last_refresh = (
-            datetime.datetime.now(datetime.timezone.utc)
-            .isoformat()
-            .replace("+00:00", "Z")
-        )
-        bundle = AuthBundle(
-            api_key=api_key, token_data=token_data, last_refresh=last_refresh
-        )
-
-        # Build success URL with all the token info
-        success_query = {
-            "id_token": token_data.id_token,
-            "access_token": token_data.access_token,
-            "refresh_token": token_data.refresh_token,
-            "org_id": org_id or "",
-            "plan_type": access_token_claims.get("chatgpt_plan_type"),
-            "platform_url": "https://platform.openai.com",
-        }
-        success_url = f"{URL_BASE}/success?{urllib.parse.urlencode(success_query)}"
-        return bundle, success_url
 
 
 class _CallbackHandler(BaseHTTPRequestHandler):
@@ -167,7 +193,9 @@ class _CallbackHandler(BaseHTTPRequestHandler):
             return
 
         if path != "/auth/callback":
-            self._send_failure(404, "Callback endpoint not found for the puppy parade.")
+            self._fail_callback(
+                404, "Callback endpoint not found for the puppy parade."
+            )
             self._shutdown()
             return
 
@@ -176,33 +204,32 @@ class _CallbackHandler(BaseHTTPRequestHandler):
 
         code = params.get("code", [None])[0]
         if not code:
-            self._send_failure(400, "Missing auth code — the token treat rolled away.")
+            self._fail_callback(400, "Missing auth code — the token treat rolled away.")
+            self._shutdown()
+            return
+
+        state = params.get("state", [None])[0]
+        if not _state_matches(self.server.context, state):
+            self._fail_callback(
+                400, "State mismatch detected; aborting authentication."
+            )
             self._shutdown()
             return
 
         try:
             auth_bundle, success_url = self.server.exchange_code(code)
         except Exception as exc:  # noqa: BLE001
-            self._send_failure(500, f"Token exchange failed: {exc}")
+            self._fail_callback(500, f"Token exchange failed: {exc}")
             self._shutdown()
             return
 
-        tokens = {
-            "id_token": auth_bundle.token_data.id_token,
-            "access_token": auth_bundle.token_data.access_token,
-            "refresh_token": auth_bundle.token_data.refresh_token,
-            "account_id": auth_bundle.token_data.account_id,
-            "last_refresh": auth_bundle.last_refresh,
-        }
-        if auth_bundle.api_key:
-            tokens["api_key"] = auth_bundle.api_key
-
-        if save_tokens(tokens):
+        if _save_auth_bundle(auth_bundle):
             self.server.exit_code = 0
+            self.server.received_event.set()
             # Redirect to the success URL returned by exchange_code
             self._send_redirect(success_url)
         else:
-            self._send_failure(
+            self._fail_callback(
                 500, "Unable to persist auth file — a puppy probably chewed it."
             )
             self._shutdown()
@@ -235,6 +262,11 @@ class _CallbackHandler(BaseHTTPRequestHandler):
         failure_html = oauth_failure_html("ChatGPT", reason)
         self._send_html(failure_html, status)
 
+    def _fail_callback(self, status: int, reason: str) -> None:
+        self.server.error = reason
+        self.server.received_event.set()
+        self._send_failure(status, reason)
+
     def _shutdown(self) -> None:
         threading.Thread(target=self.server.shutdown, daemon=True).start()
 
@@ -248,56 +280,156 @@ class _CallbackHandler(BaseHTTPRequestHandler):
         threading.Thread(target=_later, daemon=True).start()
 
 
+def _prepare_manual_context() -> OAuthContext:
+    context = prepare_oauth_context()
+    assign_redirect_uri(context, REQUIRED_PORT)
+    return context
+
+
+def _complete_pasted_input(
+    *, raw_input: str, context: OAuthContext, client_id: str
+) -> bool:
+    try:
+        parsed = parse_oauth_callback_input(raw_input)
+    except ValueError as exc:
+        emit_error(f"Could not parse pasted OAuth input: {exc}")
+        return False
+
+    if parsed.error:
+        emit_error(f"OAuth provider returned an error: {parsed.error_message}")
+        return False
+
+    if not parsed.code:
+        emit_error("Pasted OAuth input did not contain an authorization code.")
+        return False
+
+    if parsed.state:
+        if parsed.state != context.state:
+            emit_error("State mismatch detected; aborting authentication.")
+            return False
+    else:
+        emit_warning(
+            "Pasted OAuth input did not include state; continuing with this login attempt."
+        )
+
+    try:
+        auth_bundle, _ = _exchange_code_for_auth_bundle(
+            code=parsed.code,
+            context=context,
+            client_id=client_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        emit_error(f"Token exchange failed: {exc}")
+        return False
+
+    if not _save_auth_bundle(auth_bundle):
+        emit_error("Unable to persist auth file.")
+        return False
+
+    emit_success("Authorization code accepted; tokens saved.")
+    return True
+
+
+def _wait_for_auth_completion(
+    *,
+    server: Optional[_OAuthServer],
+    context: OAuthContext,
+    client_id: str,
+) -> bool:
+    emit_info(
+        "Waiting for authentication callback. If localhost cannot be reached, "
+        "paste the full callback URL or authorization code here and press Enter."
+    )
+
+    elapsed = 0.0
+    timeout = CHATGPT_OAUTH_CONFIG["callback_timeout"]
+    interval = 0.25
+    while elapsed < timeout:
+        if server and server.exit_code == 0:
+            return True
+        if server and server.received_event.is_set():
+            if server.error:
+                emit_error(f"OAuth callback error: {server.error}")
+            return server.exit_code == 0
+
+        pasted = read_available_stdin_line()
+        if pasted is not None and pasted.strip():
+            if _complete_pasted_input(
+                raw_input=pasted,
+                context=context,
+                client_id=client_id,
+            ):
+                return True
+
+        time.sleep(interval)
+        elapsed += interval
+
+    return False
+
+
 def run_oauth_flow() -> None:
     existing_tokens = load_stored_tokens()
     if existing_tokens and existing_tokens.get("access_token"):
         emit_warning("Existing ChatGPT tokens will be overwritten.")
 
+    server: Optional[_OAuthServer] = None
+    server_thread: Optional[threading.Thread] = None
+    client_id = CHATGPT_OAUTH_CONFIG["client_id"]
     try:
-        server = _OAuthServer(client_id=CHATGPT_OAUTH_CONFIG["client_id"])
+        server = _OAuthServer(client_id=client_id)
+        context = server.context
+        auth_url = server.auth_url()
     except OSError as exc:
-        emit_error(f"Could not start OAuth server on port {REQUIRED_PORT}: {exc}")
-        emit_info(f"Use `lsof -ti:{REQUIRED_PORT} | xargs kill` to free the port.")
-        return
+        emit_warning(
+            f"Could not start OAuth server on port {REQUIRED_PORT}: {exc}. "
+            "Continuing in paste-back mode."
+        )
+        emit_info(
+            f"Free port {REQUIRED_PORT} to restore automatic localhost callbacks."
+        )
+        context = _prepare_manual_context()
+        auth_url = build_authorization_url(context)
 
-    auth_url = server.auth_url()
     emit_info(f"Open this URL in your browser: {auth_url}")
 
-    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
-    server_thread.start()
+    if server:
+        server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+        server_thread.start()
 
     webbrowser_opened = False
+    suppress_browser = False
     try:
         import webbrowser
 
         from code_puppy.tools.common import should_suppress_browser
 
-        if should_suppress_browser():
+        suppress_browser = should_suppress_browser()
+        if suppress_browser:
             emit_info(f"[HEADLESS MODE] Would normally open: {auth_url}")
         else:
             webbrowser_opened = webbrowser.open(auth_url)
     except Exception as exc:  # noqa: BLE001
         emit_warning(f"Could not open browser automatically: {exc}")
 
-    if not webbrowser_opened and not should_suppress_browser():
+    if not webbrowser_opened and not suppress_browser:
         emit_warning("Please open the URL manually if the browser did not open.")
 
-    emit_info("Waiting for authentication callback…")
+    completed = _wait_for_auth_completion(
+        server=server,
+        context=context,
+        client_id=client_id,
+    )
 
-    elapsed = 0.0
-    timeout = CHATGPT_OAUTH_CONFIG["callback_timeout"]
-    interval = 0.25
-    while elapsed < timeout:
-        time.sleep(interval)
-        elapsed += interval
-        if server.exit_code == 0:
-            break
+    if server:
+        server.shutdown()
+    if server_thread:
+        server_thread.join(timeout=5)
 
-    server.shutdown()
-    server_thread.join(timeout=5)
-
-    if server.exit_code != 0:
-        emit_error("Authentication failed or timed out.")
+    if not completed:
+        if server and server.error:
+            emit_error("Authentication failed.")
+        else:
+            emit_error("Authentication failed or timed out.")
         return
 
     tokens = load_stored_tokens()

--- a/code_puppy/plugins/claude_code_oauth/register_callbacks.py
+++ b/code_puppy/plugins/claude_code_oauth/register_callbacks.py
@@ -22,6 +22,7 @@ from code_puppy.provider_identity import (
     resolve_provider_identity,
 )
 
+from ..oauth_pasteback import parse_oauth_callback_input, read_available_stdin_line
 from ..oauth_puppy_html import oauth_failure_html, oauth_success_html
 from .config import CLAUDE_CODE_OAUTH_CONFIG, get_token_storage_path
 from .fast_mode import (
@@ -123,28 +124,109 @@ def _start_callback_server(
     return None
 
 
+def _assign_manual_redirect_uri(context: OAuthContext) -> bool:
+    port_range = CLAUDE_CODE_OAUTH_CONFIG["callback_port_range"]
+    try:
+        assign_redirect_uri(context, port_range[0])
+    except Exception as exc:  # noqa: BLE001
+        emit_error(f"Failed to assign redirect URI for OAuth flow: {exc}")
+        return False
+    return True
+
+
+def _parse_pasted_callback(context: OAuthContext, raw_input: str) -> Optional[str]:
+    try:
+        parsed = parse_oauth_callback_input(raw_input)
+    except ValueError as exc:
+        emit_error(f"Could not parse pasted OAuth input: {exc}")
+        return None
+
+    if parsed.error:
+        emit_error(f"OAuth provider returned an error: {parsed.error_message}")
+        return None
+
+    if not parsed.code:
+        emit_error("Pasted OAuth input did not contain an authorization code.")
+        return None
+
+    if parsed.state:
+        if parsed.state != context.state:
+            emit_error("State mismatch detected; aborting authentication.")
+            return None
+    else:
+        emit_warning(
+            "Pasted OAuth input did not include state; continuing with this login attempt."
+        )
+
+    return parsed.code
+
+
+def _wait_for_callback_or_paste(
+    *,
+    context: OAuthContext,
+    result: Optional[_OAuthResult],
+    event: Optional[threading.Event],
+    timeout: float,
+) -> Optional[str]:
+    elapsed = 0.0
+    interval = 0.25
+
+    while elapsed < timeout:
+        if event and event.is_set() and result:
+            if result.error:
+                emit_error(f"OAuth callback error: {result.error}")
+                return None
+
+            if result.state != context.state:
+                emit_error("State mismatch detected; aborting authentication.")
+                return None
+
+            return result.code
+
+        pasted = read_available_stdin_line()
+        if pasted is not None and pasted.strip():
+            code = _parse_pasted_callback(context, pasted)
+            if code:
+                return code
+
+        time.sleep(interval)
+        elapsed += interval
+
+    emit_error("OAuth callback timed out. Please try again.")
+    return None
+
+
 def _await_callback(context: OAuthContext) -> Optional[str]:
     timeout = CLAUDE_CODE_OAUTH_CONFIG["callback_timeout"]
 
     started = _start_callback_server(context)
-    if not started:
-        return None
+    server: Optional[HTTPServer] = None
+    result: Optional[_OAuthResult] = None
+    event: Optional[threading.Event] = None
+    if started:
+        server, result, event = started
+    else:
+        emit_warning("Continuing Claude Code OAuth in paste-back mode.")
+        if not _assign_manual_redirect_uri(context):
+            return None
 
-    server, result, event = started
     redirect_uri = context.redirect_uri
     if not redirect_uri:
         emit_error("Failed to assign redirect URI for OAuth flow")
-        server.shutdown()
+        if server:
+            server.shutdown()
         return None
 
     auth_url = build_authorization_url(context)
 
+    suppress_browser = False
     try:
         import webbrowser
 
         from code_puppy.tools.common import should_suppress_browser
 
-        if should_suppress_browser():
+        suppress_browser = should_suppress_browser()
+        if suppress_browser:
             emit_info(
                 "[HEADLESS MODE] Would normally open browser for Claude Code OAuth…"
             )
@@ -154,32 +236,30 @@ def _await_callback(context: OAuthContext) -> Optional[str]:
             webbrowser.open(auth_url)
             emit_info(f"If it doesn't open automatically, visit: {auth_url}")
     except Exception as exc:  # pragma: no cover
-        if not should_suppress_browser():
+        if not suppress_browser:
             emit_warning(f"Failed to open browser automatically: {exc}")
             emit_info(f"Please open the URL manually: {auth_url}")
 
-    emit_info(f"Listening for callback on {redirect_uri}")
+    if server:
+        emit_info(f"Listening for callback on {redirect_uri}")
+    else:
+        emit_info(f"Using redirect URI for paste-back: {redirect_uri}")
     emit_info(
-        "If Claude redirects you to the console callback page, copy the full URL "
-        "and paste it back into Code Puppy."
+        "If localhost cannot be reached, paste the full callback URL or "
+        "authorization code here and press Enter."
     )
 
-    if not event.wait(timeout=timeout):
-        emit_error("OAuth callback timed out. Please try again.")
+    code = _wait_for_callback_or_paste(
+        context=context,
+        result=result,
+        event=event,
+        timeout=timeout,
+    )
+
+    if server:
         server.shutdown()
-        return None
 
-    server.shutdown()
-
-    if result.error:
-        emit_error(f"OAuth callback error: {result.error}")
-        return None
-
-    if result.state != context.state:
-        emit_error("State mismatch detected; aborting authentication.")
-        return None
-
-    return result.code
+    return code
 
 
 def _custom_help() -> List[Tuple[str, str]]:

--- a/code_puppy/plugins/claude_code_oauth/utils.py
+++ b/code_puppy/plugins/claude_code_oauth/utils.py
@@ -15,6 +15,8 @@ from urllib.parse import urlencode
 
 import requests
 
+from code_puppy.plugins.oauth_pasteback import parse_oauth_callback_input
+
 from .config import (
     CLAUDE_CODE_OAUTH_CONFIG,
     get_claude_models_path,
@@ -111,19 +113,12 @@ def build_authorization_url(context: OAuthContext) -> str:
 
 
 def parse_authorization_code(raw_input: str) -> Tuple[str, Optional[str]]:
-    value = raw_input.strip()
-    if not value:
+    parsed = parse_oauth_callback_input(raw_input)
+    if parsed.error:
+        raise ValueError(parsed.error_message or parsed.error)
+    if not parsed.code:
         raise ValueError("Authorization code cannot be empty")
-
-    if "#" in value:
-        code, state = value.split("#", 1)
-        return code.strip(), state.strip() or None
-
-    parts = value.split()
-    if len(parts) == 2:
-        return parts[0].strip(), parts[1].strip() or None
-
-    return value, None
+    return parsed.code, parsed.state
 
 
 def load_stored_tokens() -> Optional[Dict[str, Any]]:

--- a/code_puppy/plugins/oauth_pasteback.py
+++ b/code_puppy/plugins/oauth_pasteback.py
@@ -1,0 +1,110 @@
+"""Helpers for OAuth flows that support terminal paste-back."""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import parse_qs, urlparse
+
+
+@dataclass(frozen=True)
+class ParsedOAuthCallback:
+    """Parsed authorization result from a pasted callback URL or code."""
+
+    code: Optional[str] = None
+    state: Optional[str] = None
+    error: Optional[str] = None
+    error_description: Optional[str] = None
+
+    @property
+    def error_message(self) -> Optional[str]:
+        if not self.error:
+            return None
+        if self.error_description:
+            return f"{self.error}: {self.error_description}"
+        return self.error
+
+
+def _first(params: dict[str, list[str]], name: str) -> Optional[str]:
+    values = params.get(name)
+    if not values:
+        return None
+    value = values[0].strip()
+    return value or None
+
+
+def _looks_like_query(value: str) -> bool:
+    if value.startswith("?"):
+        return True
+    return "=" in value and (
+        "&" in value or value.startswith(("code=", "state=", "error="))
+    )
+
+
+def parse_oauth_callback_input(raw_input: str) -> ParsedOAuthCallback:
+    """Parse pasted OAuth input into code/state/error fields.
+
+    Supported inputs include full callback URLs, raw query strings, Claude's
+    ``code#state`` and ``code state`` console formats, and bare codes.
+    """
+    value = raw_input.strip()
+    if not value:
+        raise ValueError("Authorization code cannot be empty")
+
+    parsed_url = urlparse(value)
+    query = parsed_url.query
+    if query or _looks_like_query(value):
+        params = parse_qs(query or value.lstrip("?"), keep_blank_values=False)
+        result = ParsedOAuthCallback(
+            code=_first(params, "code"),
+            state=_first(params, "state"),
+            error=_first(params, "error"),
+            error_description=_first(params, "error_description"),
+        )
+        if result.code or result.error:
+            return result
+        raise ValueError("No authorization code found in pasted OAuth input")
+
+    if "#" in value:
+        code, state = value.split("#", 1)
+        code = code.strip()
+        state = state.strip() or None
+        if not code:
+            raise ValueError("Authorization code cannot be empty")
+        return ParsedOAuthCallback(code=code, state=state)
+
+    parts = value.split()
+    if len(parts) == 2:
+        return ParsedOAuthCallback(code=parts[0].strip(), state=parts[1].strip())
+    if len(parts) > 2:
+        raise ValueError("Pasted OAuth input has too many whitespace-separated parts")
+
+    return ParsedOAuthCallback(code=value)
+
+
+def read_available_stdin_line() -> Optional[str]:
+    """Return one stdin line when available without blocking.
+
+    The OAuth callback server can complete in parallel, so the auth flow must
+    not block indefinitely on input. This helper is intentionally POSIX-only;
+    Windows callers still retain browser callback behavior and explicit timeout.
+    """
+    if os.name == "nt":
+        return None
+
+    try:
+        import select
+
+        readable, _, _ = select.select([sys.stdin], [], [], 0)
+    except (OSError, ValueError):
+        return None
+
+    if not readable:
+        return None
+
+    line = sys.stdin.readline()
+    if line == "":
+        return None
+    return line.rstrip("\r\n")

--- a/tests/plugins/test_chatgpt_oauth_flow.py
+++ b/tests/plugins/test_chatgpt_oauth_flow.py
@@ -2,6 +2,7 @@
 
 import time
 import urllib.parse
+import threading
 from unittest.mock import Mock, patch
 
 import pytest
@@ -288,6 +289,9 @@ class TestCallbackHandler:
         server = Mock(spec=_OAuthServer)
         server.exit_code = 1
         server.exchange_code = Mock()
+        server.context = Mock(state="test_state")
+        server.received_event = threading.Event()
+        server.error = None
         return server
 
     @pytest.fixture
@@ -374,7 +378,7 @@ class TestCallbackHandler:
 
         with patch.object(callback_handler, "_send_failure") as mock_failure:
             with patch.object(callback_handler, "_shutdown") as mock_shutdown:
-                callback_handler.path = "/auth/callback?code=test_code"
+                callback_handler.path = "/auth/callback?code=test_code&state=test_state"
                 callback_handler.do_GET()
 
                 mock_failure.assert_called_once_with(
@@ -408,7 +412,7 @@ class TestCallbackHandler:
             with patch.object(
                 callback_handler, "_shutdown_after_delay"
             ) as mock_shutdown:
-                callback_handler.path = "/auth/callback?code=test_code"
+                callback_handler.path = "/auth/callback?code=test_code&state=test_state"
                 callback_handler.do_GET()
 
                 # Should save tokens
@@ -449,7 +453,7 @@ class TestCallbackHandler:
 
         with patch.object(callback_handler, "_send_failure") as mock_failure:
             with patch.object(callback_handler, "_shutdown") as mock_shutdown:
-                callback_handler.path = "/auth/callback?code=test_code"
+                callback_handler.path = "/auth/callback?code=test_code&state=test_state"
                 callback_handler.do_GET()
 
                 mock_failure.assert_called_once_with(
@@ -589,24 +593,78 @@ class TestRunOAuthFlow:
         warning_calls = [call[0][0] for call in mock_warning.call_args_list]
         assert "Existing ChatGPT tokens will be overwritten." in warning_calls
 
+    @patch("code_puppy.tools.common.should_suppress_browser", return_value=True)
     @patch("code_puppy.plugins.chatgpt_oauth.oauth_flow.load_stored_tokens")
     @patch("code_puppy.plugins.chatgpt_oauth.oauth_flow._OAuthServer")
-    @patch("code_puppy.plugins.chatgpt_oauth.oauth_flow.emit_error")
+    @patch("code_puppy.plugins.chatgpt_oauth.oauth_flow.emit_warning")
     @patch("code_puppy.plugins.chatgpt_oauth.oauth_flow.emit_info")
-    def test_server_start_error(
-        self, mock_info, mock_error, mock_server_class, mock_load_tokens
+    def test_server_start_error_falls_back_to_pasteback(
+        self,
+        mock_info,
+        mock_warning,
+        mock_server_class,
+        mock_load_tokens,
+        mock_suppress,
+        mock_context,
     ):
-        """Test OAuth server startup error handling."""
-        mock_load_tokens.return_value = None
+        """Test OAuth server startup error falls back to manual paste-back."""
+        mock_load_tokens.side_effect = [
+            None,
+            {
+                "api_key": "test_api_key",
+                "access_token": "test_access_token",
+                "account_id": "account_123",
+            },
+        ]
         mock_server_class.side_effect = OSError("Port already in use")
 
-        run_oauth_flow()
+        mock_bundle = AuthBundle(
+            api_key="test_api_key",
+            token_data=TokenData(
+                id_token="test_id_token",
+                access_token="test_access_token",
+                refresh_token="test_refresh_token",
+                account_id="account_123",
+            ),
+            last_refresh="2023-01-01T00:00:00Z",
+        )
 
-        mock_error.assert_called()
-        error_calls = [call[0][0] for call in mock_error.call_args_list]
+        pasted = (
+            "http://localhost:1455/auth/callback?"
+            f"code=pasted_code&state={mock_context.state}"
+        )
+        with patch(
+            "code_puppy.plugins.chatgpt_oauth.oauth_flow._prepare_manual_context",
+            return_value=mock_context,
+        ):
+            with patch(
+                "code_puppy.plugins.chatgpt_oauth.oauth_flow.read_available_stdin_line",
+                return_value=pasted,
+            ):
+                with patch(
+                    "code_puppy.plugins.chatgpt_oauth.oauth_flow._exchange_code_for_auth_bundle",
+                    return_value=(mock_bundle, "http://localhost:1455/success"),
+                ) as mock_exchange:
+                    with patch(
+                        "code_puppy.plugins.chatgpt_oauth.oauth_flow._save_auth_bundle",
+                        return_value=True,
+                    ):
+                        with patch(
+                            "code_puppy.plugins.chatgpt_oauth.utils.fetch_chatgpt_models",
+                            return_value=["gpt-5.4"],
+                        ):
+                            with patch(
+                                "code_puppy.plugins.chatgpt_oauth.oauth_flow.add_models_to_extra_config",
+                                return_value=True,
+                            ):
+                                run_oauth_flow()
+
+        warning_calls = [call[0][0] for call in mock_warning.call_args_list]
         info_calls = [call[0][0] for call in mock_info.call_args_list]
-        assert any("Could not start OAuth server" in call for call in error_calls)
-        assert any("lsof -ti:1455" in call for call in info_calls)
+        assert any("Continuing in paste-back mode" in call for call in warning_calls)
+        assert any("Open this URL in your browser" in call for call in info_calls)
+        mock_exchange.assert_called_once()
+        assert mock_exchange.call_args.kwargs["code"] == "pasted_code"
 
     @patch("code_puppy.plugins.chatgpt_oauth.oauth_flow.load_stored_tokens")
     @patch("code_puppy.plugins.chatgpt_oauth.oauth_flow._OAuthServer")

--- a/tests/plugins/test_chatgpt_oauth_server.py
+++ b/tests/plugins/test_chatgpt_oauth_server.py
@@ -9,6 +9,7 @@ Covers:
 """
 
 import time
+import threading
 from unittest.mock import Mock, patch
 
 import pytest
@@ -319,6 +320,9 @@ class TestCallbackHandler:
         server = Mock(spec=_OAuthServer)
         server.exit_code = 1
         server.verbose = False
+        server.context = Mock(state="test_state")
+        server.received_event = threading.Event()
+        server.error = None
         return server
 
     def test_callback_handler_success_endpoint(self, mock_server):

--- a/tests/plugins/test_claude_code_oauth.py
+++ b/tests/plugins/test_claude_code_oauth.py
@@ -231,6 +231,21 @@ class TestAuthorizationCodeParsing:
         assert code == "ABC123"
         assert state is None
 
+    def test_parse_authorization_code_full_callback_url(self):
+        """Test parsing full callback URL."""
+        code, state = parse_authorization_code(
+            "http://localhost:8765/callback?code=ABC123&state=STATE456"
+        )
+        assert code == "ABC123"
+        assert state == "STATE456"
+
+    def test_parse_authorization_code_error_raises(self):
+        """Test parsing OAuth error callback raises."""
+        with pytest.raises(ValueError, match="access_denied"):
+            parse_authorization_code(
+                "http://localhost:8765/callback?error=access_denied"
+            )
+
     def test_parse_authorization_code_strips_whitespace(self):
         """Test that whitespace is stripped."""
         code, state = parse_authorization_code("  ABC123#STATE456  ")

--- a/tests/plugins/test_claude_code_oauth_callbacks.py
+++ b/tests/plugins/test_claude_code_oauth_callbacks.py
@@ -105,13 +105,29 @@ class TestStartCallbackServer:
 
 
 class TestAwaitCallback:
+    @patch("code_puppy.tools.common.should_suppress_browser", return_value=True)
+    @patch(f"{MOD}.read_available_stdin_line")
+    @patch(f"{MOD}.build_authorization_url", return_value="https://auth.example.com")
+    @patch(
+        f"{MOD}.CLAUDE_CODE_OAUTH_CONFIG",
+        {"callback_timeout": 5, "callback_port_range": (8765, 8765)},
+    )
     @patch(f"{MOD}._start_callback_server", return_value=None)
-    def test_server_start_fails(self, _):
+    def test_server_start_falls_back_to_pasteback(
+        self, mock_start, mock_build, mock_read, mock_suppress
+    ):
         from code_puppy.plugins.claude_code_oauth.register_callbacks import (
             _await_callback,
         )
 
-        assert _await_callback(MagicMock()) is None
+        ctx = MagicMock()
+        ctx.redirect_uri = None
+        ctx.state = "state123"
+        mock_read.return_value = (
+            "http://localhost:8765/callback?code=pasted_code&state=state123"
+        )
+
+        assert _await_callback(ctx) == "pasted_code"
 
     @patch(f"{MOD}._start_callback_server")
     @patch(f"{MOD}.emit_error")

--- a/tests/plugins/test_oauth_pasteback.py
+++ b/tests/plugins/test_oauth_pasteback.py
@@ -1,0 +1,68 @@
+"""Shared OAuth paste-back parser tests."""
+
+import pytest
+
+from code_puppy.plugins.oauth_pasteback import parse_oauth_callback_input
+
+
+def test_parse_full_openai_callback_url():
+    parsed = parse_oauth_callback_input(
+        "http://localhost:1455/auth/callback?"
+        "code=abc123&scope=openid+profile+email+offline_access&state=state456"
+    )
+
+    assert parsed.code == "abc123"
+    assert parsed.state == "state456"
+    assert parsed.error is None
+
+
+def test_parse_full_claude_callback_url():
+    parsed = parse_oauth_callback_input(
+        "http://localhost:8765/callback?code=claude_code&state=claude_state"
+    )
+
+    assert parsed.code == "claude_code"
+    assert parsed.state == "claude_state"
+
+
+def test_parse_raw_query_string():
+    parsed = parse_oauth_callback_input("code=query_code&state=query_state")
+
+    assert parsed.code == "query_code"
+    assert parsed.state == "query_state"
+
+
+def test_parse_claude_hash_format():
+    parsed = parse_oauth_callback_input("CODE123#STATE456")
+
+    assert parsed.code == "CODE123"
+    assert parsed.state == "STATE456"
+
+
+def test_parse_space_separated_code_and_state():
+    parsed = parse_oauth_callback_input("CODE123 STATE456")
+
+    assert parsed.code == "CODE123"
+    assert parsed.state == "STATE456"
+
+
+def test_parse_bare_code():
+    parsed = parse_oauth_callback_input("CODE123")
+
+    assert parsed.code == "CODE123"
+    assert parsed.state is None
+
+
+def test_parse_oauth_error_url():
+    parsed = parse_oauth_callback_input(
+        "http://localhost:1455/auth/callback?"
+        "error=access_denied&error_description=User%20denied"
+    )
+
+    assert parsed.error == "access_denied"
+    assert parsed.error_message == "access_denied: User denied"
+
+
+def test_empty_input_raises():
+    with pytest.raises(ValueError, match="cannot be empty"):
+        parse_oauth_callback_input("")


### PR DESCRIPTION
I had trouble with my ChatGPT sub callback, this PR adds ability to paste

<img width="555" height="195" alt="Screenshot 2026-07-13 at 10 14 29 PM" src="https://github.com/user-attachments/assets/18699548-4ae7-42b2-901e-b0a573fdd7d6" />


## What changed

ChatGPT OAuth and Claude Code OAuth now accept pasted callback URLs or authorization codes while retaining localhost callback handling. A shared parser normalizes full callback URLs, raw query strings, `code#state`, `code state`, and bare-code inputs before provider-specific token exchange.

## Why

Remote terminal sessions can open the provider login URL on a different machine, but the final redirect targets `localhost` on the browser machine. Paste-back lets users copy that failed redirect URL or code into Code Puppy instead of relying on the remote host receiving the callback.

## Design impact

The OAuth plugins remain self-contained builtin plugins; `code_puppy/command_line/` is unchanged. ChatGPT now shares one exchange/save path between HTTP callback and pasted input, and Claude reuses the shared parser through its existing `parse_authorization_code` utility.