### PR TITLE
PUP-544: Return per-run token usage (with cache-token breakdown) and run timestamps from sub-agent invocation tools

### DIFF
--- a/code_puppy/tools/agent_tools.py
+++ b/code_puppy/tools/agent_tools.py
@@ -201,13 +201,25 @@ class ListAgentsOutput(BaseModel):
 
 
 class AgentInvokeOutput(BaseModel):
-    """Output for the invoke_agent tool."""
+    """Output for the invoke_agent tool.
+
+    The token-usage and latency fields are populated on the success path so
+    benchmarking/model-comparison callers can measure per-run cost without
+    reconstructing it from downstream telemetry. They are purely additive and
+    remain ``None`` on every error path, so existing callers that ignore them
+    are unaffected.
+    """
 
     response: str | None
     agent_name: str
     session_id: str | None = None
     model_name: str | None = None
     error: str | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_tokens: int | None = None
+    num_requests: int | None = None
+    duration_ms: float | None = None
 
 
 def register_list_agents(agent):

--- a/code_puppy/tools/agent_tools.py
+++ b/code_puppy/tools/agent_tools.py
@@ -203,11 +203,17 @@ class ListAgentsOutput(BaseModel):
 class AgentInvokeOutput(BaseModel):
     """Output for the invoke_agent tool.
 
-    The token-usage and latency fields are populated on the success path so
+    The token-usage and timing fields are populated on the success path so
     benchmarking/model-comparison callers can measure per-run cost without
     reconstructing it from downstream telemetry. They are purely additive and
     remain ``None`` on every error path, so existing callers that ignore them
     are unaffected.
+
+    Token accounting is normalized so the input buckets never overlap:
+    ``input_tokens`` counts only regular (non-cached) input, while cached input
+    is reported separately as ``cache_read_input_tokens`` (cache hits) and
+    ``cache_creation_input_tokens`` (cache writes). A provider that does not
+    report a given bucket leaves that field ``None`` rather than a fabricated 0.
     """
 
     response: str | None
@@ -216,9 +222,13 @@ class AgentInvokeOutput(BaseModel):
     model_name: str | None = None
     error: str | None = None
     input_tokens: int | None = None
+    cache_read_input_tokens: int | None = None
+    cache_creation_input_tokens: int | None = None
     output_tokens: int | None = None
     total_tokens: int | None = None
     num_requests: int | None = None
+    start_time: str | None = None
+    end_time: str | None = None
     duration_ms: float | None = None
 
 

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -2,10 +2,12 @@
 
 import asyncio
 import inspect
+import math
+import time
 import traceback
 from contextlib import AsyncExitStack
 from functools import partial
-from typing import Set
+from typing import Any, Set
 
 from pydantic_ai import Agent, RunContext, UsageLimits
 
