### PR TITLE
Add custom OpenAI Responses model type

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,23 @@ Then just use /model and tab to select your round-robin model!
 
 The `rotate_every` parameter controls how many requests are made to each model before rotating to the next one. In this example, the round-robin model will use each Qwen model for 5 consecutive requests before moving to the next model in the sequence.
 
+## Custom OpenAI API Types
+
+Use `custom_openai` for OpenAI-compatible Chat Completions endpoints. If an endpoint requires the OpenAI Responses API, use `custom_openai_responses` instead:
+
+```json
+{
+  "reasoning_proxy": {
+    "type": "custom_openai_responses",
+    "name": "gpt-5.5",
+    "custom_endpoint": {
+      "url": "https://proxy.example.com/v1",
+      "api_key": "$API_KEY"
+    }
+  }
+}
+```
+
 ## Custom Model Timeouts
 
 For custom model endpoints (`custom_openai`, `custom_anthropic`, `custom_gemini`, `cerebras`), you can configure custom timeout values to handle slow or unreliable endpoints. The default timeout for these custom endpoint models is 180 seconds.

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -59,6 +59,18 @@ _load_plugin_model_providers()
 
 # Anthropic beta header required for 1M context window support.
 CONTEXT_1M_BETA = "context-1m-2025-08-07"
+_CUSTOM_OPENAI_MODEL_TYPES = {"custom_openai", "custom_openai_responses"}
+_LEGACY_CUSTOM_OPENAI_RESPONSES_MODEL = "codex-gpt-5-codex"
+
+
+def _custom_openai_uses_responses_api(
+    model_name: str, model_config: Dict[str, Any]
+) -> bool:
+    """Return whether a custom OpenAI model should use the Responses API."""
+    return (
+        model_config.get("type") == "custom_openai_responses"
+        or model_name == _LEGACY_CUSTOM_OPENAI_RESPONSES_MODEL
+    )
 
 
 def _build_anthropic_beta_header(
@@ -287,7 +299,10 @@ def make_model_settings(
             model_type == "chatgpt_oauth"
             or model_type == "azure_foundry_openai"
             or (model_type == "openai" and "codex" in model_name)
-            or (model_type == "custom_openai" and "codex" in model_name)
+            or (
+                model_type in _CUSTOM_OPENAI_MODEL_TYPES
+                and _custom_openai_uses_responses_api(model_name, model_config)
+            )
         )
 
         if uses_responses_api:
@@ -796,7 +811,7 @@ class ModelFactory:
             )
             return OpenAIChatModel(model_name=model_config["name"], provider=provider)
 
-        elif model_type == "custom_openai":
+        elif model_type in _CUSTOM_OPENAI_MODEL_TYPES:
             url, headers, verify, api_key, timeout = get_custom_config(model_config)
             client = create_async_client(
                 headers=headers,
@@ -809,14 +824,15 @@ class ModelFactory:
             if api_key:
                 provider_args["api_key"] = api_key
             provider = make_openai_provider(provider_identity, **provider_args)
-            model = OpenAIChatModel(
+            if _custom_openai_uses_responses_api(model_name, model_config):
+                return OpenAIResponsesModel(
+                    model_name=model_config["name"], provider=provider
+                )
+            return OpenAIChatModel(
                 model_name=model_config["name"],
                 provider=provider,
                 profile=_thinking_tags_profile(model_name, model_config),
             )
-            if model_name == "codex-gpt-5-codex":
-                model = OpenAIResponsesModel(model_config["name"], provider=provider)
-            return model
         elif model_type == "zai_coding":
             api_key = get_api_key("ZAI_API_KEY")
             if not api_key:

--- a/code_puppy/provider_identity.py
+++ b/code_puppy/provider_identity.py
@@ -88,8 +88,8 @@ def resolve_provider_identity(model_key: str, model_config: dict[str, Any]) -> s
 
     if model_type == "custom_anthropic":
         return "custom_anthropic"
-    if model_type == "custom_openai":
-        return "custom_openai"
+    if model_type in {"custom_openai", "custom_openai_responses"}:
+        return model_type
 
     return model_type or "unknown"
 

--- a/tests/test_model_factory_coverage.py
+++ b/tests/test_model_factory_coverage.py
@@ -13,7 +13,7 @@ Targets the 206 uncovered lines including:
 """
 
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -1465,8 +1465,35 @@ class TestOpenAICodexModels:
                         # Should use OpenAIResponsesModel, not OpenAIChatModel
                         mock_responses.assert_called_once()
 
+    def test_custom_openai_explicit_responses_api(self):
+        """Test arbitrary custom model keys can select the Responses API."""
+        from code_puppy.model_factory import ModelFactory
+
+        config = {
+            "my-reasoning-proxy": {
+                "type": "custom_openai_responses",
+                "name": "gpt-5.5",
+                "custom_endpoint": {
+                    "url": "https://proxy.example.com/v1",
+                    "headers": {"x-api-key": "secret"},
+                },
+            }
+        }
+
+        with patch("code_puppy.model_factory.create_async_client") as mock_client:
+            with patch("code_puppy.model_factory.make_openai_provider"):
+                with patch(
+                    "code_puppy.model_factory.OpenAIResponsesModel"
+                ) as mock_responses:
+                    with patch("code_puppy.model_factory.OpenAIChatModel") as mock_chat:
+                        ModelFactory.get_model("my-reasoning-proxy", config)
+
+        mock_responses.assert_called_once_with(model_name="gpt-5.5", provider=ANY)
+        mock_chat.assert_not_called()
+        assert mock_client.call_args.kwargs["headers"] == {"x-api-key": "secret"}
+
     def test_custom_openai_chatgpt_codex(self):
-        """Test codex-gpt-5-codex uses OpenAIResponsesModel."""
+        """Test legacy codex-gpt-5-codex uses OpenAIResponsesModel."""
         from code_puppy.model_factory import ModelFactory
 
         config = {


### PR DESCRIPTION
Closes #627

## Summary
- add `custom_openai_responses` for arbitrary Responses-compatible endpoints
- share URL, headers, CA, timeout, and API-key handling with `custom_openai`
- preserve legacy `codex-gpt-5-codex` behavior
- align model settings with the selected transport
- document the new model type

## Tests
- `uv run pytest tests/test_model_factory.py tests/test_model_factory_basics.py tests/test_model_factory_coverage.py tests/test_model_settings.py` (140 passed, 2 skipped)
- `uv run ruff check --fix .`
- `uv run ruff format .`