### PR TITLE
fix(cli): harden headless session autosaves

### DIFF
--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -1377,23 +1377,13 @@ async def execute_single_prompt(
     *,
     session_name: str | None = None,
 ) -> None:
-    """Execute a single prompt and exit (for -p flag).
+    """Execute one headless ``-p`` prompt, dispatching commands and autosaving.
 
-    When ``session_name`` is supplied (i.e. the user passed ``-r NAME``),
-    history is persisted back to that named session in a ``finally`` block
-    so partial state still lands on cancel / error paths. The runtime
-    prunes interrupted tool calls before returning so the saved history is
-    coherent (see ``agents/_runtime.py`` -- the two ``_message_history``
-    commit/prune sites around lines 446 and 498).
-
-    Edge case worth knowing: when the agent returns ``(None, None)`` for an
-    empty-prompt scenario, the response emit is skipped but the ``finally``
-    still fires, producing a no-op idempotent rewrite of an existing
-    session (and a phantom ``post_autosave`` event for plugin authors who
-    count saves). Acceptable trade-off versus the complexity of a
-    'something-actually-ran' tracking flag.
+    Agent turns persist under the explicitly resumed session, when supplied,
+    or under this process's generated autosave session otherwise. Handled
+    slash commands and shell pass-through do not create or overwrite sessions
+    because they never invoke the agent.
     """
-    # Shell pass-through: !<cmd> bypasses the agent even in -p mode
     from code_puppy.command_line.shell_passthrough import (
         execute_shell_passthrough,
         is_shell_passthrough,
@@ -1401,12 +1391,10 @@ async def execute_single_prompt(
 
     if is_shell_passthrough(prompt):
         execute_shell_passthrough(prompt)
-        # Agent never ran — do NOT touch the named session, otherwise
-        # `-r mywork -p '!ls'` would clobber existing history with an empty
-        # save-back. Return before the try/finally so the save path is
-        # genuinely unreachable, not just guarded.
         return
 
+    from code_puppy.command_line.command_handler import handle_command
+    from code_puppy.config import AUTOSAVE_DIR, get_current_session_name
     from code_puppy.messaging import (
         emit_error,
         emit_info,
@@ -1414,18 +1402,34 @@ async def execute_single_prompt(
         get_message_bus,
     )
     from code_puppy.messaging.messages import AgentResponseMessage
-
-    # Hoist save-back imports here rather than into the ``finally`` block --
-    # if the user passed ``-r`` we will exercise these on every code path,
-    # and lazy-importing inside ``finally`` just hides the dependency without
-    # buying any actual startup savings (the module is already loaded).
-    from code_puppy.config import AUTOSAVE_DIR
     from code_puppy.session_lifecycle import persist_named_session
 
+    # Match interactive mode: detect commands after stripping prompt
+    # attachments, let handled commands finish without an agent run, and
+    # allow command-provided replacement text to reach the agent.
+    command_prompt = (parse_prompt_attachments(prompt).prompt or "").strip()
+    if command_prompt.startswith("/"):
+        try:
+            command_result = handle_command(command_prompt)
+        except Exception as command_error:
+            emit_error(f"Command error: {command_error}")
+            return
+
+        if command_result is True:
+            return
+        if command_result == "__AUTOSAVE_LOAD__":
+            emit_warning(
+                "/autosave_load requires interactive mode; use -r SESSION in headless mode."
+            )
+            return
+        if isinstance(command_result, str):
+            prompt = command_result
+
+    effective_session_name = session_name or get_current_session_name()
+    agent = None
     emit_info(f"Executing prompt: {prompt}")
 
     try:
-        # Get agent through runtime manager and use helper for attachments
         agent = get_current_agent()
         # Headless -p mode: no run UI (no bottom bar, no line editor) —
         # output must stay plain for pipes/CI even when stdout is a TTY.
@@ -1435,47 +1439,35 @@ async def execute_single_prompt(
             display_console=message_renderer.console,
             use_run_ui=False,
         )
-        if result is not None:
-            response_msg = AgentResponseMessage(
-                content=result.output,
-                is_markdown=True,
-            )
-            get_message_bus().emit(response_msg)
+        if result is None:
+            return
 
-            # Commit the completed turn (user prompt + assistant response)
-            # into the agent's history BEFORE the finally-block save-back.
-            # Without this, headless -r save-back persists only user prompts
-            # (the normal _do_run path never writes result.all_messages()
-            # back to agent._message_history), so resumed sessions feed the
-            # model a pile of unanswered prompts and it re-answers them all.
-            # Mirrors interactive_mode's post-run set_message_history call.
-            if hasattr(result, "all_messages"):
-                agent.set_message_history(list(result.all_messages()))
+        get_message_bus().emit(
+            AgentResponseMessage(content=result.output, is_markdown=True)
+        )
+
+        # The runtime result includes the final assistant response that the
+        # incremental history can otherwise miss.
+        if hasattr(result, "all_messages"):
+            agent.set_message_history(list(result.all_messages()))
 
     except asyncio.CancelledError:
         emit_warning("Execution cancelled by user")
-    except Exception as e:
-        emit_error(f"Error executing prompt: {str(e)}")
+    except Exception as error:
+        emit_error(f"Error executing prompt: {error}")
     finally:
-        if session_name:
-            try:
-                persist_named_session(
-                    get_current_agent(),
-                    session_name,
-                    base_dir=Path(AUTOSAVE_DIR),
-                    # Headless -r save-back is automated (user passed a
-                    # flag and walked away) rather than an explicit
-                    # /dump_context-style intent, so it carries the same
-                    # auto_saved=True bit as autosave proper. Plugins
-                    # that filter on `metadata.auto_saved` get the right
-                    # signal.
-                    auto_saved=True,
-                )
-            except Exception as save_exc:
-                # The user's primary deliverable (the agent response) has
-                # already been emitted. Report the save failure but do not
-                # re-raise -- a save bug shouldn't mask a successful turn.
-                emit_error(f"Failed to save session {session_name}: {save_exc}")
+        try:
+            session_agent = agent or get_current_agent()
+            persist_named_session(
+                session_agent,
+                effective_session_name,
+                base_dir=Path(AUTOSAVE_DIR),
+                auto_saved=True,
+            )
+        except Exception as save_error:
+            # The response has already been emitted; a persistence failure
+            # must not hide the primary result.
+            emit_error(f"Failed to save session {effective_session_name}: {save_error}")
 
 
 def _force_utf8_stdio():

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -1394,7 +1394,11 @@ async def execute_single_prompt(
         return
 
     from code_puppy.command_line.command_handler import handle_command
-    from code_puppy.config import AUTOSAVE_DIR, get_current_session_name
+    from code_puppy.config import (
+        AUTOSAVE_DIR,
+        get_current_session_name,
+        record_quick_resume_sessions,
+    )
     from code_puppy.messaging import (
         emit_error,
         emit_info,
@@ -1464,6 +1468,11 @@ async def execute_single_prompt(
                 base_dir=Path(AUTOSAVE_DIR),
                 auto_saved=True,
             )
+            # Point quick-resume at the just-saved session so both
+            # auto-generated and ``-r NAME`` headless saves are discoverable
+            # by ``--quick-resume``.  Only written on success; any exception
+            # from persist_named_session above skips this block entirely.
+            record_quick_resume_sessions(effective_session_name)
         except Exception as save_error:
             # The response has already been emitted; a persistence failure
             # must not hide the primary result.

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -1953,10 +1953,13 @@ def reset_all_banner_colors():
 def get_current_session_name() -> str:
     """Return the full filename of the session this process is writing to.
 