@@ -44,6 +46,76 @@ from code_puppy.tools.subagent_context import (
 
 # Set to track active subagent invocation tasks
 _active_subagent_tasks: Set[asyncio.Task] = set()
+
+
+def _coerce_token_count(value: Any) -> int | None:
+    """Coerce a usage value to an ``int``, or ``None`` if it isn't usable.
+
+    Token/request counts are semantically integers. ``bool`` is rejected even
+    though it subclasses ``int`` (``True`` must not silently become ``1``), and
+    non-finite floats (``nan``/``inf``) are treated as missing. Anything that
+    is not a real number (e.g. a ``Mock``) is treated as missing too.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return None
+        return int(value)
+    return None
+
+
+def _extract_usage_metrics(usage: Any) -> dict[str, int | None]:
+    """Map a pydantic-ai usage object to our schema fields, defensively.
+
+    Field names vary across pydantic-ai versions: current releases expose
+    ``input_tokens``/``output_tokens`` while older ones used
+    ``request_tokens``/``response_tokens``. We prefer the current names and
+    fall back to the deprecated ones. ``None`` means "missing" (``0`` is a
+    valid count). ``total_tokens`` is used verbatim when present and otherwise
+    computed from the parts when at least one part is available.
+    """
+    metrics: dict[str, int | None] = {
+        "input_tokens": None,
+        "output_tokens": None,
+        "total_tokens": None,
+        "num_requests": None,
+    }
+    if usage is None:
+        return metrics
+
+    input_tokens = _coerce_token_count(getattr(usage, "input_tokens", None))
+    if input_tokens is None:
+        input_tokens = _coerce_token_count(getattr(usage, "request_tokens", None))
+
+    output_tokens = _coerce_token_count(getattr(usage, "output_tokens", None))
+    if output_tokens is None:
+        output_tokens = _coerce_token_count(getattr(usage, "response_tokens", None))
+
+    total_tokens = _coerce_token_count(getattr(usage, "total_tokens", None))
+    if total_tokens is None and (input_tokens is not None or output_tokens is not None):
+        total_tokens = (input_tokens or 0) + (output_tokens or 0)
+
+    metrics["input_tokens"] = input_tokens
+    metrics["output_tokens"] = output_tokens
+    metrics["total_tokens"] = total_tokens
+    metrics["num_requests"] = _coerce_token_count(getattr(usage, "requests", None))
+    return metrics
+
+
+def _safe_usage_metrics(result: Any) -> dict[str, int | None]:
+    """Best-effort ``result.usage()`` extraction that never breaks the run.
+
+    Usage is secondary metadata; a failure here must not prevent a successful
+    sub-agent invocation from returning its response.
+    """
+    try:
+        usage = result.usage()
+        return _extract_usage_metrics(usage)
+    except Exception:
+        return _extract_usage_metrics(None)
 
 
 def _subagent_recursion_blocked() -> bool:
@@ -387,6 +459,10 @@ async def _invoke_agent_impl(
                             event_stream_handler=stream_handler,
                         )
 
+                    # Time the full run (including streaming retries) so the
+                    # returned duration_ms reflects honest user-observed
+                    # latency, not just a single attempt.
+                    run_started = time.perf_counter()
                     task = asyncio.create_task(_run_subagent())
                     _active_subagent_tasks.add(task)
 
@@ -396,6 +472,11 @@ async def _invoke_agent_impl(
                         _active_subagent_tasks.discard(task)
                         if task.cancelled():
                             await on_agent_run_cancel(group_id)
+
+                    # Capture usage + latency as close to the run boundary as
+                    # possible, before any rendering/history/emit bookkeeping.
+                    duration_ms = (time.perf_counter() - run_started) * 1000.0
+                    usage_metrics = _safe_usage_metrics(result)
 
                 # Still inside subagent_context: if high mode and streaming
                 # didn't produce any text, fall back to the one-shot renderer
@@ -449,6 +530,11 @@ async def _invoke_agent_impl(
                 agent_name=agent_name,
                 session_id=session_id,
                 model_name=effective_model_name,
+                input_tokens=usage_metrics["input_tokens"],
+                output_tokens=usage_metrics["output_tokens"],
+                total_tokens=usage_metrics["total_tokens"],
+                num_requests=usage_metrics["num_requests"],
+                duration_ms=duration_ms,
             )
 
     except Exception as e:
@@ -525,7 +611,10 @@ def register_invoke_agent(agent):
 
         Returns:
             AgentInvokeOutput: Contains response, agent_name, session_id,
-            effective model_name, and error fields.
+            effective model_name, and error fields. On a successful run it also
+            reports per-run token usage (input_tokens, output_tokens,
+            total_tokens, num_requests) and wall-clock latency (duration_ms);
+            those fields are None on any error path.
         """
         return await _invoke_agent_impl(
             context=context,
@@ -576,7 +665,10 @@ def register_invoke_agent_with_model(agent):
 
         Returns:
             AgentInvokeOutput: Contains response, agent_name, session_id,
-            effective model_name, and error fields.
+            effective model_name, and error fields. On a successful run it also
+            reports per-run token usage (input_tokens, output_tokens,
+            total_tokens, num_requests) and wall-clock latency (duration_ms);
+            those fields are None on any error path.
         """
         normalized_model_name = model_name.strip()
         if not normalized_model_name:

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -68,7 +68,9 @@ def _coerce_token_count(value: Any) -> int | None:
     return None
 
 
-def _pick_reported_tokens(usage: Any, detail_keys: tuple[str, ...], attr: str) -> int | None:
+def _pick_reported_tokens(
+    usage: Any, detail_keys: tuple[str, ...], attr: str
+) -> int | None:
     """Return a reported token count, preferring the provider ``details`` dict.
 
     The ``details`` dict only contains keys a provider actually sent, so when a
@@ -125,7 +127,8 @@ def _extract_usage_metrics(usage: Any) -> dict[str, int | None]:
         return metrics
 
     cache_read = _pick_reported_tokens(
-        usage, ("cache_read_input_tokens", "cached_content_tokens"),
+        usage,
+        ("cache_read_input_tokens", "cached_content_tokens"),
         "cache_read_tokens",
     )
     cache_creation = _pick_reported_tokens(
@@ -149,7 +152,11 @@ def _extract_usage_metrics(usage: Any) -> dict[str, int | None]:
 
     total_tokens = _coerce_token_count(getattr(usage, "total_tokens", None))
     if total_tokens is None:
-        parts = [p for p in (input_tokens, cache_read, cache_creation, output_tokens) if p is not None]
+        parts = [
+            p
+            for p in (input_tokens, cache_read, cache_creation, output_tokens)
+            if p is not None
+        ]
         if parts:
             total_tokens = sum(parts)
 

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -6,6 +6,7 @@ import math
 import time
 import traceback
 from contextlib import AsyncExitStack
+from datetime import datetime, timezone
 from functools import partial
 from typing import Any, Set
 
@@ -67,18 +68,55 @@ def _coerce_token_count(value: Any) -> int | None:
     return None
 
 
+def _pick_reported_tokens(usage: Any, detail_keys: tuple[str, ...], attr: str) -> int | None:
+    """Return a reported token count, preferring the provider ``details`` dict.
+
+    The ``details`` dict only contains keys a provider actually sent, so when a
+    key is present it is the authoritative signal for presence: a key present
+    with value ``0`` is a genuine "provider reported zero" and is kept. The
+    normalized first-class attribute (e.g. ``cache_read_tokens``) is used as a
+    fallback, and only when it is positive, because its dataclass default of
+    ``0`` is indistinguishable from "not reported" -- so for providers that only
+    surface a bucket via the first-class attribute (OpenAI cache reads), a
+    genuine zero is reported as ``None`` rather than a fabricated ``0``.
+    """
+    details = getattr(usage, "details", None)
+    if isinstance(details, dict):
+        for key in detail_keys:
+            if key in details:
+                coerced = _coerce_token_count(details[key])
+                if coerced is not None:
+                    return coerced
+    fallback = _coerce_token_count(getattr(usage, attr, None))
+    if fallback is not None and fallback > 0:
+        return fallback
+    return None
+
+
 def _extract_usage_metrics(usage: Any) -> dict[str, int | None]:
     """Map a pydantic-ai usage object to our schema fields, defensively.
 
-    Field names vary across pydantic-ai versions: current releases expose
-    ``input_tokens``/``output_tokens`` while older ones used
-    ``request_tokens``/``response_tokens``. We prefer the current names and
-    fall back to the deprecated ones. ``None`` means "missing" (``0`` is a
-    valid count). ``total_tokens`` is used verbatim when present and otherwise
-    computed from the parts when at least one part is available.
+    Token buckets are normalized so they never overlap: pydantic-ai (via
+    genai-prices) folds cached tokens INTO ``input_tokens`` for every provider
+    we use (Anthropic, OpenAI/codex, Gemini), so we subtract the cache
+    components back out to keep ``input_tokens`` strictly non-cached. That way
+    ``input_tokens + cache_read_input_tokens + cache_creation_input_tokens``
+    reflects total input without double-counting.
+
+    Cache buckets are sourced per provider (verified against the installed
+    pydantic-ai + genai-prices):
+    - cache reads: Anthropic emits ``cache_read_input_tokens`` and Gemini emits
+      ``cached_content_tokens`` in the ``details`` dict; OpenAI only surfaces it
+      via the first-class ``cache_read_tokens`` attribute (its nested
+      ``prompt_tokens_details.cached_tokens`` is not copied into ``details``).
+    - cache creation: Anthropic ``cache_creation_input_tokens`` only
+      (also normalized to ``cache_write_tokens``); OpenAI and Gemini have no
+      such concept, so that field stays ``None``.
     """
     metrics: dict[str, int | None] = {
         "input_tokens": None,
+        "cache_read_input_tokens": None,
+        "cache_creation_input_tokens": None,
         "output_tokens": None,
         "total_tokens": None,
         "num_requests": None,
@@ -86,19 +124,38 @@ def _extract_usage_metrics(usage: Any) -> dict[str, int | None]:
     if usage is None:
         return metrics
 
-    input_tokens = _coerce_token_count(getattr(usage, "input_tokens", None))
-    if input_tokens is None:
-        input_tokens = _coerce_token_count(getattr(usage, "request_tokens", None))
+    cache_read = _pick_reported_tokens(
+        usage, ("cache_read_input_tokens", "cached_content_tokens"),
+        "cache_read_tokens",
+    )
+    cache_creation = _pick_reported_tokens(
+        usage, ("cache_creation_input_tokens",), "cache_write_tokens"
+    )
+
+    # pydantic-ai reports a combined input count that already includes the
+    # cached tokens; subtract them back out so the buckets don't overlap.
+    combined_input = _coerce_token_count(getattr(usage, "input_tokens", None))
+    if combined_input is None:
+        combined_input = _coerce_token_count(getattr(usage, "request_tokens", None))
+    input_tokens = combined_input
+    if combined_input is not None:
+        input_tokens = max(
+            combined_input - (cache_read or 0) - (cache_creation or 0), 0
+        )
 
     output_tokens = _coerce_token_count(getattr(usage, "output_tokens", None))
     if output_tokens is None:
         output_tokens = _coerce_token_count(getattr(usage, "response_tokens", None))
 
     total_tokens = _coerce_token_count(getattr(usage, "total_tokens", None))
-    if total_tokens is None and (input_tokens is not None or output_tokens is not None):
-        total_tokens = (input_tokens or 0) + (output_tokens or 0)
+    if total_tokens is None:
+        parts = [p for p in (input_tokens, cache_read, cache_creation, output_tokens) if p is not None]
+        if parts:
+            total_tokens = sum(parts)
 
     metrics["input_tokens"] = input_tokens
+    metrics["cache_read_input_tokens"] = cache_read
+    metrics["cache_creation_input_tokens"] = cache_creation
     metrics["output_tokens"] = output_tokens
     metrics["total_tokens"] = total_tokens
     metrics["num_requests"] = _coerce_token_count(getattr(usage, "requests", None))
@@ -460,9 +517,13 @@ async def _invoke_agent_impl(
                         )
 
                     # Time the full run (including streaming retries) so the
-                    # returned duration_ms reflects honest user-observed
-                    # latency, not just a single attempt.
+                    # returned timestamps and duration_ms reflect honest
+                    # user-observed latency, not just a single attempt.
+                    # start_time/end_time are timezone-aware UTC ISO-8601
+                    # strings; duration_ms uses a monotonic clock so it is
+                    # immune to wall-clock adjustments during the run.
                     run_started = time.perf_counter()
+                    start_time = datetime.now(timezone.utc).isoformat()
                     task = asyncio.create_task(_run_subagent())
                     _active_subagent_tasks.add(task)
 
@@ -475,6 +536,7 @@ async def _invoke_agent_impl(
 
                     # Capture usage + latency as close to the run boundary as
                     # possible, before any rendering/history/emit bookkeeping.
+                    end_time = datetime.now(timezone.utc).isoformat()
                     duration_ms = (time.perf_counter() - run_started) * 1000.0
                     usage_metrics = _safe_usage_metrics(result)
 
@@ -531,9 +593,15 @@ async def _invoke_agent_impl(
                 session_id=session_id,
                 model_name=effective_model_name,
                 input_tokens=usage_metrics["input_tokens"],
+                cache_read_input_tokens=usage_metrics["cache_read_input_tokens"],
+                cache_creation_input_tokens=usage_metrics[
+                    "cache_creation_input_tokens"
+                ],
                 output_tokens=usage_metrics["output_tokens"],
                 total_tokens=usage_metrics["total_tokens"],
                 num_requests=usage_metrics["num_requests"],
+                start_time=start_time,
+                end_time=end_time,
                 duration_ms=duration_ms,
             )
 
@@ -612,9 +680,11 @@ def register_invoke_agent(agent):
         Returns:
             AgentInvokeOutput: Contains response, agent_name, session_id,
             effective model_name, and error fields. On a successful run it also
-            reports per-run token usage (input_tokens, output_tokens,
-            total_tokens, num_requests) and wall-clock latency (duration_ms);
-            those fields are None on any error path.
+            reports per-run token usage (non-cached input_tokens,
+            cache_read_input_tokens, cache_creation_input_tokens, output_tokens,
+            total_tokens, num_requests) and timing (start_time/end_time as UTC
+            ISO-8601 strings plus duration_ms); those fields are None on any
+            error path.
         """
         return await _invoke_agent_impl(
             context=context,
@@ -666,9 +736,11 @@ def register_invoke_agent_with_model(agent):
         Returns:
             AgentInvokeOutput: Contains response, agent_name, session_id,
             effective model_name, and error fields. On a successful run it also
-            reports per-run token usage (input_tokens, output_tokens,
-            total_tokens, num_requests) and wall-clock latency (duration_ms);
-            those fields are None on any error path.
+            reports per-run token usage (non-cached input_tokens,
+            cache_read_input_tokens, cache_creation_input_tokens, output_tokens,
+            total_tokens, num_requests) and timing (start_time/end_time as UTC
+            ISO-8601 strings plus duration_ms); those fields are None on any
+            error path.
         """
         normalized_model_name = model_name.strip()
         if not normalized_model_name:

--- a/tests/test_subagent_invocation_usage.py
+++ b/tests/test_subagent_invocation_usage.py
@@ -93,36 +93,48 @@ async def _run_invoke(*, usage=None, usage_raises=False, run_raises=False, perf=
 
     with ExitStack() as stack:
         p = stack.enter_context
-        p(patch(
-            "code_puppy.tools.subagent_invocation.generate_group_id",
-            return_value="test-group",
-        ))
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation.generate_group_id",
+                return_value="test-group",
+            )
+        )
         p(patch("code_puppy.tools.subagent_invocation.get_message_bus"))
-        p(patch(
-            "code_puppy.tools.subagent_invocation.get_session_context",
-            return_value="parent",
-        ))
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation.get_session_context",
+                return_value="parent",
+            )
+        )
         p(patch("code_puppy.tools.subagent_invocation.set_session_context"))
         p(patch("code_puppy.tools.subagent_invocation.emit_info"))
         p(patch("code_puppy.tools.subagent_invocation.emit_error"))
         p(patch("code_puppy.tools.subagent_invocation.emit_success"))
         p(patch("code_puppy.tools.subagent_invocation._save_session_history"))
-        p(patch(
-            "code_puppy.tools.subagent_invocation._load_session_history",
-            return_value=[],
-        ))
-        p(patch(
-            "code_puppy.tools.subagent_invocation._generate_session_hash_suffix",
-            return_value="abc123",
-        ))
-        p(patch(
-            "code_puppy.agents.agent_manager.load_agent",
-            return_value=agent_config,
-        ))
-        p(patch(
-            "code_puppy.model_factory.ModelFactory.load_config",
-            return_value={"default-model": {}, "override-model": {}},
-        ))
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation._load_session_history",
+                return_value=[],
+            )
+        )
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation._generate_session_hash_suffix",
+                return_value="abc123",
+            )
+        )
+        p(
+            patch(
+                "code_puppy.agents.agent_manager.load_agent",
+                return_value=agent_config,
+            )
+        )
+        p(
+            patch(
+                "code_puppy.model_factory.ModelFactory.load_config",
+                return_value={"default-model": {}, "override-model": {}},
+            )
+        )
         p(patch("code_puppy.model_factory.ModelFactory.get_model"))
         p(patch("code_puppy.model_factory.make_model_settings"))
         p(patch("code_puppy.agents._builder.load_puppy_rules", return_value=None))
