### PR TITLE
PUP-543: fix ImportError race in ask_user_question/tui_loop by deferring on_prompt_toolkit_style import

### DIFF
--- a/code_puppy/tools/ask_user_question/tui_loop.py
+++ b/code_puppy/tools/ask_user_question/tui_loop.py
@@ -34,11 +34,25 @@ from .constants import (
 )
 from .renderers import render_question_panel
 from .theme import get_rich_colors, get_tui_colors
-from code_puppy.callbacks import on_prompt_toolkit_style
 
 if TYPE_CHECKING:
     from .models import QuestionAnswer
     from .terminal_ui import QuestionUIState
+
+
+def _get_prompt_toolkit_style():
+    """Lazy import of ``on_prompt_toolkit_style``.
+
+    ``tui_loop`` is loaded lazily from inside a ``with`` block on a worker
+    thread during exception recovery (see ``terminal_ui.interactive_question_picker``).
+    If the main thread is concurrently (re-)initialising ``code_puppy.callbacks``
+    via a plugin hook, a module-level ``from code_puppy.callbacks import
+    on_prompt_toolkit_style`` can observe a partially-initialised module and
+    raise ``ImportError``. Deferring the lookup to call time avoids the race.
+    """
+    from code_puppy.callbacks import on_prompt_toolkit_style
+
+    return on_prompt_toolkit_style()
 
 
 def _wait_for_keypress() -> None:
@@ -421,7 +435,7 @@ async def run_question_tui(
         mouse_support=False,
         color_depth=ColorDepth.DEPTH_24_BIT,
         output=output,
-        style=on_prompt_toolkit_style(),
+        style=_get_prompt_toolkit_style(),
     )
 
     # Timeout checker background task

