### PR TITLE
fix: ONLY clamp sub-agent panel to terminal height

### DIFF
--- a/code_puppy/messaging/bar_painters.py
+++ b/code_puppy/messaging/bar_painters.py
@@ -103,6 +103,14 @@ def _dim(text: str) -> str:
     return f"{_DIM_ON}{text}{_DIM_OFF}" if text else text
 
 
+def _panel_overflow_row(hidden: int) -> str:
+    """A single summary row standing in for ``hidden`` sub-agent panel
+    rows that were clamped off because they don't fit the terminal
+    height. Emitted as a plain string so it dims like every other panel
+    row at paint time (no double-dimming)."""
+    return f"\u2026 +{hidden} more"
+
+
 class BarPainterMixin:
     """Layout math + reserved-row painters for :class:`BottomBar`."""
 
@@ -147,9 +155,45 @@ class BarPainterMixin:
         budget = rows - self._prompt_row_count() - 3 - len(self._visible_popup_lines())
         return max(0, min(slack, budget))
 
+    def _panel_row_budget(self) -> int:
+        """Max panel rows that fit without forcing the bar dormant.
+
+        Mirrors :meth:`_visible_popup_lines`' "prompt viewport WINS" rule:
+        the top margin, prompt, popup, and status always keep their rows,
+        plus one scroll row for the transcript region. Whatever height is
+        left is the panel's budget — so a big sub-agent swarm is shown as
+        tall as the terminal allows instead of overflowing past
+        ``rows - 1`` and tripping the ``rows < reserved + 1`` dormancy
+        guard in :meth:`_establish` (which would blank the panel, prompt,
+        AND status all at once).
+        """
+        rows = self._rows if self._rows > 0 else 24
+        non_panel = (
+            1  # top margin (blank separator below the transcript)
+            + self._prompt_row_count()
+            + len(self._visible_popup_lines())
+            + self._visible_popup_slack()
+            + (1 if self._status_visible() else 0)
+        )
+        return max(0, rows - 1 - non_panel)
+
     def _visible_panel_lines(self) -> list:
-        """Panel rows to paint — popup takes precedence while open."""
-        return [] if self._visible_popup_lines() else self._panel_lines
+        """Panel rows to paint — popup takes precedence while open, and the
+        list is clamped to :meth:`_panel_row_budget` so it can never
+        overflow the terminal height. When the panel is taller than the
+        budget, the last visible row collapses the remainder into a
+        "+N more" summary instead of dropping the whole bar.
+        """
+        if self._visible_popup_lines():
+            return []
+        panel = self._panel_lines
+        budget = self._panel_row_budget()
+        if len(panel) <= budget:
+            return panel
+        if budget <= 0:
+            return []
+        hidden = len(panel) - (budget - 1)
+        return panel[: budget - 1] + [_panel_overflow_row(hidden)]
 
     def _status_visible(self) -> bool:
         """The status row exists only while ANY slot has content."""

--- a/code_puppy/messaging/bottom_bar.py
+++ b/code_puppy/messaging/bottom_bar.py
@@ -1,9 +1,9 @@
 """Persistent bottom prompt bar via a terminal scroll region (DECSTBM).
 
-Reserves the bottom rows of the terminal (3 base rows + up to
-``PANEL_MAX_ROWS`` sub-agent panel rows):
+Reserves the bottom rows of the terminal (3 base rows plus one row for
+every active sub-agent panel entry):
 
-    rows H-2-n..H-3  sub-agent panel (n = 0..4 rows, via set_panel_lines)
+    rows H-2-n..H-3  sub-agent panel (n = number of panel rows, via set_panel_lines)
     row  H-2         status line (token/context info, via set_status)
     row  H-1         prompt line  (the always-available input line)
     row  H           blank margin
@@ -99,9 +99,6 @@ logger = logging.getLogger(__name__)
 #: prompt). The status row (below the prompt) adds one more, but only
 #: while it has content — an empty status row isn't reserved at all.
 RESERVED_ROWS = 2
-
-#: Maximum extra rows for the sub-agent panel (above the status row).
-PANEL_MAX_ROWS = 4
 
 #: Maximum rows for the completion popup (directly BELOW the prompt).
 POPUP_MAX_ROWS = 6
@@ -246,10 +243,10 @@ class BottomBar(TranscriptGuardMixin, BarPainterMixin):
     def set_panel_lines(self, lines: Optional[list]) -> None:
         """Set the sub-agent panel rows (above the status row).
 
