### PR TITLE
feat(ui): DECSTBM-free inline prompt surface for JetBrains terminals

### DIFF
--- a/code_puppy/messaging/bottom_bar.py
+++ b/code_puppy/messaging/bottom_bar.py
@@ -287,6 +287,12 @@ class BottomBar(TranscriptGuardMixin, BarPainterMixin):
             self._popup_slack = max(0, old_block - len(cleaned))
             self._sync_reserved(self._popup_seq)
 
+    @contextmanager
+    def output_transaction(self) -> Iterator[None]:
+        """Coordinate one transcript render with the live prompt surface."""
+        self.notify_transcript_output()
+        yield
+
     def notify_transcript_output(self) -> None:
         """Release ONE row of popup slack — called per rendered message.
 
@@ -698,12 +704,30 @@ _bottom_bar: Optional[BottomBar] = None
 _bottom_bar_lock = threading.Lock()
 
 
+def _use_inline_surface() -> bool:
+    """Use the DECSTBM-free surface for known-incompatible terminals."""
+    import os
+
+    mode = os.environ.get("CODE_PUPPY_PROMPT_MODE", "auto").strip().lower()
+    if mode in {"inline", "flow"}:
+        return True
+    if mode in {"pinned", "scroll-region"}:
+        return False
+    emulator = os.environ.get("TERMINAL_EMULATOR", "").strip().lower()
+    return emulator == "jetbrains-jediterm"
+
+
 def get_bottom_bar() -> BottomBar:
-    """Get or lazily create the global BottomBar singleton."""
+    """Get or lazily create the terminal-appropriate prompt surface."""
     global _bottom_bar
     with _bottom_bar_lock:
         if _bottom_bar is None:
-            _bottom_bar = BottomBar()
+            if _use_inline_surface():
+                from .inline_bar import InlineBottomBar
+
+                _bottom_bar = InlineBottomBar()
+            else:
+                _bottom_bar = BottomBar()
         return _bottom_bar
 
 

--- a/code_puppy/messaging/inline_bar.py
+++ b/code_puppy/messaging/inline_bar.py
@@ -1,0 +1,190 @@
+"""Inline prompt surface for terminals that mishandle DECSTBM.
+
+Unlike :class:`bottom_bar.BottomBar`, this surface never establishes scroll
+margins or paints at absolute screen rows.  It keeps the live UI at the normal
+terminal cursor, erases it before transcript output, then redraws it below the
+new output.  The public API intentionally matches ``BottomBar`` so the editor
+and status/panel plugins do not need terminal-specific branches.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+from .bar_rendering import (
+    CLEAR_LINE,
+    CURSOR_HIDE,
+    CURSOR_SHOW,
+    WRAP_OFF,
+    WRAP_ON,
+    render_prompt_block,
+    sanitize,
+)
+from .bottom_bar import PANEL_MAX_ROWS, POPUP_MAX_ROWS, BottomBar
+
+
+class InlineBottomBar(BottomBar):
+    """A DECSTBM-free prompt surface for embedded terminal emulators."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._displayed_rows = 0
+        self._output_depth = 0
+
+    def start(self) -> None:
+        if not self._is_tty():
+            return
+        with self._lock:
+            if self._active:
+                return
+            self._active = True
+            self._cols, self._rows = self._safe_size()
+            self._write(CURSOR_HIDE)
+            self._paint_inline()
+        self._install_sigwinch()
+        self._register_atexit()
+
+    def stop(self) -> None:
+        with self._lock:
+            if not self._active:
+                return
+            self._erase_inline()
+            self._write(CURSOR_SHOW)
+            self._active = False
+            self._displayed_rows = 0
+
+    def _sync_reserved(self, _painter) -> None:
+        """Repaint cached state without creating a terminal scroll region."""
+        if not self._active or self._suspend_depth > 0 or self._output_depth > 0:
+            return
+        self._ensure_inline_geometry()
+        self._erase_inline()
+        self._paint_inline()
+
+    def notify_transcript_output(self) -> None:
+        """Retain popup-slack semantics; erasing is owned by the transaction."""
+        with self._lock:
+            if self._popup_slack:
+                self._popup_slack -= 1
+
+    @contextmanager
+    def output_transaction(self) -> Iterator[None]:
+        """Atomically remove the live UI, allow output, then redraw it."""
+        with self._lock:
+            outermost = self._output_depth == 0
+            self._output_depth += 1
+            if outermost and self._active and self._suspend_depth == 0:
+                self.notify_transcript_output()
+                self._erase_inline()
+            try:
+                yield
+            finally:
+                self._output_depth -= 1
+                if outermost and self._active and self._suspend_depth == 0:
+                    self._ensure_inline_geometry()
+                    self._paint_inline()
+
+    @contextmanager
+    def suspended(self) -> Iterator[None]:
+        if not self._is_tty():
+            yield
+            return
+        with self._lock:
+            self._suspend_depth += 1
+            if self._suspend_depth == 1 and self._active:
+                self._erase_inline()
+        try:
+            yield
+        finally:
+            with self._lock:
+                self._suspend_depth -= 1
+                if self._suspend_depth == 0 and self._active:
+                    self._paint_inline()
+
+    def set_panel_lines(self, lines) -> None:
+        from rich.text import Text
+
+        cleaned = [
+            line.copy() if isinstance(line, Text) else sanitize(str(line))
+            for line in (lines or [])
+        ][:PANEL_MAX_ROWS]
+        with self._lock:
+            self._panel_lines = cleaned
+            self._sync_reserved(None)
+
+    def set_popup_lines(self, lines, selected: int = -1) -> None:
+        cleaned = [sanitize(str(line)) for line in (lines or [])][:POPUP_MAX_ROWS]
+        with self._lock:
+            self._popup_lines = cleaned
+            self._popup_selected = selected
+            self._popup_slack = 0
+            self._sync_reserved(None)
+
+    def _ensure_inline_geometry(self) -> None:
+        cols, rows = self._safe_size()
+        self._cols, self._rows = cols, rows
+
+    def _inline_lines(self) -> list[str]:
+        lines: list[str] = []
+        panel = [] if self._popup_lines else self._panel_lines
+        for line in panel:
+            lines.append(sanitize(line.plain if hasattr(line, "plain") else str(line)))
+
+        prompt_rows, _ = render_prompt_block(
+            self._prompt_prefix,
+            self._prompt_buffer,
+            self._prompt_cursor,
+            self._cols,
+            5,
+            prefix_sgrs=self._prompt_prefix_sgrs,
+        )
+        lines.extend(prompt_rows)
+
+        for index, line in enumerate(self._popup_lines):
+            marker = "› " if index == self._popup_selected else "  "
+            lines.append(f"{marker}{line}")
+
+        status = f"{self._status_prefix}{self._status}{self._status_suffix}"
+        if status:
+            lines.append(sanitize(status))
+        return lines or [""]
+
+    def _paint_inline(self) -> None:
+        if not self._active or self._suspend_depth > 0 or self._output_depth > 0:
+            return
+        lines = self._inline_lines()
+        parts = [WRAP_OFF]
+        for index, line in enumerate(lines):
+            if index:
+                parts.append("\r\n")
+            parts.append(f"{CLEAR_LINE}{line}")
+        if len(lines) > 1:
+            parts.append(f"\x1b[{len(lines) - 1}A")
+        parts.extend(["\r", WRAP_ON])
+        self._write("".join(parts))
+        self._displayed_rows = len(lines)
+
+    def _erase_inline(self) -> None:
+        if not self._displayed_rows:
+            return
+        parts = [WRAP_OFF, "\r"]
+        for index in range(self._displayed_rows):
+            if index:
+                parts.append("\x1b[1B\r")
+            parts.append(CLEAR_LINE)
+        if self._displayed_rows > 1:
+            parts.append(f"\x1b[{self._displayed_rows - 1}A")
+        parts.extend(["\r", WRAP_ON])
+        self._write("".join(parts))
+        self._displayed_rows = 0
+
+    def _emergency_restore(self) -> None:
+        try:
+            with self._lock:
+                if self._active:
+                    self._erase_inline()
+                self._write(CURSOR_SHOW)
+                self._active = False
+        except Exception:
+            pass

--- a/code_puppy/messaging/renderers.py
+++ b/code_puppy/messaging/renderers.py
@@ -275,18 +275,25 @@ def _classify_style(message: UIMessage) -> Optional[str]:
 
 
 def _print_message(console: Console, message: UIMessage) -> None:
+    """Print one message while coordinating with the live prompt surface."""
+    from contextlib import nullcontext
+
+    try:
+        from .bottom_bar import get_bottom_bar
+
+        transaction = get_bottom_bar().output_transaction()
+    except Exception:
+        transaction = nullcontext()
+    with transaction:
+        _print_message_uncoordinated(console, message)
+
+
+def _print_message_uncoordinated(console: Console, message: UIMessage) -> None:
     """Print ``message`` to ``console`` using the standard styling rules."""
     # New transcript output is about to scroll: the bottom bar walks
     # its popup slack back one row per message so the prompt steps down
     # with the flow (see BottomBar.notify_transcript_output). Guarded:
     # bar geometry plumbing must NEVER break (or kill) a render thread.
-    try:
-        from .bottom_bar import get_bottom_bar
-
-        get_bottom_bar().notify_transcript_output()
-    except Exception:
-        pass
-
     style = _classify_style(message)
     content = message.content
     if message.type == MessageType.QUEUED:

--- a/code_puppy/messaging/rich_renderer.py
+++ b/code_puppy/messaging/rich_renderer.py
@@ -433,6 +433,19 @@ class RichConsoleRenderer:
     # =========================================================================
 
     def _do_render(self, message: AnyMessage) -> None:
+        """Render one message while coordinating with the prompt surface."""
+        from contextlib import nullcontext
+
+        try:
+            from .bottom_bar import get_bottom_bar
+
+            transaction = get_bottom_bar().output_transaction()
+        except Exception:
+            transaction = nullcontext()
+        with transaction:
+            self._do_render_uncoordinated(message)
+
+    def _do_render_uncoordinated(self, message: AnyMessage) -> None:
         """Synchronously render a message by dispatching to the appropriate handler.
 
         Note: User input requests are skipped in sync mode as they require async.
