### PR TITLE
fix(run_stats): guard _on_post_tool_call on is_subagent()

### DIFF
--- a/code_puppy/agents/run_stats.py
+++ b/code_puppy/agents/run_stats.py
@@ -599,7 +599,18 @@ async def _on_post_tool_call(
     duration_ms: float,
     context: Any = None,
 ) -> None:
-    """Render the tool return value inline in ``high`` output mode."""
+    """Render the tool return value inline in ``high`` output mode.
+
+    Skips when running inside a sub-agent context, matching the guards
+    already present on the sibling ``_on_stream_event`` and
+    ``_on_agent_run_end`` callbacks in this module. Sub-agents render
+    through their own path (see ``tools/subagent_invocation.py``); this
+    callback is the global post-tool-return renderer for the main
+    agent, and without the guard it leaks every sub-agent's internal
+    tool returns into the user-facing TUI in high output mode.
+    """
+    if is_subagent():
+        return
     _render_high_mode_tool_result(tool_name, tool_args, result, duration_ms)
 
 

--- a/tests/test_run_stats_subagent_guard.py
+++ b/tests/test_run_stats_subagent_guard.py
@@ -1,0 +1,111 @@
+"""Tests for the sub-agent guard on ``_on_post_tool_call``.
+
+``code_puppy/agents/run_stats.py`` registers three callbacks with the
+global callback registry:
+
+- ``_on_stream_event``     — already guarded on ``is_subagent()``
+- ``_on_agent_run_end``    — already guarded on ``is_subagent()``
+- ``_on_post_tool_call``   — the one this test file covers
+
+Without a guard on ``_on_post_tool_call``, every tool return from a
+sub-agent leaks into the main agent's TUI in ``high`` output mode via
+``_render_high_mode_tool_result``. Sub-agents have their own rendering
+path (``tools/subagent_invocation.py``), so the global callback firing
+for them is unintended bleed-through, not the intended UX.
+
+These tests lock in the guard.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from code_puppy.agents.run_stats import _on_post_tool_call
+from code_puppy.tools.subagent_context import subagent_context
+
+
+@pytest.mark.asyncio
+async def test_on_post_tool_call_renders_by_default(monkeypatch):
+    """Baseline: outside any sub-agent context, the renderer is invoked."""
+    render_calls = []
+
+    def _record(*args, **kwargs):
+        render_calls.append((args, kwargs))
+
+    monkeypatch.setattr(
+        "code_puppy.agents.run_stats._render_high_mode_tool_result",
+        _record,
+    )
+
+    await _on_post_tool_call(
+        tool_name="some_tool",
+        tool_args={"foo": "bar"},
+        result={"ok": True},
+        duration_ms=1.5,
+    )
+    assert len(render_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_on_post_tool_call_skips_inside_subagent_context(monkeypatch):
+    """The load-bearing guard: sub-agent context suppresses the renderer.
+
+    Sub-agents render through their own path; this global callback
+    firing for them would leak internal tool traffic into the main
+    agent's TUI in high output mode.
+    """
+    render_calls = []
+
+    def _record(*args, **kwargs):
+        render_calls.append((args, kwargs))
+
+    monkeypatch.setattr(
+        "code_puppy.agents.run_stats._render_high_mode_tool_result",
+        _record,
+    )
+
+    with subagent_context("test-subagent"):
+        await _on_post_tool_call(
+            tool_name="some_internal_tool",
+            tool_args={"summary": "..."},
+            result={"summary": "..."},
+            duration_ms=0.1,
+        )
+    assert render_calls == [], (
+        "sub-agent tool returns must not reach the user-facing renderer; "
+        f"got {render_calls!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_post_tool_call_resumes_rendering_after_subagent_exits(
+    monkeypatch,
+):
+    """ContextVar token restore: after the sub-agent scope exits,
+    rendering resumes for the main agent's tool calls."""
+    render_calls = []
+
+    def _record(*args, **kwargs):
+        render_calls.append((args, kwargs))
+
+    monkeypatch.setattr(
+        "code_puppy.agents.run_stats._render_high_mode_tool_result",
+        _record,
+    )
+
+    with subagent_context("test-subagent"):
+        await _on_post_tool_call(
+            tool_name="some_internal_tool",
+            tool_args={},
+            result={},
+            duration_ms=0.1,
+        )
+    # Outside the scope again: main-agent tool calls should render.
+    await _on_post_tool_call(
+        tool_name="read_file",
+        tool_args={"path": "x"},
+        result="content",
+        duration_ms=2.0,
+    )
+    assert len(render_calls) == 1
+    assert render_calls[0][0][0] == "read_file"


