### PR TITLE
test: verify localized cli help wiring

### DIFF
--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -711,7 +711,27 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
             execute_shell_passthrough(initial_command)
             initial_command = None
 
-    # Initialize the runtime agent manager
+    # Initialize the runtime agent manager. Initial prompts follow the same
+    # slash-command dispatch as later interactive turns; handled commands must
+    # not be accidentally sent to the model as plain text.
+    if initial_command:
+        command_prompt = (
+            parse_prompt_attachments(initial_command).prompt or ""
+        ).strip()
+        if command_prompt.startswith("/"):
+            try:
+                command_result = handle_command(command_prompt)
+            except Exception as e:
+                from code_puppy.messaging import emit_error
+
+                emit_error(t("cli.command.error", error=e))
+                initial_command = None
+            else:
+                if command_result is True or command_result == "__AUTOSAVE_LOAD__":
+                    initial_command = None
+                elif isinstance(command_result, str):
+                    initial_command = command_result
+
     if initial_command:
         from code_puppy.agents import get_current_agent
         from code_puppy.messaging import emit_info, emit_success, emit_system_message

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -147,7 +147,11 @@ def apply_quick_resume(args) -> bool:
 async def main():
     """Main async entry point for Code Puppy CLI."""
     # Seed locale selection before argparse materializes translated help text.
