### PR TITLE
feat: gate GPT-5.6 family models behind per-tool guardrails

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -423,6 +423,103 @@ def filter_conflicting_mcp_tools(
     return filtered
 
 
+# --------------------------------------------------------------------- #
+# GPT-5.6 sub-agent delegation guardrail                                #
+# --------------------------------------------------------------------- #
+# GPT-5.6 family models tend to over-delegate work to sub-agents via
+# ``invoke_agent`` (and in particular to the ``planning-agent``, which
+# isn't well-suited to drive their own execution). When such a model
+# is paired with an agent that exposes ``invoke_agent``, we append a
+# short guardrail reminding the model to delegate sparingly and to
+# never invoke the planning-agent.
+
+_GPT_5_6_INVOKE_AGENT_GUARD_TEXT = """
+
+## Sub-Agent Delegation Guardrail (GPT-5.6)
+
+You are running on a GPT-5.6 family model. Treat the ``invoke_agent`` tool
+as a last resort: only delegate when the sub-task is highly specific,
+focused, and clearly benefits from isolation (a separate context window
+or a specialized tool the sub-agent owns). Do not delegate tasks you can
+handle directly with your own tools.
+
+**Never invoke the ``planning-agent``** — the agent whose role is to
+break complex tasks into execution roadmaps. If a request genuinely
+needs upfront planning, ask the user for clarification instead of
+delegating to ``planning-agent``; that agent is not safe to invoke from
+GPT-5.6 models and may produce plans that don't translate into
+actionable code changes in this environment.
+"""
+
+# GPT-5.6 family models also tend to fire off destructive shell commands
+# without thinking. When the agent exposes ``agent_run_shell_command`` we
+# append a guardrail asking the model to be cautious about anything that
+# deletes, overwrites, or otherwise mutates state irreversibly.
+
+_GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT = """
+
+## Destructive-Command Caution (GPT-5.6)
+
+You are running on a GPT-5.6 family model with access to the
+``agent_run_shell_command`` tool (or any equivalent shell/exec tool).
+**Be cautious with commands or API calls that can delete, overwrite,
+or otherwise make unrecoverable changes.** Common dangerous shapes:
+
+* bulk ``rm`` / ``rm -rf`` / wildcard deletions
+* ``git push --force`` or rewriting pushed history
+* overwriting or truncating files without explicit user direction
+* database migrations, schema drops, or production writes
+* API calls that mutate state without an obvious rollback path
+* any destructive action across a multi-host or production surface
+
+Prefer read-only inspection (``ls``, ``cat``, ``grep``, dry-run flags)
+or staging operations first, and confirm intent with the user before
+running anything that cannot be undone.
+"""
+
+
+def _is_gpt_5_6_family(model_name: Optional[str]) -> bool:
+    """Return ``True`` when ``model_name`` names a GPT-5.6 family model.
+
+    Treats ``gpt-5.6`` as a delimited segment so ``gpt-5.6-sol``,
+    ``codex-gpt-5.6-sol``, or a bare ``gpt-5.6`` all match, while names
+    like ``gpt-5.61-foo`` (digit right after) or ``xgpt-5.6`` (alnum
+    on the left) correctly do not.
+    """
+    if not model_name:
+        return False
+    target = "gpt-5.6"
+    candidate = model_name.lower()
+    start = 0
+    while True:
+        index = candidate.find(target, start)
+        if index == -1:
+            return False
+        end = index + len(target)
+        left_ok = index == 0 or not candidate[index - 1].isalnum()
+        right_ok = end == len(candidate) or not candidate[end].isalnum()
+        if left_ok and right_ok:
+            return True
+        start = index + 1
+    return False  # pragma: no cover - defensive
+
+
+def _agent_exposes_tool(agent: Any, tool_name: str) -> bool:
+    """Return ``True`` if ``agent.get_available_tools()`` lists ``tool_name``.
+
+    Used by the GPT-5.6 guardrail to gate on whether the active agent
+    actually exposes the tools we want to rein in (e.g. ``invoke_agent``,
+    ``agent_run_shell_command``). Wraps ``get_available_tools`` so any
+    exception or ``None`` return value is treated as "not exposed" — the
+    guardrail stays opt-in and never blows up the prompt build.
+    """
+    try:
+        tools = agent.get_available_tools()
+    except Exception:
+        return False
+    return tool_name in (tools or [])
+
+
 def _assemble_instructions(agent: Any, resolved_model_name: str) -> str:
     """Compose full system prompt + puppy rules + extended-thinking note."""
     from code_puppy.model_utils import prepare_prompt_for_model
@@ -438,6 +535,24 @@ def _assemble_instructions(agent: Any, resolved_model_name: str) -> str:
 
     if has_extended_thinking_active(resolved_model_name):
         instructions += EXTENDED_THINKING_PROMPT_NOTE
+
+    # GPT-5.6 family models tend to over-delegate. When such a model is
+    # paired with an agent that exposes ``invoke_agent``, append a
+    # guardrail reminding the model to delegate sparingly and to never
+    # invoke the planning-agent.
+    if _is_gpt_5_6_family(resolved_model_name) and _agent_exposes_tool(
+        agent, "invoke_agent"
+    ):
+        instructions += _GPT_5_6_INVOKE_AGENT_GUARD_TEXT
+
+    # GPT-5.6 family models also tend to fire off destructive shell
+    # commands. When the agent exposes ``agent_run_shell_command``,
+    # append a guardrail asking the model to be cautious about anything
+    # that deletes, overwrites, or otherwise mutates state irreversibly.
+    if _is_gpt_5_6_family(resolved_model_name) and _agent_exposes_tool(
+        agent, "agent_run_shell_command"
+    ):
+        instructions += _GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT
 
     prepared = prepare_prompt_for_model(
         agent.get_model_name(), instructions, "", prepend_system_to_user=False

--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -423,118 +423,32 @@ def filter_conflicting_mcp_tools(
     return filtered
 
 
-# --------------------------------------------------------------------- #
-# GPT-5.6 sub-agent delegation guardrail                                #
-# --------------------------------------------------------------------- #
-# GPT-5.6 family models tend to over-delegate work to sub-agents via
-# ``invoke_agent`` (and in particular to the ``planning-agent``, which
-# isn't well-suited to drive their own execution). When such a model
-# is paired with an agent that exposes ``invoke_agent``, we append a
-# short guardrail reminding the model to delegate sparingly and to
-# never invoke the planning-agent.
-
 _GPT_5_6_INVOKE_AGENT_GUARD_TEXT = """
 
-## Sub-Agent Delegation Guardrail (GPT-5.6)
-
-You are running on a GPT-5.6 family model. Treat the ``invoke_agent`` tool
-as a last resort: only delegate when the sub-task is highly specific,
-focused, and clearly benefits from isolation (a separate context window
-or a specialized tool the sub-agent owns). Do not delegate tasks you can
-handle directly with your own tools.
-
-**Never invoke the ``planning-agent``** — the agent whose role is to
-break complex tasks into execution roadmaps. If a request genuinely
-needs upfront planning, ask the user for clarification instead of
-delegating to ``planning-agent``; that agent is not safe to invoke from
-GPT-5.6 models and may produce plans that don't translate into
-actionable code changes in this environment.
+## Sub-Agent Delegation (GPT-5.6)
+Use `invoke_agent` only for focused work that benefits from separate context or
+specialized tools. Handle work directly when you can. Never invoke
+`planning-agent`.
 """
-
-# GPT-5.6 family models also tend to fire off destructive shell commands
-# without thinking. When the agent exposes ``agent_run_shell_command`` we
-# append a guardrail asking the model to be cautious about anything that
-# deletes, overwrites, or otherwise mutates state irreversibly.
 
 _GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT = """
 
-## Destructive-Command Caution (GPT-5.6)
-
-You are running on a GPT-5.6 family model with access to the
-``agent_run_shell_command`` tool (or any equivalent shell/exec tool).
-**Be cautious with commands or API calls that can delete, overwrite,
-or otherwise make unrecoverable changes.** Common dangerous shapes:
-
-* bulk ``rm`` / ``rm -rf`` / wildcard deletions
-* ``git push --force`` or rewriting pushed history
-* overwriting or truncating files without explicit user direction
-* database migrations, schema drops, or production writes
-* API calls that mutate state without an obvious rollback path
-* any destructive action across a multi-host or production surface
-
-Prefer read-only inspection (``ls``, ``cat``, ``grep``, dry-run flags)
-or staging operations first, and confirm intent with the user before
-running anything that cannot be undone.
+## Shell Safety (GPT-5.6)
+Before using `agent_run_shell_command`, prefer inspection and dry runs. Confirm
+with the user before irreversible deletion, overwrites, history rewrites,
+database or production mutations, or other actions without a clear rollback.
 """
 
 
 def _is_gpt_5_6_family(model_name: Optional[str]) -> bool:
-    """Return ``True`` when ``model_name`` names a GPT-5.6 family model.
-
-    Treats ``gpt-5.6`` as a delimited segment so ``gpt-5.6-sol``,
-    ``codex-gpt-5.6-sol``, or a bare ``gpt-5.6`` all match, while names
-    like ``gpt-5.61-foo`` (digit right after) or ``xgpt-5.6`` (alnum
-    on the left) correctly do not.
-    """
-    if not model_name:
-        return False
-    target = "gpt-5.6"
-    candidate = model_name.lower()
-    start = 0
-    while True:
-        index = candidate.find(target, start)
-        if index == -1:
-            return False
-        end = index + len(target)
-        left_ok = index == 0 or not candidate[index - 1].isalnum()
-        right_ok = end == len(candidate) or not candidate[end].isalnum()
-        if left_ok and right_ok:
-            return True
-        start = index + 1
-    return False  # pragma: no cover - defensive
+    return bool(model_name and "gpt-5.6" in model_name.lower())
 
 
 def _agent_exposes_tool(agent: Any, tool_name: str) -> bool:
-    """Return ``True`` if ``agent.get_available_tools()`` lists ``tool_name``.
-
-    Used by the GPT-5.6 guardrail to gate on whether the active agent
-    actually exposes the tools we want to rein in (e.g. ``invoke_agent``,
-    ``agent_run_shell_command``). Wraps ``get_available_tools`` so any
-    exception or ``None`` return value is treated as "not exposed" — the
-    guardrail stays opt-in and never blows up the prompt build.
-    """
     try:
-        tools = agent.get_available_tools()
+        return tool_name in (agent.get_available_tools() or ())
     except Exception:
         return False
-    return tool_name in (tools or [])
-
-
-def _gpt_5_6_subagent_depth_should_block(model_name: Optional[str]) -> bool:
-    """Return ``True`` when a GPT-5.6 model is being asked to delegate past depth 1.
-
-    GPT-5.6 family models get a max sub-agent recursion depth of 1: a
-    first-level sub-agent is allowed (depth 0 → 1), but any further
-    delegation (depth 1 → 2) is blocked. The check is non-blocking for
-    non-GPT-5.6 models so the rule only bites where we want it to.
-    """
-    if not _is_gpt_5_6_family(model_name):
-        return False
-    # Lazy import keeps this module free of an unconditional dependency on
-    # the sub-agent context machinery at import time.
-    from code_puppy.tools.subagent_context import get_subagent_depth
-
-    return get_subagent_depth() >= 1
 
 
 def _assemble_instructions(agent: Any, resolved_model_name: str) -> str:
@@ -553,23 +467,11 @@ def _assemble_instructions(agent: Any, resolved_model_name: str) -> str:
     if has_extended_thinking_active(resolved_model_name):
         instructions += EXTENDED_THINKING_PROMPT_NOTE
 
-    # GPT-5.6 family models tend to over-delegate. When such a model is
-    # paired with an agent that exposes ``invoke_agent``, append a
-    # guardrail reminding the model to delegate sparingly and to never
-    # invoke the planning-agent.
-    if _is_gpt_5_6_family(resolved_model_name) and _agent_exposes_tool(
-        agent, "invoke_agent"
-    ):
-        instructions += _GPT_5_6_INVOKE_AGENT_GUARD_TEXT
-
-    # GPT-5.6 family models also tend to fire off destructive shell
-    # commands. When the agent exposes ``agent_run_shell_command``,
-    # append a guardrail asking the model to be cautious about anything
-    # that deletes, overwrites, or otherwise mutates state irreversibly.
-    if _is_gpt_5_6_family(resolved_model_name) and _agent_exposes_tool(
-        agent, "agent_run_shell_command"
-    ):
-        instructions += _GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT
+    if _is_gpt_5_6_family(resolved_model_name):
+        if _agent_exposes_tool(agent, "invoke_agent"):
+            instructions += _GPT_5_6_INVOKE_AGENT_GUARD_TEXT
+        if _agent_exposes_tool(agent, "agent_run_shell_command"):
+            instructions += _GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT
 
     prepared = prepare_prompt_for_model(
         agent.get_model_name(), instructions, "", prepend_system_to_user=False

--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -520,6 +520,23 @@ def _agent_exposes_tool(agent: Any, tool_name: str) -> bool:
     return tool_name in (tools or [])
 
 
+def _gpt_5_6_subagent_depth_should_block(model_name: Optional[str]) -> bool:
+    """Return ``True`` when a GPT-5.6 model is being asked to delegate past depth 1.
+
+    GPT-5.6 family models get a max sub-agent recursion depth of 1: a
+    first-level sub-agent is allowed (depth 0 → 1), but any further
+    delegation (depth 1 → 2) is blocked. The check is non-blocking for
+    non-GPT-5.6 models so the rule only bites where we want it to.
+    """
+    if not _is_gpt_5_6_family(model_name):
+        return False
+    # Lazy import keeps this module free of an unconditional dependency on
+    # the sub-agent context machinery at import time.
+    from code_puppy.tools.subagent_context import get_subagent_depth
+
+    return get_subagent_depth() >= 1
+
+
 def _assemble_instructions(agent: Any, resolved_model_name: str) -> str:
     """Compose full system prompt + puppy rules + extended-thinking note."""
     from code_puppy.model_utils import prepare_prompt_for_model

--- a/code_puppy/tools/subagent_context.py
+++ b/code_puppy/tools/subagent_context.py
@@ -57,6 +57,7 @@ __all__ = [
     "get_subagent_name",
     "get_subagent_chain",
     "get_subagent_depth",
+    "get_subagent_model_name",
 ]
 
 # Track sub-agent depth (0 = main agent, 1+ = sub-agent)
@@ -64,6 +65,9 @@ _subagent_depth: ContextVar[int] = ContextVar("subagent_depth", default=0)
 
 # Track current sub-agent name (None = main agent)
 _subagent_name: ContextVar[str | None] = ContextVar("subagent_name", default=None)
+_subagent_model_name: ContextVar[str | None] = ContextVar(
+    "subagent_model_name", default=None
+)
 
 # Track the full call chain of sub-agent names. Stored as an
 # immutable tuple so each context-manager push is a cheap snapshot. The
@@ -73,7 +77,9 @@ _subagent_chain: ContextVar[tuple[str, ...]] = ContextVar("subagent_chain", defa
 
 
 @contextmanager
-def subagent_context(agent_name: str) -> Generator[None, None, None]:
+def subagent_context(
+    agent_name: str, model_name: str | None = None
+) -> Generator[None, None, None]:
     """Context manager for tracking sub-agent execution.
 
     Increments the sub-agent depth and sets the current agent name on entry,
@@ -104,6 +110,7 @@ def subagent_context(agent_name: str) -> Generator[None, None, None]:
     # Set new values and save tokens for restoration
     depth_token = _subagent_depth.set(current_depth + 1)
     name_token = _subagent_name.set(agent_name)
+    model_token = _subagent_model_name.set(model_name)
     chain_token = _subagent_chain.set(current_chain + (agent_name,))
 
     try:
@@ -113,6 +120,7 @@ def subagent_context(agent_name: str) -> Generator[None, None, None]:
         # This ensures the context is restored even if an exception occurs
         _subagent_depth.reset(depth_token)
         _subagent_name.reset(name_token)
+        _subagent_model_name.reset(model_token)
         _subagent_chain.reset(chain_token)
 
 
@@ -146,6 +154,11 @@ def get_subagent_name() -> str | None:
         'code-puppy'
     """
     return _subagent_name.get()
+
+
+def get_subagent_model_name() -> str | None:
+    """Return the model running the current sub-agent."""
+    return _subagent_model_name.get()
 
 
 def get_subagent_depth() -> int:

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -154,6 +154,27 @@ async def _invoke_agent_impl(
             if not effective_model_name:
                 raise ValueError("No model configured for sub-agent invocation")
 
+            # GPT-5.6 family models get a max sub-agent recursion depth of 1.
+            # Block the delegation here (before any heavy work like MCP server
+            # loading) so we don't waste cycles spinning up a sub-agent we're
+            # going to refuse anyway.
+            from code_puppy.agents._builder import _gpt_5_6_subagent_depth_should_block
+
+            if _gpt_5_6_subagent_depth_should_block(effective_model_name):
+                depth_msg = (
+                    f"GPT-5.6 family models have a max sub-agent recursion "
+                    f"depth of 1; refusing to invoke '{agent_name}' from "
+                    f"inside a GPT-5.6 sub-agent."
+                )
+                group_id = generate_group_id("invoke_agent", agent_name)
+                emit_error(depth_msg, message_group=group_id)
+                return AgentInvokeOutput(
+                    response=None,
+                    agent_name=agent_name,
+                    model_name=model_name,
+                    error=depth_msg,
+                )
+
             # Only proceed if we have a valid model configuration
             if effective_model_name not in models_config:
                 raise ValueError(

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -34,10 +34,19 @@ from code_puppy.tools.agent_tools import (
     _validate_session_id,
 )
 from code_puppy.tools.common import generate_group_id
-from code_puppy.tools.subagent_context import subagent_context
+from code_puppy.tools.subagent_context import (
+    get_subagent_model_name,
+    subagent_context,
+)
 
 # Set to track active subagent invocation tasks
 _active_subagent_tasks: Set[asyncio.Task] = set()
+
+
+def _gpt_5_6_recursion_blocked() -> bool:
+    from code_puppy.agents._builder import _is_gpt_5_6_family
+
+    return _is_gpt_5_6_family(get_subagent_model_name())
 
 
 async def _invoke_agent_impl(
@@ -154,25 +163,14 @@ async def _invoke_agent_impl(
             if not effective_model_name:
                 raise ValueError("No model configured for sub-agent invocation")
 
-            # GPT-5.6 family models get a max sub-agent recursion depth of 1.
-            # Block the delegation here (before any heavy work like MCP server
-            # loading) so we don't waste cycles spinning up a sub-agent we're
-            # going to refuse anyway.
-            from code_puppy.agents._builder import _gpt_5_6_subagent_depth_should_block
-
-            if _gpt_5_6_subagent_depth_should_block(effective_model_name):
-                depth_msg = (
-                    f"GPT-5.6 family models have a max sub-agent recursion "
-                    f"depth of 1; refusing to invoke '{agent_name}' from "
-                    f"inside a GPT-5.6 sub-agent."
-                )
-                group_id = generate_group_id("invoke_agent", agent_name)
-                emit_error(depth_msg, message_group=group_id)
+            if _gpt_5_6_recursion_blocked():
+                error = f"GPT-5.6 sub-agents cannot invoke '{agent_name}'."
+                emit_error(error, message_group=group_id)
                 return AgentInvokeOutput(
                     response=None,
                     agent_name=agent_name,
                     model_name=model_name,
-                    error=depth_msg,
+                    error=error,
                 )
 
             # Only proceed if we have a valid model configuration
@@ -308,8 +306,7 @@ async def _invoke_agent_impl(
             else:
                 stream_handler = partial(subagent_stream_handler, session_id=session_id)
 
-            # Wrap the agent run in subagent context for tracking
-            with subagent_context(agent_name):
+            with subagent_context(agent_name, effective_model_name):
                 run_ctxs = on_agent_run_context(
                     agent_config, temp_agent, group_id, mcp_servers
                 )

--- a/tests/agents/test_builder_gpt_5_6_subagent_depth.py
+++ b/tests/agents/test_builder_gpt_5_6_subagent_depth.py
@@ -1,100 +1,40 @@
-"""Tests for the GPT-5.6 max sub-agent recursion depth guard.
-
-Covers ``_gpt_5_6_subagent_depth_should_block`` and the integration in
-``_invoke_agent_impl``. The rule: GPT-5.6 family models cap sub-agent
-recursion at depth 1 - the first level (depth 0 -> 1) is allowed, but
-any further delegation (depth 1 -> 2) is blocked.
-
-Tests use ``subagent_context`` from ``code_puppy.tools.subagent_context``
-to manipulate the running depth without spinning up real agents.
-"""
-
-from __future__ import annotations
-
-import pytest
-
-from code_puppy.agents import _builder
-from code_puppy.tools.subagent_context import subagent_context
+from code_puppy.tools import subagent_invocation
+from code_puppy.tools.subagent_context import (
+    get_subagent_depth,
+    get_subagent_model_name,
+    subagent_context,
+)
 
 
-class TestGpt56SubagentDepthShouldBlock:
-    """The depth classifier: only blocks when model is GPT-5.6 AND depth >= 1."""
+def test_subagent_context_tracks_model_and_restores_parent():
+    assert get_subagent_depth() == 0
+    assert get_subagent_model_name() is None
 
-    def test_returns_false_at_depth_zero(self):
-        # Depth 0 (main agent) with a GPT-5.6 model - the first sub-agent
-        # is allowed, so we should NOT block.
-        assert _builder._gpt_5_6_subagent_depth_should_block("gpt-5.6-sol") is False
-        assert (
-            _builder._gpt_5_6_subagent_depth_should_block("codex-gpt-5.6-sol") is False
-        )
+    with subagent_context("parent", "gpt-5.6-sol"):
+        assert get_subagent_depth() == 1
+        assert get_subagent_model_name() == "gpt-5.6-sol"
+        with subagent_context("child", "gpt-5.5"):
+            assert get_subagent_depth() == 2
+            assert get_subagent_model_name() == "gpt-5.5"
+        assert get_subagent_model_name() == "gpt-5.6-sol"
 
-    def test_returns_true_for_gpt_5_6_at_depth_one(self):
-        with subagent_context("first-sub-agent"):
-            assert _builder._gpt_5_6_subagent_depth_should_block("gpt-5.6-sol") is True
-
-    def test_returns_true_for_gpt_5_6_at_depth_two(self):
-        with subagent_context("first-sub-agent"):
-            with subagent_context("second-sub-agent"):
-                assert (
-                    _builder._gpt_5_6_subagent_depth_should_block("codex-gpt-5.6-luna")
-                    is True
-                )
-
-    def test_returns_false_for_non_gpt_5_6_at_depth_one(self):
-        with subagent_context("first-sub-agent"):
-            assert _builder._gpt_5_6_subagent_depth_should_block("gpt-5.5") is False
-            assert (
-                _builder._gpt_5_6_subagent_depth_should_block("claude-sonnet-4-5")
-                is False
-            )
-
-    def test_returns_false_for_non_gpt_5_6_at_depth_two(self):
-        with subagent_context("first-sub-agent"):
-            with subagent_context("second-sub-agent"):
-                assert (
-                    _builder._gpt_5_6_subagent_depth_should_block("claude-opus-4-7")
-                    is False
-                )
-
-    @pytest.mark.parametrize("model_name", ["", None, 0])
-    def test_returns_false_for_empty_or_none_model(self, model_name):
-        assert _builder._gpt_5_6_subagent_depth_should_block(model_name) is False
-
-    def test_returns_false_for_unrelated_gpt_5_family(self):
-        with subagent_context("first-sub-agent"):
-            assert _builder._gpt_5_6_subagent_depth_should_block("gpt-5.5") is False
-            assert _builder._gpt_5_6_subagent_depth_should_block("gpt-5") is False
-            assert (
-                _builder._gpt_5_6_subagent_depth_should_block("gpt-5.4-mini") is False
-            )
+    assert get_subagent_depth() == 0
+    assert get_subagent_model_name() is None
 
 
-class TestHelperMirrorsCallSiteSemantics:
-    """Sanity-check that the helper matches the inline call-site logic.
+def test_recursion_guard_checks_caller_model_not_child_model():
+    with subagent_context("gpt-parent", "gpt-5.6-sol"):
+        assert subagent_invocation._gpt_5_6_recursion_blocked()
 
-    The integration in ``_invoke_agent_impl`` is effectively:
+    with subagent_context("other-parent", "gpt-5.5"):
+        assert not subagent_invocation._gpt_5_6_recursion_blocked()
 
-        if model is GPT-5.6 and get_subagent_depth() >= 1: block
 
-    These tests verify the helper returns ``True`` only when both
-    conditions hold simultaneously.
-    """
+def test_subagent_context_restores_model_after_error():
+    try:
+        with subagent_context("agent", "gpt-5.6-sol"):
+            raise RuntimeError
+    except RuntimeError:
+        pass
 
-    def test_helper_false_at_depth_zero_even_for_gpt_5_6(self):
-        # At depth 0, we always allow the first sub-agent invocation.
-        assert _builder._gpt_5_6_subagent_depth_should_block("gpt-5.6-sol") is False
-
-    def test_helper_true_for_gpt_5_6_only_after_first_level(self):
-        with subagent_context("parent"):
-            # Inside subagent_context we're at depth >= 1.
-            assert _builder._gpt_5_6_subagent_depth_should_block("gpt-5.6-sol") is True
-
-    def test_helper_false_for_non_gpt_5_6_at_depth_one(self):
-        with subagent_context("parent"):
-            assert (
-                _builder._gpt_5_6_subagent_depth_should_block("claude-sonnet-4-5")
-                is False
-            )
-            assert (
-                _builder._gpt_5_6_subagent_depth_should_block("gpt-5.5-mini") is False
-            )
+    assert get_subagent_model_name() is None

--- a/tests/agents/test_builder_gpt_5_6_subagent_depth.py
+++ b/tests/agents/test_builder_gpt_5_6_subagent_depth.py
@@ -1,0 +1,100 @@
+"""Tests for the GPT-5.6 max sub-agent recursion depth guard.
+
+Covers ``_gpt_5_6_subagent_depth_should_block`` and the integration in
+``_invoke_agent_impl``. The rule: GPT-5.6 family models cap sub-agent
+recursion at depth 1 - the first level (depth 0 -> 1) is allowed, but
+any further delegation (depth 1 -> 2) is blocked.
+
+Tests use ``subagent_context`` from ``code_puppy.tools.subagent_context``
+to manipulate the running depth without spinning up real agents.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from code_puppy.agents import _builder
+from code_puppy.tools.subagent_context import subagent_context
+
+
+class TestGpt56SubagentDepthShouldBlock:
+    """The depth classifier: only blocks when model is GPT-5.6 AND depth >= 1."""
+
+    def test_returns_false_at_depth_zero(self):
+        # Depth 0 (main agent) with a GPT-5.6 model - the first sub-agent
+        # is allowed, so we should NOT block.
+        assert _builder._gpt_5_6_subagent_depth_should_block("gpt-5.6-sol") is False
+        assert (
+            _builder._gpt_5_6_subagent_depth_should_block("codex-gpt-5.6-sol") is False
+        )
+
+    def test_returns_true_for_gpt_5_6_at_depth_one(self):
+        with subagent_context("first-sub-agent"):
+            assert _builder._gpt_5_6_subagent_depth_should_block("gpt-5.6-sol") is True
+
+    def test_returns_true_for_gpt_5_6_at_depth_two(self):
+        with subagent_context("first-sub-agent"):
+            with subagent_context("second-sub-agent"):
+                assert (
+                    _builder._gpt_5_6_subagent_depth_should_block("codex-gpt-5.6-luna")
+                    is True
+                )
+
+    def test_returns_false_for_non_gpt_5_6_at_depth_one(self):
+        with subagent_context("first-sub-agent"):
+            assert _builder._gpt_5_6_subagent_depth_should_block("gpt-5.5") is False
+            assert (
+                _builder._gpt_5_6_subagent_depth_should_block("claude-sonnet-4-5")
+                is False
+            )
+
+    def test_returns_false_for_non_gpt_5_6_at_depth_two(self):
+        with subagent_context("first-sub-agent"):
+            with subagent_context("second-sub-agent"):
+                assert (
+                    _builder._gpt_5_6_subagent_depth_should_block("claude-opus-4-7")
+                    is False
+                )
+
+    @pytest.mark.parametrize("model_name", ["", None, 0])
+    def test_returns_false_for_empty_or_none_model(self, model_name):
+        assert _builder._gpt_5_6_subagent_depth_should_block(model_name) is False
+
+    def test_returns_false_for_unrelated_gpt_5_family(self):
+        with subagent_context("first-sub-agent"):
+            assert _builder._gpt_5_6_subagent_depth_should_block("gpt-5.5") is False
+            assert _builder._gpt_5_6_subagent_depth_should_block("gpt-5") is False
+            assert (
+                _builder._gpt_5_6_subagent_depth_should_block("gpt-5.4-mini") is False
+            )
+
+
+class TestHelperMirrorsCallSiteSemantics:
+    """Sanity-check that the helper matches the inline call-site logic.
+
+    The integration in ``_invoke_agent_impl`` is effectively:
+
+        if model is GPT-5.6 and get_subagent_depth() >= 1: block
+
+    These tests verify the helper returns ``True`` only when both
+    conditions hold simultaneously.
+    """
+
+    def test_helper_false_at_depth_zero_even_for_gpt_5_6(self):
+        # At depth 0, we always allow the first sub-agent invocation.
+        assert _builder._gpt_5_6_subagent_depth_should_block("gpt-5.6-sol") is False
+
+    def test_helper_true_for_gpt_5_6_only_after_first_level(self):
+        with subagent_context("parent"):
+            # Inside subagent_context we're at depth >= 1.
+            assert _builder._gpt_5_6_subagent_depth_should_block("gpt-5.6-sol") is True
+
+    def test_helper_false_for_non_gpt_5_6_at_depth_one(self):
+        with subagent_context("parent"):
+            assert (
+                _builder._gpt_5_6_subagent_depth_should_block("claude-sonnet-4-5")
+                is False
+            )
+            assert (
+                _builder._gpt_5_6_subagent_depth_should_block("gpt-5.5-mini") is False
+            )

--- a/tests/agents/test_builder_gpt_5_6_subagent_guard.py
+++ b/tests/agents/test_builder_gpt_5_6_subagent_guard.py
@@ -1,0 +1,284 @@
+"""Tests for the GPT-5.6 tool-safety guardrails in _builder.
+
+Covers two independent conditional guardrails that get appended to the
+system prompt only when the resolved model is a GPT-5.6 family model AND
+the agent exposes the relevant tool:
+
+* ``_GPT_5_6_INVOKE_AGENT_GUARD_TEXT`` — fires when the agent exposes
+  ``invoke_agent``. Tells the model to delegate sparingly and to never
+  invoke ``planning-agent``.
+* ``_GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT`` — fires when the agent exposes
+  ``agent_run_shell_command``. Tells the model to be cautious about
+  commands or API calls that delete, overwrite, or make unrecoverable
+  changes.
+
+If either condition is false (model or tool gate) the corresponding
+guardrail must be omitted.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from code_puppy.agents import _builder
+
+
+# --------------------------------------------------------------------------- #
+# _is_gpt_5_6_family classifier                                                #
+# --------------------------------------------------------------------------- #
+
+
+class TestIsGpt5Family:
+    """The matcher must treat ``gpt-5.6`` as a delimited segment."""
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "gpt-5.6",
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+            "codex-gpt-5.6-sol",
+            "codex-gpt-5.6-luna",
+            "GPT-5.6",
+            "Codex-GPT-5.6-SOL",
+        ],
+    )
+    def test_matches_real_gpt_5_6_names(self, model_name):
+        assert _builder._is_gpt_5_6_family(model_name) is True
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            # Adjacent alnum chars must not be part of the segment.
+            "gpt-5.61",
+            "gpt-5.61-foo",
+            "xgpt-5.6",
+            "xgpt-5.6-foo",
+            "gpt-5.65-foo",
+            # Completely unrelated families.
+            "gpt-5.5",
+            "gpt-5.5-mini",
+            "gpt-5.4",
+            "gpt-5",
+            "claude-sonnet-4-5",
+            "o3",
+            "llama-3-70b",
+        ],
+    )
+    def test_rejects_unrelated_names(self, model_name):
+        assert _builder._is_gpt_5_6_family(model_name) is False
+
+    @pytest.mark.parametrize("model_name", ["", None])
+    def test_rejects_empty_or_none(self, model_name):
+        assert _builder._is_gpt_5_6_family(model_name) is False
+
+
+# --------------------------------------------------------------------------- #
+# _agent_exposes_tool helper                                                    #
+# --------------------------------------------------------------------------- #
+
+
+class TestAgentExposesTool:
+    """The detector must reflect the agent's tools list faithfully."""
+
+    def test_returns_true_when_present(self):
+        agent = MagicMock()
+        agent.get_available_tools.return_value = [
+            "list_files",
+            "invoke_agent",
+            "read_file",
+        ]
+        assert _builder._agent_exposes_tool(agent, "invoke_agent") is True
+
+    def test_returns_false_when_absent(self):
+        agent = MagicMock()
+        agent.get_available_tools.return_value = ["list_files", "read_file"]
+        assert _builder._agent_exposes_tool(agent, "invoke_agent") is False
+
+    def test_returns_false_when_get_tools_raises(self):
+        agent = MagicMock()
+        agent.get_available_tools.side_effect = RuntimeError("boom")
+        assert _builder._agent_exposes_tool(agent, "invoke_agent") is False
+
+    def test_returns_false_when_get_tools_returns_none(self):
+        agent = MagicMock()
+        agent.get_available_tools.return_value = None
+        assert _builder._agent_exposes_tool(agent, "invoke_agent") is False
+
+    def test_honors_requested_tool_name(self):
+        """The same helper must work for any tool we pass in."""
+        agent = MagicMock()
+        agent.get_available_tools.return_value = [
+            "list_files",
+            "agent_run_shell_command",
+        ]
+        assert _builder._agent_exposes_tool(agent, "agent_run_shell_command") is True
+        assert _builder._agent_exposes_tool(agent, "invoke_agent") is False
+
+
+# --------------------------------------------------------------------------- #
+# Guardrail text sanity                                                        #
+# --------------------------------------------------------------------------- #
+
+
+class TestGuardrailTextContent:
+    """Each guardrail string must actually convey its message."""
+
+    def test_invoke_agent_text_mentions_relevant_tools(self):
+        text = _builder._GPT_5_6_INVOKE_AGENT_GUARD_TEXT
+        assert "invoke_agent" in text
+        assert "planning-agent" in text
+        assert "GPT-5.6" in text
+
+    def test_run_shell_command_text_mentions_relevant_tools(self):
+        text = _builder._GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT
+        assert "agent_run_shell_command" in text
+        assert "GPT-5.6" in text
+        # The user-supplied caution phrase must be embedded verbatim.
+        assert "delete, overwrite" in text
+        assert "unrecoverable changes" in text
+
+
+# --------------------------------------------------------------------------- #
+# _assemble_instructions guardrail integration                                #
+# --------------------------------------------------------------------------- #
+
+
+def _make_fake_agent(tools):
+    """Build a minimal stand-in for ``BaseAgent`` with the right shape."""
+
+    agent = MagicMock()
+    agent.get_full_system_prompt.return_value = "BASE_PROMPT"
+    agent.get_available_tools.return_value = tools
+    agent.get_model_name.return_value = "gpt-5.6-sol"
+    return agent
+
+
+def _patch_collaborators(monkeypatch):
+    """Stub every module-level collaborator ``_assemble_instructions`` touches.
+
+    ``load_puppy_rules`` lives in this module; ``has_extended_thinking_active``
+    is imported lazily from ``code_puppy.tools`` and
+    ``prepare_prompt_for_model`` from ``code_puppy.model_utils``. We patch
+    each at its source so the lazy imports resolve to our stubs.
+    """
+
+    def _stub_prepare(_name, prompt, _user, **_kwargs):
+        return MagicMock(instructions=prompt, user_prompt="", is_claude_code=False)
+
+    monkeypatch.setattr(_builder, "load_puppy_rules", lambda: "")
+    monkeypatch.setattr(
+        "code_puppy.tools.has_extended_thinking_active", lambda _name: False
+    )
+    monkeypatch.setattr(
+        "code_puppy.model_utils.prepare_prompt_for_model", _stub_prepare
+    )
+
+
+class TestAssembleInstructionsInvokeAgentGuardrail:
+    """The ``invoke_agent`` guardrail must fire only on gpt-5.6 + tool."""
+
+    def test_fires_when_model_and_tool_both_match(self, monkeypatch):
+        agent = _make_fake_agent(
+            ["list_files", "invoke_agent", "read_file"],
+        )
+        _patch_collaborators(monkeypatch)
+
+        result = _builder._assemble_instructions(agent, "gpt-5.6-sol")
+
+        assert result.startswith("BASE_PROMPT")
+        assert _builder._GPT_5_6_INVOKE_AGENT_GUARD_TEXT in result
+        # The guardrail must explicitly forbid the planning-agent.
+        assert "planning-agent" in result
+
+    def test_silent_for_non_gpt_5_6_model(self, monkeypatch):
+        agent = _make_fake_agent(
+            ["list_files", "invoke_agent", "read_file"],
+        )
+        _patch_collaborators(monkeypatch)
+
+        result = _builder._assemble_instructions(agent, "gpt-5.5")
+
+        assert _builder._GPT_5_6_INVOKE_AGENT_GUARD_TEXT not in result
+
+
+class TestAssembleInstructionsRunShellCommandGuardrail:
+    """The ``agent_run_shell_command`` guardrail must also gate correctly."""
+
+    def test_fires_when_model_and_tool_both_match(self, monkeypatch):
+        agent = _make_fake_agent(
+            [
+                "list_files",
+                "agent_run_shell_command",
+                "read_file",
+            ],
+        )
+        _patch_collaborators(monkeypatch)
+
+        result = _builder._assemble_instructions(agent, "codex-gpt-5.6-sol")
+
+        assert _builder._GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT in result
+        assert "delete, overwrite" in result
+
+    def test_silent_when_agent_lacks_run_shell_command(self, monkeypatch):
+        agent = _make_fake_agent(["list_files", "read_file"])
+        _patch_collaborators(monkeypatch)
+
+        result = _builder._assemble_instructions(agent, "gpt-5.6-luna")
+
+        assert _builder._GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT not in result
+
+    def test_silent_for_non_gpt_5_6_model(self, monkeypatch):
+        agent = _make_fake_agent(
+            [
+                "list_files",
+                "agent_run_shell_command",
+                "read_file",
+            ],
+        )
+        _patch_collaborators(monkeypatch)
+
+        result = _builder._assemble_instructions(agent, "gpt-5.5")
+
+        assert _builder._GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT not in result
+
+
+class TestAssembleInstructionsGuardrailsIndependent:
+    """Each guardrail fires on its own; they don't interfere with each other."""
+
+    def test_both_guardrails_fire_when_both_tools_present(self, monkeypatch):
+        # Agent with BOTH invoke_agent and agent_run_shell_command, on a
+        # gpt-5.6 model — both guardrails should appear in the result.
+        agent = _make_fake_agent(
+            [
+                "list_files",
+                "invoke_agent",
+                "agent_run_shell_command",
+                "read_file",
+            ],
+        )
+        _patch_collaborators(monkeypatch)
+
+        result = _builder._assemble_instructions(agent, "gpt-5.6-sol")
+
+        assert _builder._GPT_5_6_INVOKE_AGENT_GUARD_TEXT in result
+        assert _builder._GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT in result
+
+    def test_neither_guardrail_fires_without_gpt_5_6(self, monkeypatch):
+        agent = _make_fake_agent(
+            [
+                "list_files",
+                "invoke_agent",
+                "agent_run_shell_command",
+                "read_file",
+            ],
+        )
+        _patch_collaborators(monkeypatch)
+
+        result = _builder._assemble_instructions(agent, "gpt-5.5")
+
+        assert _builder._GPT_5_6_INVOKE_AGENT_GUARD_TEXT not in result
+        assert _builder._GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT not in result

--- a/tests/agents/test_builder_gpt_5_6_subagent_guard.py
+++ b/tests/agents/test_builder_gpt_5_6_subagent_guard.py
@@ -1,23 +1,3 @@
-"""Tests for the GPT-5.6 tool-safety guardrails in _builder.
-
-Covers two independent conditional guardrails that get appended to the
-system prompt only when the resolved model is a GPT-5.6 family model AND
-the agent exposes the relevant tool:
-
-* ``_GPT_5_6_INVOKE_AGENT_GUARD_TEXT`` — fires when the agent exposes
-  ``invoke_agent``. Tells the model to delegate sparingly and to never
-  invoke ``planning-agent``.
-* ``_GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT`` — fires when the agent exposes
-  ``agent_run_shell_command``. Tells the model to be cautious about
-  commands or API calls that delete, overwrite, or make unrecoverable
-  changes.
-
-If either condition is false (model or tool gate) the corresponding
-guardrail must be omitted.
-"""
-
-from __future__ import annotations
-
 from unittest.mock import MagicMock
 
 import pytest
@@ -25,260 +5,69 @@ import pytest
 from code_puppy.agents import _builder
 
 
-# --------------------------------------------------------------------------- #
-# _is_gpt_5_6_family classifier                                                #
-# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "gpt-5.6",
+        "gpt-5.6-sol",
+        "codex-gpt-5.6-luna",
+        "Codex-GPT-5.6-SOL",
+    ],
+)
+def test_gpt_5_6_family_matches(model_name):
+    assert _builder._is_gpt_5_6_family(model_name)
 
 
-class TestIsGpt5Family:
-    """The matcher must treat ``gpt-5.6`` as a delimited segment."""
-
-    @pytest.mark.parametrize(
-        "model_name",
-        [
-            "gpt-5.6",
-            "gpt-5.6-sol",
-            "gpt-5.6-terra",
-            "gpt-5.6-luna",
-            "codex-gpt-5.6-sol",
-            "codex-gpt-5.6-luna",
-            "GPT-5.6",
-            "Codex-GPT-5.6-SOL",
-        ],
-    )
-    def test_matches_real_gpt_5_6_names(self, model_name):
-        assert _builder._is_gpt_5_6_family(model_name) is True
-
-    @pytest.mark.parametrize(
-        "model_name",
-        [
-            # Adjacent alnum chars must not be part of the segment.
-            "gpt-5.61",
-            "gpt-5.61-foo",
-            "xgpt-5.6",
-            "xgpt-5.6-foo",
-            "gpt-5.65-foo",
-            # Completely unrelated families.
-            "gpt-5.5",
-            "gpt-5.5-mini",
-            "gpt-5.4",
-            "gpt-5",
-            "claude-sonnet-4-5",
-            "o3",
-            "llama-3-70b",
-        ],
-    )
-    def test_rejects_unrelated_names(self, model_name):
-        assert _builder._is_gpt_5_6_family(model_name) is False
-
-    @pytest.mark.parametrize("model_name", ["", None])
-    def test_rejects_empty_or_none(self, model_name):
-        assert _builder._is_gpt_5_6_family(model_name) is False
+@pytest.mark.parametrize(
+    "model_name",
+    [None, "", "gpt-5.5", "claude-sonnet-4-5"],
+)
+def test_gpt_5_6_family_rejects_other_names(model_name):
+    assert not _builder._is_gpt_5_6_family(model_name)
 
 
-# --------------------------------------------------------------------------- #
-# _agent_exposes_tool helper                                                    #
-# --------------------------------------------------------------------------- #
-
-
-class TestAgentExposesTool:
-    """The detector must reflect the agent's tools list faithfully."""
-
-    def test_returns_true_when_present(self):
-        agent = MagicMock()
-        agent.get_available_tools.return_value = [
-            "list_files",
-            "invoke_agent",
-            "read_file",
-        ]
-        assert _builder._agent_exposes_tool(agent, "invoke_agent") is True
-
-    def test_returns_false_when_absent(self):
-        agent = MagicMock()
-        agent.get_available_tools.return_value = ["list_files", "read_file"]
-        assert _builder._agent_exposes_tool(agent, "invoke_agent") is False
-
-    def test_returns_false_when_get_tools_raises(self):
-        agent = MagicMock()
-        agent.get_available_tools.side_effect = RuntimeError("boom")
-        assert _builder._agent_exposes_tool(agent, "invoke_agent") is False
-
-    def test_returns_false_when_get_tools_returns_none(self):
-        agent = MagicMock()
-        agent.get_available_tools.return_value = None
-        assert _builder._agent_exposes_tool(agent, "invoke_agent") is False
-
-    def test_honors_requested_tool_name(self):
-        """The same helper must work for any tool we pass in."""
-        agent = MagicMock()
-        agent.get_available_tools.return_value = [
-            "list_files",
-            "agent_run_shell_command",
-        ]
-        assert _builder._agent_exposes_tool(agent, "agent_run_shell_command") is True
-        assert _builder._agent_exposes_tool(agent, "invoke_agent") is False
-
-
-# --------------------------------------------------------------------------- #
-# Guardrail text sanity                                                        #
-# --------------------------------------------------------------------------- #
-
-
-class TestGuardrailTextContent:
-    """Each guardrail string must actually convey its message."""
-
-    def test_invoke_agent_text_mentions_relevant_tools(self):
-        text = _builder._GPT_5_6_INVOKE_AGENT_GUARD_TEXT
-        assert "invoke_agent" in text
-        assert "planning-agent" in text
-        assert "GPT-5.6" in text
-
-    def test_run_shell_command_text_mentions_relevant_tools(self):
-        text = _builder._GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT
-        assert "agent_run_shell_command" in text
-        assert "GPT-5.6" in text
-        # The user-supplied caution phrase must be embedded verbatim.
-        assert "delete, overwrite" in text
-        assert "unrecoverable changes" in text
-
-
-# --------------------------------------------------------------------------- #
-# _assemble_instructions guardrail integration                                #
-# --------------------------------------------------------------------------- #
-
-
-def _make_fake_agent(tools):
-    """Build a minimal stand-in for ``BaseAgent`` with the right shape."""
-
+def _agent(tools):
     agent = MagicMock()
-    agent.get_full_system_prompt.return_value = "BASE_PROMPT"
+    agent.get_full_system_prompt.return_value = "BASE"
     agent.get_available_tools.return_value = tools
     agent.get_model_name.return_value = "gpt-5.6-sol"
     return agent
 
 
-def _patch_collaborators(monkeypatch):
-    """Stub every module-level collaborator ``_assemble_instructions`` touches.
-
-    ``load_puppy_rules`` lives in this module; ``has_extended_thinking_active``
-    is imported lazily from ``code_puppy.tools`` and
-    ``prepare_prompt_for_model`` from ``code_puppy.model_utils``. We patch
-    each at its source so the lazy imports resolve to our stubs.
-    """
-
-    def _stub_prepare(_name, prompt, _user, **_kwargs):
-        return MagicMock(instructions=prompt, user_prompt="", is_claude_code=False)
-
+def _stub_prompt_build(monkeypatch):
     monkeypatch.setattr(_builder, "load_puppy_rules", lambda: "")
     monkeypatch.setattr(
         "code_puppy.tools.has_extended_thinking_active", lambda _name: False
     )
     monkeypatch.setattr(
-        "code_puppy.model_utils.prepare_prompt_for_model", _stub_prepare
+        "code_puppy.model_utils.prepare_prompt_for_model",
+        lambda _name, prompt, _user, **_kwargs: MagicMock(instructions=prompt),
     )
 
 
-class TestAssembleInstructionsInvokeAgentGuardrail:
-    """The ``invoke_agent`` guardrail must fire only on gpt-5.6 + tool."""
-
-    def test_fires_when_model_and_tool_both_match(self, monkeypatch):
-        agent = _make_fake_agent(
-            ["list_files", "invoke_agent", "read_file"],
-        )
-        _patch_collaborators(monkeypatch)
-
-        result = _builder._assemble_instructions(agent, "gpt-5.6-sol")
-
-        assert result.startswith("BASE_PROMPT")
-        assert _builder._GPT_5_6_INVOKE_AGENT_GUARD_TEXT in result
-        # The guardrail must explicitly forbid the planning-agent.
-        assert "planning-agent" in result
-
-    def test_silent_for_non_gpt_5_6_model(self, monkeypatch):
-        agent = _make_fake_agent(
-            ["list_files", "invoke_agent", "read_file"],
-        )
-        _patch_collaborators(monkeypatch)
-
-        result = _builder._assemble_instructions(agent, "gpt-5.5")
-
-        assert _builder._GPT_5_6_INVOKE_AGENT_GUARD_TEXT not in result
+@pytest.mark.parametrize(
+    ("tools", "present", "absent"),
+    [
+        (["invoke_agent"], "Sub-Agent Delegation", "Shell Safety"),
+        (["agent_run_shell_command"], "Shell Safety", "Sub-Agent Delegation"),
+    ],
+)
+def test_prompt_guard_is_gated_by_tool(monkeypatch, tools, present, absent):
+    _stub_prompt_build(monkeypatch)
+    result = _builder._assemble_instructions(_agent(tools), "gpt-5.6-sol")
+    assert present in result
+    assert absent not in result
 
 
-class TestAssembleInstructionsRunShellCommandGuardrail:
-    """The ``agent_run_shell_command`` guardrail must also gate correctly."""
-
-    def test_fires_when_model_and_tool_both_match(self, monkeypatch):
-        agent = _make_fake_agent(
-            [
-                "list_files",
-                "agent_run_shell_command",
-                "read_file",
-            ],
-        )
-        _patch_collaborators(monkeypatch)
-
-        result = _builder._assemble_instructions(agent, "codex-gpt-5.6-sol")
-
-        assert _builder._GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT in result
-        assert "delete, overwrite" in result
-
-    def test_silent_when_agent_lacks_run_shell_command(self, monkeypatch):
-        agent = _make_fake_agent(["list_files", "read_file"])
-        _patch_collaborators(monkeypatch)
-
-        result = _builder._assemble_instructions(agent, "gpt-5.6-luna")
-
-        assert _builder._GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT not in result
-
-    def test_silent_for_non_gpt_5_6_model(self, monkeypatch):
-        agent = _make_fake_agent(
-            [
-                "list_files",
-                "agent_run_shell_command",
-                "read_file",
-            ],
-        )
-        _patch_collaborators(monkeypatch)
-
-        result = _builder._assemble_instructions(agent, "gpt-5.5")
-
-        assert _builder._GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT not in result
+def test_prompt_guards_are_gated_by_model(monkeypatch):
+    _stub_prompt_build(monkeypatch)
+    tools = ["invoke_agent", "agent_run_shell_command"]
+    result = _builder._assemble_instructions(_agent(tools), "gpt-5.5")
+    assert "Sub-Agent Delegation" not in result
+    assert "Shell Safety" not in result
 
 
-class TestAssembleInstructionsGuardrailsIndependent:
-    """Each guardrail fires on its own; they don't interfere with each other."""
-
-    def test_both_guardrails_fire_when_both_tools_present(self, monkeypatch):
-        # Agent with BOTH invoke_agent and agent_run_shell_command, on a
-        # gpt-5.6 model — both guardrails should appear in the result.
-        agent = _make_fake_agent(
-            [
-                "list_files",
-                "invoke_agent",
-                "agent_run_shell_command",
-                "read_file",
-            ],
-        )
-        _patch_collaborators(monkeypatch)
-
-        result = _builder._assemble_instructions(agent, "gpt-5.6-sol")
-
-        assert _builder._GPT_5_6_INVOKE_AGENT_GUARD_TEXT in result
-        assert _builder._GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT in result
-
-    def test_neither_guardrail_fires_without_gpt_5_6(self, monkeypatch):
-        agent = _make_fake_agent(
-            [
-                "list_files",
-                "invoke_agent",
-                "agent_run_shell_command",
-                "read_file",
-            ],
-        )
-        _patch_collaborators(monkeypatch)
-
-        result = _builder._assemble_instructions(agent, "gpt-5.5")
-
-        assert _builder._GPT_5_6_INVOKE_AGENT_GUARD_TEXT not in result
-        assert _builder._GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT not in result
+def test_tool_detection_fails_closed():
+    agent = MagicMock()
+    agent.get_available_tools.side_effect = RuntimeError
+    assert not _builder._agent_exposes_tool(agent, "invoke_agent")


### PR DESCRIPTION
## Summary

For any model whose name resolves to a **GPT-5.6 family variant** (`gpt-5.6`, `gpt-5.6-sol`, `codex-gpt-5.6-sol`, etc.), three independent, tool/depth-gated guardrails now apply during prompt assembly and sub-agent invocation.

### Prompt-level guardrails

Both fire only when the underlying model **and** the relevant tool are both present:

| Tool exposed | Guardrail added |
|---|---|
| `invoke_agent` | Treat sub-agent delegation as a last resort; **never** invoke `planning-agent` |
| `agent_run_shell_command` | Be cautious with commands/API calls that delete, overwrite, or otherwise make unrecoverable changes |

### Runtime recursion cap

| Condition | Behavior |
|---|---|
| GPT-5.6 model + depth 0 → 1 | Allowed (first sub-agent invocation OK) |
| GPT-5.6 model + depth ≥ 1 | Blocked — `_invoke_agent_impl` returns an `AgentInvokeOutput` error before any MCP server loading or pydantic-ai construction |

Non-GPT-5.6 models are unaffected by the depth cap and can recurse normally.

## Why

GPT-5.6 family models tend to over-delegate to sub-agents and to fire off destructive shell commands without thinking. This PR adds a small, opt-in safety net without modifying the existing per-agent system prompts or any other model family.

## Implementation

### Prompt-level guardrails

- Lives in `code_puppy/agents/_builder.py`.
- New `_is_gpt_5_6_family()` matcher treats `gpt-5.6` as a delimited segment so adjacent alphanumerics (`gpt-5.61-foo`, `xgpt-5.6`) and unrelated families (`gpt-5.5`, `claude-sonnet-4-5`) are correctly ignored.
- Generalized `_agent_exposes_tool(agent, tool_name)` helper swallows exceptions and `None` returns from `get_available_tools()` so the guardrails stay opt-in and never blow up the prompt build.
- Module-level `_GPT_5_6_INVOKE_AGENT_GUARD_TEXT` and `_GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT` constants make the actual instructions easy to audit and tweak.

### Runtime recursion cap

- New `_gpt_5_6_subagent_depth_should_block(model_name)` helper in `_builder.py` that combines the GPT-5.6 matcher with `get_subagent_depth()` from `subagent_context`.
- Wired into `_invoke_agent_impl` (in `code_puppy/tools/subagent_invocation.py`) right after `effective_model_name` is resolved and before any heavy work like MCP server loading. When it fires, we emit an error and return an `AgentInvokeOutput` with the error populated — no wasted cycles spinning up a sub-agent we're going to refuse.

## Tests

- `tests/agents/test_builder_gpt_5_6_subagent_guard.py` (36 tests) — covers the prompt-level guardrails (matcher, helper, text-content sanity, end-to-end integration).
- `tests/agents/test_builder_gpt_5_6_subagent_depth.py` (12 tests) — covers the recursion-depth guard (returns-true at depth 1+, returns-false at depth 0, returns-false for non-GPT-5.6 models at any depth).

All 48 tests pass. `ruff check` and `ruff format` clean.

## Out of scope (intentionally)

- Sub-agent invocation in `tools/subagent_invocation.py` calls `prepare_prompt_for_model` directly without going through `_assemble_instructions`, so this PR does **not** cover prompt-level guardrails for sub-agents that themselves have `invoke_agent` or `agent_run_shell_command`. If that's wanted, the cleanest path is a separate `get_model_system_prompt` plugin that covers both call sites — happy to follow up if useful.