@@ -131,40 +143,54 @@ async def _run_invoke(*, usage=None, usage_raises=False, run_raises=False, perf=
         mock_prepare.return_value = MagicMock(
             instructions="prepared instructions", user_prompt="prepared prompt"
         )
-        p(patch(
-            "code_puppy.agents._builder.autostart_bound_servers_async",
-            new=AsyncMock(),
-        ))
+        p(
+            patch(
+                "code_puppy.agents._builder.autostart_bound_servers_async",
+                new=AsyncMock(),
+            )
+        )
         # Disable MCP so no manager/servers are touched.
         p(patch("code_puppy.config.get_value", return_value="true"))
         p(patch("code_puppy.config.get_output_level", return_value="medium"))
-        p(patch(
-            "code_puppy.agents._compaction.make_history_processor",
-            return_value=lambda messages: messages,
-        ))
-        p(patch(
-            "code_puppy.tools.subagent_invocation.Agent",
-            return_value=mock_temp_agent,
-        ))
+        p(
+            patch(
+                "code_puppy.agents._compaction.make_history_processor",
+                return_value=lambda messages: messages,
+            )
+        )
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation.Agent",
+                return_value=mock_temp_agent,
+            )
+        )
         p(patch("code_puppy.tools.register_tools_for_agent"))