@@ -462,17 +475,6 @@ class RichConsoleRenderer:
             # In high mode, thinking is never suppressed.
             if get_output_level() != "high" and get_suppress_thinking_messages():
                 return
-
-        # New transcript output is about to scroll (peek or full render):
-        # the bottom bar walks its completion-popup slack back one row
-        # per message so the prompt steps down with the flow. Guarded:
-        # bar geometry plumbing must NEVER break a render path.
-        try:
-            from .bottom_bar import get_bottom_bar
-
-            get_bottom_bar().notify_transcript_output()
-        except Exception:
-            pass
 
         # -- Output-level density gate --
         if self._should_collapse(message):

--- a/tests/messaging/test_inline_bar.py
+++ b/tests/messaging/test_inline_bar.py
@@ -1,0 +1,90 @@
+"""JediTerm-safe inline prompt surface tests."""
+
+import io
+
+from code_puppy.messaging import bottom_bar as bottom_bar_mod
+from code_puppy.messaging.bottom_bar import BottomBar
+from code_puppy.messaging.inline_bar import InlineBottomBar
+
+
+class FakeTTY(io.StringIO):
+    def isatty(self):
+        return True
+
+
+def test_jediterm_selects_inline_surface(monkeypatch):
+    monkeypatch.setenv("TERMINAL_EMULATOR", "JetBrains-JediTerm")
+    monkeypatch.delenv("CODE_PUPPY_PROMPT_MODE", raising=False)
+    bottom_bar_mod.reset_bottom_bar()
+    try:
+        assert isinstance(bottom_bar_mod.get_bottom_bar(), InlineBottomBar)
+    finally:
+        bottom_bar_mod.reset_bottom_bar()
+
+
+def test_android_studio_bundle_needs_no_special_case(monkeypatch):
+    """Android Studio is covered by its shared JediTerm emulator marker."""
+    monkeypatch.setenv("TERMINAL_EMULATOR", "JetBrains-JediTerm")
+    monkeypatch.setenv("__CFBundleIdentifier", "com.google.android.studio")
+    monkeypatch.delenv("CODE_PUPPY_PROMPT_MODE", raising=False)
+    bottom_bar_mod.reset_bottom_bar()
+    try:
+        assert isinstance(bottom_bar_mod.get_bottom_bar(), InlineBottomBar)
+    finally:
+        bottom_bar_mod.reset_bottom_bar()
+
+
+def test_non_jediterm_keeps_scroll_region_surface(monkeypatch):
+    monkeypatch.setenv("TERMINAL_EMULATOR", "iTerm2")
+    monkeypatch.delenv("CODE_PUPPY_PROMPT_MODE", raising=False)
+    bottom_bar_mod.reset_bottom_bar()
+    try:
+        bar = bottom_bar_mod.get_bottom_bar()
+        assert type(bar) is BottomBar
+    finally:
+        bottom_bar_mod.reset_bottom_bar()
+
+
+def test_prompt_mode_override_wins(monkeypatch):
+    monkeypatch.setenv("TERMINAL_EMULATOR", "JetBrains-JediTerm")
+    monkeypatch.setenv("CODE_PUPPY_PROMPT_MODE", "pinned")
+    bottom_bar_mod.reset_bottom_bar()
+    try:
+        assert type(bottom_bar_mod.get_bottom_bar()) is BottomBar
+    finally:
+        bottom_bar_mod.reset_bottom_bar()
+
+
+def test_inline_surface_never_emits_scroll_margins():
+    tty = FakeTTY()
+    bar = InlineBottomBar(stream=tty, get_size=lambda: (80, 24))
+
+    bar.start()
+    bar.set_prompt_text("> ", "hello", 5)
+    bar.set_status("working")
+    with bar.output_transaction():
+        tty.write("agent output\n")
+    bar.stop()
+
+    output = tty.getvalue()
+    assert "\x1b[1;" not in output
+    assert "\x1b[r" not in output
+    assert "agent output\n" in output
+    assert "hello" in output
+    assert "working" in output
+
+
+def test_output_transaction_erases_then_redraws_prompt():
+    tty = FakeTTY()
+    bar = InlineBottomBar(stream=tty, get_size=lambda: (80, 24))
+    bar.start()
+    bar.set_prompt_text("> ", "draft", 5)
+    tty.seek(0)
+    tty.truncate(0)
+
+    with bar.output_transaction():
+        tty.write("new output\n")
+
+    output = tty.getvalue()
+    assert output.index("\x1b[2K") < output.index("new output")
+    assert output.rindex("draft") > output.index("new output")


