### PR TITLE
fix(azure_foundry): disable reasoning ID replay for GPT-5.x models

### DIFF
--- a/code_puppy/plugins/azure_foundry/register_callbacks.py
+++ b/code_puppy/plugins/azure_foundry/register_callbacks.py
@@ -417,7 +417,11 @@ def _create_azure_foundry_openai_model(
     """
     try:
         from openai import AsyncAzureOpenAI
-        from pydantic_ai.models.openai import OpenAIChatModel, OpenAIResponsesModel
+        from pydantic_ai.models.openai import (
+            OpenAIChatModel,
+            OpenAIResponsesModel,
+            OpenAIResponsesModelSettings,
+        )
     except ImportError as e:
         emit_error(f"Failed to create Azure Foundry OpenAI model '{model_name}': {e}")
         return None
@@ -462,7 +466,15 @@ def _create_azure_foundry_openai_model(
         provider = make_openai_provider(provider_identity, openai_client=azure_client)
 
         if deployment_name.startswith("gpt-5"):
-            model = OpenAIResponsesModel(model_name=deployment_name, provider=provider)
+            # Azure returns reasoning items without encrypted_content, so pydantic-ai
+            # drops the reasoning item while still replaying its function_call by ID —
+            # causing HTTP 400 "function_call provided without its required reasoning item".
+            # openai_send_reasoning_ids=False disables ID replay; thinking is re-sent as
+            # plain assistant text instead.
+            settings = OpenAIResponsesModelSettings(openai_send_reasoning_ids=False)
+            model = OpenAIResponsesModel(
+                model_name=deployment_name, provider=provider, settings=settings
+            )
         else:
             model = OpenAIChatModel(model_name=deployment_name, provider=provider)
         logger.info(


### PR DESCRIPTION

**Problem**

Multi-turn conversations with Azure Foundry GPT-5.x models fail with HTTP 400 when tool calls are involved:

"function_call provided without its required reasoning item"

Azure Foundry returns reasoning items with  encrypted_content: null . pydantic-ai's default behavior for reasoning models ( openai_send_reasoning_ids=True ) replays function call items using their provider-assigned IDs — but the preceding reasoning item is silently dropped because its  encrypted_content  is missing. Azure then rejects the function call as having no matching reasoning context.

This is a known upstream gap: pydantic/pydantic-ai#3230, pydantic/pydantic-ai#2915, pydantic/pydantic-ai#4608. A fix was proposed upstream (PR #6289) but closed without merging. The library has no automatic workaround for Azure today.

**Fix**

Set  OpenAIResponsesModelSettings(openai_send_reasoning_ids=False)  when creating  OpenAIResponsesModel  for  gpt-5.x  deployments. This disables ID-based replay entirely — thinking content is re-sent as plain assistant text across turns, which Azure handles correctly.

**Testing**

Manually verified: GPT-5.x models on Azure Foundry now complete multi-turn tool-call conversations without HTTP 400 errors.