### PR TITLE
feat: add Pi-style /tree conversation navigation

### DIFF
--- a/code_puppy/i18n/locales/en-US.json
+++ b/code_puppy/i18n/locales/en-US.json
@@ -123,5 +123,21 @@
   "codex.imagegen.usage": "Usage: /codex-imagegen <prompt>",
   "codex.imagegen.generating": "Generating image with Codex OAuth...",
   "codex.imagegen.saved": "Generated image saved to {path}",
-  "codex.logout.reload_failed": "ChatGPT logout: agent reload failed: {error}"
+  "codex.logout.reload_failed": "ChatGPT logout: agent reload failed: {error}",
+  "tree.title": "Session Tree",
+  "tree.frame_title": "tree",
+  "tree.controls": "↑↓ navigate  Enter select  Esc cancel/clear search  Ctrl/Alt+←→ fold  Ctrl+X copy",
+  "tree.filter_search": "filter: {filter} (Ctrl+O cycle)  search: {query}",
+  "tree.no_results": "No entries found",
+  "tree.visible_count": "{current}/{total} visible",
+  "tree.inspect_failed": "/tree: could not inspect conversation history — {error}",
+  "tree.selector_failed": "/tree: selector failed — {error}",
+  "tree.selection_missing": "/tree: selected entry disappeared — {error}",
+  "tree.empty": "No entries in session",
+  "tree.already_here": "Already at this point",
+  "tree.prompt_restored_fallback": "Moved before the selected prompt. Re-submit or edit it:\n{prompt}",
+  "tree.switched": "Switched conversation branch",
+  "tree.usage": "Usage: /tree",
+  "tree.help": "Navigate the current session tree and switch branches",
+  "tree.persistence_failed": "/tree: could not save inactive branches; they remain available until exit"
 }

--- a/code_puppy/plugins/tree/__init__.py
+++ b/code_puppy/plugins/tree/__init__.py
@@ -1,0 +1,1 @@
+"""Pi-style in-session conversation tree navigation."""