-        Accepts up to ``PANEL_MAX_ROWS`` rows (extra lines are dropped),
-        each either a plain string (sanitized here, painted dim) or a
-        ``rich.text.Text`` (kept styled; content sanitized per-segment at
-        paint time -- see ``bar_rendering.render_styled_line``).
+        Accepts every supplied row, each either a plain string (sanitized
+        here, painted dim) or a ``rich.text.Text`` (kept styled; content
+        sanitized per-segment at paint time -- see
+        ``bar_rendering.render_styled_line``).
         An empty list collapses the panel rows and returns them to the
         scroll region. Growing/shrinking re-establishes the region with
         the appropriate row clears so scrollback isn't corrupted.
@@ -261,7 +258,7 @@ class BottomBar(TranscriptGuardMixin, BarPainterMixin):
         cleaned = [
             line.copy() if isinstance(line, Text) else _sanitize(str(line))
             for line in (lines or [])
-        ][:PANEL_MAX_ROWS]
+        ]
         with self._lock:
             self._panel_lines = cleaned
             self._sync_reserved(self._panel_seq)
@@ -744,7 +741,6 @@ def reset_bottom_bar() -> None:
 
 
 __all__ = [
-    "PANEL_MAX_ROWS",
     "POPUP_MAX_ROWS",
     "PROMPT_MAX_ROWS",
     "RESERVED_ROWS",

--- a/code_puppy/messaging/inline_bar.py
+++ b/code_puppy/messaging/inline_bar.py
@@ -22,7 +22,7 @@ from .bar_rendering import (
     render_prompt_block,
     sanitize,
 )
-from .bottom_bar import PANEL_MAX_ROWS, POPUP_MAX_ROWS, BottomBar
+from .bottom_bar import POPUP_MAX_ROWS, BottomBar
 
 
 class InlineBottomBar(BottomBar):
@@ -109,7 +109,7 @@ class InlineBottomBar(BottomBar):
         cleaned = [
             line.copy() if isinstance(line, Text) else sanitize(str(line))
             for line in (lines or [])
-        ][:PANEL_MAX_ROWS]
+        ]
         with self._lock:
             self._panel_lines = cleaned
             self._sync_reserved(None)

--- a/code_puppy/messaging/inline_bar.py
+++ b/code_puppy/messaging/inline_bar.py
@@ -139,7 +139,11 @@ class InlineBottomBar(BottomBar):
         # sabotage.
         max_cells = max(1, self._cols - 1)
         lines: list[str] = []
-        panel = [] if self._popup_lines else self._panel_lines
+        # Height-relative clamp (shared with the DECSTBM path via
+        # BarPainterMixin): the block must never exceed the viewport, or
+        # the cursor-up repaint count in ``_paint_inline`` goes off and
+        # strands stale copies in scrollback every spinner tick.
+        panel = self._visible_panel_lines()
         for line in panel:
             plain = sanitize(line.plain if hasattr(line, "plain") else str(line))
             lines.append(clip_cells(plain, max_cells))

--- a/code_puppy/plugins/subagent_panel/README.md
+++ b/code_puppy/plugins/subagent_panel/README.md
@@ -16,8 +16,11 @@ Milo is thinking... (  o  )
 - Line 2 is a single-char animated spinner + `mm:ss` elapsed + the current
   activity, color-coded: **yellow** = calling a tool, **magenta** = thinking,
   **green** = writing the response.
