### PR TITLE
feat: default to summarization compaction

### DIFF
--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -1509,8 +1509,9 @@ def get_compaction_strategy() -> str:
     val = get_value("compaction_strategy")
     if val and val.lower() in ["summarization", "truncation"]:
         return val.lower()
-    # Default to summarization
-    return "truncation"
+    # Summarization preserves useful long-running context by default. Users can
+    # explicitly select truncation as a zero-cost rollback strategy.
+    return "summarization"
 
 
 def get_http2() -> bool:

--- a/tests/command_line/test_set_menu_values.py
+++ b/tests/command_line/test_set_menu_values.py
@@ -66,15 +66,15 @@ class TestEffectiveSettingValue:
         )
         assert get_effective_setting_value(s) == "true"
 
-    def test_compaction_strategy_default_truncation(self):
+    def test_compaction_strategy_default_summarization(self):
         s = Setting(
             key="compaction_strategy",
             display_name="",
             description="",
             type_hint="choice",
-            effective_getter=lambda: "truncation",
+            effective_getter=lambda: "summarization",
         )
-        assert get_effective_setting_value(s) == "truncation"
+        assert get_effective_setting_value(s) == "summarization"
 
     def test_protected_token_count_returns_int_as_string(self):
         s = Setting(

--- a/tests/test_compaction_strategy.py
+++ b/tests/test_compaction_strategy.py
@@ -10,11 +10,11 @@ from code_puppy.config import (
 
 
 def test_default_compaction_strategy():
-    """Test that the default compaction strategy is truncation"""
+    """Summarization is the default when no strategy is configured."""
     with patch("code_puppy.config.get_value") as mock_get_value:
         mock_get_value.return_value = None
         strategy = get_compaction_strategy()
-        assert strategy == "truncation"
+        assert strategy == "summarization"
 
 
 def test_set_compaction_strategy_truncation():
@@ -70,7 +70,7 @@ def test_set_compaction_strategy_summarization():
 
 
 def test_set_compaction_strategy_invalid():
-    """Test that an invalid compaction strategy defaults to truncation"""
+    """Invalid strategies safely fall back to summarization."""
     import code_puppy.config
 
     original_config_dir = code_puppy.config.CONFIG_DIR
@@ -89,7 +89,7 @@ def test_set_compaction_strategy_invalid():
                 config.write(f)
 
             strategy = get_compaction_strategy()
-            assert strategy == "truncation"
+            assert strategy == "summarization"
         finally:
             code_puppy.config.CONFIG_DIR = original_config_dir
             code_puppy.config.CONFIG_FILE = original_config_file

--- a/tests/test_config_extended_part2.py
+++ b/tests/test_config_extended_part2.py
@@ -59,7 +59,7 @@ class TestConfigExtendedPart2:
         with patch("code_puppy.config.get_value") as mock_get:
             mock_get.return_value = None
             result = get_compaction_strategy()
-            assert result == "truncation"  # Default value
+            assert result == "summarization"  # Default value
             mock_get.assert_called_once_with("compaction_strategy")
 
         # Test valid strategies
@@ -73,7 +73,7 @@ class TestConfigExtendedPart2:
         with patch("code_puppy.config.get_value") as mock_get:
             mock_get.return_value = "invalid_strategy"
             result = get_compaction_strategy()
-            assert result == "truncation"  # Default fallback
+            assert result == "summarization"  # Default fallback
 
     def test_get_compaction_threshold(self, mock_config_file):
         """Test getting compaction threshold configuration"""
@@ -184,7 +184,7 @@ class TestConfigExtendedPart2:
             mock_get.return_value = "  summarization  "
             result = get_compaction_strategy()
             # The actual implementation doesn't strip whitespace, so it falls back to default
-            assert result == "truncation"  # Default fallback for non-exact match
+            assert result == "summarization"  # Default fallback for non-exact match
 
         # Test compaction strategy with exact match
         with patch("code_puppy.config.get_value") as mock_get:

--- a/tests/test_config_full_coverage.py
+++ b/tests/test_config_full_coverage.py
@@ -194,7 +194,7 @@ class TestNumericGetters:
         assert cp_config.get_compaction_threshold() == 0.85
 
     def test_get_compaction_strategy_default(self):
-        assert cp_config.get_compaction_strategy() in ["summarization", "truncation"]
+        assert cp_config.get_compaction_strategy() == "summarization"
 
     def test_get_compaction_strategy_values(self):
         cp_config.set_config_value("compaction_strategy", "summarization")
@@ -204,7 +204,7 @@ class TestNumericGetters:
 
     def test_get_compaction_strategy_invalid(self):
         cp_config.set_config_value("compaction_strategy", "invalid")
-        assert cp_config.get_compaction_strategy() == "truncation"
+        assert cp_config.get_compaction_strategy() == "summarization"
 
     def test_get_message_limit_default(self):
         cp_config.reset_value("message_limit")


### PR DESCRIPTION
## Summary

- default `compaction_strategy` to `summarization` when unset
- fall back to summarization for invalid strategy values
- preserve explicit `compaction_strategy=truncation` as the zero-cost rollback option
- update config and settings tests to assert the new default

The existing compaction pipeline remains unchanged: it triggers near the configured context threshold (85% by default), preserves the system prompt and protected recent-token tail (50k by default), and uses the separately configurable summarization model for older history.

## Tests

- `uv run pytest -q --no-cov tests/test_compaction_strategy.py tests/test_config_extended_part2.py tests/test_config_full_coverage.py tests/command_line/test_set_menu_values.py tests/agents/test_compaction.py` — 242 passed
- `uv run ruff check code_puppy/config.py tests/test_compaction_strategy.py tests/test_config_extended_part2.py tests/test_config_full_coverage.py tests/command_line/test_set_menu_values.py`
- `git diff --check`