-    get_locale()
+    # A malformed optional config must not block --help or --version.
+    try:
+        get_locale()
+    except Exception:
+        pass
     parser = argparse.ArgumentParser(description="Code Puppy - A code generation agent")
     parser.add_argument(
         "--version",

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -31,6 +31,7 @@ from code_puppy.config import (
     ensure_config_exists,
     finalize_autosave_session,
     get_current_session_name,
+    get_locale,
     initialize_command_history_file,
     record_terminal_session,
     save_command_to_history,
@@ -145,6 +146,8 @@ def apply_quick_resume(args) -> bool:
 
 async def main():
     """Main async entry point for Code Puppy CLI."""
+    # Seed locale selection before argparse materializes translated help text.
+    get_locale()
     parser = argparse.ArgumentParser(description="Code Puppy - A code generation agent")
     parser.add_argument(
         "--version",
@@ -157,13 +160,13 @@ async def main():
         "--interactive",
         "-i",
         action="store_true",
-        help="Run interactively; with --prompt, continue after the first response",
+        help=t("cli.args.interactive_help"),
     )
     parser.add_argument(
         "--prompt",
         "-p",
         type=str,
-        help="Execute a prompt and exit, or use with --interactive to continue",
+        help=t("cli.args.prompt_help"),
     )
     parser.add_argument(
         "--agent",

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -712,12 +712,20 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
             initial_command = None
 
     # Initialize the runtime agent manager. Initial prompts follow the same
-    # slash-command dispatch as later interactive turns; handled commands must
-    # not be accidentally sent to the model as plain text.
+    # pre-dispatch rules as later interactive turns; handled commands must not
+    # be accidentally sent to the model as plain text.
+    pending_initial_command = None
     if initial_command:
         command_prompt = (
             parse_prompt_attachments(initial_command).prompt or ""
         ).strip()
+        if command_prompt.lower() == "clear":
+            command_prompt = "/clear"
+        if command_prompt.lower() in {"/exit", "/quit"}:
+            from code_puppy.messaging import emit_success
+
+            emit_success(t("cli.goodbye"))
+            return
         if command_prompt.startswith("/"):
             try:
                 command_result = handle_command(command_prompt)
@@ -727,7 +735,10 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
                 emit_error(t("cli.command.error", error=e))
                 initial_command = None
             else:
-                if command_result is True or command_result == "__AUTOSAVE_LOAD__":
+                if command_result is True:
+                    initial_command = None
+                elif command_result == "__AUTOSAVE_LOAD__":
+                    pending_initial_command = command_prompt
                     initial_command = None
                 elif isinstance(command_result, str):
                     initial_command = command_result
@@ -864,7 +875,12 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
             emit_info(f"{user_prompt}\n")
 
         try:
-            if persistent_prompt:
+            if pending_initial_command is not None:
+                task = pending_initial_command
+                pending_initial_command = None
+                if persistent_prompt:
+                    emit_info(_prompt_echo_text(task))
+            elif persistent_prompt:
                 from code_puppy.messaging.run_ui import (
                     set_idle_prompt_prefix,
                     wait_for_idle_submission,
@@ -1027,6 +1043,10 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
                         if os.getenv("CODE_PUPPY_NO_TUI") == "1":
                             use_interactive_picker = False
 
+                        from code_puppy.session_storage import (
+                            restore_autosave_interactively,
+                        )
+
                         if use_interactive_picker:
                             # Use interactive picker for terminal sessions
                             from code_puppy.agents.agent_manager import (
@@ -1043,10 +1063,7 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
                                 emit_success,
                                 emit_warning,
                             )
-                            from code_puppy.session_storage import (
-                                load_session,
-                                restore_autosave_interactively,
-                            )
+                            from code_puppy.session_storage import load_session
 
                             from code_puppy.messaging.run_ui import (
                                 suspended_run_ui,

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -157,13 +157,13 @@ async def main():
         "--interactive",
         "-i",
         action="store_true",
-        help=t("cli.args.interactive_help"),
+        help="Run interactively; with --prompt, continue after the first response",
     )
     parser.add_argument(
         "--prompt",
         "-p",
         type=str,
-        help=t("cli.args.prompt_help"),
+        help="Execute a prompt and exit, or use with --interactive to continue",
     )
     parser.add_argument(
         "--agent",
@@ -721,7 +721,7 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
         ).strip()
         if command_prompt.lower() == "clear":
             command_prompt = "/clear"
-        if command_prompt.lower() in {"/exit", "/quit"}:
+        if command_prompt.lower() in {"exit", "quit", "/exit", "/quit"}:
             from code_puppy.messaging import emit_success
 
             emit_success(t("cli.goodbye"))

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -157,13 +157,13 @@ async def main():
         "--interactive",
         "-i",
         action="store_true",
-        help="Run in interactive mode",
+        help=t("cli.args.interactive_help"),
     )
     parser.add_argument(
         "--prompt",
         "-p",
         type=str,
-        help="Execute a single prompt and exit (no interactive mode)",
+        help=t("cli.args.prompt_help"),
     )
     parser.add_argument(
         "--agent",
@@ -214,6 +214,11 @@ async def main():
         if isinstance(result, dict) and result.get("handled"):
             return result.get("exit_code", 0)
 
+    # A prompt is headless by default. Explicit interactive mode promotes it
+    # to the REPL's first turn instead, preserving the historical behavior of
+    # both flags when they are used separately.
+    prompt_only_mode = bool(args.prompt and not args.interactive)
+
     from code_puppy.messaging import (
         RichConsoleRenderer,
         SynchronousInteractiveRenderer,
@@ -237,10 +242,9 @@ async def main():
     initialize_command_history_file()
     from code_puppy.messaging import emit_error, emit_system_message
 
-    # Show the awesome Code Puppy logo when entering interactive mode
-    # This happens when: no -p flag (prompt-only mode) is used
-    # The logo should appear for both `code-puppy` and `code-puppy -i`
-    if not args.prompt:
+    # Show the awesome Code Puppy logo when entering interactive mode,
+    # including when -p supplies the first prompt for an explicit -i session.
+    if not prompt_only_mode:
         try:
             import pyfiglet
 
@@ -493,14 +497,11 @@ async def main():
     shutdown_flag = False
     try:
         initial_command = None
-        prompt_only_mode = False
 
         if args.prompt:
             initial_command = args.prompt
-            prompt_only_mode = True
         elif args.command:
             initial_command = " ".join(args.command)
-            prompt_only_mode = False
 
         if prompt_only_mode:
             await execute_single_prompt(

--- a/code_puppy/i18n/locales/en-US.json
+++ b/code_puppy/i18n/locales/en-US.json
@@ -20,8 +20,6 @@
   "version.undetected": "Could not detect current version, using fallback",
   "confirm.yes": "Yes",
   "confirm.no": "No",
-  "cli.args.interactive_help": "Run interactively; with --prompt, continue after the first response",
-  "cli.args.prompt_help": "Execute a prompt and exit, or use with --interactive to continue",
   "cli.loading": "\ud83d\udc36 Code Puppy is Loading...",
   "cli.error.no_ports": "No available ports in range 8090-9010!",
   "cli.error.model_transient": "\ud83d\udd0c The model connection hit a transient error ({error_type}) and didn't recover after auto-retries. This is almost always a VPN/WiFi/provider blip \u2014 just re-run your last prompt. Your session history is intact.",

--- a/code_puppy/i18n/locales/en-US.json
+++ b/code_puppy/i18n/locales/en-US.json
@@ -20,6 +20,8 @@
   "version.undetected": "Could not detect current version, using fallback",
   "confirm.yes": "Yes",
   "confirm.no": "No",
+  "cli.args.interactive_help": "Run interactively; with --prompt, continue after the first response",
+  "cli.args.prompt_help": "Execute a prompt and exit, or use with --interactive to continue",
   "cli.loading": "\ud83d\udc36 Code Puppy is Loading...",
   "cli.error.no_ports": "No available ports in range 8090-9010!",
   "cli.error.model_transient": "\ud83d\udd0c The model connection hit a transient error ({error_type}) and didn't recover after auto-retries. This is almost always a VPN/WiFi/provider blip \u2014 just re-run your last prompt. Your session history is intact.",

--- a/tests/plugins/test_chatgpt_oauth_utils.py
+++ b/tests/plugins/test_chatgpt_oauth_utils.py
@@ -1105,11 +1105,10 @@ class TestAddModelsToConfig:
             "codex-gpt-5.4",
         ):
             model_config = saved_config[model_name]
-            assert model_config["supported_settings"] == [
-                "reasoning_effort",
-                "summary",
-                "verbosity",
-            ]
+            expected_settings = ["reasoning_effort", "summary", "verbosity"]
+            if model_name.startswith("codex-gpt-5.6-"):
+                expected_settings.extend(["reasoning_context", "reasoning_mode"])
+            assert model_config["supported_settings"] == expected_settings
             assert model_config["supports_xhigh_reasoning"] is True
             assert model_config["supports_ultra_reasoning"] is model_name.startswith(
                 "codex-gpt-5.6-"

--- a/tests/test_cli_runner_full_coverage.py
+++ b/tests/test_cli_runner_full_coverage.py
@@ -180,11 +180,17 @@ class TestMain:
     @pytest.mark.anyio
     async def test_prompt_mode(self):
         mock_exec = AsyncMock()
+        mock_inter = AsyncMock()
         await self._run_main(
             ["code-puppy", "-p", "hello world"],
-            extra_patches={"code_puppy.cli_runner.execute_single_prompt": mock_exec},
+            extra_patches={
+                "code_puppy.cli_runner.execute_single_prompt": mock_exec,
+                "code_puppy.cli_runner.interactive_mode": mock_inter,
+            },
         )
-        mock_exec.assert_called_once()
+        mock_exec.assert_awaited_once()
+        assert mock_exec.call_args.args[0] == "hello world"
+        mock_inter.assert_not_awaited()
 
     @pytest.mark.anyio
     async def test_interactive_mode_default(self):
@@ -197,6 +203,33 @@ class TestMain:
             },
         )
         mock_inter.assert_called_once()
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["code-puppy", "-p", "first prompt", "-i"],
+            ["code-puppy", "--interactive", "--prompt", "first prompt"],
+        ],
+    )
+    async def test_prompt_starts_interactive_session_when_requested(self, argv):
+        mock_exec = AsyncMock()
+        mock_inter = AsyncMock()
+        mock_logo = MagicMock(return_value="LOGO\n\n")
+
+        await self._run_main(
+            argv,
+            extra_patches={
+                "code_puppy.cli_runner.execute_single_prompt": mock_exec,
+                "code_puppy.cli_runner.interactive_mode": mock_inter,
+                "pyfiglet.figlet_format": mock_logo,
+            },
+        )
+
+        mock_exec.assert_not_awaited()
+        mock_inter.assert_awaited_once()
+        assert mock_inter.call_args.kwargs["initial_command"] == "first prompt"
+        mock_logo.assert_called_once()
 
     @pytest.mark.anyio
     async def test_with_command_args(self):

--- a/tests/test_cli_runner_full_coverage.py
+++ b/tests/test_cli_runner_full_coverage.py
@@ -858,6 +858,48 @@ class TestInteractiveMode:
         mock_run.assert_not_awaited()
 
     @pytest.mark.anyio
+    async def test_initial_exit_command_stops_before_prompt(self):
+        agent = MagicMock()
+        agent.get_user_prompt.return_value = "task:"
+        mock_input = AsyncMock(side_effect=AssertionError("prompt should not run"))
+
+        await _run_interactive(
+            _mock_renderer(),
+            _interactive_patches(),
+            mock_input,
+            agent=agent,
+            initial_command="/exit",
+        )
+
+        mock_input.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_initial_autosave_command_is_deferred_to_repl_dispatch(self):
+        agent = MagicMock()
+        agent.get_user_prompt.return_value = "task:"
+        mock_handle = MagicMock(side_effect=["__AUTOSAVE_LOAD__", "__AUTOSAVE_LOAD__"])
+        mock_restore = AsyncMock()
+        mock_stdin = MagicMock(isatty=MagicMock(return_value=False))
+        mock_stdout = MagicMock(isatty=MagicMock(return_value=False))
+
+        await _run_interactive(
+            _mock_renderer(),
+            _interactive_patches(),
+            AsyncMock(return_value="/exit"),
+            agent=agent,
+            initial_command="/autosave_load",
+            extra_patches={
+                "code_puppy.command_line.command_handler.handle_command": mock_handle,
+                "code_puppy.session_storage.restore_autosave_interactively": mock_restore,
+                "sys.stdin": mock_stdin,
+                "sys.stdout": mock_stdout,
+            },
+        )
+
+        assert mock_handle.call_count == 2
+        mock_restore.assert_awaited_once()
+
+    @pytest.mark.anyio
     async def test_initial_command_error(self):
         agent = MagicMock()
         agent.get_user_prompt.return_value = "task:"

--- a/tests/test_cli_runner_full_coverage.py
+++ b/tests/test_cli_runner_full_coverage.py
@@ -833,6 +833,31 @@ class TestInteractiveMode:
         )
 
     @pytest.mark.anyio
+    async def test_initial_slash_command_is_handled_before_agent(self):
+        agent = MagicMock()
+        agent.get_user_prompt.return_value = "task:"
+        mock_handle = MagicMock(return_value=True)
+        mock_run = AsyncMock()
+
+        await _run_interactive(
+            _mock_renderer(),
+            _interactive_patches(),
+            AsyncMock(return_value="/exit"),
+            agent=agent,
+            initial_command="/help",
+            extra_patches={
+                "code_puppy.cli_runner.get_current_agent": MagicMock(
+                    return_value=agent
+                ),
+                "code_puppy.command_line.command_handler.handle_command": mock_handle,
+                "code_puppy.cli_runner.run_prompt_with_attachments": mock_run,
+            },
+        )
+
+        mock_handle.assert_called_once_with("/help")
+        mock_run.assert_not_awaited()
+
+    @pytest.mark.anyio
     async def test_initial_command_error(self):
         agent = MagicMock()
         agent.get_user_prompt.return_value = "task:"

--- a/tests/test_cli_runner_full_coverage.py
+++ b/tests/test_cli_runner_full_coverage.py
@@ -858,7 +858,8 @@ class TestInteractiveMode:
         mock_run.assert_not_awaited()
 
     @pytest.mark.anyio
-    async def test_initial_exit_command_stops_before_prompt(self):
+    @pytest.mark.parametrize("initial_command", ["exit", "quit", "/exit", "/quit"])
+    async def test_initial_exit_command_stops_before_prompt(self, initial_command):
         agent = MagicMock()
         agent.get_user_prompt.return_value = "task:"
         mock_input = AsyncMock(side_effect=AssertionError("prompt should not run"))
@@ -868,7 +869,7 @@ class TestInteractiveMode:
             _interactive_patches(),
             mock_input,
             agent=agent,
-            initial_command="/exit",
+            initial_command=initial_command,
         )
 
         mock_input.assert_not_awaited()

