### PR TITLE
fix(ui): cell-clip inline bar rows so JediTerm wrap can't desync the block

### DIFF
--- a/code_puppy/messaging/inline_bar.py
+++ b/code_puppy/messaging/inline_bar.py
@@ -18,6 +18,7 @@ from .bar_rendering import (
     CURSOR_SHOW,
     WRAP_OFF,
     WRAP_ON,
+    clip_cells,
     render_prompt_block,
     sanitize,
 )
@@ -126,16 +127,28 @@ class InlineBottomBar(BottomBar):
         self._cols, self._rows = cols, rows
 
     def _inline_lines(self) -> list[str]:
+        # Clip every row to one cell LESS than the terminal width.  The
+        # pinned bar can trust DECAWM-off to stop overlong rows from
+        # wrapping, but the whole reason this surface exists is that
+        # JediTerm fumbles exactly this kind of VT state (double-width
+        # emoji at the margin still wrap).  A wrapped row makes the block
+        # one row taller than ``_displayed_rows`` believes, the cursor-up
+        # count goes off by one, and every 5fps spinner tick strands a
+        # stale copy in scrollback -- the keystroke bug reborn as a
+        # spinner bug.  Hard-clipping is the only defence JediTerm can't
+        # sabotage.
+        max_cells = max(1, self._cols - 1)
         lines: list[str] = []
         panel = [] if self._popup_lines else self._panel_lines
         for line in panel:
-            lines.append(sanitize(line.plain if hasattr(line, "plain") else str(line)))
+            plain = sanitize(line.plain if hasattr(line, "plain") else str(line))
+            lines.append(clip_cells(plain, max_cells))
 
         prompt_rows, _ = render_prompt_block(
             self._prompt_prefix,
             self._prompt_buffer,
             self._prompt_cursor,
-            self._cols,
+            max_cells,
             5,
             prefix_sgrs=self._prompt_prefix_sgrs,
         )
@@ -143,11 +156,11 @@ class InlineBottomBar(BottomBar):
 
         for index, line in enumerate(self._popup_lines):
             marker = "› " if index == self._popup_selected else "  "
-            lines.append(f"{marker}{line}")
+            lines.append(clip_cells(f"{marker}{line}", max_cells))
 
         status = f"{self._status_prefix}{self._status}{self._status_suffix}"
         if status:
-            lines.append(sanitize(status))
+            lines.append(clip_cells(sanitize(status), max_cells))
         return lines or [""]
 
     def _paint_inline(self) -> None:

--- a/tests/messaging/test_inline_bar.py
+++ b/tests/messaging/test_inline_bar.py
@@ -74,6 +74,50 @@ def test_inline_surface_never_emits_scroll_margins():
     assert "working" in output
 
 
+def test_overlong_rows_are_cell_clipped_below_terminal_width():
+    """No painted row may reach the terminal width: JediTerm wraps at the
+    margin even with DECAWM off (double-width emoji especially), which
+    desyncs the cursor-up bookkeeping and strands stale copies -- the
+    spinner-spam bug."""
+    from rich.cells import cell_len
+
+    cols = 40
+    bar = InlineBottomBar(stream=FakeTTY(), get_size=lambda: (cols, 24))
+    bar.start()
+    bar.set_prompt_text("> ", "hi", 2)
+    bar.set_status_prefix("\U0001f436  ")  # double-width puppy spinner frame
+    bar.set_status("tokens 123,456/200,000 " * 5)  # way past 40 cells
+    bar.set_status_suffix(" | queued: 3")
+    bar.set_panel_lines(["sub-agent panel line " * 5])
+
+    for line in bar._inline_lines():
+        assert cell_len(line) < cols
+
+
+def test_spinner_tick_repaints_in_place_without_growing_block():
+    """A status-prefix tick (the 5fps puppy) must erase and repaint the
+    same number of rows -- never leaving extra lines behind."""
+    tty = FakeTTY()
+    bar = InlineBottomBar(stream=tty, get_size=lambda: (80, 24))
+    bar.start()
+    bar.set_prompt_text("> ", "steer me", 8)
+    bar.set_status("ctx 12k/200k")
+    rows_before = bar._displayed_rows
+
+    tty.seek(0)
+    tty.truncate(0)
+    for frame in ("\U0001f436   ", " \U0001f436  ", "  \U0001f436 "):
+        bar.set_status_prefix(frame)
+
+    assert bar._displayed_rows == rows_before
+    output = tty.getvalue()
+    # Each of the 3 ticks repaints the same block: exactly rows-1
+    # newlines per repaint, and never a lone "\n" that would scroll
+    # rows into scrollback.
+    assert output.count("\r\n") == 3 * (rows_before - 1)
+    assert output.count("\n") == output.count("\r\n")
+
+
 def test_output_transaction_erases_then_redraws_prompt():
     tty = FakeTTY()
     bar = InlineBottomBar(stream=tty, get_size=lambda: (80, 24))


### PR DESCRIPTION
## Problem

Follow-up to #631. The inline prompt surface fixed the per-keystroke prompt duplication in JetBrains terminals, but the **spinner** could still spam scrollback during agent runs.

The pinned (DECSTBM) bar cell-clips its status row and trusts DECAWM-off as backup against wrapping. The inline surface did neither — and JediTerm wraps at the margin even with wrap-off, especially with double-width emoji (the  spinner frame). One wrapped row makes the inline block one row taller than `_displayed_rows` believes, the `cursor-up N` bookkeeping goes off by one, and every 5fps spinner tick strands a stale copy in scrollback — the keystroke bug reborn as a spinner bug.

## Fix

Hard-clip every painted row (panel / prompt / popup / status) to `cols − 1` cells via the same `clip_cells` helper the pinned painter uses, so wrap physically cannot occur regardless of emulator VT fidelity. `WRAP_OFF` stays as belt-and-braces.

## Testing

Two new tests in `tests/messaging/test_inline_bar.py`:
- **cell-clip invariant:** overlong status (double-width emoji + long token context), panel, and popup rows all render strictly below terminal width
- **spinner-tick repaint-in-place:** three `set_status_prefix` ticks keep `_displayed_rows` stable and emit no bare newlines that would push rows into scrollback

8 passed; `test_bottom_bar` / `test_run_ui` suites (106 total) green; ruff clean.