-- Parallel sub-agents stack, each with its own live row; the panel does not
-  collapse active agents into an overflow summary.
+- Parallel sub-agents stack, each with its own live row. There is no arbitrary
+  cap: every tracked agent renders as long as it fits. The row count is only
+  clamped to the terminal height (the prompt + status always keep their rows) --
+  if a swarm is taller than the viewport, the rows that don't fit collapse into a
+  single `… +N more` summary rather than blanking the whole bar.
 - **Nested sub-agents render as a true tree.** A sub-agent that itself calls
   `invoke_agent` is shown indented under its parent. Only top-level (depth-0)
   agents get the full two-line `INVOKE AGENT` banner; deeper agents collapse to

--- a/code_puppy/plugins/subagent_panel/README.md
+++ b/code_puppy/plugins/subagent_panel/README.md
@@ -16,8 +16,8 @@ Milo is thinking... (  o  )
 - Line 2 is a single-char animated spinner + `mm:ss` elapsed + the current
   activity, color-coded: **yellow** = calling a tool, **magenta** = thinking,
   **green** = writing the response.
-- Parallel sub-agents stack, each with its own block. Beyond `MAX_ROWS` the
-  extras collapse to a `(+N more)` line.
+- Parallel sub-agents stack, each with its own live row; the panel does not
+  collapse active agents into an overflow summary.
 - **Nested sub-agents render as a true tree.** A sub-agent that itself calls
   `invoke_agent` is shown indented under its parent. Only top-level (depth-0)
   agents get the full two-line `INVOKE AGENT` banner; deeper agents collapse to
@@ -89,7 +89,6 @@ Environment startup hard-disable:
 |-----|---------|---------|
 | DISABLE_SUBAGENT_PANEL | unset | Set 1 to skip registration entirely |
 | SUBAGENT_PANEL | 1 | Set 0 to skip registration entirely |
-| SUBAGENT_PANEL_MAX_ROWS | 24 | Max sub-agent blocks shown |
 | SUBAGENT_PANEL_IDLE_S | 600 | Prune after this many idle seconds (safety net) |
 
 ## Notes

--- a/code_puppy/plugins/subagent_panel/register_callbacks.py
+++ b/code_puppy/plugins/subagent_panel/register_callbacks.py
@@ -132,19 +132,13 @@ def _resolve_model(agent_name, override):
 # Live panel rendering (event-driven, pushed to the bottom bar)
 # ---------------------------------------------------------------------------
 #
-# Compression scheme (bottom bar caps the panel at PANEL_MAX_ROWS=4 rows):
-#   * The live format is already ONE aligned row per agent (badge/elbow +
-#     name + model + spin/check + elapsed + status) — information-complete,
-#     so no per-agent compression is needed.
-#   * <= 4 agents: one row each.
-#   * >  4 agents: first 3 rows (DFS order, parents first) + "(+N more)".
+# The live format is one aligned, information-complete row per agent
+# (badge/elbow + name + model + spin/check + elapsed + status). Render every
+# tracked agent in DFS order; a summary row would hide active work.
 # Rows are rendered via the shared _row_lines() (same as the transcript)
 # and pushed as rich.text.Text — the bottom bar paints styled Text rows in
 # full color (SGRs regenerated from trusted Style objects; content still
 # sanitized per-segment), so the live rows match the frozen record.
-
-#: Max rows the bottom bar will display for us (mirrors PANEL_MAX_ROWS).
-_PANEL_ROW_CAP = 4
 
 #: Same-shape repaints (spin frame / elapsed churn) at most 10x/second.
 _PUSH_MIN_INTERVAL = 0.1
@@ -162,18 +156,7 @@ def _panel_lines():
     rows = state.snapshot()
     if not rows:
         return []