--- a/code_puppy/plugins/tree/register_callbacks.py
+++ b/code_puppy/plugins/tree/register_callbacks.py
@@ -1,0 +1,154 @@
+"""Register Pi-style ``/tree`` navigation without colliding with ``/fork``."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from code_puppy.callbacks import register_callback
+from code_puppy.i18n import t
+from code_puppy.plugins.tree.tree_model import ConversationTree
+
+_TREES: dict[tuple[str, str], ConversationTree] = {}
+
+
+def _tree_key(agent: Any) -> tuple[str, str]:
+    from code_puppy.config import get_current_session_name
+
+    return get_current_session_name(), str(getattr(agent, "name", "agent"))
+
+
+def _tree_for(agent: Any) -> ConversationTree:
+    from code_puppy.plugins.tree.tree_storage import load_tree
+
+    key = _tree_key(agent)
+    tree = _TREES.get(key)
+    if tree is None:
+        tree = load_tree(*key) or ConversationTree()
+        _TREES[key] = tree
+    return tree
+
+
+def _save_agent_tree(agent: Any, tree: ConversationTree) -> bool:
+    from code_puppy.plugins.tree.tree_storage import save_tree
+
+    session_name, agent_name = _tree_key(agent)
+    return save_tree(session_name, agent_name, tree)
+
+
+def _emit(kind: str, message: Any) -> None:
+    from code_puppy import messaging
+
+    getattr(messaging, f"emit_{kind}")(message)
+
+
+def _on_interactive_turn_end(
+    agent: Any,
+    prompt: str,
+    result: Any = None,
+    *,
+    success: bool = True,
+    error: Optional[BaseException] = None,
+) -> None:
+    """Capture the completed path after the CLI commits result history."""
+    del prompt, result, error
+    if not success:
+        return
+    try:
+        tree = _tree_for(agent)
+        tree.sync(list(agent.get_message_history()))
+        if not _save_agent_tree(agent, tree):
+            _emit("warning", t("tree.persistence_failed"))
+    except Exception:
+        # Navigation is an optional UI feature; a custom provider message must
+        # never poison the normal agent run.
+        return
+
+
+def _restore_editor_text(text: str) -> bool:
+    """Restore a selected user prompt when the persistent editor is idle."""
+    try:
+        from code_puppy.messaging.run_ui import get_run_editor, is_run_active
+
+        editor = get_run_editor()
+        if editor is None or is_run_active() or editor.buffer.strip():
+            return False
+        editor.replace_buffer_text(text)
+        return True
+    except Exception:
+        return False
+
+
+def _launch_tree() -> None:
+    from code_puppy.agents.agent_manager import get_current_agent
+    from code_puppy.plugins.tree.tree_menu import TreeMenu
+
+    try:
+        agent = get_current_agent()
+        tree = _tree_for(agent)
+        tree.sync(list(agent.get_message_history()))
+    except Exception as exc:
+        _emit("error", t("tree.inspect_failed", error=exc))
+        return
+
+    if not tree.nodes:
+        _emit("info", t("tree.empty"))
+        return
+
+    try:
+        selected_id = TreeMenu(tree, initial_id=tree.leaf_id).run()
+    except Exception as exc:
+        _emit("error", t("tree.selector_failed", error=exc))
+        return
+
+    if selected_id is None:
+        return
+
+    try:
+        navigation = tree.navigate(selected_id)
+    except (KeyError, ValueError) as exc:
+        _emit("warning", t("tree.selection_missing", error=exc))
+        return
+
+    if not navigation.changed:
+        _emit("info", t("tree.already_here"))
+        return
+
+    agent.set_message_history(navigation.history)
+    if navigation.editor_text:
+        if not _restore_editor_text(navigation.editor_text):
+            _emit(
+                "info",
+                t("tree.prompt_restored_fallback", prompt=navigation.editor_text),
+            )
+    _emit("success", t("tree.switched"))
+
+
+def _handle_custom_command(command: str, name: str) -> Optional[bool]:
+    if name != "tree":
+        return None
+    if command.strip() != "/tree":
+        _emit("warning", t("tree.usage"))
+        return True
+    _launch_tree()
+    return True
+
+
+def _custom_help() -> list[tuple[str, str]]:
+    return [("tree", t("tree.help"))]
+
+
+register_callback("custom_command", _handle_custom_command)
+register_callback("custom_command_help", _custom_help)
+register_callback("interactive_turn_end", _on_interactive_turn_end)
+
+
+__all__ = [
+    "_TREES",
+    "_custom_help",
+    "_handle_custom_command",
+    "_launch_tree",
+    "_on_interactive_turn_end",
+    "_restore_editor_text",
+    "_tree_for",
+    "_tree_key",
+]

--- a/code_puppy/plugins/tree/tree_menu.py
+++ b/code_puppy/plugins/tree/tree_menu.py
@@ -1,0 +1,334 @@
+"""Searchable prompt_toolkit selector for Pi-style session trees."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import time
+from typing import Optional
+
+from prompt_toolkit.application import Application
+from prompt_toolkit.formatted_text import FormattedText
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.keys import Keys
+from prompt_toolkit.layout import Layout, Window
+from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.widgets import Frame
+
+from code_puppy.callbacks import on_prompt_toolkit_style
+from code_puppy.i18n import t
+from code_puppy.plugins.tree.tree_model import ConversationTree
+
+_FILTERS = ("default", "no-tools", "user", "all")
+
+
+class TreeMenu:
+    """Single-pane tree browser with search, folding, filters, and copy."""
+
+    def __init__(
+        self, tree: ConversationTree, initial_id: Optional[str] = None
+    ) -> None:
+        if not tree.nodes:
+            raise ValueError("TreeMenu requires at least one entry")
+        self.tree = tree
+        self.query = ""
+        self.filter_mode = "default"
+        self.folded: set[str] = set()
+        self.rows: list[str] = []
+        self.cursor = 0
+        self.viewport_top = 0
+        self.visible_rows = 20
+        self.control: Optional[FormattedTextControl] = None
+        self.result: Optional[str] = None
+        self._preferred_id = initial_id or tree.leaf_id
+        self.refresh()
+
+    def refresh(self) -> None:
+        previous = self.current_id or self._preferred_id
+        candidates = self.tree.visible_nodes(self.filter_mode, self.query)
+        hidden: set[str] = set()
+        for node_id in self.folded:
+            hidden.update(self._descendants(node_id))
+        self.rows = [node_id for node_id in candidates if node_id not in hidden]
+        if previous in self.rows:
+            self.cursor = self.rows.index(previous)
+        elif self.rows:
+            ancestor = self._nearest_visible_ancestor(previous)
+            self.cursor = self.rows.index(ancestor) if ancestor else len(self.rows) - 1
+        else:
+            self.cursor = 0
+        self._scroll_into_view()
+        if self.control:
+            self.control.text = self.render()
+
+    @property
+    def current_id(self) -> Optional[str]:
+        if not self.rows:
+            return None
+        return self.rows[self.cursor]
+
+    def _descendants(self, node_id: str) -> set[str]:
+        found: set[str] = set()
+        stack = list(self.tree.nodes[node_id].children)
+        while stack:
+            child = stack.pop()
+            found.add(child)
+            stack.extend(self.tree.nodes[child].children)
+        return found
+
+    def _nearest_visible_ancestor(self, node_id: Optional[str]) -> Optional[str]:
+        while node_id and node_id in self.tree.nodes:
+            if node_id in self.rows:
+                return node_id
+            node_id = self.tree.nodes[node_id].parent_id
+        return None
+
+    def _depth(self, node_id: str) -> int:
+        depth = 0
+        parent = self.tree.nodes[node_id].parent_id
+        while parent is not None and parent in self.tree.nodes:
+            depth += 1
+            parent = self.tree.nodes[parent].parent_id
+        return depth
+
+    def _scroll_into_view(self) -> None:
+        page = max(1, self.visible_rows)
+        if self.cursor < self.viewport_top:
+            self.viewport_top = self.cursor
+        elif self.cursor >= self.viewport_top + page:
+            self.viewport_top = self.cursor - page + 1
+        self.viewport_top = min(self.viewport_top, max(0, len(self.rows) - page))
+
+    def render(self) -> FormattedText:
+        fragments: list[tuple[str, str]] = [
+            ("class:tui.title", f" {t('tree.title')}\n"),
+            ("class:tui.muted", f" {t('tree.controls')}\n"),
+            (
+                "class:tui.muted",
+                " "
+                + t(
+                    "tree.filter_search",
+                    filter=self.filter_mode,
+                    query=self.query or "—",
+                )
+                + "\n\n",
+            ),
+        ]
+        if not self.rows:
+            fragments.append(("class:tui.warning", f" {t('tree.no_results')}\n"))
+            return FormattedText(fragments)
+
+        active = set(self.tree.active_path)
+        end = min(len(self.rows), self.viewport_top + self.visible_rows)
+        for index in range(self.viewport_top, end):
+            node_id = self.rows[index]
+            node = self.tree.nodes[node_id]
+            selected = index == self.cursor
+            marker = "›" if selected else " "
+            active_marker = "•" if node_id in active else " "
+            fold = "⊞" if node_id in self.folded else ("⊟" if node.children else " ")
+            indent = "  " * self._depth(node_id)
+            label = f" [{node.label}]" if node.label else ""
+            preview = " ".join(node.text.replace("\t", " ").splitlines())
+            if len(preview) > 160:
+                preview = preview[:159] + "…"
+            style = "class:tui.selected" if selected else _role_style(node.role)
+            fragments.append(
+                (
+                    style,
+                    f"{marker} {indent}{fold}{active_marker} {node.role}{label}: {preview}\n",
+                )
+            )
+        fragments.append(
+            (
+                "class:tui.muted",
+                "\n "
+                + t(
+                    "tree.visible_count",
+                    current=self.cursor + 1,
+                    total=len(self.rows),
+                )
+                + "\n",
+            )
+        )
+        return FormattedText(fragments)
+
+    def _move(self, amount: int, *, wrap: bool = True) -> None:
+        if not self.rows:
+            return
+        if wrap:
+            self.cursor = (self.cursor + amount) % len(self.rows)
+        else:
+            self.cursor = max(0, min(len(self.rows) - 1, self.cursor + amount))
+        self.refresh()
+
+    def _toggle_fold(self, folded: bool) -> None:
+        node_id = self.current_id
+        if not node_id or not self.tree.nodes[node_id].children:
+            return
+        if folded:
+            self.folded.add(node_id)
+        else:
+            self.folded.discard(node_id)
+        self.refresh()
+
+    def _cycle_filter(self) -> None:
+        index = (_FILTERS.index(self.filter_mode) + 1) % len(_FILTERS)
+        self.filter_mode = _FILTERS[index]
+        self.folded.clear()
+        self.refresh()
+
+    def _copy_current(self, clipboard) -> None:
+        node_id = self.current_id
+        if not node_id:
+            return
+        try:
+            clipboard.set_text(self.tree.nodes[node_id].text)
+        except Exception:
+            pass
+
+    def build_keybindings(self) -> KeyBindings:
+        kb = KeyBindings()
+
+        @kb.add("up")
+        @kb.add("c-p")
+        def _up(event):
+            self._move(-1)
+
+        @kb.add("down")
+        @kb.add("c-n")
+        def _down(event):
+            self._move(1)
+
+        @kb.add("pageup")
+        @kb.add("left")
+        @kb.add("c-b")
+        def _page_up(event):
+            self._move(-max(1, self.visible_rows), wrap=False)
+
+        @kb.add("pagedown")
+        @kb.add("right")
+        @kb.add("c-f")
+        def _page_down(event):
+            self._move(max(1, self.visible_rows), wrap=False)
+
+        @kb.add("c-left")
+        @kb.add("escape", "left")
+        def _fold(event):
+            self._toggle_fold(True)
+
+        @kb.add("c-right")
+        @kb.add("escape", "right")
+        def _unfold(event):
+            self._toggle_fold(False)
+
+        @kb.add("c-o")
+        def _filter(event):
+            self._cycle_filter()
+
+        @kb.add("c-d")
+        def _default_filter(event):
+            self.filter_mode = "default"
+            self.refresh()
+
+        @kb.add("c-t")
+        def _no_tools_filter(event):
+            self.filter_mode = "no-tools"
+            self.refresh()
+
+        @kb.add("c-u")
+        def _user_filter(event):
+            self.filter_mode = "user"
+            self.refresh()
+
+        @kb.add("c-a")
+        def _all_filter(event):
+            self.filter_mode = "all"
+            self.refresh()
+
+        @kb.add("c-x")
+        def _copy(event):
+            self._copy_current(event.app.clipboard)
+
+        @kb.add("backspace")
+        def _backspace(event):
+            if self.query:
+                self.query = self.query[:-1]
+                self.folded.clear()
+                self.refresh()
+
+        @kb.add("enter")
+        def _select(event):
+            self.result = self.current_id
+            event.app.exit()
+
+        @kb.add("escape")
+        @kb.add("c-c")
+        def _cancel(event):
+            if self.query:
+                self.query = ""
+                self.folded.clear()
+                self.refresh()
+            else:
+                self.result = None
+                event.app.exit()
+
+        @kb.add(Keys.Any)
+        def _search(event):
+            value = event.data
+            if value and (
+                value.isprintable() and (not value.isspace() or value == " ")
+            ):
+                self.query += value
+                self.folded.clear()
+                self.refresh()
+
+        return kb
+
+    def run(self) -> Optional[str]:
+        cols, rows = shutil.get_terminal_size(fallback=(120, 40))
+        self.visible_rows = max(5, rows - 9)
+        self.control = FormattedTextControl(self.render())
+        root = Frame(
+            Window(self.control, wrap_lines=False), title=t("tree.frame_title")
+        )
+        app = Application(
+            layout=Layout(root),
+            key_bindings=self.build_keybindings(),
+            full_screen=False,
+            mouse_support=False,
+            style=on_prompt_toolkit_style(),
+        )
+        try:
+            from code_puppy.tools.command_runner import set_awaiting_user_input
+
+            set_awaiting_user_input(True)
+        except Exception:
+            pass
+        sys.stdout.write("\033[?1049h\033[2J\033[H")
+        sys.stdout.flush()
+        time.sleep(0.05)
+        try:
+            app.run(in_thread=True)
+        finally:
+            sys.stdout.write("\033[?1049l")
+            sys.stdout.flush()
+            try:
+                from code_puppy.tools.command_runner import set_awaiting_user_input
+
+                set_awaiting_user_input(False)
+            except Exception:
+                pass
+        return self.result
+
+
+def _role_style(role: str) -> str:
+    return {
+        "user": "class:tui.success",
+        "assistant": "class:tui.header",
+        "tool": "class:tui.warning",
+        "system": "class:tui.muted",
+    }.get(role, "")
+
+
+__all__ = ["TreeMenu"]

