### PR TITLE
fix: reuse plugin-skills cache when registrations unchanged

### DIFF
--- a/code_puppy/plugins/agent_skills/discovery.py
+++ b/code_puppy/plugins/agent_skills/discovery.py
@@ -25,6 +25,16 @@ _PLUGIN_SKILLS_CACHE_DIR = Path(CACHE_DIR) / "plugin-skills"
 # ``OSError: [Errno 22] Invalid argument``.
 _PLUGIN_SKILLS_LOCK = threading.Lock()
 
+# Memoised result of the last successful build, keyed by a signature of the
+# plugin skill registrations. Registrations are deterministic within a process,
+# so the cache dir is rebuilt only when they actually change. This keeps the
+# lock's producers serialised AND stops the wipe-and-rebuild from tearing the
+# shared dir out from under lock-free readers of ``SkillInfo.path`` (e.g.
+# ``parse_skill_metadata`` on the prompt path, ``load_full_skill_content`` in
+# the /skills command) that consume the returned paths after the lock releases.
+_plugin_skills_cache: Optional[List["SkillInfo"]] = None
+_plugin_skills_signature: Optional[tuple] = None
+
 
 @dataclass
 class SkillInfo:
@@ -191,8 +201,39 @@ def _iter_plugin_skill_registrations() -> Iterable[tuple[str, str, dict[str, Any
             yield callback.__module__, callback.__name__, entry
 
 
+def _plugin_registration_signature(
+    registrations: List[tuple[str, str, dict[str, Any]]],
+) -> tuple:
+    """Deterministic signature of the plugin skill registrations.
+
+    Used to decide whether the on-disk cache still reflects the registered
+    skills. Sorting each entry's items by key keeps the signature stable
+    regardless of dict ordering.
+    """
+    return tuple(
+        (module, name, repr(sorted(entry.items(), key=lambda kv: kv[0])))
+        for module, name, entry in registrations
+    )
+
+
 def _collect_plugin_skills() -> List[SkillInfo]:
+    global _plugin_skills_cache, _plugin_skills_signature
+
     with _PLUGIN_SKILLS_LOCK:
+        registrations = list(_iter_plugin_skill_registrations())
+        signature = _plugin_registration_signature(registrations)
+
+        # Reuse the already-materialised cache when the registrations are
+        # unchanged and the files are still on disk. Skipping the wipe here is
+        # what prevents a concurrent rebuild from deleting a SKILL.md while a
+        # lock-free reader is consuming a path returned by an earlier call.
+        if (
+            _plugin_skills_cache is not None
+            and signature == _plugin_skills_signature
+            and _PLUGIN_SKILLS_CACHE_DIR.exists()
+        ):
+            return list(_plugin_skills_cache)
+
         if _PLUGIN_SKILLS_CACHE_DIR.exists():
             shutil.rmtree(_PLUGIN_SKILLS_CACHE_DIR, ignore_errors=True)
         _PLUGIN_SKILLS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
@@ -200,7 +241,7 @@ def _collect_plugin_skills() -> List[SkillInfo]:
         plugin_skills: List[SkillInfo] = []
         seen_names: set[str] = set()
 
-        for callback_module, callback_name, entry in _iter_plugin_skill_registrations():
+        for callback_module, callback_name, entry in registrations:
             skill = _materialize_plugin_skill(callback_module, callback_name, entry)
             if skill is None:
                 continue
@@ -215,7 +256,9 @@ def _collect_plugin_skills() -> List[SkillInfo]:
             seen_names.add(skill.name)
             plugin_skills.append(skill)
 
-        return plugin_skills
+        _plugin_skills_cache = plugin_skills
+        _plugin_skills_signature = signature
+        return list(plugin_skills)
 
 
 def discover_skills(directories: Optional[List[Path]] = None) -> List[SkillInfo]:

--- a/code_puppy/plugins/agent_skills/discovery.py
+++ b/code_puppy/plugins/agent_skills/discovery.py
@@ -2,6 +2,7 @@
 
 import logging
 import shutil
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, List, Optional
@@ -13,6 +14,16 @@ from code_puppy.plugins.agent_skills.config import get_skill_directories
 logger = logging.getLogger(__name__)
 
 _PLUGIN_SKILLS_CACHE_DIR = Path(CACHE_DIR) / "plugin-skills"
+
+# Serialises the wipe-and-rebuild of the shared plugin-skills cache dir.
+# ``discover_skills`` (and thus ``_collect_plugin_skills``) is called from both
+# the main loop (prompt assembly, statusline, the /skills menu) AND from worker
+# threads (pydantic-ai runs the sync ``list_or_search_skills`` tool via anyio
+# ``to_thread``; a /steer re-triggers prompt assembly mid-run). Without this
+# lock two threads race on the same directory -- one ``rmtree``s it while the
+# other is ``mkdir``-ing/writing into it -- which on macOS surfaces as
+# ``OSError: [Errno 22] Invalid argument``.
+_PLUGIN_SKILLS_LOCK = threading.Lock()
 
 
 @dataclass
@@ -181,29 +192,30 @@ def _iter_plugin_skill_registrations() -> Iterable[tuple[str, str, dict[str, Any
 
 
 def _collect_plugin_skills() -> List[SkillInfo]:
-    if _PLUGIN_SKILLS_CACHE_DIR.exists():
-        shutil.rmtree(_PLUGIN_SKILLS_CACHE_DIR, ignore_errors=True)
-    _PLUGIN_SKILLS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    with _PLUGIN_SKILLS_LOCK:
+        if _PLUGIN_SKILLS_CACHE_DIR.exists():
+            shutil.rmtree(_PLUGIN_SKILLS_CACHE_DIR, ignore_errors=True)
+        _PLUGIN_SKILLS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
-    plugin_skills: List[SkillInfo] = []
-    seen_names: set[str] = set()
+        plugin_skills: List[SkillInfo] = []
+        seen_names: set[str] = set()
 
-    for callback_module, callback_name, entry in _iter_plugin_skill_registrations():
-        skill = _materialize_plugin_skill(callback_module, callback_name, entry)
-        if skill is None:
-            continue
-        if skill.name in seen_names:
-            logger.warning(
-                "Skipping duplicate plugin skill registration for '%s' from %s.%s",
-                skill.name,
-                callback_module,
-                callback_name,
-            )
-            continue
-        seen_names.add(skill.name)
-        plugin_skills.append(skill)
+        for callback_module, callback_name, entry in _iter_plugin_skill_registrations():
+            skill = _materialize_plugin_skill(callback_module, callback_name, entry)
+            if skill is None:
+                continue
+            if skill.name in seen_names:
+                logger.warning(
+                    "Skipping duplicate plugin skill registration for '%s' from %s.%s",
+                    skill.name,
+                    callback_module,
+                    callback_name,
+                )
+                continue
+            seen_names.add(skill.name)
+            plugin_skills.append(skill)
 
-    return plugin_skills
+        return plugin_skills
 
 
 def discover_skills(directories: Optional[List[Path]] = None) -> List[SkillInfo]:

--- a/tests/plugins/test_agent_skills.py
+++ b/tests/plugins/test_agent_skills.py
@@ -145,9 +145,18 @@ class TestSkillDiscovery:
 
     def setup_method(self):
         clear_callbacks("register_skills")
+        self._reset_plugin_skills_cache()
 
     def teardown_method(self):
         clear_callbacks("register_skills")
+        self._reset_plugin_skills_cache()
+
+    @staticmethod
+    def _reset_plugin_skills_cache():
+        from code_puppy.plugins.agent_skills import discovery as discovery_module
+
+        discovery_module._plugin_skills_cache = None
+        discovery_module._plugin_skills_signature = None
 
     def test_get_default_skill_directories(self):
         """Test default skill directories are correctly returned."""
@@ -450,6 +459,75 @@ class TestSkillDiscovery:
         assert not errors, "concurrent discovery raced: " + repr(errors[:3])
         # Every completed call must see the full, consistent set of plugin skills.
         assert counts and all(c == 8 for c in counts), sorted(set(counts))
+
+    @pytest.mark.plugin_skills
+    def test_plugin_skill_files_readable_during_concurrent_discovery(
+        self, tmp_path, monkeypatch
+    ):
+        """Lock-free readers of ``SkillInfo.path`` must not race the rebuild.
+
+        Consumers read the materialised ``SKILL.md`` files *after*
+        ``_collect_plugin_skills`` releases the lock (e.g. ``parse_skill_metadata``
+        on the prompt path, ``load_full_skill_content`` in the /skills command).
+        If discovery wiped-and-rebuilt the shared dir on every call, a concurrent
+        rebuild could ``rmtree`` a SKILL.md out from under a reader mid-read.
+        Because the registrations are unchanged here, discovery must reuse the
+        cache and leave the files in place, so every read succeeds.
+        """
+        import threading
+
+        from code_puppy.plugins.agent_skills import discovery as discovery_module
+
+        monkeypatch.setattr(
+            discovery_module, "_PLUGIN_SKILLS_CACHE_DIR", tmp_path / "plugin-cache"
+        )
+
+        register_callback(
+            "register_skills",
+            lambda: [
+                {"name": "reader-skill-" + str(i), "skill_md": "# body " + str(i)}
+                for i in range(6)
+            ],
+        )
+
+        # Prime the cache so readers have real paths to consume.
+        primed = [s for s in discover_skills(directories=[]) if s.has_skill_md]
+        assert len(primed) == 6
+
+        errors: list[BaseException] = []
+        stop = threading.Event()
+        barrier = threading.Barrier(2)
+
+        def rebuilder():
+            barrier.wait()
+            while not stop.is_set():
+                try:
+                    discover_skills(directories=[])
+                except BaseException as exc:  # noqa: BLE001
+                    errors.append(exc)
+                    return
+
+        def reader():
+            barrier.wait()
+            for _ in range(200):
+                for skill in primed:
+                    try:
+                        skill_md = skill.path / "SKILL.md"
+                        # The file must exist and be readable throughout.
+                        assert skill_md.read_text().startswith("# body")
+                    except BaseException as exc:  # noqa: BLE001 - capture the race
+                        errors.append(exc)
+                        return
+
+        t_read = threading.Thread(target=reader)
+        t_build = threading.Thread(target=rebuilder)
+        t_read.start()
+        t_build.start()
+        t_read.join()
+        stop.set()
+        t_build.join()
+
+        assert not errors, "reader raced the rebuild: " + repr(errors[:3])
 
     def test_discover_skills_caching(self, tmp_path, monkeypatch):
         """Test that skill discovery uses caching correctly."""

--- a/tests/plugins/test_agent_skills.py
+++ b/tests/plugins/test_agent_skills.py
@@ -389,6 +389,68 @@ class TestSkillDiscovery:
         assert "fresh-skill" in str(fresh_skill_files[0])
         assert fresh_skill_files[0].read_text() == "# fresh"
 
+    @pytest.mark.plugin_skills
+    def test_collect_plugin_skills_is_thread_safe(self, tmp_path, monkeypatch):
+        """Concurrent discovery must not race on the shared plugin-skills cache.
+
+        ``discover_skills`` runs on the main loop (prompt assembly) AND on worker
+        threads (pydantic-ai runs the sync ``list_or_search_skills`` tool via
+        ``anyio.to_thread``; a /steer re-triggers prompt assembly mid-run). The
+        old unsynchronised ``rmtree``+rebuild let one thread wipe the cache dir
+        while another was writing into it -> ``OSError: [Errno 22]`` on macOS.
+        Widen the materialize window with a sleep and hammer it from many
+        threads; the lock must keep every call crash-free and complete.
+        """
+        import threading
+
+        from code_puppy.plugins.agent_skills import discovery as discovery_module
+
+        monkeypatch.setattr(
+            discovery_module, "_PLUGIN_SKILLS_CACHE_DIR", tmp_path / "plugin-cache"
+        )
+
+        register_callback(
+            "register_skills",
+            lambda: [
+                {"name": "race-skill-" + str(i), "skill_md": "# race " + str(i)}
+                for i in range(8)
+            ],
+        )
+
+        # The Errno 22 crash is a true concurrent-syscall collision: one thread's
+        # top-level ``rmtree`` physically overlapping another thread's per-skill
+        # ``mkdir``/``write``. Reproduce it with sustained churn -- many threads
+        # each looping the full wipe-and-rebuild -- rather than a paused thread
+        # (a pause can't overlap two live syscalls). The lock must make every
+        # iteration crash-free and complete.
+        errors: list[BaseException] = []
+        counts: list[int] = []
+        n_threads = 12
+        n_iters = 40
+        barrier = threading.Barrier(n_threads)
+
+        def worker():
+            barrier.wait()  # start all threads together for maximum overlap
+            for _ in range(n_iters):
+                try:
+                    skills = discover_skills(directories=[])
+                    counts.append(
+                        sum(1 for s in skills if s.name.startswith("race-skill-"))
+                    )
+                except BaseException as exc:  # noqa: BLE001 - capture the race crash
+                    errors.append(exc)
+                    return
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, "concurrent discovery raced: " + repr(errors[:3])
+        # Every completed call must see the full, consistent set of plugin skills.
+        assert counts and all(c == 8 for c in counts), sorted(set(counts))
+
     def test_discover_skills_caching(self, tmp_path, monkeypatch):
         """Test that skill discovery uses caching correctly."""
         # First discovery


### PR DESCRIPTION
# Fix concurrent plugin-skills cache crash (`OSError: [Errno 22]`)

## What
`_collect_plugin_skills()` wiped (`shutil.rmtree`) and rebuilt the shared
`plugin-skills` cache directory on **every** call with no synchronization.
This PR serializes the rebuild behind a lock **and** memoizes the result so the
wipe-and-rebuild only happens when the registered skill set actually changes.

## Why
`discover_skills()` runs from **two concurrent contexts**:

- the **main loop** — prompt assembly, statusline, the `/skills` menu
- **worker threads** — pydantic-ai runs the sync `list_or_search_skills` tool via
  `anyio.to_thread`, and a `/steer` re-triggers prompt assembly mid-run

Two threads then collided on one directory — one `rmtree`'d it while the other
was `mkdir`-ing/writing into it — surfacing on macOS as
`OSError: [Errno 22] Invalid argument` (with companion `FileExistsError` /
`FileNotFoundError` races). A second, subtler window: consumers read
`SkillInfo.path` files (`parse_skill_metadata` on the prompt path,
`load_full_skill_content` in the `/skills` command) **after** the lock is
released, so a concurrent rebuild could `rmtree` a `SKILL.md` out from under a
lock-free reader mid-read.

## How
- Guard the wipe-and-rebuild with a module-level `threading.Lock` (serializes
  producers).
- Memoize the materialized result keyed by a deterministic **signature of the
  plugin registrations**. Registrations are deterministic within a process, so
  the cache dir is rebuilt only on first build or an actual registration change;
  unchanged calls reuse the cache and never `rmtree`. This closes the
  producer↔reader window too — the shared dir is no longer torn down under live
  readers — and is more efficient (no per-call rebuild).
- First-call safety preserved: a leftover on-disk cache from a prior process is
  still wiped (cache starts `None`); a partial/exception build never sets the
  cache, so the next call rebuilds.

## Testing
- **New regression test** (`test_collect_plugin_skills_is_thread_safe`): 12
  threads × 40 iterations of full discovery. Without the fix it deterministically
  reproduces the reported `OSError: [Errno 22] Invalid argument` (plus
  `FileExistsError` / `FileNotFoundError`); with the fix it passes.
- **New reader-race test** (`test_plugin_skill_files_readable_during_concurrent_discovery`):
  readers consume `SKILL.md` paths while another thread hammers
  `discover_skills()`; files stay readable throughout.
- Full `agent_skills` + merged messaging/panel suites: **246 passed**, `ruff
  check`/`ruff format` clean.
- **Live smoke test**: launched the OSS build (isolated sandbox, Codex model),
  ran a 3-sub-agent parallel swarm while firing 5 `/steer` messages, ×3 runs —
  zero crashes, no `errors.log` written.

## Scope
Two files: `code_puppy/plugins/agent_skills/discovery.py` and
`tests/plugins/test_agent_skills.py`. No dependency or API changes.