-    frame = state.spinner_frame()
-    ordered = _ordered_tree(rows)
-    if len(ordered) <= _PANEL_ROW_CAP:
-        shown = ordered
-        extra = 0
-    else:
-        shown = ordered[: _PANEL_ROW_CAP - 1]
-        extra = len(ordered) - len(shown)
-    lines = list(_row_lines(shown, frame))
-    if extra > 0:
-        lines.append(f"  (+{extra} more)")
-    return lines
+    return list(_row_lines(_ordered_tree(rows), state.spinner_frame()))
 
 
 # ---------------------------------------------------------------------------

--- a/code_puppy/plugins/subagent_panel/state.py
+++ b/code_puppy/plugins/subagent_panel/state.py
@@ -23,7 +23,6 @@ _AGENTS: "Dict[str, Dict[str, Any]]" = {}
 _LOCK = threading.RLock()
 
 # --- tunables (env-overridable) -------------------------------------------
-MAX_ROWS = int(os.environ.get("SUBAGENT_PANEL_MAX_ROWS", "24"))
 IDLE_PRUNE_S = float(os.environ.get("SUBAGENT_PANEL_IDLE_S", "600"))
 
 # Single-char braille spinner frames (defined via escapes to keep the source

--- a/tests/messaging/test_bottom_bar.py
+++ b/tests/messaging/test_bottom_bar.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 import pytest
 
 from code_puppy.messaging.bottom_bar import (
-    PANEL_MAX_ROWS,
     RESERVED_ROWS,
     BottomBar,
     get_bottom_bar,
@@ -406,15 +405,19 @@ def test_panel_same_count_repaints_without_region_change(bar, tty):
     assert "r" not in out.replace("\r", "")  # no DECSTBM re-issue
 
 
-def test_panel_capped_at_max_rows(bar, tty):
+def test_panel_retains_every_row(bar, tty):
+    lines = [f"line{i}" for i in range(10)]
     bar.start()
     drain(tty)
-    bar.set_panel_lines([f"line{i}" for i in range(10)])
+    bar.set_panel_lines(lines)
+
     out = written(tty)
-    assert bar.get_panel_lines() == ["line0", "line1", "line2", "line3"]
-    # Region for 2 base + PANEL_MAX_ROWS reserved rows: 1..18.
-    assert PANEL_MAX_ROWS == 4
-    assert "\x1b[1;18r" in out
+
+    assert bar.get_panel_lines() == lines
+    # Region for 2 base + 10 panel rows: 1..12.
+    assert "\x1b[1;12r" in out
+    assert "\x1b[14;1H\x1b[2K\x1b[2mline0\x1b[22m" in out
+    assert "\x1b[23;1H\x1b[2K\x1b[2mline9\x1b[22m" in out
 
 
 def test_panel_and_status_coexist(bar, tty):

--- a/tests/messaging/test_bottom_bar.py
+++ b/tests/messaging/test_bottom_bar.py
@@ -630,14 +630,36 @@ def test_empty_status_row_has_no_stray_sgr(bar, tty):
     assert "\x1b[2m" not in out  # _dim() no-ops on empty text
 
 
-def test_panel_too_tall_for_terminal_goes_dormant(tty):
+def test_panel_too_tall_for_terminal_clamps_with_overflow(tty):
+    """A panel taller than the terminal no longer blanks the whole bar:
+    it clamps to the rows that fit and collapses the remainder into a
+    '+N more' summary, keeping the prompt + status on screen."""
     bar = BottomBar(stream=tty, get_size=lambda: (80, 6))
     bar.start()  # 2 reserved + 1 scrollable fits in 6 rows
     assert "\x1b[1;4r" in written(tty)
     drain(tty)
-    bar.set_panel_lines(["a", "b", "c", "d"])  # needs 6 reserved + 1 > 6
+    bar.set_panel_lines(["a", "b", "c", "d"])  # 4 rows, only 3 fit
     out = written(tty)
-    assert "\x1b[r" in out  # region reset -> dormant until there's room
+    # NOT dormant: budget is 3 (6 - 1 margin - 1 prompt - 1 scroll), so
+    # 2 rows show + a summary. Reserved = 5 -> region re-established at 1;1.
+    assert "\x1b[1;1r" in out
+    assert "+2 more" in out  # the 2 clamped rows collapse into a summary
+    assert bar.is_active()
+    # The raw panel state still holds every row (clamp is render-only).
+    assert bar.get_panel_lines() == ["a", "b", "c", "d"]
+    bar.stop()
+
+
+def test_panel_all_rows_render_when_they_fit(bar, tty):
+    """On a roomy terminal every tracked agent renders -- no summary."""
+    lines = [f"agent-{i}" for i in range(12)]
+    bar.start()
+    drain(tty)
+    bar.set_panel_lines(lines)
+    out = written(tty)
+    for i in range(12):
+        assert f"agent-{i}" in out
+    assert "more" not in out  # no overflow summary when everything fits
 
 
 def test_teardown_clears_panel_rows_too(bar, tty):

--- a/tests/messaging/test_inline_bar.py
+++ b/tests/messaging/test_inline_bar.py
@@ -94,6 +94,17 @@ def test_overlong_rows_are_cell_clipped_below_terminal_width():
         assert cell_len(line) < cols
 
 
+def test_inline_surface_retains_every_panel_row():
+    bar = InlineBottomBar(stream=FakeTTY(), get_size=lambda: (80, 24))
+    lines = [f"agent-{index}" for index in range(6)]
+
+    bar.start()
+    bar.set_panel_lines(lines)
+
+    assert bar.get_panel_lines() == lines
+    assert bar._inline_lines()[:6] == lines
+
+
 def test_spinner_tick_repaints_in_place_without_growing_block():
     """A status-prefix tick (the 5fps puppy) must erase and repaint the
     same number of rows -- never leaving extra lines behind."""

--- a/tests/messaging/test_inline_bar.py
+++ b/tests/messaging/test_inline_bar.py
@@ -105,6 +105,26 @@ def test_inline_surface_retains_every_panel_row():
     assert bar._inline_lines()[:6] == lines
 
 
+def test_inline_panel_clamps_to_viewport_with_overflow():
+    """On a short viewport the panel can't render one row per agent -- the
+    block would exceed terminal height and desync the cursor-up repaint
+    count. It clamps to what fits and collapses the rest into '+N more',
+    keeping the raw panel state intact."""
+    bar = InlineBottomBar(stream=FakeTTY(), get_size=lambda: (80, 8))
+    lines = [f"agent-{index}" for index in range(10)]
+
+    bar.start()
+    bar.set_panel_lines(lines)
+    rendered = bar._inline_lines()
+
+    # The whole block never exceeds the viewport height.
+    assert len(rendered) <= 8
+    # The clamped overflow is summarized rather than dropped silently.
+    assert any("more" in row for row in rendered)
+    # Raw panel state still holds every tracked agent (clamp is render-only).
+    assert bar.get_panel_lines() == lines
+
+
 def test_spinner_tick_repaints_in_place_without_growing_block():
     """A status-prefix tick (the 5fps puppy) must erase and repaint the
     same number of rows -- never leaving extra lines behind."""

--- a/tests/plugins/subagent_panel/test_panel_lines.py
+++ b/tests/plugins/subagent_panel/test_panel_lines.py
@@ -1,6 +1,6 @@
 """Tests for the bottom-bar panel rendering path (Phase 4).
 
-Covers: styled Text row rendering, the >4-agents compression scheme,
+Covers: styled Text row rendering, every tracked agent being visible,
 throttled pushes, collapse on completion, and the swarm-cancel wipe via
 command_runner._tear_down_live_panels.
 """
@@ -78,22 +78,15 @@ def test_nested_child_renders_tree_elbow():
     assert "child-agent" in _plain(lines[1])
 
 
-def test_more_than_cap_compresses_with_overflow_row():
+def test_all_agents_render_without_an_overflow_summary():
     for i in range(6):
         state.register(f"sid-{i}", f"agent-{i}", "gpt-5.4")
-    lines = rc._panel_lines()
-    assert len(lines) == 4  # 3 agent rows + overflow row
-    assert lines[3] == "  (+3 more)"  # overflow row stays a plain string
-    assert "agent-0" in _plain(lines[0])
-    assert "agent-2" in _plain(lines[2])
 
-
-def test_exactly_cap_agents_render_without_overflow_row():
-    for i in range(4):
-        state.register(f"sid-{i}", f"agent-{i}", "gpt-5.4")
     lines = rc._panel_lines()
-    assert len(lines) == 4
-    assert "more)" not in _plain(lines[3])
+
+    assert len(lines) == 6
+    assert [f"agent-{i}" in _plain(line) for i, line in enumerate(lines)] == [True] * 6
+    assert all("more)" not in _plain(line) for line in lines)
 
 
 def test_done_agent_shows_completed():


### PR DESCRIPTION
## What

Make the sub-agent status panel show **every** tracked sub-agent instead of
truncating to a hard-coded 4 rows + a `(+N more)` summary — but do it safely, so
a large swarm can never blank the bottom bar.

## Why

The panel was capped at `PANEL_MAX_ROWS` (4). During high-parallelism runs
(swarms, fan-out workers) most agents were hidden behind `(+N more)`, defeating
the point of a live panel.

Naively removing the cap introduced a worse bug: `_total_reserved()` then grew
one row per agent with **no ceiling**. Once the reserved rows exceeded the
terminal height, `BottomBar._establish()`'s `rows < reserved + 1` dormancy guard
tripped and blanked the **panel, prompt, AND status all at once** — you couldn't
even type. The inline (JediTerm/embedded) surface had the same unbounded-block
problem, which desynced its cursor-up repaint count and stranded stale copies in
scrollback on every spinner tick.

## How

- **Remove the fixed cap** so the plugin emits one row per tracked agent.
- **Add a shared height-relative clamp** in `BarPainterMixin`:
  - `_panel_row_budget()` reserves the top margin + prompt + popup + status (plus
    one scroll row), mirroring the existing "prompt viewport wins" rule used by
    `_visible_popup_lines()`.
  - `_visible_panel_lines()` caps the panel to that budget and collapses only the
    genuine overflow into a single `… +N more` row.
- **Both surfaces share one clamp:** `inline_bar._inline_lines()` now consumes
  `_visible_panel_lines()`, so the DECSTBM and inline paths behave identically.

Net effect: on any normal terminal you see *far* more agents than the old cap of
4 — every agent that physically fits — and the bar never goes dormant.

## Testing

- `tests/messaging/test_bottom_bar.py`: replaced the old
  "panel too tall → goes dormant" test with one asserting the clamp keeps the bar
  alive and renders `+N more`; added a "roomy terminal renders all rows, no
  summary" test.
- `tests/messaging/test_inline_bar.py`: added a short-viewport clamp test
  (block never exceeds terminal height, overflow summarized, raw state intact).
- Full messaging + subagent_panel suites green (`122 passed`); focused run across
  the branch diff green (`524 passed`).
- `ruff check` / `ruff format` clean on all touched files.

## Scope

Rendering-layer only. The panel plugin's tracked state is untouched
(`get_panel_lines()` still returns every row); the clamp is purely a paint-time
concern shared by both bottom-bar surfaces.

## Testing evidence

The panel now renders a deep parallel swarm in full -- three top-level
`INVOKE AGENT` banners, each with nested children, all visible at once with
no `(+N more)` truncation and the prompt + status row intact:

![sub-agent panel rendering a full nested swarm](https://github.com/user-attachments/assets/e1ee6856-f6c1-4f7c-8bd4-7a6cc4ecd759)