### PR DESCRIPTION
## Problem

Running code-puppy inside any JetBrains IDE terminal (PyCharm, IntelliJ, Android Studio, WebStorm, Rider — all powered by JediTerm) duplicates the entire prompt into scrollback on **every keystroke**. JediTerm mishandles the DECSTBM scroll-region + DECSC/DECRC + absolute-positioning combination the persistent bottom bar relies on, so each repaint gets committed as a new transcript line instead of replacing the reserved prompt row.

## Fix

Adds an `InlineBottomBar` backend that keeps the full line editor (history, completions, status line, panels, mid-run steering) but renders with a plain erase → output → redraw cycle at the normal cursor position — no scroll margins at all.

- **Auto-detection:** `TERMINAL_EMULATOR=JetBrains-JediTerm` selects the inline backend. This single marker covers every JetBrains IDE, including Android Studio.
- **All other terminals** keep the existing pinned DECSTBM prompt, unchanged.
- **Manual override:** `CODE_PUPPY_PROMPT_MODE=inline` or `=pinned`.
- Transcript output is coordinated through a new `output_transaction()` context manager on `BottomBar` (no-op for the pinned backend, erase/redraw for inline). Renderer plumbing degrades gracefully if the bar explodes — a broken bar never blocks transcript printing.

## Testing

- New `tests/messaging/test_inline_bar.py`: backend selection (JediTerm vs iTerm2 vs override), no-scroll-margin invariant, erase-before/redraw-after transaction ordering.
- `test_bottom_bar.py`, `test_run_ui.py`, and renderer suites: **104 passed**, ruff clean.