--- a/tests/tools/test_ask_user_question/test_tui_loop_lazy_imports.py
+++ b/tests/tools/test_ask_user_question/test_tui_loop_lazy_imports.py
@@ -1,0 +1,107 @@
+"""Regression tests for lazy imports in ``ask_user_question.tui_loop``.
+
+These pin the behaviour of the lazy-import helper in ``tui_loop``:
+``tui_loop`` must NOT resolve
+``code_puppy.callbacks.on_prompt_toolkit_style`` at module import time. Because
+``tui_loop`` is loaded lazily from a worker thread inside an exception-recovery
+path, a module-level ``from code_puppy.callbacks import on_prompt_toolkit_style``
+can observe a partially-initialised ``code_puppy.callbacks`` and raise
+``ImportError``. Deferring the lookup to call time removes that window.
+
+If a future refactor moves the import back to module top, these tests will fail
+loudly at import time and remind the next hacker why the indirection exists.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import pytest
+
+_CALLBACKS = "code_puppy.callbacks"
+_TUI_LOOP = "code_puppy.tools.ask_user_question.tui_loop"
+
+
+@pytest.fixture
+def restore_modules():
+    """Snapshot and restore both modules so tests can safely stub ``callbacks``.
+
+    Also pre-imports ``code_puppy.tools.ask_user_question`` before the stub is
+    installed. Without that, a cold pytest run in which this file is collected
+    first would trip over ``code_puppy.tools.__init__`` re-importing symbols
+    from ``code_puppy.callbacks`` (``on_register_agent_tools``,
+    ``on_register_tools``) that the stub does not carry -- the test would then
+    pass or fail based on collection order rather than the invariant it claims
+    to pin. Pre-importing the parent package ensures we exercise exactly the
+    race the fix targets: a partially-initialised ``code_puppy.callbacks``
+    observed by a fresh import of ``tui_loop`` alone.
+    """
+    importlib.import_module("code_puppy.tools.ask_user_question")
+    saved = {name: sys.modules.get(name) for name in (_CALLBACKS, _TUI_LOOP)}
+    try:
+        yield
+    finally:
+        for name, module in saved.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+def _install_partial_callbacks_stub() -> types.ModuleType:
+    """Replace ``code_puppy.callbacks`` with a stub missing the target symbol.
+
+    Mirrors what the worker thread would see if it imported ``tui_loop`` while
+    the main thread had ``code_puppy.callbacks`` only partially initialised: the
+    module exists in ``sys.modules`` but ``on_prompt_toolkit_style`` is absent.
+    """
+    stub = types.ModuleType(_CALLBACKS)
+    # Intentionally do NOT set ``on_prompt_toolkit_style`` — that is the race we
+    # are pinning against.
+    sys.modules[_CALLBACKS] = stub
+    sys.modules.pop(_TUI_LOOP, None)
+    return stub
+
+
+def test_tui_loop_imports_without_on_prompt_toolkit_style(restore_modules):
+    """Importing ``tui_loop`` must not require the symbol to exist yet."""
+    _install_partial_callbacks_stub()
+
+    module = importlib.import_module(_TUI_LOOP)
+
+    # The lazy indirection is what makes the import survive the stub.
+    assert hasattr(module, "_get_prompt_toolkit_style"), (
+        "Regression: tui_loop should expose a lazy helper for "
+        "on_prompt_toolkit_style so its module-import path does not depend on "
+        "code_puppy.callbacks being fully initialised."
+    )
+
+    # And the anti-pattern must stay gone: no direct top-level binding.
+    assert "on_prompt_toolkit_style" not in vars(module), (
+        "Regression: tui_loop reintroduced a module-level import of "
+        "on_prompt_toolkit_style. That resurrects the partially-initialised "
+        "code_puppy.callbacks race the lazy helper was introduced to avoid."
+    )
+
+
+def test_get_prompt_toolkit_style_resolves_lazily(restore_modules):
+    """The helper must resolve the real symbol on each call, not at import."""
+    stub = _install_partial_callbacks_stub()
+
+    module = importlib.import_module(_TUI_LOOP)
+
+    # First call: symbol still missing -> AttributeError (surfaced as ImportError
+    # by ``from X import Y``). Either exception type is acceptable evidence that
+    # nothing was cached at import time.
+    with pytest.raises((AttributeError, ImportError)):
+        module._get_prompt_toolkit_style()
+
+    # Populate the symbol after ``tui_loop`` was imported.
+    sentinel = object()
+    stub.on_prompt_toolkit_style = lambda: sentinel
+
+    # Second call: helper picks up the freshly-populated symbol. Proves the
+    # lookup is deferred to call time, not frozen at module load.
+    assert module._get_prompt_toolkit_style() is sentinel


### PR DESCRIPTION
## Summary

Fix an intermittent `ImportError: cannot import name 'on_prompt_toolkit_style' from 'code_puppy.callbacks'` that fires from inside `ask_user_question` tool calls, always right after a preceding model failure pushes the runtime into its exception-recovery path.

## The bug

The symbol is defined in `code_puppy/callbacks.py` and cold imports work fine — this isn't a missing name. It's a partially-initialised-module race.

`tui_loop.py` is the **only** caller of `on_prompt_toolkit_style` loaded lazily, and its load path is unusually hostile:

```python
# code_puppy/tools/ask_user_question/terminal_ui.py
337:    from code_puppy.agents._key_listeners import suspended_key_listener
340:        with suspended_key_listener():
341:            from .tui_loop import run_question_tui   # first-time import of tui_loop
```

That import fires on an anyio worker thread (`run_sync_in_worker_thread` → `asyncio.run(...)` → new event loop in the worker), inside a `with` block, mid-exception-recovery. If the main thread is concurrently touching `code_puppy.callbacks` (any plugin hook, error callback, etc.), the worker thread sees `code_puppy.callbacks` in `sys.modules` but only partially initialised — and Python raises the ImportError.

Every other caller of `on_prompt_toolkit_style` (15+ across `command_line/*_menu.py`, `plugins/**/*_menu.py`, `tools/common.py`) is unaffected because they're loaded eagerly at startup.

## The fix

Defer the `on_prompt_toolkit_style` lookup from module-load time to call time inside `tui_loop.py`. Three-line change:

- Remove the module-top `from code_puppy.callbacks import on_prompt_toolkit_style`.
- Add a small `_get_prompt_toolkit_style()` helper with a docstring explaining why the lazy indirection exists.
- Change the single call site to use the helper.

Behaviour is unchanged — the value flowing into `Application(style=...)` is identical.

## Tests

New file `tests/tools/test_ask_user_question/test_tui_loop_lazy_imports.py` (did not extend `test_tui_loop.py` because it's already over the file-size guideline). Two regression tests, both order-independent (fixture pre-imports the parent `code_puppy.tools.ask_user_question` package so only `code_puppy.callbacks` and `tui_loop` are torn down / stubbed):

1. `test_tui_loop_imports_without_on_prompt_toolkit_style` — swaps in a stub `code_puppy.callbacks` that omits the symbol, re-imports `tui_loop`, asserts import succeeds AND that the symbol is NOT re-bound at module top. If a future refactor rips the helper out and puts the import back at module top, this test fails loudly with a clear regression message.
2. `test_get_prompt_toolkit_style_resolves_lazily` — proves the lookup is deferred to call time and not cached at import.

## Verification

```
$ pytest tests/tools/test_ask_user_question/test_tui_loop_lazy_imports.py -v --no-cov -p no:cacheprovider
2 passed in 0.10s

$ pytest tests/tools/test_ask_user_ques/ -q --no-cov
185 passed in 9.61s
```

## Scope

- Two files: `code_puppy/tools/ask_user_question/tui_loop.py` (+18/-2) and the new test file (+107).
- `uv.lock` intentionally untouched.

## Ticket

Internal ref: [PUP-543](https://jira.walmart.com/browse/PUP-543)