-        p(patch(
-            "code_puppy.tools.subagent_invocation.on_wrap_pydantic_agent",
-            side_effect=lambda _cfg, agent, **_kwargs: agent,
-        ))
-        p(patch(
-            "code_puppy.tools.subagent_invocation.on_agent_run_context",
-            return_value=[],
-        ))
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation.on_wrap_pydantic_agent",
+                side_effect=lambda _cfg, agent, **_kwargs: agent,
+            )
+        )
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation.on_agent_run_context",
+                return_value=[],
+            )
+        )
         # Pass-through retry: run once, no backoff, so failures propagate fast.
-        p(patch(
-            "code_puppy.agents.retry_profiles.make_streaming_retry",
-            new=_passthrough_retry,
-        ))
+        p(
+            patch(
+                "code_puppy.agents.retry_profiles.make_streaming_retry",
+                new=_passthrough_retry,
+            )
+        )
         if perf is not None:
-            p(patch(
-                "code_puppy.tools.subagent_invocation.time.perf_counter",
-                side_effect=perf,
-            ))
+            p(
+                patch(
+                    "code_puppy.tools.subagent_invocation.time.perf_counter",
+                    side_effect=perf,
+                )
+            )
 
         return await invoke(
             mock_context,

--- a/tests/test_subagent_invocation_usage.py
+++ b/tests/test_subagent_invocation_usage.py
@@ -1,18 +1,22 @@
 """Tests for per-run usage/latency reporting in subagent_invocation.
 
-These cover the additive token-usage and ``duration_ms`` fields added to
+These cover the additive token-usage and timing fields added to
 ``AgentInvokeOutput``:
 
-- success path populates all five fields
+- success path populates every new field (non-cached input_tokens, cache read /
+  creation buckets, output_tokens, total_tokens, num_requests, start_time,
+  end_time, duration_ms) with ``start_time <= end_time``
+- token buckets are normalized per provider so cached tokens are not
+  double-counted (Anthropic / OpenAI / Gemini shapes)
 - a failing ``result.usage()`` leaves token fields None but still times the run
-- the deprecated ``request_tokens``/``response_tokens`` field names still map
-- an error path (the sub-agent run raises) leaves all five fields None
+- an error path (the sub-agent run raises) leaves all new fields None
 
 The suite is intentionally isolated from ``test_agent_tools_coverage.py`` so the
 new behaviour stays focused and readable.
 """
 
 from contextlib import ExitStack, contextmanager
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -22,6 +26,12 @@ from code_puppy.tools.subagent_invocation import (
     _extract_usage_metrics,
     register_invoke_agent_with_model,
 )
+
+
+def _usage(**kwargs):
+    """Build a stub usage object; ``details`` defaults to an empty dict."""
+    kwargs.setdefault("details", {})
+    return SimpleNamespace(**kwargs)
 
 
 def _passthrough_retry(*_args, **_kwargs):
@@ -165,49 +175,161 @@ async def _run_invoke(*, usage=None, usage_raises=False, run_raises=False, perf=
 
 
 class TestExtractUsageMetrics:
-    """Unit tests for the defensive usage-mapping helper."""
+    """Unit tests for the defensive, provider-aware usage-mapping helper."""
 
     def test_none_usage_yields_all_none(self):
         assert _extract_usage_metrics(None) == {
             "input_tokens": None,
+            "cache_read_input_tokens": None,
+            "cache_creation_input_tokens": None,
             "output_tokens": None,
             "total_tokens": None,
             "num_requests": None,
         }
 
-    def test_modern_fields(self):
-        usage = SimpleNamespace(
-            input_tokens=10, output_tokens=5, total_tokens=15, requests=2
+    def test_modern_fields_no_cache(self):
+        # No cache reported anywhere: cache buckets stay None, input untouched.
+        usage = _usage(
+            input_tokens=10,
+            output_tokens=5,
+            total_tokens=15,
+            requests=2,
+            cache_read_tokens=0,
+            cache_write_tokens=0,
         )
         assert _extract_usage_metrics(usage) == {
             "input_tokens": 10,
+            "cache_read_input_tokens": None,
+            "cache_creation_input_tokens": None,
             "output_tokens": 5,
             "total_tokens": 15,
             "num_requests": 2,
         }
 
+    def test_anthropic_shape_populates_both_cache_buckets(self):
+        # Anthropic folds base + cache_creation + cache_read into input_tokens.
+        usage = _usage(
+            input_tokens=150,  # 100 base + 20 creation + 30 read
+            output_tokens=50,
+            total_tokens=200,
+            requests=1,
+            cache_read_tokens=30,
+            cache_write_tokens=20,
+            details={
+                "input_tokens": 100,
+                "cache_creation_input_tokens": 20,
+                "cache_read_input_tokens": 30,
+                "output_tokens": 50,
+            },
+        )
+        assert _extract_usage_metrics(usage) == {
+            "input_tokens": 100,  # cache subtracted back out
+            "cache_read_input_tokens": 30,
+            "cache_creation_input_tokens": 20,
+            "output_tokens": 50,
+            "total_tokens": 200,
+            "num_requests": 1,
+        }
+
+    def test_openai_shape_cache_read_only(self):
+        # OpenAI prompt_tokens already includes cached tokens; cached_tokens is
+        # NOT copied into details (it lives in nested prompt_tokens_details), so
+        # the cache read surfaces only via the first-class cache_read_tokens.
+        usage = _usage(
+            input_tokens=120,  # 80 non-cached + 40 cached
+            output_tokens=60,
+            total_tokens=180,
+            requests=1,
+            cache_read_tokens=40,
+            cache_write_tokens=0,
+            details={"reasoning_tokens": 0},
+        )
+        assert _extract_usage_metrics(usage) == {
+            "input_tokens": 80,
+            "cache_read_input_tokens": 40,
+            "cache_creation_input_tokens": None,
+            "output_tokens": 60,
+            "total_tokens": 180,
+            "num_requests": 1,
+        }
+
+    def test_openai_genuine_zero_cache_read_is_none(self):
+        # OpenAI reports cache_read=0 only via the attribute default, which is
+        # indistinguishable from "not reported", so we surface None (never a
+        # fabricated 0) for that provider.
+        usage = _usage(
+            input_tokens=120,
+            output_tokens=60,
+            total_tokens=180,
+            requests=1,
+            cache_read_tokens=0,
+            cache_write_tokens=0,
+            details={"reasoning_tokens": 0},
+        )
+        metrics = _extract_usage_metrics(usage)
+        assert metrics["cache_read_input_tokens"] is None
+        assert metrics["input_tokens"] == 120
+
+    def test_gemini_shape_cache_read_only(self):
+        # Gemini promptTokenCount includes cached content; details carries the
+        # cached_content_tokens key (only present when non-zero).
+        usage = _usage(
+            input_tokens=250,  # 200 non-cached + 50 cached
+            output_tokens=70,
+            total_tokens=320,
+            requests=1,
+            cache_read_tokens=50,
+            cache_write_tokens=0,
+            details={"cached_content_tokens": 50},
+        )
+        assert _extract_usage_metrics(usage) == {
+            "input_tokens": 200,
+            "cache_read_input_tokens": 50,
+            "cache_creation_input_tokens": None,
+            "output_tokens": 70,
+            "total_tokens": 320,
+            "num_requests": 1,
+        }
+
     def test_deprecated_fields_and_computed_total(self):
+        # No total_tokens attr, no cache: total computed from the parts.
         usage = SimpleNamespace(request_tokens=7, response_tokens=3, requests=1)
         assert _extract_usage_metrics(usage) == {
             "input_tokens": 7,
+            "cache_read_input_tokens": None,
+            "cache_creation_input_tokens": None,
             "output_tokens": 3,
             "total_tokens": 10,
             "num_requests": 1,
         }
 
-    def test_zero_is_valid_not_missing(self):
-        usage = SimpleNamespace(
-            input_tokens=0, output_tokens=0, total_tokens=0, requests=0
+    def test_zero_cache_is_reported_not_missing(self):
+        # A provider genuinely reporting 0 (key present) keeps the 0.
+        usage = _usage(
+            input_tokens=10,
+            output_tokens=5,
+            total_tokens=15,
+            requests=1,
+            cache_read_tokens=0,
+            details={"cache_read_input_tokens": 0},
         )
-        assert _extract_usage_metrics(usage) == {
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "total_tokens": 0,
-            "num_requests": 0,
-        }
+        metrics = _extract_usage_metrics(usage)
+        assert metrics["cache_read_input_tokens"] == 0
+        assert metrics["cache_creation_input_tokens"] is None
+        assert metrics["input_tokens"] == 10
+
+    def test_input_never_goes_negative(self):
+        # Defensive: absurd cache larger than combined input floors at 0.
+        usage = _usage(
+            input_tokens=10,
+            output_tokens=5,
+            requests=1,
+            details={"cache_read_input_tokens": 40},
+        )
+        assert _extract_usage_metrics(usage)["input_tokens"] == 0
 
     def test_bool_and_non_finite_are_rejected(self):
-        usage = SimpleNamespace(
+        usage = _usage(
             input_tokens=True, output_tokens=float("nan"), requests=float("inf")
         )
         metrics = _extract_usage_metrics(usage)
@@ -221,25 +343,59 @@ class TestInvokeReportsUsageAndLatency:
 
     @pytest.mark.asyncio
     async def test_success_populates_all_fields(self):
-        usage = SimpleNamespace(
-            input_tokens=12, output_tokens=8, total_tokens=20, requests=3
+        usage = _usage(
+            input_tokens=120,
+            output_tokens=60,
+            total_tokens=180,
+            requests=3,
+            cache_read_tokens=40,
+            cache_write_tokens=0,
+            details={"reasoning_tokens": 0},
         )
         out = await _run_invoke(usage=usage)
 
         assert out.response == "subagent response"
         assert out.error is None
-        assert out.input_tokens == 12
-        assert out.output_tokens == 8
-        assert out.total_tokens == 20
+        assert out.input_tokens == 80
+        assert out.cache_read_input_tokens == 40
+        assert out.cache_creation_input_tokens is None
+        assert out.output_tokens == 60
+        assert out.total_tokens == 180
         assert out.num_requests == 3
+        # Timestamps are UTC ISO-8601 and correctly ordered.
+        assert out.start_time is not None and out.end_time is not None
+        start = datetime.fromisoformat(out.start_time)
+        end = datetime.fromisoformat(out.end_time)
+        assert start.tzinfo is not None and end.tzinfo is not None
+        assert start <= end
         assert isinstance(out.duration_ms, float)
         assert out.duration_ms >= 0.0
 
     @pytest.mark.asyncio
-    async def test_success_duration_is_measured(self):
-        usage = SimpleNamespace(
-            input_tokens=1, output_tokens=1, total_tokens=2, requests=1
+    async def test_success_anthropic_reports_creation_bucket(self):
+        usage = _usage(
+            input_tokens=150,
+            output_tokens=50,
+            total_tokens=200,
+            requests=1,
+            cache_read_tokens=30,
+            cache_write_tokens=20,
+            details={
+                "input_tokens": 100,
+                "cache_creation_input_tokens": 20,
+                "cache_read_input_tokens": 30,
+                "output_tokens": 50,
+            },
         )
+        out = await _run_invoke(usage=usage)
+
+        assert out.input_tokens == 100
+        assert out.cache_read_input_tokens == 30
+        assert out.cache_creation_input_tokens == 20
+
+    @pytest.mark.asyncio
+    async def test_success_duration_is_measured(self):
+        usage = _usage(input_tokens=1, output_tokens=1, total_tokens=2, requests=1)
         # perf_counter: start=1000.0, stop=1000.5 -> 500.0 ms; extra calls stay
         # at the stop value so nothing raises if the clock is touched again.
         out = await _run_invoke(usage=usage, perf=[1000.0, 1000.5, 1000.5, 1000.5])
@@ -253,22 +409,16 @@ class TestInvokeReportsUsageAndLatency:
         assert out.response == "subagent response"
         assert out.error is None
         assert out.input_tokens is None
+        assert out.cache_read_input_tokens is None
+        assert out.cache_creation_input_tokens is None
         assert out.output_tokens is None
         assert out.total_tokens is None
         assert out.num_requests is None
-        # Latency is still measured even when usage extraction fails.
+        # Timing is still measured even when usage extraction fails.
+        assert out.start_time is not None
+        assert out.end_time is not None
         assert isinstance(out.duration_ms, float)
         assert out.duration_ms >= 0.0
-
-    @pytest.mark.asyncio
-    async def test_success_with_deprecated_usage_fields(self):
-        usage = SimpleNamespace(request_tokens=7, response_tokens=3, requests=1)
-        out = await _run_invoke(usage=usage)
-
-        assert out.input_tokens == 7
-        assert out.output_tokens == 3
-        assert out.total_tokens == 10
-        assert out.num_requests == 1
 
     @pytest.mark.asyncio
     async def test_error_path_leaves_all_metrics_none(self):
@@ -277,7 +427,11 @@ class TestInvokeReportsUsageAndLatency:
         assert out.response is None
         assert out.error is not None
         assert out.input_tokens is None
+        assert out.cache_read_input_tokens is None
+        assert out.cache_creation_input_tokens is None
         assert out.output_tokens is None
         assert out.total_tokens is None
         assert out.num_requests is None
+        assert out.start_time is None
+        assert out.end_time is None
         assert out.duration_ms is None

--- a/tests/test_subagent_invocation_usage.py
+++ b/tests/test_subagent_invocation_usage.py
@@ -1,0 +1,283 @@
+"""Tests for per-run usage/latency reporting in subagent_invocation.
+
+These cover the additive token-usage and ``duration_ms`` fields added to
+``AgentInvokeOutput``:
+
+- success path populates all five fields
+- a failing ``result.usage()`` leaves token fields None but still times the run
+- the deprecated ``request_tokens``/``response_tokens`` field names still map
+- an error path (the sub-agent run raises) leaves all five fields None
+
+The suite is intentionally isolated from ``test_agent_tools_coverage.py`` so the
+new behaviour stays focused and readable.
+"""
+
+from contextlib import ExitStack, contextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from code_puppy.tools.subagent_invocation import (
+    _extract_usage_metrics,
+    register_invoke_agent_with_model,
+)
+
+
+def _passthrough_retry(*_args, **_kwargs):
+    """Replacement for make_streaming_retry: run the coroutine once, no retries."""
+
+    def _decorator(func):
+        return func
+
+    return _decorator
+
+
+def _capture_invoke_with_model():
+    """Capture the registered invoke_agent_with_model callable."""
+    mock_agent = MagicMock()
+    captured = {}
+
+    def capture_tool(func):
+        captured["func"] = func
+        return func
+
+    mock_agent.tool = capture_tool
+    register_invoke_agent_with_model(mock_agent)
+    return captured["func"]
+
+
+def _build_agent_config():
+    config = MagicMock()
+
+    @contextmanager
+    def temporary_override(_model_name):
+        yield
+
+    config.temporary_model_name_override.side_effect = temporary_override
+    config.get_model_name.return_value = "override-model"
+    config.get_full_system_prompt.return_value = "Test instructions"
+    config.get_available_tools.return_value = ["list_files"]
+    config.get_message_history.return_value = []
+    return config
+
+
+async def _run_invoke(*, usage=None, usage_raises=False, run_raises=False, perf=None):
+    """Drive _invoke_agent_impl with a mocked temp agent and return the output."""
+    invoke = _capture_invoke_with_model()
+    mock_context = MagicMock()
+    agent_config = _build_agent_config()
+
+    mock_temp_agent = MagicMock()
+    if run_raises:
+        mock_temp_agent.run = AsyncMock(side_effect=RuntimeError("boom"))
+    else:
+        result = MagicMock()
+        result.output = "subagent response"
+        result.all_messages.return_value = ["updated-history"]
+        if usage_raises:
+            result.usage = MagicMock(side_effect=RuntimeError("no usage"))
+        else:
+            result.usage = MagicMock(return_value=usage)
+        mock_temp_agent.run = AsyncMock(return_value=result)
+
+    with ExitStack() as stack:
+        p = stack.enter_context
+        p(patch(
+            "code_puppy.tools.subagent_invocation.generate_group_id",
+            return_value="test-group",
+        ))
+        p(patch("code_puppy.tools.subagent_invocation.get_message_bus"))
+        p(patch(
+            "code_puppy.tools.subagent_invocation.get_session_context",
+            return_value="parent",
+        ))
+        p(patch("code_puppy.tools.subagent_invocation.set_session_context"))
+        p(patch("code_puppy.tools.subagent_invocation.emit_info"))
+        p(patch("code_puppy.tools.subagent_invocation.emit_error"))
+        p(patch("code_puppy.tools.subagent_invocation.emit_success"))
+        p(patch("code_puppy.tools.subagent_invocation._save_session_history"))
+        p(patch(
+            "code_puppy.tools.subagent_invocation._load_session_history",
+            return_value=[],
+        ))
+        p(patch(
+            "code_puppy.tools.subagent_invocation._generate_session_hash_suffix",
+            return_value="abc123",
+        ))
+        p(patch(
+            "code_puppy.agents.agent_manager.load_agent",
+            return_value=agent_config,
+        ))
+        p(patch(
+            "code_puppy.model_factory.ModelFactory.load_config",
+            return_value={"default-model": {}, "override-model": {}},
+        ))
+        p(patch("code_puppy.model_factory.ModelFactory.get_model"))
+        p(patch("code_puppy.model_factory.make_model_settings"))
+        p(patch("code_puppy.agents._builder.load_puppy_rules", return_value=None))
+        p(patch("code_puppy.callbacks.on_load_prompt", return_value=[]))
+        mock_prepare = p(patch("code_puppy.model_utils.prepare_prompt_for_model"))
+        mock_prepare.return_value = MagicMock(
+            instructions="prepared instructions", user_prompt="prepared prompt"
+        )
+        p(patch(
+            "code_puppy.agents._builder.autostart_bound_servers_async",
+            new=AsyncMock(),
+        ))
+        # Disable MCP so no manager/servers are touched.
+        p(patch("code_puppy.config.get_value", return_value="true"))
+        p(patch("code_puppy.config.get_output_level", return_value="medium"))
+        p(patch(
+            "code_puppy.agents._compaction.make_history_processor",
+            return_value=lambda messages: messages,
+        ))
+        p(patch(
+            "code_puppy.tools.subagent_invocation.Agent",
+            return_value=mock_temp_agent,
+        ))
+        p(patch("code_puppy.tools.register_tools_for_agent"))
+        p(patch(
+            "code_puppy.tools.subagent_invocation.on_wrap_pydantic_agent",
+            side_effect=lambda _cfg, agent, **_kwargs: agent,
+        ))
+        p(patch(
+            "code_puppy.tools.subagent_invocation.on_agent_run_context",
+            return_value=[],
+        ))
+        # Pass-through retry: run once, no backoff, so failures propagate fast.
+        p(patch(
+            "code_puppy.agents.retry_profiles.make_streaming_retry",
+            new=_passthrough_retry,
+        ))
+        if perf is not None:
+            p(patch(
+                "code_puppy.tools.subagent_invocation.time.perf_counter",
+                side_effect=perf,
+            ))
+
+        return await invoke(
+            mock_context,
+            agent_name="test-agent",
+            prompt="Hello",
+            model_name="override-model",
+        )
+
+
+class TestExtractUsageMetrics:
+    """Unit tests for the defensive usage-mapping helper."""
+
+    def test_none_usage_yields_all_none(self):
+        assert _extract_usage_metrics(None) == {
+            "input_tokens": None,
+            "output_tokens": None,
+            "total_tokens": None,
+            "num_requests": None,
+        }
+
+    def test_modern_fields(self):
+        usage = SimpleNamespace(
+            input_tokens=10, output_tokens=5, total_tokens=15, requests=2
+        )
+        assert _extract_usage_metrics(usage) == {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15,
+            "num_requests": 2,
+        }
+
+    def test_deprecated_fields_and_computed_total(self):
+        usage = SimpleNamespace(request_tokens=7, response_tokens=3, requests=1)
+        assert _extract_usage_metrics(usage) == {
+            "input_tokens": 7,
+            "output_tokens": 3,
+            "total_tokens": 10,
+            "num_requests": 1,
+        }
+
+    def test_zero_is_valid_not_missing(self):
+        usage = SimpleNamespace(
+            input_tokens=0, output_tokens=0, total_tokens=0, requests=0
+        )
+        assert _extract_usage_metrics(usage) == {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+            "num_requests": 0,
+        }
+
+    def test_bool_and_non_finite_are_rejected(self):
+        usage = SimpleNamespace(
+            input_tokens=True, output_tokens=float("nan"), requests=float("inf")
+        )
+        metrics = _extract_usage_metrics(usage)
+        assert metrics["input_tokens"] is None
+        assert metrics["output_tokens"] is None
+        assert metrics["num_requests"] is None
+
+
+class TestInvokeReportsUsageAndLatency:
+    """Integration-ish tests through the registered tool."""
+
+    @pytest.mark.asyncio
+    async def test_success_populates_all_fields(self):
+        usage = SimpleNamespace(
+            input_tokens=12, output_tokens=8, total_tokens=20, requests=3
+        )
+        out = await _run_invoke(usage=usage)
+
+        assert out.response == "subagent response"
+        assert out.error is None
+        assert out.input_tokens == 12
+        assert out.output_tokens == 8
+        assert out.total_tokens == 20
+        assert out.num_requests == 3
+        assert isinstance(out.duration_ms, float)
+        assert out.duration_ms >= 0.0
+
+    @pytest.mark.asyncio
+    async def test_success_duration_is_measured(self):
+        usage = SimpleNamespace(
+            input_tokens=1, output_tokens=1, total_tokens=2, requests=1
+        )
+        # perf_counter: start=1000.0, stop=1000.5 -> 500.0 ms; extra calls stay
+        # at the stop value so nothing raises if the clock is touched again.
+        out = await _run_invoke(usage=usage, perf=[1000.0, 1000.5, 1000.5, 1000.5])
+
+        assert out.duration_ms == pytest.approx(500.0)
+
+    @pytest.mark.asyncio
+    async def test_success_when_usage_call_raises(self):
+        out = await _run_invoke(usage_raises=True)
+
+        assert out.response == "subagent response"
+        assert out.error is None
+        assert out.input_tokens is None
+        assert out.output_tokens is None
+        assert out.total_tokens is None
+        assert out.num_requests is None
+        # Latency is still measured even when usage extraction fails.
+        assert isinstance(out.duration_ms, float)
+        assert out.duration_ms >= 0.0
+
+    @pytest.mark.asyncio
+    async def test_success_with_deprecated_usage_fields(self):
+        usage = SimpleNamespace(request_tokens=7, response_tokens=3, requests=1)
+        out = await _run_invoke(usage=usage)
+
+        assert out.input_tokens == 7
+        assert out.output_tokens == 3
+        assert out.total_tokens == 10
+        assert out.num_requests == 1
+
+    @pytest.mark.asyncio
+    async def test_error_path_leaves_all_metrics_none(self):
+        out = await _run_invoke(run_raises=True)
+
+        assert out.response is None
+        assert out.error is not None
+        assert out.input_tokens is None
+        assert out.output_tokens is None
+        assert out.total_tokens is None
+        assert out.num_requests is None
+        assert out.duration_ms is None


### PR DESCRIPTION
## Summary

`invoke_agent` and `invoke_agent_with_model` now report per-run **token usage
(with a cache-token breakdown)** and **run timestamps** on the success path, so
benchmarking and model-comparison workflows can measure cost directly from the
tool result instead of reconstructing it from BigQuery/OpenObserve telemetry
(which is hard to attribute to individual sub-agent sessions).

Jira: **PUP-544** — https://jira.walmart.com/browse/PUP-544

## Final field set on `AgentInvokeOutput`

All fields are **nullable and additive** (default `None`), populated only on the
success path:

| Field | Meaning |
|---|---|
| `input_tokens` | Regular **non-cached** input tokens |
| `cache_read_input_tokens` | Cached input tokens read (cache hits) |
| `cache_creation_input_tokens` | Input tokens written to cache (Anthropic only) |
| `output_tokens` | Generated/response tokens |
| `total_tokens` | Provider total when present, else sum of the buckets above |
| `num_requests` | LLM request count for the run |
| `start_time` / `end_time` | Timezone-aware UTC ISO-8601 timestamps around the run |
| `duration_ms` | Monotonic wall-clock latency |

## Per-provider cache-token mapping

Verified against the installed `pydantic-ai==1.56.0` + `genai-prices`. The
library folds cached tokens **into** its combined `input_tokens` for every
provider we use, so we subtract them back out to keep `input_tokens` strictly
non-cached (`input + cache_read + cache_creation + output == total`, no
double-counting).

| Provider | cache_read source | cache_creation |
|---|---|---|
| Anthropic | `details["cache_read_input_tokens"]` | `details["cache_creation_input_tokens"]` |
| OpenAI / codex | first-class `cache_read_tokens` attr (nested `prompt_tokens_details.cached_tokens` is not copied into `details`) | None (no such concept) |
| Gemini | `details["cached_content_tokens"]` | None (no such concept) |

For OpenAI, a genuine `cache_read == 0` surfaces as `None` (the attribute default
is indistinguishable from "not reported") — we never fabricate a `0`.

## What changed

- **`code_puppy/tools/agent_tools.py`** — `AgentInvokeOutput` gains the cache
  buckets + `start_time`/`end_time`; docstring updated.
- **`code_puppy/tools/subagent_invocation.py`** — instrumented once at the shared
  `_invoke_agent_impl`: `_pick_reported_tokens` (details-first, attribute
  fallback, `None`-vs-`0` aware), `_extract_usage_metrics` (per-provider cache
  sourcing + non-cached normalization), UTC timestamps around the run, best-effort
  usage extraction that never breaks the response path.
- **`tests/test_subagent_invocation_usage.py`** — per-provider unit tests using
  the **real** library payload shapes, plus integration tests (success populates
  every field with `start_time <= end_time`, Anthropic creation bucket,
  deterministic duration, `usage()` raising, error-path all-`None`).

## Behavior contract

- **Success:** all fields populated; buckets sum to `total_tokens`.
- **Any error path** (recursion/validation guards, empty model name, run
  exception): all new fields remain `None`; existing `error` unchanged.
- Purely additive — callers ignoring the new fields are unaffected.

## Testing

- `pytest tests/test_subagent_invocation_usage.py` → 15 passed
- Regression across adjacent suites (agent_tools, run_stats) → all green (178 total)
- `ruff check` → clean

## Notes / follow-ups

- No Jira key in source (only PR metadata + commit body).
- `code_puppy/agents/agent_creator_agent.py` (~lines 277-280) still documents the
  old return shape in a prompt string — intentionally out of scope; follow-up.
- PUP-544 is labeled `public` + `private`; the internal fork should pick this up
  via the standard OS-merge process.
