### PR TITLE
fix(i18n): stop routing Latin American Spanish through removed es-419

### DIFF
--- a/code_puppy/i18n/locale.py
+++ b/code_puppy/i18n/locale.py
@@ -28,40 +28,17 @@ _POSIX_LOCALE_VARS = ("LC_ALL", "LC_MESSAGES", "LANG", "LANGUAGE")
 _LOCALE_RE = re.compile(r"^[A-Za-z]{2,3}(?:[_-][A-Za-z0-9]+)*")
 
 # CLDR parent-locale overrides: locales whose fallback parent is NOT simply
-# their truncated form. The big one for us is Latin American Spanish, where
-# every Central/South American country falls back through the ``es-419``
-# umbrella before reaching generic (Iberian-ish) ``es``.
+# their truncated form (see :func:`fallback_chain`). Source: CLDR
+# supplementalData <parentLocales>. Kept as an explicit, testable map so a
+# plugin / the private fork can register a non-truncation parent in one line.
 #
-# Source: CLDR supplementalData <parentLocales>. Kept as an explicit map so
-# adding a dialect is a one-line change and the behavior is testable.
-_LATIN_AMERICAN_ES = (
-    # Central America (+ Mexico)
-    "es-MX",
-    "es-GT",
-    "es-HN",
-    "es-SV",
-    "es-NI",
-    "es-CR",
-    "es-PA",
-    "es-BZ",
-    # South America
-    "es-AR",
-    "es-BO",
-    "es-CL",
-    "es-CO",
-    "es-EC",
-    "es-PY",
-    "es-PE",
-    "es-UY",
-    "es-VE",
-    # Caribbean + US Spanish (also parented to 419 by CLDR)
-    "es-CU",
-    "es-DO",
-    "es-PR",
-    "es-US",
-)
-PARENT_LOCALES: dict = {loc: "es-419" for loc in _LATIN_AMERICAN_ES}
-PARENT_LOCALES["es-419"] = "es"
+# Currently empty: the only override we shipped was the Latin American Spanish
+# ``es-419`` umbrella, which has been deprecated and folded into the base
+# ``es`` catalog. Every Central/South American dialect (``es-MX``, ``es-AR``,
+# ...) now truncates straight to ``es`` (``es-MX -> es -> en-US``), keeping its
+# own regional override file on top. To reintroduce a CLDR umbrella, add e.g.
+# ``PARENT_LOCALES["es-AR"] = "es-419"``.
+PARENT_LOCALES: dict = {}
 
 
 def normalize_locale(raw: Optional[str]) -> Optional[str]:
