### PR TITLE
feat: resume interrupted goals by UUID

### DIFF
--- a/code_puppy/plugins/wiggum/goal_runs.py
+++ b/code_puppy/plugins/wiggum/goal_runs.py
@@ -1,0 +1,91 @@
+"""Durable records for resumable ``/goal`` runs."""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from code_puppy.config import STATE_DIR
+
+_RUNS_DIR = Path(STATE_DIR) / "goal_runs"
+
+
+@dataclass(frozen=True)
+class GoalRun:
+    """The minimum state required to continue an interrupted goal."""
+
+    run_id: str
+    prompt: str
+    loop_count: int = 0
+    remediation_notes: str | None = None
+    status: str = "active"
+
+
+def create(prompt: str) -> GoalRun:
+    """Create and persist a new goal run."""
+    run = GoalRun(run_id=str(uuid.uuid4()), prompt=prompt)
+    save(run)
+    return run
+
+
+def save(run: GoalRun) -> None:
+    """Atomically persist a goal run."""
+    _RUNS_DIR.mkdir(parents=True, exist_ok=True)
+    destination = _path(run.run_id)
+    temporary = destination.with_suffix(f".tmp-{os.getpid()}")
+    temporary.write_text(json.dumps(asdict(run), indent=2), encoding="utf-8")
+    temporary.replace(destination)
+
+
+def load(run_id: str) -> GoalRun | None:
+    """Load a run by UUID, returning ``None`` for invalid or missing IDs."""
+    normalized = _normalize_uuid(run_id)
+    if normalized is None:
+        return None
+    try:
+        payload = json.loads(_path(normalized).read_text(encoding="utf-8"))
+        return GoalRun(
+            run_id=normalized,
+            prompt=str(payload["prompt"]),
+            loop_count=max(0, int(payload.get("loop_count", 0))),
+            remediation_notes=payload.get("remediation_notes"),
+            status=str(payload.get("status", "active")),
+        )
+    except (OSError, ValueError, TypeError, KeyError, json.JSONDecodeError):
+        return None
+
+
+def update(
+    run_id: str,
+    *,
+    loop_count: int,
+    remediation_notes: str | None,
+    status: str = "active",
+) -> None:
+    """Update mutable progress fields when the run still exists."""
+    run = load(run_id)
+    if run is None:
+        return
+    save(
+        GoalRun(
+            run_id=run.run_id,
+            prompt=run.prompt,
+            loop_count=loop_count,
+            remediation_notes=remediation_notes,
+            status=status,
+        )
+    )
+
+
+def _path(run_id: str) -> Path:
+    return _RUNS_DIR / f"{run_id}.json"
+
+
+def _normalize_uuid(value: str) -> str | None:
+    try:
+        return str(uuid.UUID(value.strip()))
+    except (AttributeError, ValueError):
+        return None

--- a/code_puppy/plugins/wiggum/register_callbacks.py
+++ b/code_puppy/plugins/wiggum/register_callbacks.py
@@ -15,7 +15,7 @@ from code_puppy.messaging import (
     emit_warning,
 )
 
-from . import state
+from . import goal_runs, state
 from .judge import GoalJudgement, judge_goal
 from .judge_config import JudgeConfig, get_enabled_judges_or_default, load_judges
 