-    On first call, lazily mints a fresh auto-flavored name
-    (``auto_session_<YYYYMMDD>_<HHMMSS>``). Subsequent calls return the
-    same string until ``rotate_session_name`` or ``pin_current_session_name``
-    is called.
+    On first call, lazily mints a fresh auto-flavored name of the form
+    ``auto_session_<YYYYMMDD>_<HHMMSS>_<ffffff>_<PID>`` where ``ffffff`` is
+    the microsecond field of the current timestamp and ``PID`` is the calling
+    process ID.  The combined suffix eliminates same-second cross-process
+    name collisions when multiple Code Puppy instances start concurrently.
+    Subsequent calls return the same string until ``rotate_session_name`` or
+    ``pin_current_session_name`` is called.
 
     The ``auto_session_`` prefix is RESERVED for system-generated names;
     user-input names cannot start with it (enforced by
@@ -1968,8 +1971,9 @@ def get_current_session_name() -> str:
     """
     global _CURRENT_AUTOSAVE_ID
     if not _CURRENT_AUTOSAVE_ID:
+        now = datetime.datetime.now()
         _CURRENT_AUTOSAVE_ID = (
-            f"auto_session_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}"
+            f"auto_session_{now.strftime('%Y%m%d_%H%M%S_%f')}_{os.getpid()}"
         )
     return _CURRENT_AUTOSAVE_ID
 

--- a/tests/test_cli_runner.py
+++ b/tests/test_cli_runner.py
@@ -422,7 +422,8 @@ class TestHeadlessSessionPersistence:
     and ``session_lifecycle.persist_named_session`` -- specifically that the
     save happens in a ``finally`` block (so cancel/error paths still persist),
     that shell-passthrough never clobbers a named session, and that the
-    no-``-r`` default stays disk-silent.
+    no-``-r`` default autosaves under the process's generated session name
+    rather than being disk-silent.
     """
 
     @staticmethod
@@ -457,6 +458,7 @@ class TestHeadlessSessionPersistence:
             patch(
                 "code_puppy.session_lifecycle.fire_post_autosave_callback"
             ) as fire_cb,
+            patch("code_puppy.config.record_quick_resume_sessions") as mock_qr,
         ):
             await execute_single_prompt(
                 "hi",
@@ -471,6 +473,48 @@ class TestHeadlessSessionPersistence:
         # plugins that decorate the auto-save line (e.g. the walmart
         # token-quota plugin) don't double-print.
         assert fire_cb.call_count == 0
+        # quick-resume pointer must be written after a successful persist so
+        # ``--quick-resume`` can rediscover both auto-generated and ``-r``
+        # headless saves.
+        mock_qr.assert_called_once_with("mywork")
+
+    @pytest.mark.asyncio
+    async def test_quick_resume_pointer_not_written_on_persist_failure(self, tmp_path):
+        """record_quick_resume_sessions is NOT called when persist_named_session fails.
+
+        The quick-resume pointer must only be updated when persistence
+        actually succeeds.  A filesystem error, pickle failure, or any other
+        exception from ``persist_named_session`` must leave the pointer
+        untouched so ``--quick-resume`` does not point at a missing/corrupt
+        session file.
+        """
+        from code_puppy.cli_runner import execute_single_prompt
+
+        agent = self._agent_with_history([{"role": "user", "content": "hi"}])
+        run_result = MagicMock()
+        run_result.output = "ok"
+
+        with (
+            patch("code_puppy.cli_runner.get_current_agent", return_value=agent),
+            patch(
+                "code_puppy.cli_runner.run_prompt_with_attachments",
+                new=AsyncMock(return_value=(run_result, MagicMock())),
+            ),
+            patch("code_puppy.config.AUTOSAVE_DIR", str(tmp_path)),
+            patch(
+                "code_puppy.session_lifecycle.persist_named_session",
+                side_effect=OSError("disk full"),
+            ),
+            patch("code_puppy.config.record_quick_resume_sessions") as mock_qr,
+        ):
+            # Should not raise; error is swallowed and emitted as a message.
+            await execute_single_prompt(
+                "hi",
+                self._renderer(),
+                session_name="mywork",
+            )
+
+        mock_qr.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_save_back_on_cancelled_error(self, tmp_path):
@@ -516,10 +560,20 @@ class TestHeadlessSessionPersistence:
         assert (tmp_path / "mywork.pkl").exists()
 
     @pytest.mark.asyncio
-    async def test_no_save_when_session_name_is_none(self, tmp_path):
-        """Default headless -p must remain disk-silent (no -r passed)."""
+    async def test_default_autosave_uses_generated_session_name(self, tmp_path):
+        """Without -r, headless -p autosaves under the process's generated session name.
+
+        ``execute_single_prompt(..., session_name=None)`` resolves the
+        effective name via ``get_current_session_name()`` and forwards it
+        to ``persist_named_session`` exactly once with the generated name and
+        the configured AUTOSAVE_DIR -- so a clean process always persists its
+        history rather than being disk-silent.
+        """
+        from pathlib import Path
+
         from code_puppy.cli_runner import execute_single_prompt
 
+        generated_name = "auto_session_20250101_000000"
         agent = self._agent_with_history([{"role": "user", "content": "ephemeral"}])
         run_result = MagicMock()
         run_result.output = "ok"
@@ -531,13 +585,20 @@ class TestHeadlessSessionPersistence:
                 new=AsyncMock(return_value=(run_result, MagicMock())),
             ),
             patch("code_puppy.config.AUTOSAVE_DIR", str(tmp_path)),