@@ -111,10 +88,12 @@ def language_of(locale: str) -> str:
 def fallback_chain(locale: str, default: str = DEFAULT_LOCALE) -> list[str]:
     """Build the lookup chain for a locale, most-specific first.
 
-    Honors CLDR parent-locale overrides (see :data:`PARENT_LOCALES`), so
-    Latin American Spanish resolves through the ``es-419`` umbrella::
+    Walks each locale to its parent, most-specific first. A tag's parent is
+    its truncated form (``es-MX -> es -> en-US``, ``zh-Hans-CN -> zh-Hans ->
+    zh -> en-US``) unless a CLDR override is registered in
+    :data:`PARENT_LOCALES`::
 
-        es-AR  -> ["es-AR", "es-419", "es", "en-US"]
+        es-MX  -> ["es-MX", "es", "en-US"]
         zh-Hans-CN -> ["zh-Hans-CN", "zh-Hans", "zh", "en-US"]
 
     The default locale is always appended last (deduplicated) so a missing

--- a/code_puppy/plugins/code_puppy_agent/SKILL.md
+++ b/code_puppy/plugins/code_puppy_agent/SKILL.md
@@ -530,11 +530,12 @@ emit_info(lazy("startup.ready"))                 # resolved at render time
 
 - JSON per locale: `i18n/locales/<locale>.json` (dotted-key → string, or a
   plural dict `{"one": ..., "other": ...}`).
-- Shipped: `en-US` (source), `es`, `es-419` (Latin American umbrella), `fr-CA`
+- Shipped: `en-US` (source), `es` (Latin American `es-419` folded in), `fr-CA`
   + `es-MX/AR/CO/CL` stubs.
-- **CLDR parent chain**: `es-AR → es-419 → es → en-US` (see
-  `i18n.locale.PARENT_LOCALES`). Plugins / the private fork can register extra
-  catalog dirs via `i18n.catalog.add_catalog_dir()`.
+- **Fallback chain**: plain BCP-47 truncation, `es-AR → es → en-US` (see
+  `i18n.locale.fallback_chain`). `i18n.locale.PARENT_LOCALES` is a currently-
+  empty CLDR override seam for non-truncation parents. Plugins / the private
+  fork can register extra catalog dirs via `i18n.catalog.add_catalog_dir()`.
 
 ### 12.3 How it wires in
 

--- a/docs/I18N.md
+++ b/docs/I18N.md
@@ -15,34 +15,41 @@ The first languages we translate to are:
 | Locale   | Catalog file              | Notes                                    |
 |----------|---------------------------|------------------------------------------|
 | `en-US`  | `locales/en-US.json`      | Source / default. Never missing a key.   |
-| `es`     | `locales/es.json`         | Generic (Iberian-leaning) Spanish base.  |
-| `es-419` | `locales/es-419.json`     | **Latin American Spanish umbrella** — the standard shared across Central & South America and the Caribbean. |
+| `es`     | `locales/es.json`         | Spanish base — the Latin American `es-419` copy has been folded in here. |
 | `fr-CA`  | `locales/fr-CA.json`      | Canadian French specifically.            |
+
+> **Note on `es-419`:** the Latin American Spanish umbrella tier has been
+> **deprecated**. Its strings were folded into the base `es.json`, so there is
+> no `locales/es-419.json` anymore and the resolver no longer probes for one.
+> Regional dialects override `es` directly (see below).
 
 ### Central & South American Spanish dialects
 
-Per CLDR *parent-locale* rules, every Central/South American country's Spanish
-falls back through the `es-419` umbrella **before** generic `es`:
+Every Central/South American country's Spanish falls back to the base `es`
+catalog, then `en-US`:
 
 ```
-es-AR -> es-419 -> es -> en-US     (Argentina, voseo)
-es-MX -> es-419 -> es -> en-US     (Mexico)
-es-CO -> es-419 -> es -> en-US     (Colombia)
+es-AR -> es -> en-US     (Argentina, voseo)
+es-MX -> es -> en-US     (Mexico)
+es-CO -> es -> en-US     (Colombia)
 ...
-es-ES -> es -> en-US               (Spain does NOT route through es-419)
+es-ES -> es -> en-US     (Spain, same plain-truncation chain)
 ```
 
-This is implemented via `PARENT_LOCALES` in `code_puppy/i18n/locale.py`. To
-add a specific country dialect (e.g. Argentine voseo), create
-`locales/es-AR.json` containing **only** the strings that differ from
-`es-419` — everything else is inherited automatically. Adding a new country
-to the umbrella is a one-line change to `PARENT_LOCALES`.
+This is plain BCP-47 truncation in `fallback_chain` (`code_puppy/i18n/locale.py`).
+To add a specific country dialect (e.g. Argentine voseo), create
+`locales/es-AR.json` containing **only** the strings that differ from `es` —
+everything else is inherited automatically.
+
+`PARENT_LOCALES` (in the same module) remains available as a CLDR override
+seam if a non-truncation parent is ever needed again (e.g. reintroducing an
+`es-419` umbrella), but it currently ships empty.
 
 #### Country dialect files shipped (stubs — pending native review)
 
 These four ship as **empty override files** today. They are wired into the
-fallback chain and fully inherit `es-419`; a native speaker fills in only the
-keys that genuinely differ. **Do not** copy the whole `es-419` catalog into
+fallback chain and fully inherit base `es`; a native speaker fills in only the
+keys that genuinely differ. **Do not** copy the whole `es` catalog into
 them — only add divergent strings.
 
 | Locale  | Country   | Notable divergence to watch for                 | Status            |
@@ -212,11 +219,10 @@ code_puppy/i18n/
 ├── pseudo.py        # pseudolocalization transform
 └── locales/
     ├── en-US.json   # source / default
-    ├── es.json      # Spanish (generic / Iberian base)
-    ├── es-419.json  # Latin American Spanish umbrella (Central & South America)
-    ├── es-MX.json   # Mexico       (stub -> inherits es-419)
-    ├── es-AR.json   # Argentina    (stub -> inherits es-419)
-    ├── es-CO.json   # Colombia     (stub -> inherits es-419)
-    ├── es-CL.json   # Chile        (stub -> inherits es-419)
+    ├── es.json      # Spanish base (Latin American es-419 folded in)
+    ├── es-MX.json   # Mexico       (stub -> inherits es)
+    ├── es-AR.json   # Argentina    (stub -> inherits es)
+    ├── es-CO.json   # Colombia     (stub -> inherits es)
+    ├── es-CL.json   # Chile        (stub -> inherits es)
     └── fr-CA.json   # Canadian French
 ```

--- a/tests/i18n/test_i18n_foundation.py
+++ b/tests/i18n/test_i18n_foundation.py
@@ -86,12 +86,14 @@ def test_fallback_chain():
 
 
 def test_fallback_chain_latin_american_spanish():
-    # Central/South American Spanish resolves through the es-419 umbrella
-    # before generic (Iberian-ish) es.
-    assert locale.fallback_chain("es-AR") == ["es-AR", "es-419", "es", "en-US"]
-    assert locale.fallback_chain("es-MX") == ["es-MX", "es-419", "es", "en-US"]
+    # es-419 is deprecated (folded into base es), so Latin American Spanish
+    # now truncates straight to es -- keeping its own regional override file
+    # on top and never probing the removed es-419 catalog.
+    assert locale.fallback_chain("es-AR") == ["es-AR", "es", "en-US"]
+    assert locale.fallback_chain("es-MX") == ["es-MX", "es", "en-US"]
+    # An explicit es-419 request still degrades gracefully to base es.
     assert locale.fallback_chain("es-419") == ["es-419", "es", "en-US"]
-    # Iberian Spanish does NOT route through es-419.
+    # Iberian Spanish resolves the same way (plain truncation).
     assert locale.fallback_chain("es-ES") == ["es-ES", "es", "en-US"]
 
 
@@ -235,7 +237,7 @@ def test_spanish_catalog_ships_and_resolves():
     )
 
 
-def test_latin_american_umbrella_ships_and_resolves():
+def test_deprecated_es419_resolves_through_base_es():
     # es-419 has no catalog of its own (deprecated); resolves through base es.
     translate.set_locale("es-419")
     assert i18n.t("startup.ready") == "Listo para ir por el c\u00f3digo. \U0001f436"
@@ -248,14 +250,14 @@ def test_spanish_region_falls_back_to_base_language():
     assert i18n.t("confirm.yes") == "S\u00ed"
 
 
-def test_central_south_american_dialect_inherits_es419(tmp_path):
+def test_central_south_american_dialect_inherits_base_es(tmp_path):
     # A country dialect that only overrides ONE string still inherits the rest
-    # from es, then es, then en-US.
+    # from base es, then en-US (es-419 deprecated; no umbrella tier).
     _write_catalog(tmp_path, "es-AR", {"confirm.yes": "Dale"})
     catalog.add_catalog_dir(str(tmp_path))
     translate.set_locale("es-AR")
     assert i18n.t("confirm.yes") == "Dale"  # from es-AR
-    # Inherited from base es (es-419 deprecated; chain skips missing catalogs).
+    # Inherited from base es (chain skips the missing es-419 catalog).
     assert i18n.t("startup.ready") == "Listo para ir por el c\u00f3digo. \U0001f436"
     # Inherited from en-US default.
     assert i18n.t("confirm.no") == "No"
@@ -309,7 +311,7 @@ def test_target_locales_are_available():
         assert expected in available, f"{expected} catalog is missing"
 
 
-def test_dialect_stubs_inherit_from_umbrella():
+def test_dialect_stubs_inherit_from_base_es():
     # The empty country stubs must resolve every key via es -> en-US.
     for dialect in ("es-MX", "es-AR", "es-CO", "es-CL"):
         translate.set_locale(dialect)


### PR DESCRIPTION
## What & why

PR #639 folded the `es-419` Latin American Spanish umbrella into base `es.json` and **deleted `locales/es-419.json`** — but `code_puppy/i18n/locale.py` still mapped every Central/South American dialect (`es-MX`, `es-AR`, …) to `es-419` as their CLDR parent via `PARENT_LOCALES`.

Net effect: the resolver kept **probing the now-missing `es-419.json`** on every Latin American lookup (harmless-but-wasteful `FileNotFoundError` swallowed by the loader), and the documented fallback chain no longer matched reality.

## The fix

- Empty out `PARENT_LOCALES` so LatAm dialects truncate straight to `es`:
  - `es-MX -> es -> en-US` (previously `es-MX -> es-419 -> es -> en-US`)
- **Regional override files are untouched** — `es-MX/AR/CO/CL.json` still sit on top of base `es`.
- `PARENT_LOCALES` is kept as an **empty, documented CLDR override seam** (with a one-liner showing how to reintroduce a non-truncation parent), so the generic `fallback_chain` mechanism and its tests stay intact.
- An explicit `es-419` request still degrades gracefully (`es-419 -> es -> en-US`).

## Also updated

- `docs/I18N.md` — locale table, dialect fallback diagram, directory tree, and the `PARENT_LOCALES` guidance.
- `code_puppy_agent/SKILL.md` — i18n reference section.
- `tests/i18n/test_i18n_foundation.py` — fallback-chain assertions + a few now-misleading test names/comments ("umbrella"/"es419").

## Verification

- `uv run pytest tests/i18n/ -q` → **86 passed**
- Runtime spot check:
  ```
  es-MX  -> ['es-MX', 'es', 'en-US']
  es-419 -> ['es-419', 'es', 'en-US']
  PARENT_LOCALES = {}
  es-MX confirm.yes = Sí   # regional override still resolves via base es
  ```