### PR TITLE
Extend the token usage data reported through agent_run_end hook

### DIFF
--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -987,7 +987,14 @@ async def _run_with_mcp_impl(
     run_success = False
     run_error: Optional[BaseException] = None
     run_response_text = ""
-    run_usage_output_tokens: Optional[int] = None
+    run_usage_metadata: dict[str, int | None] = {
+        "usage_input_tokens": None,
+        "usage_output_tokens": None,
+        "usage_total_tokens": None,
+        "usage_cached_read_tokens": None,
+        "usage_cached_write_tokens": None,
+        "usage_thought_tokens": None,
+    }
 
     try:
         # Nested runs (e.g. shell_safety mid-run) leave the SIGINT handler
@@ -1044,13 +1051,37 @@ async def _run_with_mcp_impl(
         run_success = True
         run_response_text = _extract_response_text(result)
         try:
-            # Real billed output tokens -- calibrates the run-stats TG
-            # estimate (see run_stats.snapshot_cycle_into_aggregates).
-            run_usage_output_tokens = (
-                int(getattr(result.usage(), "output_tokens", 0) or 0) or None
-            )
+            usage = result.usage()
+
+            def _pick_usage_int(*names: str) -> int | None:
+                for name in names:
+                    value = getattr(usage, name, None)
+                    if value is not None:
+                        return int(value) or None
+                return None
+
+            run_usage_metadata = {
+                "usage_input_tokens": _pick_usage_int(
+                    "input_tokens", "request_tokens", "prompt_tokens"
+                ),
+                # Real billed output tokens -- calibrates the run-stats TG
+                # estimate (see run_stats.snapshot_cycle_into_aggregates).
+                "usage_output_tokens": _pick_usage_int(
+                    "output_tokens", "response_tokens", "completion_tokens"
+                ),
+                "usage_total_tokens": _pick_usage_int("total_tokens"),
+                "usage_cached_read_tokens": _pick_usage_int(
+                    "cache_read_tokens", "cached_read_tokens"
+                ),
+                "usage_cached_write_tokens": _pick_usage_int(
+                    "cache_write_tokens", "cached_write_tokens"
+                ),
+                "usage_thought_tokens": _pick_usage_int(
+                    "thinking_tokens", "thought_tokens", "reasoning_tokens"
+                ),
+            }
         except Exception:
-            run_usage_output_tokens = None
+            pass
         return result
     except asyncio.CancelledError:
         run_response_text = ""
@@ -1086,7 +1117,7 @@ async def _run_with_mcp_impl(
                 response_text=run_response_text,
                 metadata={
                     "model": agent.get_model_name(),
-                    "usage_output_tokens": run_usage_output_tokens,
+                    **run_usage_metadata,
                 },
             )
         except Exception:

--- a/code_puppy/plugins/claude_code_hooks/register_callbacks.py
+++ b/code_puppy/plugins/claude_code_hooks/register_callbacks.py
@@ -366,6 +366,8 @@ async def on_agent_run_end_hook(
             "session_id": session_id,
             "success": success,
             "error": str(error) if error else None,
+            "response_text": response_text,
+            "metadata": metadata,
         },
     )
 

--- a/tests/plugins/test_claude_code_hooks_plugin.py
+++ b/tests/plugins/test_claude_code_hooks_plugin.py
@@ -464,6 +464,57 @@ class TestOnPostToolCallHook:
 
 
 # ---------------------------------------------------------------------------
+# register_callbacks.py: on_agent_run_end_hook
+# ---------------------------------------------------------------------------
+
+
+class TestOnAgentRunEndHook:
+    @pytest.mark.asyncio
+    async def test_reports_additional_agent_run_end_fields(self):
+        from code_puppy.hook_engine.models import EventData, ProcessEventResult
+        from code_puppy.plugins.claude_code_hooks import register_callbacks
+
+        mock_engine = MagicMock()
+        mock_result = ProcessEventResult(blocked=False, executed_hooks=0, results=[])
+        mock_engine.process_event = AsyncMock(return_value=mock_result)
+
+        original = register_callbacks._hook_engine
+        register_callbacks._hook_engine = mock_engine
+        try:
+            metadata = {
+                "model": "claude-code-opus",
+                "input_tokens": 12,
+                "output_tokens": 34,
+            }
+            await register_callbacks.on_agent_run_end_hook(
+                agent_name="code-puppy",
+                model_name="claude-code-opus",
+                session_id="sess-123",
+                success=False,
+                error=RuntimeError("run failed"),
+                response_text="partial response",
+                metadata=metadata,
+            )
+
+            call_args = mock_engine.process_event.call_args
+            assert call_args[0][0] == "SubagentStop"
+            event_data = call_args[0][1]
+            assert isinstance(event_data, EventData)
+            assert event_data.tool_name == "code-puppy"
+            assert event_data.context == {
+                "agent_name": "code-puppy",
+                "model_name": "claude-code-opus",
+                "session_id": "sess-123",
+                "success": False,
+                "error": "run failed",
+                "response_text": "partial response",
+                "metadata": metadata,
+            }
+        finally:
+            register_callbacks._hook_engine = original
+
+
+# ---------------------------------------------------------------------------
 # Callback registration wiring
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem statement
Code Puppy reports only output tokens through the agent_run_end interface. While useful, this does not provide enough information for completely understanding how tokens are being consumed.

## Proposed solution
Extend the number of token usage fields reported through the agent_run_end hook.

## Benefits
By doing this, then Code Puppy can be registered in token tracking tools like [tokentelemetry](https://tokentelemetry.com) and [tokentracker](https://tokentracker.cc), which report token usage across a variety of tools by scanning local logs provided by each coding agent. Also, an intangible benefit is that Code Puppy support in those tools will help to expand the visibility of the tool.

## Testing
- `uv run ruff check code_puppy/agents/_runtime.py tests/plugins/test_claude_code_hooks_plugin.py`
- `uv run ruff format --check code_puppy/agents/_runtime.py tests/plugins/test_claude_code_hooks_plugin.py`
- `uv run pytest tests/plugins/test_claude_code_hooks_plugin.py -q` (23 passed)

## Scope
This involves adding additional token count collection fields to the agent runtime and exposing them in the metadata object over the agent_run_end hook. Existing plugins that are looking at the output_tokens are not affected.

## Next Steps
The next step after this is to create a plugin that will log data in a format consumable by these applications, but this is the minimum change required to the Code Puppy core that can enable the use of those tools.