+            patch(
+                "code_puppy.config.get_current_session_name",
+                return_value=generated_name,
+            ),
             patch("code_puppy.session_lifecycle.persist_named_session") as mock_persist,
         ):
             await execute_single_prompt("hi", self._renderer(), session_name=None)
 
-        mock_persist.assert_not_called()
-        # And nothing landed on disk under the (empty) contexts dir.
-        assert list(tmp_path.iterdir()) == []
+        mock_persist.assert_called_once_with(
+            agent,
+            generated_name,
+            base_dir=Path(str(tmp_path)),
+            auto_saved=True,
+        )
 
     @pytest.mark.asyncio
     async def test_shell_passthrough_does_not_clobber_session(self, tmp_path):

--- a/tests/test_cli_runner_coverage.py
+++ b/tests/test_cli_runner_coverage.py
@@ -221,6 +221,231 @@ class TestExecuteSinglePrompt:
             await execute_single_prompt("hello", mock_renderer)
 
 
+class TestExecuteSinglePromptRegression:
+    """Focused regression tests for the freshly-updated execute_single_prompt.
+
+    Four cases:
+      1. Handled slash command → handle_command called, no agent run, no persist.
+      2. Slash command returning replacement → replacement forwarded to agent.
+      3. Ordinary headless turn → persist_named_session called with AUTOSAVE_DIR
+         and full result.all_messages() history; both auto and explicit session.
+      4. Shell ! pass-through → execute_shell_passthrough called, no persist.
+    """
+
+    def _renderer(self):
+        r = MagicMock()
+        r.console = MagicMock()
+        return r
+
+    def _parsed(self, text):
+        """Stub for parse_prompt_attachments result."""
+        m = MagicMock()
+        m.prompt = text
+        return m
+
+    @pytest.mark.anyio
+    async def test_slash_handled_skips_run_and_persist(self):
+        """Case 1: handle_command returns True → no agent run, no session persist."""
+        from code_puppy.cli_runner import execute_single_prompt
+
+        with (
+            patch(
+                "code_puppy.command_line.shell_passthrough.is_shell_passthrough",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.cli_runner.parse_prompt_attachments",
+                return_value=self._parsed("/help"),
+            ),
+            patch(
+                "code_puppy.command_line.command_handler.handle_command",
+                return_value=True,
+            ) as mock_handle,
+            patch(
+                "code_puppy.cli_runner.run_prompt_with_attachments",
+                new_callable=AsyncMock,
+            ) as mock_run,
+            patch("code_puppy.session_lifecycle.persist_named_session") as mock_persist,
+            patch("code_puppy.messaging.emit_info"),
+            patch("code_puppy.messaging.emit_error"),
+            patch("code_puppy.messaging.emit_warning"),
+            patch("code_puppy.messaging.get_message_bus", return_value=MagicMock()),
+        ):
+            await execute_single_prompt("/help", self._renderer())
+
+        mock_handle.assert_called_once_with("/help")
+        mock_run.assert_not_called()
+        mock_persist.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_slash_replacement_prompt_forwarded_to_agent(self):
+        """Case 2: handle_command returning a string sends that string to agent."""
+        from code_puppy.cli_runner import execute_single_prompt
+
+        replacement = "refactor all dead code"
+        mock_result = MagicMock()
+        mock_result.output = "done"
+        mock_result.all_messages.return_value = []
+        mock_agent = MagicMock()
+        mock_agent.set_message_history = MagicMock()
+
+        with (
+            patch(
+                "code_puppy.command_line.shell_passthrough.is_shell_passthrough",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.cli_runner.parse_prompt_attachments",
+                return_value=self._parsed("/do-stuff"),
+            ),
+            patch(
+                "code_puppy.command_line.command_handler.handle_command",
+                return_value=replacement,
+            ),
+            patch("code_puppy.cli_runner.get_current_agent", return_value=mock_agent),
+            patch(
+                "code_puppy.cli_runner.run_prompt_with_attachments",
+                new_callable=AsyncMock,
+                return_value=(mock_result, MagicMock()),
+            ) as mock_run,
+            patch("code_puppy.session_lifecycle.persist_named_session"),
+            patch(
+                "code_puppy.config.get_current_session_name",
+                return_value="auto_session_test",
+            ),
+            patch("code_puppy.messaging.emit_info"),
+            patch("code_puppy.messaging.emit_error"),
+            patch("code_puppy.messaging.emit_warning"),
+            patch("code_puppy.messaging.get_message_bus", return_value=MagicMock()),
+            patch("code_puppy.messaging.messages.AgentResponseMessage", MagicMock()),
+        ):
+            await execute_single_prompt("/do-stuff", self._renderer())
+
+        mock_run.assert_called_once()
+        # Second positional arg to run_prompt_with_attachments is the prompt.
+        assert mock_run.call_args[0][1] == replacement
+        # Headless mode must always pass use_run_ui=False.
+        assert mock_run.call_args[1].get("use_run_ui") is False
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "explicit_session",
+        [None, "headless-explicit"],
+        ids=["default-session", "explicit-session"],
+    )
+    async def test_ordinary_turn_persists_to_disk(self, tmp_path, explicit_session):
+        """Case 3: real persist_named_session + load_session prove history reloadable.
+
+        Covers both sub-cases:
+        - default-session: session_name=None uses get_current_session_name().
+        - explicit-session: session_name provided; get_current_session_name never called.
+
+        Uses a temp AUTOSAVE_DIR so the real I/O path runs end-to-end and the
+        completed result.all_messages() history is verifiable after a roundtrip.
+        External messaging is mocked; persist_named_session and load_session are real.
+        """
+        from code_puppy.cli_runner import execute_single_prompt
+        from code_puppy.session_storage import load_session
+
+        autosaves_dir = tmp_path / "autosaves"
+        auto_session = "auto_session_20240101_120000"
+
+        # Plain strings are picklable — survive persist/load roundtrip faithfully.
+        fake_msgs = ["user: write some code", "assistant: here is the code"]
+
+        # Wire the mock agent so set_message_history feeds get_message_history,
+        # giving the real persist_named_session genuine data to pickle.
+        history_store: list = []
+
+        def _set(msgs):
+            history_store.clear()
+            history_store.extend(msgs)
+
+        mock_agent = MagicMock()
+        mock_agent.set_message_history.side_effect = _set
+        mock_agent.get_message_history.side_effect = lambda: list(history_store)
+        mock_agent.estimate_tokens_for_message.return_value = 0
+
+        mock_result = MagicMock()
+        mock_result.output = "here is the code"
+        mock_result.all_messages.return_value = fake_msgs
+
+        with (
+            patch(
+                "code_puppy.command_line.shell_passthrough.is_shell_passthrough",
+                return_value=False,
+            ),
+            patch(
+                "code_puppy.cli_runner.parse_prompt_attachments",
+                return_value=self._parsed("write some code"),
+            ),
+            patch("code_puppy.cli_runner.get_current_agent", return_value=mock_agent),
+            patch(
+                "code_puppy.cli_runner.run_prompt_with_attachments",
+                new_callable=AsyncMock,
+                return_value=(mock_result, MagicMock()),
+            ),
+            # Redirect AUTOSAVE_DIR to our temp tree so real I/O stays isolated.
+            patch("code_puppy.config.AUTOSAVE_DIR", str(autosaves_dir)),
+            patch(
+                "code_puppy.config.get_current_session_name",
+                return_value=auto_session,
+            ) as mock_gcsn,
+            patch("code_puppy.messaging.emit_info"),
+            patch("code_puppy.messaging.emit_error"),
+            patch("code_puppy.messaging.emit_warning"),
+            patch("code_puppy.messaging.get_message_bus", return_value=MagicMock()),
+            patch("code_puppy.messaging.messages.AgentResponseMessage", MagicMock()),
+        ):
+            await execute_single_prompt(
+                "write some code", self._renderer(), session_name=explicit_session
+            )
+
+        # ── session-name routing assertions ──────────────────────────────────
+        expected_session = explicit_session or auto_session
+        if explicit_session is None:
+            # Default path: auto-generated name must be fetched.
+            mock_gcsn.assert_called_once()
+        else:
+            # Explicit name short-circuits get_current_session_name entirely.
+            mock_gcsn.assert_not_called()
+
+        # ── agent history populated before persist ────────────────────────────
+        mock_agent.set_message_history.assert_called_once_with(fake_msgs)
+
+        # ── real disk roundtrip: load_session must reproduce the full history ─
+        loaded = load_session(expected_session, autosaves_dir)
+        assert loaded == fake_msgs, (
+            f"Disk roundtrip mismatch for session {expected_session!r}: {loaded!r}"
+        )
+
+    @pytest.mark.anyio
+    async def test_shell_passthrough_skips_agent_and_persist(self):
+        """Case 4: ! prefix routes to execute_shell_passthrough; nothing else fires."""
+        from code_puppy.cli_runner import execute_single_prompt
+
+        with (
+            patch(
+                "code_puppy.command_line.shell_passthrough.is_shell_passthrough",
+                return_value=True,
+            ) as mock_is_shell,
+            patch(
+                "code_puppy.command_line.shell_passthrough.execute_shell_passthrough"
+            ) as mock_exec_shell,
+            patch(
+                "code_puppy.cli_runner.run_prompt_with_attachments",
+                new_callable=AsyncMock,
+            ) as mock_run,
+            patch("code_puppy.session_lifecycle.persist_named_session") as mock_persist,
+        ):
+            await execute_single_prompt("!ls -la", self._renderer())
+
+        mock_is_shell.assert_called_once_with("!ls -la")
+        mock_exec_shell.assert_called_once_with("!ls -la")
+        mock_run.assert_not_called()
+        mock_persist.assert_not_called()
+
+
 class TestMainEntry:
     @patch("asyncio.run")
     def test_normal_exit(self, mock_run):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1005,6 +1005,43 @@ class TestSessionSingletonAndAliases:
             warnings.simplefilter("ignore", DeprecationWarning)
             assert cp_config.get_current_autosave_id() == "mywork"
 