--- a/tests/test_cli_runner_plugin_cli_args.py
+++ b/tests/test_cli_runner_plugin_cli_args.py
@@ -86,27 +86,31 @@ def test_plugin_flag_appears_in_help(clean_cli_hooks, capsys):
 
 
 def test_prompt_mode_help_uses_catalog_strings(clean_cli_hooks, capsys):
-    """The prompt-mode options expose their localized argparse help text."""
-    from code_puppy.i18n import set_locale
+    """The prompt-mode options expose localized argparse help text."""
+    from code_puppy.i18n import PSEUDO_LOCALE, set_locale, t
 
-    set_locale("en-US")
-
-    with ExitStack() as stack:
-        stack.enter_context(patch("sys.argv", ["code-puppy", "--help"]))
-        with pytest.raises(SystemExit) as excinfo:
-            asyncio.run(main())
+    set_locale(PSEUDO_LOCALE)
+    expected_interactive = t("cli.args.interactive_help")
+    expected_prompt = t("cli.args.prompt_help")
+    try:
+        with ExitStack() as stack:
+            stack.enter_context(patch("sys.argv", ["code-puppy", "--help"]))
+            with pytest.raises(SystemExit) as excinfo:
+                asyncio.run(main())
+    finally:
+        set_locale("en-US")
 
     assert excinfo.value.code == 0
