### PR TITLE
fix(ci): serialize PyPI publishes and self-heal version collisions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,13 @@ on:
     branches:
       - main
 
+# Serialize publishes: two back-to-back pushes once raced, both bumped to the
+# same patch version, and the loser stranded git a version behind PyPI.
+# Queue (never cancel) so every push still gets released, one at a time.
+concurrency:
+  group: pypi-publish
+  cancel-in-progress: false
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -143,7 +150,10 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: uv run twine upload --verbose dist/*
+        # --skip-existing: if a version already reached PyPI from a run that
+        # died before pushing its bump commit, warn instead of failing so the
+        # bump+tag still land and the next run moves past the collision.
+        run: uv run twine upload --verbose --skip-existing dist/*
 
       - name: Push version bump and tag to GitHub
         if: ${{ success() }}


### PR DESCRIPTION
## What happened

Publish runs for two pushes 46s apart (`timestamp_heartbeat`, `.worktrees`) raced: both read `version = 0.0.661`, both bumped to `0.0.662`. One uploaded to PyPI, then its `git push` of the bump commit was rejected because main had moved. Git ended up a version **behind** PyPI, and every subsequent publish (incl. the #669 merge) failed with `400 File already exists`.

The stranded state has already been repaired on main (`f9db66cb` syncs `0.0.662` + tag, `[ci skip]`). This PR prevents recurrence:

## Changes

- **`concurrency` group** (queue, `cancel-in-progress: false`) — publish runs execute one at a time; every push still gets its release.
- **`twine upload --skip-existing`** — if a collision ever sneaks through anyway, the upload warns instead of failing, so the bump commit + tag still push and the next run moves past it. Self-healing instead of wedged.

## Note

Merging this PR triggers a publish → expect **0.0.663** on PyPI, which also ships yesterday's stranded changes (timestamp_heartbeat, worktrees ignore, ruff pin).