+    def test_distinct_pids_generate_distinct_names(self):
+        """Same wall-clock timestamp but different PIDs produce distinct names.
+
+        Regression guard for the cross-process autosave collision fix: two
+        processes that happen to call ``get_current_session_name()`` within
+        the same second must never mint the same filename.  Microseconds alone
+        are not sufficient when the OS schedules two processes in the same
+        microsecond (unlikely but possible), so the PID is appended as a
+        second disambiguator.
+        """
+        import datetime as dt
+        from unittest.mock import patch
+
+        fixed_dt = dt.datetime(2026, 1, 1, 12, 0, 0, 123456)
+
+        self._reset_singleton()
+        with (
+            patch("code_puppy.config.datetime") as mock_dt_mod,
+            patch("code_puppy.config.os.getpid", return_value=1111),
+        ):
+            mock_dt_mod.datetime.now.return_value = fixed_dt
+            name_pid1 = cp_config.get_current_session_name()
+
+        self._reset_singleton()
+        with (
+            patch("code_puppy.config.datetime") as mock_dt_mod,
+            patch("code_puppy.config.os.getpid", return_value=2222),
+        ):
+            mock_dt_mod.datetime.now.return_value = fixed_dt
+            name_pid2 = cp_config.get_current_session_name()
+
+        assert name_pid1 != name_pid2
+        assert name_pid1.startswith("auto_session_")
+        assert name_pid2.startswith("auto_session_")
+        assert name_pid1.endswith("_1111")
+        assert name_pid2.endswith("_2222")
+
 
 class TestStoredNameValidator:
     """``_is_valid_autosave_session_name`` is now a stored-name validator.


### PR DESCRIPTION
## What
Fix headless `code-puppy -p` session persistence and slash-command dispatch.

## Why
Plain headless prompts previously skipped session persistence unless `-r` was supplied, so their history could not be recovered through `/resume`. They also bypassed the interactive command dispatcher, sending inputs such as `/clone ...` to the model as literal prompt text.

## How
- Dispatch leading slash commands through the existing command handler before the headless agent run.
- Persist completed agent history for both named `-r` sessions and generated default sessions.
- Preserve shell pass-through behavior: it does not invoke the model or write session state.
- Use microsecond + PID auto-session suffixes to prevent concurrent headless runs from colliding.
- Update the established quick-resume pointer only after a successful session write.
- Add/update regression coverage for default persistence, named save-back, command dispatch, quick-resume wiring, persistence failures, and generated-name uniqueness.

## Testing
- `uv run --frozen ruff check ...` — passed
- `uv run --frozen ruff format --check ...` — passed
- Focused CLI/config/quick-resume pytest suite — **169 passed**
- Snyk Code: no High findings; advisory findings match `main`.
- Snyk Open Source: dependency manifest and lockfile are byte-identical to `main`; inherited findings only.

## Scope
Only headless CLI session/command behavior and its regression tests. No dependency changes.