@@ -68,7 +68,7 @@ def handle_wiggum_command(command: str) -> str | bool:
 @register_command(
     name="goal",
     description="Retry a task until all LLM judges say it is complete 🎯",
-    usage="/goal <prompt>",
+    usage="/goal <prompt> | /goal resume <UUID>",
     # /kibble and /chow are puppy-themed aliases for /goal — same behavior,
     # just more on-brand for a code puppy.
     aliases=["kibble", "chow"],
@@ -78,14 +78,23 @@ def handle_goal_command(command: str) -> str | bool:
     """Start goal mode and execute the prompt immediately."""
     prompt = _extract_prompt(command)
     if not prompt:
-        emit_warning("Usage: /goal <prompt>  (aliases: /kibble, /chow)")
+        emit_warning(
+            "Usage: /goal <prompt> | /goal resume <UUID>  (aliases: /kibble, /chow)"
+        )
         emit_info("Example: /goal make tests pass for the auth flow")
         emit_info("Press Ctrl+C or run /goal_stop to stop the loop.")
         return True
 
-    state.start(prompt, mode="goal")
-    _display_banner_message("GOAL MODE", "🎯 ACTIVATED!", banner_name="llm_judge")
+    if prompt.lower().startswith("resume"):
+        return _resume_goal(prompt)
+
+    run = goal_runs.create(prompt)
+    state.start(prompt, mode="goal", run_id=run.run_id)
+    _display_banner_message(
+        "GOAL MODE", "\U0001f3af ACTIVATED!", banner_name="llm_judge"
+    )
     emit_info(f"Goal: {prompt}")
+    emit_info(f"Goal UUID: {run.run_id}")
     emit_info(
         "After each iteration, every enabled LLM judge will verify completion in parallel."
     )
@@ -108,8 +117,12 @@ def handle_wiggum_stop_command(command: str) -> bool:
     """Stop Wiggum/goal loop mode."""
     del command
     if state.is_active():
+        run_id = state.get_state().run_id
+        _persist_goal_progress(status="interrupted")
         state.stop()
-        emit_success("🍩 Wiggum/goal mode stopped!")
+        emit_success("\U0001f369 Wiggum/goal mode stopped!")
+        if run_id:
+            emit_info(f"Resume it with: /goal resume {run_id}")
     else:
         emit_info("Wiggum/goal mode is not active.")
     return True
@@ -172,6 +185,41 @@ def _emit_configured_judges_summary() -> None:
             "using the implementor's model."
         )
     emit_info("Run /judges to add, edit, enable, or disable judges.")
+
+
+def _resume_goal(arguments: str) -> str | bool:
+    """Restore a durable goal run and dispatch its next iteration."""
+    parts = arguments.split()
+    if len(parts) != 2 or parts[0].lower() != "resume":
+        emit_warning("Usage: /goal resume <UUID>")
+        return True
+
+    run = goal_runs.load(parts[1])
+    if run is None:
+        emit_warning(f"Goal run not found: {parts[1]}")
+        return True
+    if run.status in {"completed", "stopped"}:
+        emit_warning(f"Goal run {run.run_id} is already {run.status}.")
+        return True
+
+    state.start(
+        run.prompt,
+        mode="goal",
+        run_id=run.run_id,
+        loop_count=run.loop_count,
+        remediation_notes=run.remediation_notes,
+    )
+    goal_runs.update(
+        run.run_id,
+        loop_count=run.loop_count,
+        remediation_notes=run.remediation_notes,
+    )
+    _display_banner_message("GOAL MODE", "\U0001f3af RESUMED!", banner_name="llm_judge")
+    emit_info(f"Goal UUID: {run.run_id}")
+    emit_info(f"Resuming after {run.loop_count} completed iteration(s).")
+    if run.remediation_notes:
+        return f"{run.prompt}\n\nJudge remediation notes:\n{run.remediation_notes}"
+    return run.prompt
 
 
 def _extract_prompt(command: str) -> str:
@@ -443,13 +491,16 @@ async def _on_interactive_turn_end(
                 error=error,
             )
         except (asyncio.CancelledError, KeyboardInterrupt):
-            # Belt-and-suspenders: _run_goal_judges already swallows these
-            # but we never want a stray Ctrl+C to escape the plugin and
-            # take down the whole REPL.
-            _display_llm_judge("⛔ Goal loop cancelled (Ctrl+C).")
+            # Keep enough durable state for an explicit UUID resume.
+            run_id = state.get_state().run_id
+            _persist_goal_progress(status="interrupted")
+            _display_llm_judge("\u26d4 Goal loop cancelled (Ctrl+C).")
             state.stop()
+            if run_id:
+                emit_info(f"Resume it with: /goal resume {run_id}")
             return None
         if complete:
+            _persist_goal_progress(status="completed")
             # Per-judge verdicts were already shown by _run_goal_judges —
             # no need to re-dump the notes block here.
             _display_llm_judge("✅ GOAL COMPLETE!", final=True)
