### PR TITLE
fix(ci): pin ruff to >=0.15,<0.16 to stop default-ruleset drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,9 @@ jobs:
           python-version: '3.13'
 
       - name: Install dev dependencies (ruff)
-        run: pip install ruff
+        # Keep in sync with the ruff pin in pyproject.toml. Unpinned ruff let
+        # 0.16.0 sneak in and change the default rule set (5,901 "new" errors).
+        run: pip install 'ruff>=0.15,<0.16'
 
       - name: Install code_puppy
         run: pip install .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev-dependencies = [
     "pytest>=8.3.4",
     "pytest-cov>=6.1.1",
     "pytest-asyncio>=0.23.1",
-    "ruff>=0.11.11",
+    "ruff>=0.15,<0.16",
     "pexpect>=4.9.0",
 ]
 authors = [
@@ -113,6 +113,6 @@ dev = [
     "pytest>=8.3.4",
     "pytest-cov>=6.1.1",
     "pytest-asyncio>=0.23.1",
-    "ruff>=0.11.11",
+    "ruff>=0.15,<0.16",
     "pexpect>=4.9.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -400,7 +400,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-asyncio", specifier = ">=0.23.1" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
-    { name = "ruff", specifier = ">=0.11.11" },
+    { name = "ruff", specifier = ">=0.15,<0.16" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Ruff **0.16.0** dropped between CI runs and changed the default rule selection. Result: every PR (e.g. #656) instantly fails the `quality` job with **5,901** pre-existing lint errors (`BLE001`, `EXE001`, `SIM114`, `I001`, ...) that have nothing to do with the diff. Last green run used 0.15.22; failing runs got 0.16.0. See run 30037325756.

## What

- **`.github/workflows/ci.yml`**: `pip install ruff` (bare = latest) → `pip install 'ruff>=0.15,<0.16'`
- **`pyproject.toml`**: both `ruff>=0.11.11` specs → `ruff>=0.15,<0.16`
- **`uv.lock`**: re-resolved (stays on 0.15.13)

## Verified

`uv run ruff check .` → `All checks passed!` and `ruff format --check .` → clean, on ruff 0.15.13.

## Follow-up (separate PR)

Adopt 0.16 deliberately: either fix the new violations or add an explicit `[tool.ruff.lint] select` so default-set changes can never ambush CI again. Explicit > implicit.