### PR DESCRIPTION
## Problem

In `high` output mode, every tool call made by a sub-agent leaks into the main agent's TUI as:

```
↩ some_tool returned (0.1 ms): { ... structured result ... }
```

Sub-agents render through their own dedicated path (`tools/subagent_invocation.py` → `StreamingTextDetector(_main_stream_handler)` in high mode, or `subagent_stream_handler` otherwise), so this is unintended bleed-through from a global callback — not the designed sub-agent UX.

## Root cause

`code_puppy/agents/run_stats.py` registers three callbacks with the global callback registry:

| Callback | Guarded on `is_subagent()`? |
|---|---|
| `_on_stream_event` |  (line 572) |
| `_on_agent_run_end` |  (line 627) |
| `_on_post_tool_call` |  ⟵ **this PR** |

`_on_post_tool_call` calls `_render_high_mode_tool_result(...)`, which prints tool returns inline in `high` output mode. The callback fires from a global monkey-patch on `ToolManager._call_tool` in `code_puppy/pydantic_patches.py`, so it runs for every tool call in every agent — including sub-agents.

## Fix

One-line guard, matching the pattern already used by the two sibling callbacks in the same file:

```python
async def _on_post_tool_call(...):
    if is_subagent():
        return
    _render_high_mode_tool_result(tool_name, tool_args, result, duration_ms)
```

Plus a documenting docstring explaining why the guard is there.

## Tests

New file: `tests/test_run_stats_subagent_guard.py` — 3 focused regression tests:

- **`test_on_post_tool_call_renders_by_default`** — baseline: outside any sub-agent context, the renderer is invoked.
- **`test_on_post_tool_call_skips_inside_subagent_context`** — load-bearing: inside `subagent_context(...)`, the renderer is skipped.
- **`test_on_post_tool_call_resumes_rendering_after_subagent_exits`** — ContextVar token-restore: main-agent tool calls render again after the sub-agent scope exits.

Anti-tautology verified locally: reverting the guard causes 2/3 tests to fail with expected `False != True` assertion diffs. Restored → 3/3 pass.

```
pytest tests/test_run_stats_subagent_guard.py -v    # 3 passed
pytest tests/ -k "run_stat or subagent" --ignore=tests/integration    # 341 passed, 0 regressions
```

## No impact on user-invoked sub-agents in high mode

The concern: does this guard suppress sub-agent visibility in high mode, where users *want* to see sub-agent activity?

**Answer: no.** High-mode sub-agent rendering flows through `StreamingTextDetector(_main_stream_handler)` wrapping the pydantic-ai `event_stream_handler` (see `tools/subagent_invocation.py` around line 272). That's a **separate, designed** rendering path from the global tool-return callback. This PR only silences the accidental bleed-through from the global callback; the intentional high-mode sub-agent UX (thinking, tool calls, final response) is unchanged.

If someone ever explicitly wants full per-tool-return bodies from user-invoked sub-agents in high mode, that would need a designed rendering path in the sub-agent UX layer — not accidental bleed-through from a global stats callback.

## Discovery

Found this in the wild while debugging a background summarization plugin whose internal LLM tool calls were leaking into the user's terminal on every scan cycle. The plugin wraps its `agent.run(...)` in `subagent_context("scanner")` for exactly this purpose (matching how `_on_stream_event` / `_on_agent_run_end` handle it), but `_on_post_tool_call` was ignoring the flag. Fixing this one callback makes the sub-agent contract consistent across all three run-stats hooks.