--- a/code_puppy/plugins/tree/tree_model.py
+++ b/code_puppy/plugins/tree/tree_model.py
@@ -1,0 +1,258 @@
+"""Append-only conversation graph used by the ``/tree`` plugin.
+
+Code Puppy's provider history is linear.  This model keeps old linear paths as
+branches whenever the user rewinds and submits a replacement prompt.  Provider
+message objects remain untouched, so selecting a node can restore the exact
+root-to-node history expected by pydantic-ai.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import pickle
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Optional
+
+
+@dataclass(slots=True)
+class TreeNode:
+    id: str
+    parent_id: Optional[str]
+    message: Any
+    role: str
+    text: str
+    fingerprint: str
+    children: list[str] = field(default_factory=list)
+    label: Optional[str] = None
+
+
+@dataclass(slots=True)
+class Navigation:
+    history: list[Any]
+    editor_text: Optional[str]
+    leaf_id: Optional[str]
+    changed: bool
+
+
+def message_fingerprint(message: Any) -> str:
+    """Return a stable-enough identity for prefix comparison.
+
+    Pickle is already Code Puppy's session format and preserves all provider
+    fields.  The repr fallback keeps third-party/custom message types usable.
+    """
+    try:
+        payload = pickle.dumps(message, protocol=pickle.HIGHEST_PROTOCOL)
+    except Exception:
+        payload = repr(message).encode("utf-8", errors="replace")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def describe_message(message: Any) -> tuple[str, str]:
+    """Extract a Pi-like role and searchable/copyable text."""
+    role = "unknown"
+    text: list[str] = []
+    try:
+        from pydantic_ai.messages import (
+            ModelRequest,
+            ModelResponse,
+            SystemPromptPart,
+            TextPart,
+            ToolCallPart,
+            ToolReturnPart,
+            UserPromptPart,
+        )
+
+        if isinstance(message, ModelRequest):
+            role = "request"
+            for part in getattr(message, "parts", ()) or ():
+                if isinstance(part, UserPromptPart):
+                    role = "user"
+                    content = getattr(part, "content", "")
+                    text.append(_content_text(content))
+                elif isinstance(part, ToolReturnPart):
+                    if role != "user":
+                        role = "tool"
+                    tool_name = getattr(part, "tool_name", "tool")
+                    content = getattr(part, "content", "")
+                    text.append(f"[{tool_name} result: {_content_text(content)}]")
+                elif isinstance(part, SystemPromptPart) and role == "request":
+                    role = "system"
+        elif isinstance(message, ModelResponse):
+            role = "assistant"
+            saw_text = False
+            saw_tool = False
+            for part in getattr(message, "parts", ()) or ():
+                if isinstance(part, TextPart):
+                    content = str(getattr(part, "content", ""))
+                    if content:
+                        saw_text = True
+                        text.append(content)
+                elif isinstance(part, ToolCallPart):
+                    saw_tool = True
+                    tool_name = getattr(part, "tool_name", "tool")
+                    args = getattr(part, "args", "")
+                    text.append(f"[{tool_name}: {args}]")
+            if saw_tool and not saw_text:
+                role = "tool-call"
+    except Exception:
+        pass
+
+    clean = " ".join(fragment for fragment in text if fragment).strip()
+    return role, clean or str(message)
+
+
+def _content_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, Iterable) and not isinstance(content, (bytes, dict)):
+        fragments: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                fragments.append(item)
+            else:
+                value = getattr(item, "content", None)
+                if isinstance(value, str):
+                    fragments.append(value)
+        return " ".join(fragments)
+    return str(content)
+
+
+class ConversationTree:
+    """A graph projection of one agent's current conversation session."""
+
+    def __init__(self) -> None:
+        self.nodes: dict[str, TreeNode] = {}
+        self.roots: list[str] = []
+        self.active_path: list[str] = []
+        self.branching_armed = False
+
+    @property
+    def leaf_id(self) -> Optional[str]:
+        return self.active_path[-1] if self.active_path else None
+
+    def sync(self, history: list[Any]) -> None:
+        """Merge a provider's current linear history into the graph."""
+        if not history:
+            # Session identity is owned by the plugin's session-keyed store.
+            # Empty history can legitimately mean /tree rewound before the
+            # first prompt, so it must not erase inactive branches.
+            self.active_path = []
+            return
+
+        fingerprints = [message_fingerprint(message) for message in history]
+        active_fingerprints = [
+            self.nodes[node_id].fingerprint for node_id in self.active_path
+        ]
+        common = 0
+        while (
+            common < len(fingerprints)
+            and common < len(active_fingerprints)
+            and fingerprints[common] == active_fingerprints[common]
+        ):
+            common += 1
+
+        # A replaced prefix can be provider compaction. Session identity is
+        # handled outside this model, so retain old roots and append the new
+        # compacted path instead of destroying inactive branches.
+        path = self.active_path[:common]
+        parent_id = path[-1] if path else None
+        for message, fingerprint in zip(history[common:], fingerprints[common:]):
+            node_id = uuid.uuid4().hex[:12]
+            role, text = describe_message(message)
+            node = TreeNode(
+                id=node_id,
+                parent_id=parent_id,
+                message=message,
+                role=role,
+                text=text,
+                fingerprint=fingerprint,
+            )
+            self.nodes[node_id] = node
+            if parent_id is None:
+                self.roots.append(node_id)
+            else:
+                self.nodes[parent_id].children.append(node_id)
+            path.append(node_id)
+            parent_id = node_id
+        self.active_path = path
+        self.branching_armed = False
+
+    def clear(self) -> None:
+        self.nodes.clear()
+        self.roots.clear()
+        self.active_path.clear()
+        self.branching_armed = False
+
+    def path_to(self, node_id: str) -> list[str]:
+        if node_id not in self.nodes:
+            raise KeyError(node_id)
+        path: list[str] = []
+        seen: set[str] = set()
+        current: Optional[str] = node_id
+        while current is not None and current not in seen:
+            seen.add(current)
+            path.append(current)
+            current = self.nodes[current].parent_id
+        path.reverse()
+        return path
+
+    def navigate(self, node_id: str) -> Navigation:
+        """Apply Pi semantics: user nodes rewind before the prompt."""
+        if node_id == self.leaf_id:
+            return Navigation(self.current_history(), None, self.leaf_id, False)
+
+        selected = self.nodes[node_id]
+        selected_path = self.path_to(node_id)
+        editor_text: Optional[str] = None
+        if selected.role == "user":
+            destination = selected_path[:-1]
+            editor_text = selected.text
+        else:
+            destination = selected_path
+
+        self.active_path = destination
+        self.branching_armed = True
+        return Navigation(
+            history=[self.nodes[item].message for item in destination],
+            editor_text=editor_text,
+            leaf_id=self.leaf_id,
+            changed=True,
+        )
+
+    def current_history(self) -> list[Any]:
+        return [self.nodes[node_id].message for node_id in self.active_path]
+
+    def ordered_children(self, node_id: Optional[str]) -> list[str]:
+        children = self.roots if node_id is None else self.nodes[node_id].children
+        active = set(self.active_path)
+        active_children = [item for item in children if item in active]
+        inactive_children = [item for item in children if item not in active]
+        return active_children + inactive_children
+
+    def visible_nodes(self, mode: str = "default", query: str = "") -> list[str]:
+        """Flatten active branches first, then apply Pi's useful filters."""
+        ordered: list[str] = []
+        stack = list(reversed(self.ordered_children(None)))
+        while stack:
+            node_id = stack.pop()
+            ordered.append(node_id)
+            stack.extend(reversed(self.ordered_children(node_id)))
+
+        tokens = query.casefold().split()
+
+        def keep(node: TreeNode) -> bool:
+            if mode == "user" and node.role != "user":
+                return False
+            if mode == "no-tools" and node.role in {"tool", "tool-call"}:
+                return False
+            if (
+                mode == "default"
+                and node.role == "tool-call"
+                and node.id != self.leaf_id
+            ):
+                return False
+            haystack = f"{node.role} {node.label or ''} {node.text}".casefold()
+            return all(token in haystack for token in tokens)
+
+        return [node_id for node_id in ordered if keep(self.nodes[node_id])]

