### PR TITLE
Fix /cd autocomplete for bare tilde (~) paths

### DIFF
--- a/code_puppy/command_line/prompt_toolkit_completion.py
+++ b/code_puppy/command_line/prompt_toolkit_completion.py
@@ -309,33 +309,39 @@ class CDCompleter(Completer):
         start_position = -(len(dir_path))
 
         try:
-            prefix = os.path.expanduser(dir_path)
-            part = os.path.dirname(prefix) if os.path.dirname(prefix) else "."
-            dirs, _ = list_directory(part)
-            dirnames = [d for d in dirs if d.startswith(os.path.basename(prefix))]
-            base_dir = os.path.dirname(prefix)
+            # Treat a bare `~` as `~/` for lookup so we complete inside the
+            # user's home directory (not the parent directory containing their
+            # username folder).
+            lookup_path = "~/" if dir_path == "~" else dir_path
+            expanded_lookup = os.path.expanduser(lookup_path)
 
-            # Preserve the user's original prefix (e.g., ~/ or relative paths)
-            # Extract what the user originally typed (with ~ or ./ preserved)
-            if dir_path.startswith("~"):
-                # User typed something with ~, preserve it
-                user_prefix = "~" + os.sep
-                # For suggestion, we replace the expanded base_dir back with ~/
-                original_prefix = dir_path.rstrip(os.sep)
+            # If the typed path ends with a separator, we're completing inside
+            # that directory and should match all child names.
+            if lookup_path.endswith(os.sep):
+                part = expanded_lookup
+                name_prefix = ""
             else:
-                user_prefix = None
-                original_prefix = None
+                part = os.path.dirname(expanded_lookup) or "."
+                name_prefix = os.path.basename(expanded_lookup)
+
+            dirs, _ = list_directory(part)
+            dirnames = [d for d in dirs if d.startswith(name_prefix)]
+
+            # Preserve user's typed style (~, relative, absolute) in emitted
+            # completion text instead of leaking expanded absolute paths.
+            if dir_path == "~":
+                typed_base = "~"
+            elif dir_path.endswith(os.sep):
+                stripped_base = dir_path.rstrip(os.sep)
+                if not stripped_base and dir_path.startswith(os.sep):
+                    typed_base = os.sep
+                else:
+                    typed_base = stripped_base
+            else:
+                typed_base = os.path.dirname(dir_path.rstrip(os.sep))
 
             for d in dirnames:
-                # Build the completion text so we keep the already-typed directory parts.
-                if user_prefix and original_prefix:
-                    # Restore ~ prefix
-                    suggestion = user_prefix + d + os.sep
-                elif base_dir and base_dir != ".":
-                    suggestion = os.path.join(base_dir, d)
-                else:
-                    suggestion = d
-                # Append trailing slash so the user can continue tabbing into sub-dirs.
+                suggestion = os.path.join(typed_base, d) if typed_base else d
                 suggestion = suggestion.rstrip(os.sep) + os.sep
                 yield Completion(
                     suggestion,

--- a/tests/test_prompt_toolkit_completion.py
+++ b/tests/test_prompt_toolkit_completion.py
@@ -405,6 +405,24 @@ def test_cd_completer_home_directory_expansion(setup_cd_test_dirs, monkeypatch):
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="Path separator expectations differ on Windows")
+def test_cd_completer_home_directory_expansion_bare_tilde(
+    setup_cd_test_dirs, monkeypatch
+):
+    _, mock_home_path = setup_cd_test_dirs
+    monkeypatch.setattr(
+        os.path, "expanduser", lambda p: p.replace("~", str(mock_home_path))
+    )
+
+    completer = CDCompleter()
+    doc = Document(text="/cd ~", cursor_position=len("/cd ~"))
+    completions = list(completer.get_completions(doc, None))
+    texts = sorted([c.text for c in completions])
+
+    assert texts == sorted(["~/Desktop/", "~/Documents/", "~/Downloads/"])
+    assert "~/user/" not in texts
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="Path separator expectations differ on Windows")
 def test_cd_completer_home_directory_expansion_partial(setup_cd_test_dirs, monkeypatch):
     _, mock_home_path = setup_cd_test_dirs
     monkeypatch.setattr(
@@ -431,6 +449,20 @@ def test_cd_completer_non_existent_base(setup_cd_test_dirs, monkeypatch):
     )
     completions = list(completer.get_completions(doc, None))
     assert completions == []
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="Path separator expectations differ on Windows")
+def test_cd_completer_root_path_keeps_absolute_prefix():
+    completer = CDCompleter()
+    with patch(
+        "code_puppy.command_line.prompt_toolkit_completion.list_directory",
+        return_value=(["usr", "tmp"], []),
+    ):
+        doc = Document(text="/cd /", cursor_position=len("/cd /"))
+        completions = list(completer.get_completions(doc, None))
+
+    texts = sorted([c.text for c in completions])
+    assert texts == sorted(["/usr/", "/tmp/"])
 
 
 def test_cd_completer_permission_error_silently_handled(monkeypatch):


### PR DESCRIPTION
## Summary
- fix `/cd` completion for bare `~` so suggestions come from the user's home directory
- preserve typed path style in completion text (`~`, relative, absolute)
- keep absolute prefix when completing from root (`/cd /`)

## Why
Typing `/cd ~` incorrectly suggested `~/<username>/` from the parent directory instead of home directory contents.

## Tests
- added regression: `test_cd_completer_home_directory_expansion_bare_tilde`
- added regression: `test_cd_completer_root_path_keeps_absolute_prefix`
- ran: `uv run ruff check --fix code_puppy/command_line/prompt_toolkit_completion.py tests/test_prompt_toolkit_completion.py`
- ran: `uv run ruff format code_puppy/command_line/prompt_toolkit_completion.py tests/test_prompt_toolkit_completion.py`
- ran: `uv run pytest tests/test_prompt_toolkit_completion.py -k "cd_completer_home_directory_expansion or cd_completer_root_path_keeps_absolute_prefix or cd_completer_partial_sub_directory"`