@@ -458,6 +509,7 @@ async def _on_interactive_turn_end(
 
         max_iters = _get_goal_max_iterations()
         if loop_num >= max_iters:
+            _persist_goal_progress(status="stopped")
             _display_llm_judge(
                 f"🛑 GOAL STOPPED — Hit max iterations ({max_iters}). "
                 f"Raise the cap with /set goal_max_iterations=<int>.",
@@ -467,6 +519,7 @@ async def _on_interactive_turn_end(
             return None
 
         state.get_state().remediation_notes = notes
+        _persist_goal_progress()
         _display_llm_judge(
             f"❌ GOAL INCOMPLETE — Retrying! (Loop #{loop_num}/{max_iters})",
             final=True,
@@ -493,11 +546,28 @@ async def _on_interactive_turn_end(
     }
 
 
+def _persist_goal_progress(*, status: str = "active") -> None:
+    current = state.get_state()
+    if current.mode != "goal" or current.run_id is None:
+        return
+    goal_runs.update(
+        current.run_id,
+        loop_count=current.loop_count,
+        remediation_notes=current.remediation_notes,
+        status=status,
+    )
+
+
 def _on_interactive_turn_cancel(prompt: str, *, reason: str = "cancelled") -> None:
     del prompt
     if state.is_active():
+        current = state.get_state()
+        run_id = current.run_id
+        _persist_goal_progress(status="interrupted")
         state.stop()
-        emit_warning(f"🍩 Wiggum/goal loop stopped due to {reason}")
+        emit_warning(f"\U0001f369 Wiggum/goal loop stopped due to {reason}")
+        if run_id:
+            emit_info(f"Resume it with: /goal resume {run_id}")
 
 
 register_callback("interactive_turn_end", _on_interactive_turn_end)

--- a/code_puppy/plugins/wiggum/state.py
+++ b/code_puppy/plugins/wiggum/state.py
@@ -14,13 +14,23 @@ class WiggumState:
     loop_count: int = 0
     mode: str = "wiggum"
     remediation_notes: str | None = None
+    run_id: str | None = None
 
-    def start(self, prompt: str, *, mode: str = "wiggum") -> None:
+    def start(
+        self,
+        prompt: str,
+        *,
+        mode: str = "wiggum",
+        run_id: str | None = None,
+        loop_count: int = 0,
+        remediation_notes: str | None = None,
+    ) -> None:
         self.active = True
         self.prompt = prompt
-        self.loop_count = 0
+        self.loop_count = loop_count
         self.mode = mode
-        self.remediation_notes = None
+        self.remediation_notes = remediation_notes
+        self.run_id = run_id
 
     def stop(self) -> None:
         self.active = False
@@ -28,6 +38,7 @@ class WiggumState:
         self.loop_count = 0
         self.mode = "wiggum"
         self.remediation_notes = None
+        self.run_id = None
 
     def increment(self) -> int:
         self.loop_count += 1
@@ -53,8 +64,21 @@ def get_prompt() -> str | None:
     return _STATE.prompt if _STATE.active else None
 
 
-def start(prompt: str, *, mode: str = "wiggum") -> None:
-    _STATE.start(prompt, mode=mode)
+def start(
+    prompt: str,
+    *,
+    mode: str = "wiggum",
+    run_id: str | None = None,
+    loop_count: int = 0,
+    remediation_notes: str | None = None,
+) -> None:
+    _STATE.start(
+        prompt,
+        mode=mode,
+        run_id=run_id,
+        loop_count=loop_count,
+        remediation_notes=remediation_notes,
+    )
 
 
 def stop() -> None:

--- a/tests/plugins/test_goal_resume.py
+++ b/tests/plugins/test_goal_resume.py
@@ -1,0 +1,74 @@
+"""Tests for durable UUID-based goal resumption."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from code_puppy.plugins.wiggum import goal_runs, state
+from code_puppy.plugins.wiggum.register_callbacks import (
+    _on_interactive_turn_cancel,
+    handle_goal_command,
+)
+
+
+def test_goal_run_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setattr(goal_runs, "_RUNS_DIR", tmp_path)
+
+    created = goal_runs.create("ship the feature")
+    goal_runs.update(
+        created.run_id,
+        loop_count=3,
+        remediation_notes="add a regression test",
+        status="interrupted",
+    )
+
+    loaded = goal_runs.load(created.run_id)
+    assert loaded is not None
+    assert loaded.prompt == "ship the feature"
+    assert loaded.loop_count == 3
+    assert loaded.remediation_notes == "add a regression test"
+    assert loaded.status == "interrupted"
+    assert goal_runs.load("definitely-not-a-uuid") is None
+
+
+def test_goal_resume_restores_progress(tmp_path, monkeypatch):
+    monkeypatch.setattr(goal_runs, "_RUNS_DIR", tmp_path)
+    run = goal_runs.create("ship the feature")
+    goal_runs.update(
+        run.run_id,
+        loop_count=2,
+        remediation_notes="fix the flaky test",
+        status="interrupted",
+    )
+
+    with (
+        patch("code_puppy.plugins.wiggum.register_callbacks._display_banner_message"),
+        patch("code_puppy.plugins.wiggum.register_callbacks.emit_info"),
+    ):
+        prompt = handle_goal_command(f"/goal resume {run.run_id}")
+
+    current = state.get_state()
+    assert current.active is True
+    assert current.run_id == run.run_id
+    assert current.loop_count == 2
+    assert prompt == "ship the feature\n\nJudge remediation notes:\nfix the flaky test"
+    state.stop()
+
+
+def test_cancel_marks_goal_interrupted_and_prints_resume(tmp_path, monkeypatch):
+    monkeypatch.setattr(goal_runs, "_RUNS_DIR", tmp_path)
+    run = goal_runs.create("ship the feature")
+    state.start(run.prompt, mode="goal", run_id=run.run_id, loop_count=4)
+
+    with (
+        patch("code_puppy.plugins.wiggum.register_callbacks.emit_warning"),
+        patch("code_puppy.plugins.wiggum.register_callbacks.emit_info") as emit_info,
+    ):
+        _on_interactive_turn_cancel(run.prompt, reason="cancelled")
+
+    saved = goal_runs.load(run.run_id)
+    assert saved is not None
+    assert saved.status == "interrupted"
+    assert saved.loop_count == 4
+    emit_info.assert_called_once_with(f"Resume it with: /goal resume {run.run_id}")
+    assert state.is_active() is False

--- a/tests/plugins/test_wiggum_plugin.py
+++ b/tests/plugins/test_wiggum_plugin.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import importlib
-
+from types import SimpleNamespace
 from unittest.mock import patch
 
 
@@ -24,12 +24,21 @@ def test_goal_command_uses_banner_for_activation():
         patch.object(module, "_display_banner_message") as mock_banner,
         patch.object(module, "emit_info") as mock_info,
         patch.object(module, "load_judges", return_value=fake_registry),
+        patch.object(
+            module.goal_runs,
+            "create",
+            return_value=SimpleNamespace(run_id="00000000-0000-4000-8000-000000000001"),
+        ),
         patch.object(module.state, "start") as mock_start,
     ):
         result = module.handle_goal_command("/goal say hi")
 
     assert result == "say hi"
-    mock_start.assert_called_once_with("say hi", mode="goal")
+    mock_start.assert_called_once_with(
+        "say hi",
+        mode="goal",
+        run_id="00000000-0000-4000-8000-000000000001",
+    )
     mock_banner.assert_called_once_with(
         "GOAL MODE",
         "🎯 ACTIVATED!",


### PR DESCRIPTION
## Summary
- persist goal prompt, iteration count, remediation notes, and status under the state directory
- show a UUID for each new goal and preserve resumable state on cancellation or explicit stop
- support `/goal resume <UUID>` without resetting iteration progress
- reject missing, invalid, completed, and max-iteration-stopped goal runs

## Tests
- `uv run pytest -q --no-cov tests/plugins/test_wiggum_plugin.py tests/plugins/test_goal_resume.py tests/plugins/test_judge_orchestration.py` (30 passed)
- `uv run ruff check code_puppy/plugins/wiggum tests/plugins/test_wiggum_plugin.py tests/plugins/test_goal_resume.py`
- `uv run ruff format --check code_puppy/plugins/wiggum tests/plugins/test_wiggum_plugin.py tests/plugins/test_goal_resume.py`
- `git diff --check`