--- a/code_puppy/plugins/tree/tree_storage.py
+++ b/code_puppy/plugins/tree/tree_storage.py
@@ -1,0 +1,50 @@
+"""Atomic sidecar persistence for conversation trees.
+
+The normal Code Puppy session pickle remains linear for backwards
+compatibility.  A sibling tree sidecar retains inactive branches; if it is
+missing or unreadable, the plugin simply rebuilds from linear history.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import pickle
+from pathlib import Path
+from typing import Optional
+
+from code_puppy.plugins.tree.tree_model import ConversationTree
+
+
+def storage_path(session_name: str, agent_name: str) -> Path:
+    from code_puppy.config import AUTOSAVE_DIR
+
+    agent_key = hashlib.sha256(agent_name.encode("utf-8")).hexdigest()[:12]
+    return Path(AUTOSAVE_DIR) / "trees" / f"{session_name}_{agent_key}.pkl"
+
+
+def load_tree(session_name: str, agent_name: str) -> Optional[ConversationTree]:
+    path = storage_path(session_name, agent_name)
+    if not path.is_file():
+        return None
+    try:
+        value = pickle.loads(path.read_bytes())  # noqa: S301
+    except Exception:
+        return None
+    return value if isinstance(value, ConversationTree) else None
+
+
+def save_tree(session_name: str, agent_name: str, tree: ConversationTree) -> bool:
+    path = storage_path(session_name, agent_name)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.with_suffix(".tmp")
+        temporary.write_bytes(pickle.dumps(tree, protocol=pickle.HIGHEST_PROTOCOL))
+        temporary.replace(path)
+        return True
+    except Exception:
+        # Losing optional branch metadata is preferable to breaking autosave or
+        # the active conversation because a cache directory became read-only.
+        return False
+
+
+__all__ = ["load_tree", "save_tree", "storage_path"]

--- a/tests/plugins/test_tree_plugin.py
+++ b/tests/plugins/test_tree_plugin.py
@@ -1,0 +1,311 @@
+"""Behavior and integration tests for the Pi-style ``/tree`` plugin."""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    SystemPromptPart,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+
+from code_puppy.plugins.tree.tree_menu import TreeMenu
+from code_puppy.plugins.tree.tree_model import ConversationTree, describe_message
+
+
+def user(text: str, *, system: bool = False) -> ModelRequest:
+    parts = [UserPromptPart(content=text)]
+    if system:
+        parts.insert(0, SystemPromptPart(content="be a puppy"))
+    return ModelRequest(parts=parts)
+
+
+def assistant(text: str) -> ModelResponse:
+    return ModelResponse(parts=[TextPart(content=text)])
+
+
+def tool_call() -> ModelResponse:
+    return ModelResponse(
+        parts=[
+            ToolCallPart(
+                tool_name="read",
+                args={"path": "README.md"},
+                tool_call_id="call-1",
+            )
+        ]
+    )
+
+
+def tool_result(text: str = "ok") -> ModelRequest:
+    return ModelRequest(
+        parts=[ToolReturnPart(tool_name="read", content=text, tool_call_id="call-1")]
+    )
+
+
+def test_describe_real_pydantic_messages() -> None:
+    assert describe_message(user("hello", system=True)) == ("user", "hello")
+    assert describe_message(assistant("world")) == ("assistant", "world")
+    assert describe_message(tool_result())[0] == "tool"
+
+
+def test_selecting_user_rewinds_before_prompt_and_restores_text() -> None:
+    tree = ConversationTree()
+    history = [
+        user("first", system=True),
+        assistant("one"),
+        user("second"),
+        assistant("two"),
+    ]
+    tree.sync(history)
+
+    selected = tree.active_path[-2]
+    navigation = tree.navigate(selected)
+
+    assert navigation.changed is True
+    assert navigation.editor_text == "second"
+    assert navigation.history == history[:2]
+    assert tree.leaf_id == tree.active_path[-1]
+
+
+def test_selecting_root_user_rewinds_to_empty_history() -> None:
+    tree = ConversationTree()
+    tree.sync([user("first", system=True), assistant("one")])
+
+    navigation = tree.navigate(tree.active_path[0])
+
+    assert navigation.history == []
+    assert navigation.editor_text == "first"
+    assert navigation.leaf_id is None
+
+
+def test_selecting_non_user_keeps_selected_message() -> None:
+    tree = ConversationTree()
+    history = [user("first"), assistant("one"), user("second"), assistant("two")]
+    tree.sync(history)
+
+    navigation = tree.navigate(tree.active_path[1])
+
+    assert navigation.history == history[:2]
+    assert navigation.editor_text is None
+
+
+def test_resubmitting_after_rewind_preserves_both_branches() -> None:
+    tree = ConversationTree()
+    original = [user("first"), assistant("one"), user("old"), assistant("old answer")]
+    tree.sync(original)
+    original_leaf = tree.leaf_id
+    old_prompt_id = tree.active_path[2]
+    parent_id = tree.nodes[old_prompt_id].parent_id
+
+    navigation = tree.navigate(old_prompt_id)
+    replacement = navigation.history + [user("new"), assistant("new answer")]
+    tree.sync(replacement)
+
+    assert original_leaf in tree.nodes
+    assert len(tree.nodes[parent_id].children) == 2
+    assert {tree.nodes[item].text for item in tree.nodes[parent_id].children} == {
+        "old",
+        "new",
+    }
+    assert tree.nodes[tree.leaf_id].text == "new answer"
+
+
+def test_same_leaf_is_noop() -> None:
+    tree = ConversationTree()
+    tree.sync([user("first"), assistant("one")])
+    assert tree.navigate(tree.leaf_id).changed is False
+
+
+def test_compacted_prefix_retains_inactive_branches() -> None:
+    tree = ConversationTree()
+    tree.sync([user("first"), assistant("one"), user("old"), assistant("old answer")])
+    old_nodes = set(tree.nodes)
+    tree.navigate(tree.active_path[2])
+    tree.sync(tree.current_history() + [user("new"), assistant("new answer")])
+
+    tree.sync([user("compacted summary"), assistant("continued")])
+
+    assert old_nodes <= set(tree.nodes)
+    assert {node.text for node in tree.nodes.values()} >= {
+        "old",
+        "new",
+        "compacted summary",
+    }
+
+
+def test_empty_history_rewind_does_not_erase_branches() -> None:
+    tree = ConversationTree()
+    tree.sync([user("first"), assistant("one")])
+    existing = set(tree.nodes)
+    tree.navigate(tree.active_path[0])
+
+    tree.sync([])
+
+    assert set(tree.nodes) == existing
+    assert tree.active_path == []
+
+
+def test_filters_search_and_active_branch_ordering() -> None:
+    tree = ConversationTree()
+    tree.sync([user("first"), assistant("one"), tool_result(), user("old")])
+    tree.navigate(tree.active_path[-1])
+    tree.sync(tree.current_history() + [user("replacement")])
+
+    assert all(tree.nodes[item].role == "user" for item in tree.visible_nodes("user"))
+    assert all(
+        tree.nodes[item].role != "tool" for item in tree.visible_nodes("no-tools")
+    )
+    matches = tree.visible_nodes(query="REPLACE")
+    assert len(matches) == 1
+    assert tree.nodes[matches[0]].text == "replacement"
+
+
+def test_tool_only_assistant_is_hidden_by_default_and_no_tools() -> None:
+    tree = ConversationTree()
+    tree.sync([user("read it"), tool_call(), tool_result(), assistant("done")])
+    tool_call_id = tree.active_path[1]
+
+    assert tree.nodes[tool_call_id].role == "tool-call"
+    assert tool_call_id not in tree.visible_nodes("default")
+    assert tool_call_id not in tree.visible_nodes("no-tools")
+    assert "README.md" in tree.nodes[tool_call_id].text
+    assert "ok" in tree.nodes[tree.active_path[2]].text
+
+
+def test_menu_search_escape_and_nearest_visible_ancestor() -> None:
+    tree = ConversationTree()
+    tree.sync([user("first"), assistant("one"), user("second")])
+    menu = TreeMenu(tree)
+    selected = tree.leaf_id
+    menu.query = "does-not-exist"
+    menu.refresh()
+    assert menu.rows == []
+
+    menu.query = ""
+    menu.refresh()
+    assert menu.current_id == selected
+
+    menu.filter_mode = "user"
+    menu._preferred_id = tree.active_path[1]
+    menu.cursor = 0
+    menu.refresh()
+    assert menu.current_id in tree.active_path
+
+
+def test_custom_command_end_to_end_switches_history_and_prefills_editor() -> None:
+    from code_puppy.plugins.tree import register_callbacks as plugin
+
+    history = [
+        user("first", system=True),
+        assistant("one"),
+        user("edit me"),
+        assistant("old answer"),
+    ]
+    agent = MagicMock()
+    agent.get_message_history.return_value = history
+    tree = ConversationTree()
+    tree.sync(history)
+    plugin._TREES.clear()
+    plugin._TREES[plugin._tree_key(agent)] = tree
+    selected = tree.active_path[-2]
+
+    menu = MagicMock()
+    menu.run.return_value = selected
+    editor = SimpleNamespace(buffer="", replace_buffer_text=MagicMock())
+
+    with (
+        patch("code_puppy.agents.agent_manager.get_current_agent", return_value=agent),
+        patch("code_puppy.plugins.tree.tree_menu.TreeMenu", return_value=menu),
+        patch("code_puppy.messaging.run_ui.get_run_editor", return_value=editor),
+        patch("code_puppy.messaging.run_ui.is_run_active", return_value=False),
+        patch.object(plugin, "_emit"),
+    ):
+        assert plugin._handle_custom_command("/tree", "tree") is True
+
+    agent.set_message_history.assert_called_once_with(history[:2])
+    editor.replace_buffer_text.assert_called_once_with("edit me")
+
+
+def test_tree_sidecar_round_trip_preserves_inactive_branch(tmp_path) -> None:
+    from code_puppy.plugins.tree import tree_storage
+
+    tree = ConversationTree()
+    tree.sync([user("first"), assistant("one"), user("old"), assistant("old answer")])
+    tree.navigate(tree.active_path[2])
+    tree.sync(tree.current_history() + [user("new"), assistant("new answer")])
+    sidecar = tmp_path / "session.pkl"
+
+    with patch.object(tree_storage, "storage_path", return_value=sidecar):
+        tree_storage.save_tree("session", "code-puppy", tree)
+        restored = tree_storage.load_tree("session", "code-puppy")
+
+    assert restored is not None
+    assert len(restored.nodes) == len(tree.nodes)
+    assert {node.text for node in restored.nodes.values()} >= {"old", "new"}
+    assert restored.active_path == tree.active_path
+
+
+@pytest.mark.skipif(os.name == "nt", reason="PTY smoke test is POSIX-only")
+def test_tree_selector_pty_end_to_end() -> None:
+    """Drive the real selector and plugin boundary through a pseudo-terminal."""
+    import pexpect
+
+    script = r"""
+from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
+from code_puppy.agents import agent_manager
+from code_puppy.plugins.tree import register_callbacks as plugin
+
+class Agent:
+    name = "code-puppy"
+    def __init__(self):
+        self.history = [
+            ModelRequest(parts=[UserPromptPart(content="first")]),
+            ModelResponse(parts=[TextPart(content="one")]),
+            ModelRequest(parts=[UserPromptPart(content="edit me")]),
+            ModelResponse(parts=[TextPart(content="old answer")]),
+        ]
+    def get_message_history(self):
+        return self.history
+    def set_message_history(self, history):
+        self.history = history
+
+agent = Agent()
+agent_manager.get_current_agent = lambda: agent
+plugin._TREES.clear()
+plugin._handle_custom_command("/tree", "tree")
+assert len(agent.history) == 2, len(agent.history)
+print("TREE_E2E_OK", flush=True)
+"""
+    child = pexpect.spawn(
+        sys.executable,
+        ["-c", script],
+        cwd=os.getcwd(),
+        encoding="utf-8",
+        timeout=15,
+        dimensions=(40, 120),
+    )
+    child.expect("Session Tree")
+    child.send("\u001b[A")
+    child.send("\r")
+    child.expect("TREE_E2E_OK")
+    child.expect(pexpect.EOF)
+    child.close()
+    assert child.exitstatus == 0
+
+
+def test_tree_does_not_claim_fork_or_arguments() -> None:
+    from code_puppy.plugins.tree import register_callbacks as plugin
+
+    assert plugin._handle_custom_command("/fork do work", "fork") is None
+    with patch.object(plugin, "_emit") as emit:
+        assert plugin._handle_custom_command("/tree nope", "tree") is True
+    emit.assert_called_once()


### PR DESCRIPTION
## Summary

Add a built-in `/tree` plugin for navigating and branching the current conversation without changing Code Puppy's existing `/fork` background-agent command.

### Behavior

- renders the complete append-only conversation graph with the active path first
- selecting a user message rewinds **before** that prompt and restores its text into the idle editor for editing/resubmission
- selecting assistant/tool entries rewinds **at** that entry
- selecting the current leaf is a no-op
- resubmitting after a rewind preserves the abandoned path as an alternate branch
- persists inactive branches in atomic, session/agent-keyed sidecars
- retains branches across provider history compaction and root rewinds
- supports search, active-path markers, folding, paging, copy, and default/no-tools/user/all filters
- hides tool-call-only assistant nodes in the default and no-tools views
- localizes all new user-facing strings

`/fork` and `/forks` are intentionally untouched; their existing background sub-agent semantics and tests remain intact.

## Implementation

The feature is plugin-first under `code_puppy/plugins/tree/`:

- `tree_model.py` — append-only graph, provider-message extraction, filtering, and Pi-compatible navigation semantics
- `tree_menu.py` — prompt_toolkit selector and keyboard controls
- `tree_storage.py` — atomic sidecar persistence
- `register_callbacks.py` — slash-command/help/lifecycle integration and editor restoration

No command-line command was added to core.

## Test plan

- `uv run ruff check code_puppy/plugins/tree tests/plugins/test_tree_plugin.py`
- `uv run ruff format --check code_puppy/plugins/tree tests/plugins/test_tree_plugin.py`
- `uv run pytest -q tests/plugins/test_tree_plugin.py tests/plugins/test_fork_plugin.py tests/plugins/test_plugin_contributions.py tests/i18n/test_i18n_coverage.py --no-cov`
  - **77 passed** before the final compaction/tool visibility hardening
- final focused run:
  - **42 passed** across `/tree`, `/fork`, and i18n suites
- full repository suite:
  - **12,457 passed, 81 skipped, 1 xpassed**
  - one unrelated order-dependent config assertion failed (`protected_token_count` expected `25000`, observed `24576`)
  - the same test passes in isolation

The `/tree` suite includes a real POSIX pseudo-terminal smoke test that opens the selector, sends Up + Enter, and verifies the selected user prompt rewinds provider history to its parent.
