### PR TITLE
Fix: terminal outputs raw text on code blocks

### DIFF
--- a/code_puppy/messaging/__init__.py
+++ b/code_puppy/messaging/__init__.py
@@ -30,11 +30,11 @@ Example (new):
 """
 
 # =============================================================================
-# Apply Rich Markdown patches (left-justified headers)
+# Apply Rich Markdown patches (left-justified headers, unpadded code blocks)
 # =============================================================================
-from .markdown_patches import patch_markdown_headings
+from .markdown_patches import patch_markdown
 
-patch_markdown_headings()
+patch_markdown()
 
 # =============================================================================
 # Legacy API (backward compatible)
@@ -290,7 +290,7 @@ __all__ = [
     "DEFAULT_STYLES",
     "DIFF_STYLES",
     # Markdown patches
-    "patch_markdown_headings",
+    "patch_markdown",
     # Sub-agent console manager
     "AgentState",
     "SubAgentConsoleManager",

--- a/code_puppy/messaging/markdown_patches.py
+++ b/code_puppy/messaging/markdown_patches.py
@@ -1,12 +1,16 @@
 """Patches for Rich's Markdown rendering.
 
-This module provides customizations to Rich's default Markdown rendering,
-particularly for header justification which is hardcoded to center in Rich.
+- Headings: Rich hardcodes them to center-justified; we want left.
+- Code blocks: Rich pads every line to fill a rectangular highlight
+  background, and that padding survives copy/paste (#505). See
+  ``NoPadCodeBlock``.
 """
 
 from rich import box
-from rich.markdown import Heading, Markdown
+from rich.markdown import CodeBlock, Heading, Markdown
 from rich.panel import Panel
+from rich.rule import Rule
+from rich.syntax import Syntax
 from rich.text import Text
 
 
@@ -37,21 +41,49 @@ class LeftJustifiedHeading(Heading):
             yield text
 
 
+class NoPadCodeBlock(CodeBlock):
+    """Code block with per-character background but no padding (#505).
+
+    Rich's default ``CodeBlock`` pads every line to width so the theme
+    background fills a rectangle -- that padding survives copy/paste.
+    We bypass ``Syntax``'s line-filling and yield each highlighted line
+    directly: theme background stays on real characters, box is "ragged"
+    (hugs each line's own width) instead of a filled rectangle. Language
+    label + boundary drawn with ``Rule``.
+    """
+
+    def __rich_console__(self, console, options):
+        code = str(self.text).rstrip()
+        syntax = Syntax(
+            code,
+            self.lexer_name,
+            theme=self.theme,
+            word_wrap=True,
+            background_color=None,
+        )
+        yield Rule(title=self.lexer_name, align="left", style="dim")
+        for line in syntax.highlight(code).split("\n"):
+            # ``Text.highlight()`` sets ``justify="left"`` for opaque
+            # backgrounds, which re-pads to container width. Undo it;
+            # per-character bg from the base style is unaffected.
+            line.justify = None
+            yield line
+        yield Rule(style="dim")
+
+
 _patched = False
 
 
-def patch_markdown_headings():
-    """Patch Rich's Markdown to use left-justified headings.
-
-    This function is idempotent - calling it multiple times has no effect
-    after the first call.
-    """
+def patch_markdown():
+    """Install left-justified headings + unpadded code blocks. Idempotent."""
     global _patched
     if _patched:
         return
 
     Markdown.elements["heading_open"] = LeftJustifiedHeading
+    Markdown.elements["fence"] = NoPadCodeBlock
+    Markdown.elements["code_block"] = NoPadCodeBlock
     _patched = True
 
 
-__all__ = ["patch_markdown_headings", "LeftJustifiedHeading"]
+__all__ = ["patch_markdown", "LeftJustifiedHeading", "NoPadCodeBlock"]

--- a/code_puppy/pydantic_patches.py
+++ b/code_puppy/pydantic_patches.py
@@ -529,6 +529,33 @@ def patch_termflow_clipboard() -> None:
         pass  # never crash on patch failure
 
 
+def _no_pad_render_code_line(_line, highlighted, width, margin, style, pretty_pad=True):
+    """Drop-in for ``render_code_line`` minus the ``' ' * padding`` suffix."""
+    return f"{margin}{highlighted}"
+
+
+def patch_termflow_code_padding() -> None:
+    """Strip trailing-space padding from termflow code lines (#505).
+
+    termflow's ``render_code_line`` right-pads to render width, but
+    termflow doesn't color code backgrounds -- so the padding is pure
+    invisible filler that corrupts copy/paste. Must patch both
+    ``termflow.render.code`` (the definition) AND
+    ``termflow.render.renderer`` (did ``from … import render_code_line``,
+    so it holds a stale reference).
+    """
+    try:
+        import termflow.render.code as _termflow_code
+        import termflow.render.renderer as _termflow_renderer
+
+        _termflow_code.render_code_line = _no_pad_render_code_line
+        _termflow_renderer.render_code_line = _no_pad_render_code_line
+    except ImportError:
+        pass  # termflow not available
+    except Exception:
+        pass  # never crash on patch failure
+
+
 def apply_all_patches() -> None:
     """Apply all monkey patches.
 
@@ -541,3 +568,4 @@ def apply_all_patches() -> None:
     patch_tool_call_callbacks()
     patch_prompt_toolkit_emoji_width()
     patch_termflow_clipboard()
+    patch_termflow_code_padding()

--- a/tests/messaging/test_markdown_patches.py
+++ b/tests/messaging/test_markdown_patches.py
@@ -7,21 +7,24 @@ from rich.markdown import Markdown
 
 from code_puppy.messaging.markdown_patches import (
     LeftJustifiedHeading,
-    patch_markdown_headings,
+    NoPadCodeBlock,
+    patch_markdown,
 )
 
 
-def test_patch_markdown_headings_idempotent():
-    """Calling patch_markdown_headings multiple times is safe."""
-    patch_markdown_headings()
-    patch_markdown_headings()  # Should be no-op
+def test_patch_markdown_idempotent():
+    """Calling patch_markdown multiple times is safe."""
+    patch_markdown()
+    patch_markdown()  # Should be no-op
     assert Markdown.elements["heading_open"] is LeftJustifiedHeading
+    assert Markdown.elements["fence"] is NoPadCodeBlock
+    assert Markdown.elements["code_block"] is NoPadCodeBlock
 
 
 def test_left_justified_heading_h1():
     """H1 should render as a panel."""
     console = Console(file=StringIO(), force_terminal=False, width=80)
-    patch_markdown_headings()
+    patch_markdown()
     md = Markdown("# Hello World")
     console.print(md)
     output = console.file.getvalue()
@@ -31,7 +34,7 @@ def test_left_justified_heading_h1():
 def test_left_justified_heading_h2():
     """H2 should render as styled text with blank line."""
     console = Console(file=StringIO(), force_terminal=False, width=80)
-    patch_markdown_headings()
+    patch_markdown()
     md = Markdown("## Section Title")
     console.print(md)
     output = console.file.getvalue()
@@ -41,8 +44,55 @@ def test_left_justified_heading_h2():
 def test_left_justified_heading_h3():
     """H3+ should render as styled text."""
     console = Console(file=StringIO(), force_terminal=False, width=80)
-    patch_markdown_headings()
+    patch_markdown()
     md = Markdown("### Subsection")
     console.print(md)
     output = console.file.getvalue()
     assert "Subsection" in output
+
+
+def test_code_block_no_trailing_whitespace():
+    """Regression for #505: code lines must not carry trailing spaces."""
+    console = Console(file=StringIO(), force_terminal=False, width=40)
+    patch_markdown()
+    md = Markdown("```python\nprint('hi')\n```")
+    console.print(md)
+    output = console.file.getvalue()
+    for line in output.splitlines():
+        assert line == line.rstrip(), f"line has trailing whitespace: {line!r}"
+
+
+def test_code_block_indented_no_trailing_whitespace():
+    """Regression for #505: indented (non-fenced) code blocks too."""
+    console = Console(file=StringIO(), force_terminal=False, width=40)
+    patch_markdown()
+    md = Markdown("    print('hi')\n    print('bye')")
+    console.print(md)
+    output = console.file.getvalue()
+    assert "print" in output  # sanity: block actually rendered
+    for line in output.splitlines():
+        assert line == line.rstrip(), f"line has trailing whitespace: {line!r}"
+
+
+def test_code_block_still_highlighted():
+    """Removing padding must not disable syntax highlighting."""
+    console = Console(
+        file=StringIO(), force_terminal=True, width=40, color_system="standard"
+    )
+    patch_markdown()
+    md = Markdown("```python\ndef foo():\n    return 1\n```")
+    console.print(md)
+    output = console.file.getvalue()
+    assert "\x1b[" in output  # ANSI styling present => tokens still colored
+
+
+def test_code_block_has_real_background_color():
+    """Ragged box still paints per-character theme background (#505)."""
+    console = Console(
+        file=StringIO(), force_terminal=True, width=40, color_system="truecolor"
+    )
+    patch_markdown()
+    md = Markdown("```python\nprint('hi')\n```")
+    console.print(md)
+    output = console.file.getvalue()
+    assert "48;2;" in output  # 48;2;r;g;b = truecolor background SGR code

--- a/tests/test_completions_and_small_modules.py
+++ b/tests/test_completions_and_small_modules.py
@@ -397,9 +397,9 @@ class TestMarkdownPatches:
         from code_puppy.messaging import markdown_patches
 
         markdown_patches._patched = False
-        markdown_patches.patch_markdown_headings()
+        markdown_patches.patch_markdown()
         assert markdown_patches._patched is True
-        markdown_patches.patch_markdown_headings()  # no-op
+        markdown_patches.patch_markdown()  # no-op
         assert markdown_patches._patched is True
 
 

--- a/tests/test_messaging_init.py
+++ b/tests/test_messaging_init.py
@@ -183,7 +183,7 @@ class TestMessagingPackageExports:
             "DEFAULT_STYLES",
             "DIFF_STYLES",
             # Markdown patches
-            "patch_markdown_headings",
+            "patch_markdown",
             # Session management
             "set_session_context",
             "get_session_context",

--- a/tests/test_pydantic_patches_full_coverage.py
+++ b/tests/test_pydantic_patches_full_coverage.py
@@ -275,6 +275,56 @@ class TestPatchTermflowClipboard:
             patch_termflow_clipboard()  # must not raise
 
 
+class TestPatchTermflowCodePadding:
+    """Regression guard for #505: no trailing spaces on termflow code lines."""
+
+    def test_code_block_lines_have_no_trailing_whitespace(self):
+        import io
+
+        from code_puppy.pydantic_patches import patch_termflow_code_padding
+
+        patch_termflow_code_padding()
+        from termflow import Parser as TermflowParser
+        from termflow import Renderer as TermflowRenderer
+
+        buf = io.StringIO()
+        renderer = TermflowRenderer(output=buf, width=40)
+        parser = TermflowParser()
+        for line in ["```python", "print('hi')", "def foo():", "    return 1", "```"]:
+            for event in parser.parse_line(line):
+                renderer.render(event)
+        for event in parser.finalize():
+            renderer.render(event)
+        for rendered_line in buf.getvalue().splitlines():
+            assert rendered_line == rendered_line.rstrip(), (
+                f"line has trailing whitespace: {rendered_line!r}"
+            )
+
+    def test_patch_idempotent(self):
+        from code_puppy.pydantic_patches import patch_termflow_code_padding
+        import termflow.render.code as termflow_code
+        import termflow.render.renderer as termflow_renderer
+
+        patch_termflow_code_padding()
+        patch_termflow_code_padding()  # should be a no-op the second time
+        assert termflow_code.render_code_line is termflow_renderer.render_code_line
+
+    def test_patch_does_not_crash_without_termflow(self):
+        import builtins
+
+        from code_puppy.pydantic_patches import patch_termflow_code_padding
+
+        _real_import = builtins.__import__
+
+        def _block_termflow(name, *args, **kwargs):
+            if name.startswith("termflow"):
+                raise ImportError("simulated: termflow not installed")
+            return _real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=_block_termflow):
+            patch_termflow_code_padding()  # must not raise
+
+
 class TestApplyAllPatches:
     def test_apply_all_patches(self):
         from code_puppy.pydantic_patches import apply_all_patches


### PR DESCRIPTION
Closes issue #505 .

This fix addresses code blocks coming with trailing right spaces, which in my experience messes up the copy/paste workflow. This is mainly found for me through copy/pasting curls to postman or my terminal, where the curl gets broken apart and not treated as one request.

Before fix:
<img width="590" height="203" alt="Screenshot 2026-07-15 at 5 03 45 PM" src="https://github.com/user-attachments/assets/46ce541f-6053-4e98-8380-3ab186e06cdc" />
<img width="1512" height="95" alt="Screenshot 2026-07-15 at 4 57 54 PM" src="https://github.com/user-attachments/assets/d3e1d446-68e9-4550-b8a4-32e8c8425ad1" />

After fix:
<img width="580" height="213" alt="Screenshot 2026-07-15 at 4 55 31 PM" src="https://github.com/user-attachments/assets/8126f949-444c-4988-956e-a66253b47c0c" />
<img width="1512" height="102" alt="Screenshot 2026-07-15 at 4 59 07 PM" src="https://github.com/user-attachments/assets/9bbc90d9-ec15-4ff1-982d-93b9d1ca540e" />

The main tradeoff to this fix is that the text loses the background color it gets when copy/pasted into a notes app or something similar to that. Raw text is the output now with no trailing spaces on lines.