-    out = capsys.readouterr().out
-    assert "Run interactively; with --prompt" in out
-    assert "Execute a prompt and exit" in out
+    out = " ".join(capsys.readouterr().out.split())
+    assert expected_interactive.split("\u2003", 1)[0] in out
+    assert expected_prompt.split("\u2003", 1)[0] in out
 
 
 def test_help_survives_locale_bootstrap_failure(clean_cli_hooks, capsys):
     """Malformed optional config cannot block argparse's own help path."""
     with ExitStack() as stack:
         stack.enter_context(patch("sys.argv", ["code-puppy", "--help"]))
-        stack.enter_context(
+        mock_locale = stack.enter_context(
             patch(
                 "code_puppy.cli_runner.get_locale",
                 side_effect=RuntimeError("bad config"),
@@ -116,6 +120,7 @@ def test_help_survives_locale_bootstrap_failure(clean_cli_hooks, capsys):
             asyncio.run(main())
 
     assert excinfo.value.code == 0
+    mock_locale.assert_called_once_with()
     assert "--interactive" in capsys.readouterr().out
 
 

--- a/tests/test_cli_runner_plugin_cli_args.py
+++ b/tests/test_cli_runner_plugin_cli_args.py
@@ -85,6 +85,40 @@ def test_plugin_flag_appears_in_help(clean_cli_hooks, capsys):
     assert "the all-important xyz flag" in out
 
 
+def test_prompt_mode_help_uses_catalog_strings(clean_cli_hooks, capsys):
+    """The prompt-mode options expose their localized argparse help text."""
+    from code_puppy.i18n import set_locale
+
+    set_locale("en-US")
+
+    with ExitStack() as stack:
+        stack.enter_context(patch("sys.argv", ["code-puppy", "--help"]))
+        with pytest.raises(SystemExit) as excinfo:
+            asyncio.run(main())
+
+    assert excinfo.value.code == 0
+    out = capsys.readouterr().out
+    assert "Run interactively; with --prompt" in out
+    assert "Execute a prompt and exit" in out
+
+
+def test_help_survives_locale_bootstrap_failure(clean_cli_hooks, capsys):
+    """Malformed optional config cannot block argparse's own help path."""
+    with ExitStack() as stack:
+        stack.enter_context(patch("sys.argv", ["code-puppy", "--help"]))
+        stack.enter_context(
+            patch(
+                "code_puppy.cli_runner.get_locale",
+                side_effect=RuntimeError("bad config"),
+            )
+        )
+        with pytest.raises(SystemExit) as excinfo:
+            asyncio.run(main())
+
+    assert excinfo.value.code == 0
+    assert "--interactive" in capsys.readouterr().out
+
+
 def test_duplicate_option_strings_raise_argparse_error(clean_cli_hooks):
     """Two callbacks declaring the same option string fail fast.
 


### PR DESCRIPTION
[CodePuppy Agent] - 
## What
Allow `-p/--prompt` to provide the first turn while `-i/--interactive` keeps Code Puppy running for follow-up prompts.

## Why
Previously, supplying both flags still exited after the prompt because prompt mode took precedence. Initial interactive commands also needed to preserve normal REPL semantics.

## How
- Select prompt-only mode only when `--interactive` is absent.
- Route initial slash, exit, quit, clear, and autosave commands through interactive dispatch.
- Localize prompt-mode argparse help with fail-open locale bootstrap.
- Add regression coverage for flag ordering, command dispatch, autosave deferral, exit handling, localized help, and malformed config startup.
- Fix the stale GPT reasoning-settings test expectation: GPT-5.6 models include `reasoning_context` and `reasoning_mode`, while GPT-5.4/5.5 retain the base settings.

## Testing
- 77 affected CLI tests passed.
- 11 i18n tests passed.
- 74 ChatGPT OAuth plugin tests passed after the reasoning-settings test fix.
- Ruff lint and format checks passed.
- JSON catalog validation passed.
- Pre-PR findings-only review: clean.
- Snyk skipped explicitly with `--skip-snyk` because the Snyk endpoint repeatedly timed out during the initial run.

## Scope
Focused CLI behavior, i18n catalog, regression tests, and the stale reasoning-settings test expectation. No dependency or lockfile changes.
