### PR TITLE
chore: ignore local .worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ code_puppy/bundled_skills/
 .json
 
 .state/
+
+# Local git worktrees for parallel PR development
+.worktrees/


### PR DESCRIPTION
One-liner: adds `.worktrees/` to `.gitignore` so contributors using `git worktree add .worktrees/<name>` for parallel branch development don't have to worry about worktree scaffolding leaking into commits or cluttering `git status`.

No behavior change; ignore-only.