### PR TITLE
feat(config): add puppy_token provider hook for plugin-based credential backends

### DIFF
--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -859,13 +859,37 @@ def set_summarization_model_name(model: str) -> None:
     set_config_value("summarization_model", model or "")
 
 
+# ---------------------------------------------------------------------------
+# Puppy-token provider hook — lets plugins inject a custom credential
+# backend (e.g. OS keyring) without baking that logic into core.
+# ---------------------------------------------------------------------------
+_puppy_token_getter = None
+_puppy_token_setter = None
+
+
+def register_puppy_token_provider(*, getter, setter) -> None:
+    """Register custom get/set functions for the puppy_token credential.
+
+    Called by distribution-specific plugins at startup to route token
+    storage through the OS keyring or another secure backend.  When no
+    provider is registered the default plaintext config-file path is used.
+    """
+    global _puppy_token_getter, _puppy_token_setter
+    _puppy_token_getter = getter
+    _puppy_token_setter = setter
+
+
 def get_puppy_token():
-    """Returns the puppy_token from config, or None if not set."""
+    """Returns the puppy_token, delegating to a registered provider if set."""
+    if _puppy_token_getter is not None:
+        return _puppy_token_getter()
     return get_value("puppy_token")
 
 
 def set_puppy_token(token: str):
-    """Sets the puppy_token in the persistent config file."""
+    """Sets the puppy_token, delegating to a registered provider if set."""
+    if _puppy_token_setter is not None:
+        return _puppy_token_setter(token)
     set_config_value("puppy_token", token)
 
 

--- a/tests/test_config_and_storage_edge_cases.py
+++ b/tests/test_config_and_storage_edge_cases.py
@@ -181,6 +181,46 @@ class TestPuppyTokens:
         assert saved_config["puppy"]["puppy_token"] == "new-token-456"
 
 
+class TestPuppyTokenProviderHook:
+    """Test that plugins can override puppy token storage via the provider hook."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_provider(self):
+        """Ensure provider hooks are clean before and after each test."""
+        cp_config._puppy_token_getter = None
+        cp_config._puppy_token_setter = None
+        yield
+        cp_config._puppy_token_getter = None
+        cp_config._puppy_token_setter = None
+
+    def test_get_delegates_to_registered_provider(self):
+        cp_config.register_puppy_token_provider(
+            getter=lambda: "from-provider",
+            setter=lambda t: None,
+        )
+        assert cp_config.get_puppy_token() == "from-provider"
+
+    def test_set_delegates_to_registered_provider(self):
+        captured = {}
+        cp_config.register_puppy_token_provider(
+            getter=lambda: None,
+            setter=lambda t: captured.__setitem__("token", t),
+        )
+        cp_config.set_puppy_token("custom-token")
+        assert captured["token"] == "custom-token"
+
+    def test_falls_back_to_plaintext_when_no_provider(self, mock_config_paths):
+        mock_cfg_dir, mock_cfg_file, _ = mock_config_paths
+        config = configparser.ConfigParser()
+        config["puppy"] = {"puppy_token": "plaintext-tok"}
+        os.makedirs(mock_cfg_dir, exist_ok=True)
+        with open(mock_cfg_file, "w") as f:
+            config.write(f)
+
+        # No provider registered — should read from puppy.cfg
+        assert cp_config.get_puppy_token() == "plaintext-tok"
+
+
 class TestXDGDirectoryHandling:
     """Test XDG Base Directory support."""
 


### PR DESCRIPTION
## Summary

Adds `register_puppy_token_provider(getter, setter)` to `config.py` so
distribution-specific plugins can route `puppy_token` storage through a
secure backend (e.g. OS keyring) without modifying core code.

## Motivation

Downstream enterprise distributions need to migrate `puppy_token` from
plaintext `puppy.cfg` into the OS keyring. Today, that requires editing
the core `get_puppy_token` / `set_puppy_token` functions directly,
which creates merge conflicts and mixes organization-specific logic into
the open-source core.

This hook lets the plugin layer own the credential backend entirely.

## Changes

### `config.py` (+26 lines)
- `register_puppy_token_provider(*, getter, setter)` — registers custom
  get/set functions for the puppy_token credential
- `get_puppy_token()` — delegates to registered provider, falls back to
  `get_value('puppy_token')` when none is registered
- `set_puppy_token()` — same pattern

**Zero breaking changes.** When no provider is registered (the default),
behavior is identical to the current code.

### `tests/test_config_and_storage_edge_cases.py` (+40 lines)
Three new tests:
- Provider getter delegation
- Provider setter delegation
- Plaintext fallback when no provider is registered

## Usage (downstream plugin example)
```python
# In a plugin's register_callbacks.py:
from code_puppy.config import register_puppy_token_provider

def my_get():
    return keyring.get_password('my-service', 'puppy_token')

def my_set(token):
    keyring.set_password('my-service', 'puppy_token', token)

register_callback('startup', lambda: register_puppy_token_provider(
    getter=my_get, setter=my_set,
))
```