### PR TITLE
fix(subagents): preserve interrupted sessions so Ctrl-C is resumable

### DIFF
--- a/code_puppy/agents/_run_signals.py
+++ b/code_puppy/agents/_run_signals.py
@@ -174,6 +174,54 @@ def prepare_queued_steer_injection(agent: Any, result: Any) -> Optional[Any]:
     return content
 
 
+def inject_interrupted_subagent_notes(agent: Any) -> None:
+    """Tell the agent about any sub-agents interrupted since the last run.
+
+    Ctrl+C cancels both the delegated sub-agent task and the parent run, and
+    the parent's return-less ``invoke_agent`` tool call is pruned from history
+    as a dangling call -- so without this the model would have no memory that
+    it ever delegated. We drain the records left by the sub-agent cancel path
+    and append one plain user-message note per interrupted session (the same
+    injection shape the steer processor uses), which survives the interrupted
+    tool-call prune because it is a valid standalone message.
+
+    Called at run start (never nested) so a foreground cancel surfaces on the
+    user's next turn, and a ``/fork`` cancelled while the agent was idle
+    surfaces on the next run too.
+    """
+    from pydantic_ai.messages import ModelRequest, UserPromptPart
+
+    from code_puppy.tools.subagent_invocation import drain_interrupted_subagents
+
+    if not hasattr(agent, "_message_history"):
+        return
+    records = drain_interrupted_subagents()
+    if not records:
+        return
+
+    injected = []
+    for rec in records:
+        session_id = rec["session_id"]
+        saved = rec["saved_count"]
+        saved_phrase = (
+            f"{saved} message(s) of its work were saved"
+            if saved is not None
+            else "no completed messages had been produced yet"
+        )
+        note = (
+            f"[system note] The sub-agent '{rec['agent_name']}' you invoked was "
+            f"interrupted by the user before it finished; {saved_phrase}. Its "
+            f"partial session is saved as '{session_id}'."
+        )
+        injected.append(ModelRequest(parts=[UserPromptPart(content=note)]))
+        emit_info(
+            f"Noting interrupted sub-agent '{rec['agent_name']}' "
+            f"(session {session_id}) for the agent's next turn."
+        )
+
+    agent._message_history = list(agent._message_history) + injected
+
+
 def drain_pause_state_on_cancel() -> None:
     """Clear ``PauseController`` state when a run is cancelled.
 
@@ -192,8 +240,9 @@ def drain_pause_state_on_cancel() -> None:
         )
 
 
-__all__ = [
+all__ = [
     "drain_pause_state_on_cancel",
+    "inject_interrupted_subagent_notes",
     "make_schedule_cancel",
     "prepare_queued_steer_injection",
     "reset_pause_state_at_run_start",

--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -75,6 +75,7 @@ from code_puppy.agents._non_streaming_render import (
 )
 from code_puppy.agents._run_signals import (
     drain_pause_state_on_cancel,
+    inject_interrupted_subagent_notes,
     make_schedule_cancel,
     prepare_queued_steer_injection,
     reset_pause_state_at_run_start,
@@ -663,6 +664,10 @@ async def _run_with_mcp_impl(
     # steers it would drain are the OUTER run's live ones.
     if not is_nested_run:
         reset_pause_state_at_run_start()
+        # Surface any sub-agent interrupted since the last run (foreground
+        # cancel, or a /fork cancelled while the agent was idle) so the model
+        # knows the delegation was stopped and where to resume it.
+        inject_interrupted_subagent_notes(agent)
 
     prompt = _sanitize_prompt(prompt)
     group_id = str(uuid.uuid4())

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -57,6 +57,34 @@ from code_puppy.tools.subagent_usage_metrics import (
 # Set to track active subagent invocation tasks
 _active_subagent_tasks: Set[asyncio.Task] = set()
 
+# Records of sub-agents interrupted by cancellation, drained into the parent
+# agent's message history at the next run start so the model learns a delegated
+# run was stopped and where to resume it. Populated on the event loop (the
+# cancel raises inside the coroutine), drained on the same loop -- a plain list
+# is safe. Both foreground ``invoke_agent`` and detached ``/fork`` share
+# ``_invoke_agent_impl``, so this single seam covers both.
+_interrupted_subagents: list[dict] = []
+
+
+def record_interrupted_subagent(
+    *, agent_name: str, session_id: str, saved_count: int | None
+) -> None:
+    """Remember that ``agent_name``'s session was interrupted."""
+    _interrupted_subagents.append(
+        {
+            "agent_name": agent_name,
+            "session_id": session_id,
+            "saved_count": saved_count,
+        }
+    )
+
+
+def drain_interrupted_subagents() -> list[dict]:
+    """Return and clear all pending interrupted-subagent records."""
+    drained = list(_interrupted_subagents)
+    _interrupted_subagents.clear()
+    return drained
+
 
 def _subagent_recursion_blocked() -> bool:
     """Return whether another invocation would exceed the configured depth."""
@@ -588,6 +616,16 @@ async def _invoke_agent_impl(
                 f"{saved} message(s) saved"
                 if saved is not None
                 else "no new messages to save"
+            )
+            # Leave a durable breadcrumb for the parent agent: its awaited
+            # tool call is about to be pruned from history as a dangling
+            # (return-less) call, so without this the model would forget the
+            # delegation ever happened. Drained + injected at the next run
+            # start.
+            record_interrupted_subagent(
+                agent_name=agent_name,
+                session_id=session_id,
+                saved_count=saved,
             )
             emit_warning(
                 f"{agent_name} interrupted - {detail}. "

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -28,6 +28,7 @@ from code_puppy.messaging import (
     emit_error,
     emit_info,
     emit_success,
+    emit_warning,
     get_message_bus,
     get_session_context,
     set_session_context,
@@ -98,6 +99,52 @@ Default to no further delegation. If delegation is truly essential, invoke at
 most one child level for a narrowly scoped task, tell that child to complete the
 work directly without further delegation, then finish the task yourself. Do not
 create recursive, cyclic, or open-ended agent chains."""
+
+
+def _contains_cancellation(exc: BaseException) -> bool:
+    """True if ``exc`` is a cancellation, including one nested in a group.
+
+    Async teardown (e.g. ``AsyncExitStack``) can wrap ``CancelledError`` in a
+    ``BaseExceptionGroup``. Such a shape is still an interruption, not a crash,
+    so it must follow the cancellation path rather than the failure path.
+    """
+    if isinstance(exc, asyncio.CancelledError):
+        return True
+    if isinstance(exc, BaseExceptionGroup):
+        return any(_contains_cancellation(inner) for inner in exc.exceptions)
+    return False
+
+
+def _save_partial_session(
+    *,
+    agent_config,
+    session_id: str,
+    agent_name: str,
+    baseline_count: int,
+    initial_prompt: str | None,
+) -> int | None:
+    """Persist any progress made before an interruption or crash.
+
+    The history processor keeps ``agent_config._message_history`` in sync with
+    each completed turn, so this captures every committed turn up to the exit
+    point. Best-effort: a save failure must never mask the original error, so
+    anything the save itself raises is swallowed.
+
+    Returns the saved message count, or ``None`` if nothing was persisted.
+    """
+    try:
+        partial_history = agent_config.get_message_history() if agent_config else []
+        if partial_history and len(partial_history) > baseline_count:
+            _save_session_history(
+                session_id=session_id,
+                message_history=partial_history,
+                agent_name=agent_name,
+                initial_prompt=initial_prompt,
+            )
+            return len(partial_history)
+    except Exception:
+        pass
+    return None
 
 
 async def _invoke_agent_impl(
@@ -519,35 +566,62 @@ async def _invoke_agent_impl(
                 duration_ms=duration_ms,
             )
 
-    except Exception as e:
+    except BaseException as e:
+        interrupted = isinstance(
+            e, (asyncio.CancelledError, KeyboardInterrupt)
+        ) or _contains_cancellation(e)
+
+        if interrupted:
+            # Ctrl-C raises CancelledError, which derives from BaseException and
+            # therefore slipped past the old ``except Exception`` save path --
+            # so an interrupted subagent lost both its partial history and its
+            # session ID. Persist progress, tell the user how to resume, then
+            # re-raise: persistence must not convert cancellation into success.
+            saved = _save_partial_session(
+                agent_config=agent_config,
+                session_id=session_id,
+                agent_name=agent_name,
+                baseline_count=len(message_history),
+                initial_prompt=prompt if is_new_session else None,
+            )
+            detail = (
+                f"{saved} message(s) saved"
+                if saved is not None
+                else "no new messages to save"
+            )
+            emit_warning(
+                f"{agent_name} interrupted - {detail}. "
+                f"Resume: invoke_agent(session_id='{session_id}')",
+                message_group=group_id,
+            )
+            raise
+
+        if not isinstance(e, Exception):
+            # A non-cancellation BaseException (e.g. SystemExit): don't swallow
+            # it into a failure result.
+            raise
+
         # Emit clean failure summary
-        emit_error(f"✗ {agent_name} failed: {str(e)}", message_group=group_id)
+        emit_error(f"{agent_name} failed: {str(e)}", message_group=group_id)
 
         # Full traceback for debugging
         error_msg = f"Error invoking agent '{agent_name}': {traceback.format_exc()}"
         emit_error(error_msg, message_group=group_id)
 
-        # Save whatever progress the agent made before crashing. The history
-        # processor keeps ``agent_config._message_history`` in sync with each
-        # completed turn, so this captures every committed turn up to the
-        # failure point. Best-effort: a save failure must not mask the
-        # original error, so we swallow anything the save itself raises.
-        try:
-            partial_history = agent_config.get_message_history() if agent_config else []
-            if partial_history and len(partial_history) > len(message_history):
-                _save_session_history(
-                    session_id=session_id,
-                    message_history=partial_history,
-                    agent_name=agent_name,
-                    initial_prompt=prompt if is_new_session else None,
-                )
-                emit_info(
-                    f"💾 Saved partial session '{session_id}' "
-                    f"({len(partial_history)} message(s)) before error",
-                    message_group=group_id,
-                )
-        except Exception:
-            pass
+        # Save whatever progress the agent made before crashing.
+        saved = _save_partial_session(
+            agent_config=agent_config,
+            session_id=session_id,
+            agent_name=agent_name,
+            baseline_count=len(message_history),
+            initial_prompt=prompt if is_new_session else None,
+        )
+        if saved is not None:
+            emit_info(
+                f"Saved partial session '{session_id}' "
+                f"({saved} message(s)) before error",
+                message_group=group_id,
+            )
 
         return build_invoke_output(
             include_usage_metrics=include_usage_metrics,

--- a/tests/agents/test_interrupted_subagent_notes.py
+++ b/tests/agents/test_interrupted_subagent_notes.py
@@ -1,0 +1,100 @@
+"""Parent-agent awareness of interrupted sub-agents.
+
+When Ctrl-C cancels a delegated sub-agent, the parent run is torn down and its
+return-less ``invoke_agent`` tool call is pruned from history -- so without an
+explicit breadcrumb the model forgets it ever delegated. ``_invoke_agent_impl``
+records each interruption; ``inject_interrupted_subagent_notes`` drains those
+records at the next run start and appends a plain user-message note so the
+model learns the run was stopped and exactly how to resume it.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from pydantic_ai.messages import ModelRequest, UserPromptPart
+
+from code_puppy.agents._run_signals import inject_interrupted_subagent_notes
+from code_puppy.tools.subagent_invocation import (
+    drain_interrupted_subagents,
+    record_interrupted_subagent,
+)
+
+
+def _note_text(message: ModelRequest) -> str:
+    part = message.parts[0]
+    assert isinstance(part, UserPromptPart)
+    return part.content
+
+
+def setup_function(_func):
+    # Isolate the process-wide queue before every test.
+    drain_interrupted_subagents()
+
+
+def test_records_are_drained_and_injected_as_notes():
+    record_interrupted_subagent(
+        agent_name="code-reviewer",
+        session_id="code-reviewer-session-a3f2b1",
+        saved_count=18,
+    )
+    agent = SimpleNamespace(_message_history=["prior"])
+
+    with patch("code_puppy.agents._run_signals.emit_info"):
+        inject_interrupted_subagent_notes(agent)
+
+    assert len(agent._message_history) == 2
+    note = _note_text(agent._message_history[1])
+    assert "code-reviewer" in note
+    assert "code-reviewer-session-a3f2b1" in note
+    assert "18 message(s)" in note
+    # Queue is emptied so the note is injected exactly once.
+    assert drain_interrupted_subagents() == []
+
+
+def test_zero_saved_count_uses_no_completed_work_phrasing():
+    record_interrupted_subagent(
+        agent_name="researcher",
+        session_id="researcher-session-xyz",
+        saved_count=None,
+    )
+    agent = SimpleNamespace(_message_history=[])
+
+    with patch("code_puppy.agents._run_signals.emit_info"):
+        inject_interrupted_subagent_notes(agent)
+
+    note = _note_text(agent._message_history[0])
+    assert "no completed messages" in note
+    assert "researcher-session-xyz" in note
+
+
+def test_multiple_interruptions_each_get_a_note():
+    for i in range(3):
+        record_interrupted_subagent(
+            agent_name=f"agent-{i}",
+            session_id=f"agent-{i}-session",
+            saved_count=i,
+        )
+    agent = SimpleNamespace(_message_history=[])
+
+    with patch("code_puppy.agents._run_signals.emit_info"):
+        inject_interrupted_subagent_notes(agent)
+
+    assert len(agent._message_history) == 3
+    assert all(isinstance(m, ModelRequest) for m in agent._message_history)
+
+
+def test_empty_queue_is_a_noop():
+    agent = SimpleNamespace(_message_history=["prior"])
+    inject_interrupted_subagent_notes(agent)
+    assert agent._message_history == ["prior"]
+
+
+def test_agent_without_history_does_not_crash():
+    record_interrupted_subagent(agent_name="a", session_id="a-session", saved_count=1)
+    agent = SimpleNamespace()  # no _message_history attribute
+
+    with patch("code_puppy.agents._run_signals.emit_info"):
+        inject_interrupted_subagent_notes(agent)  # must not raise
+
+    # Records are only consumed when there is somewhere to put them.
+    assert not hasattr(agent, "_message_history")

--- a/tests/test_subagent_invocation_usage.py
+++ b/tests/test_subagent_invocation_usage.py
@@ -593,6 +593,9 @@ class TestCancellationPersistence:
 
     @pytest.mark.asyncio
     async def test_cancellation_saves_partial_and_reraises(self):
+        from code_puppy.tools.subagent_invocation import drain_interrupted_subagents
+
+        drain_interrupted_subagents()  # isolate module-level queue
         cap = {}
         with pytest.raises(asyncio.CancelledError):
             await _run_invoke(
@@ -612,6 +615,15 @@ class TestCancellationPersistence:
         assert "interrupted" in warn_text
         assert "test-agent-session-abc123" in warn_text
         assert "resume" in warn_text.lower()
+
+        # The parent agent must be able to learn about this interruption.
+        records = drain_interrupted_subagents()
+        assert len(records) == 1
+        assert records[0] == {
+            "agent_name": "test-agent",
+            "session_id": "test-agent-session-abc123",
+            "saved_count": 2,
+        }
 
     @pytest.mark.asyncio
     async def test_grouped_cancellation_is_treated_as_interruption(self):
@@ -650,6 +662,9 @@ class TestCancellationPersistence:
     @pytest.mark.asyncio
     async def test_ordinary_failure_still_returns_error_output(self):
         """Non-cancellation crashes keep the existing failure-result contract."""
+        from code_puppy.tools.subagent_invocation import drain_interrupted_subagents
+
+        drain_interrupted_subagents()  # isolate module-level queue
         cap = {}
         out = await _run_invoke(
             run_raises=True,
@@ -662,3 +677,5 @@ class TestCancellationPersistence:
         assert out.error is not None
         cap["save"].assert_called_once()
         cap["warning"].assert_not_called()
+        # A crash is not an interruption: nothing to resume, no parent note.
+        assert drain_interrupted_subagents() == []

--- a/tests/test_subagent_invocation_usage.py
+++ b/tests/test_subagent_invocation_usage.py
@@ -20,6 +20,7 @@ new behaviour stays focused and readable.
 """
 
 from contextlib import ExitStack, contextmanager
+import asyncio
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -92,20 +93,39 @@ def _build_agent_config():
 
 
 async def _run_invoke(
-    *, usage=None, usage_raises=False, run_raises=False, perf=None, use_default=False
+    *,
+    usage=None,
+    usage_raises=False,
+    run_raises=False,
+    run_exc=None,
+    partial_history=None,
+    capture=None,
+    perf=None,
+    use_default=False,
 ):
     """Drive _invoke_agent_impl with a mocked temp agent and return the output.
 
     ``use_default=True`` drives it through the plain ``invoke_agent`` tool
     (no model override, no usage instrumentation) instead of
     ``invoke_agent_with_model``.
+
+    ``run_exc`` injects an arbitrary exception as the temp agent's run failure
+    (e.g. ``asyncio.CancelledError()``); it takes precedence over
+    ``run_raises``. ``partial_history`` seeds the config's in-flight history so
+    the interruption/failure save path has progress to persist. ``capture``, a
+    dict, is populated with handles to the patched ``emit_warning``,
+    ``emit_info``, and ``_save_session_history`` mocks for assertions.
     """
     invoke = _capture_invoke_default() if use_default else _capture_invoke_with_model()
     mock_context = MagicMock()
     agent_config = _build_agent_config()
+    if partial_history is not None:
+        agent_config.get_message_history.return_value = partial_history
 
     mock_temp_agent = MagicMock()
-    if run_raises:
+    if run_exc is not None:
+        mock_temp_agent.run = AsyncMock(side_effect=run_exc)
+    elif run_raises:
         mock_temp_agent.run = AsyncMock(side_effect=RuntimeError("boom"))
     else:
         result = MagicMock()
@@ -136,7 +156,13 @@ async def _run_invoke(
         p(patch("code_puppy.tools.subagent_invocation.emit_info"))
         p(patch("code_puppy.tools.subagent_invocation.emit_error"))
         p(patch("code_puppy.tools.subagent_invocation.emit_success"))
-        p(patch("code_puppy.tools.subagent_invocation._save_session_history"))
+        mock_warning = p(patch("code_puppy.tools.subagent_invocation.emit_warning"))
+        mock_save = p(
+            patch("code_puppy.tools.subagent_invocation._save_session_history")
+        )
+        if capture is not None:
+            capture["warning"] = mock_warning
+            capture["save"] = mock_save
         p(
             patch(
                 "code_puppy.tools.subagent_invocation._load_session_history",
@@ -553,3 +579,86 @@ class TestInvokeAgentUnaffected:
 
         assert out.response == "subagent response"
         mock_perf.assert_not_called()
+
+
+class TestCancellationPersistence:
+    """Ctrl-C (CancelledError) must persist partial work and re-raise.
+
+    ``CancelledError`` derives from ``BaseException``, so the historical
+    ``except Exception`` save path never ran on cancellation -- both the
+    partial history and the transient session ID were lost. These lock in the
+    minimal fix: save-then-re-raise, with a resume hint naming the exact
+    session ID.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cancellation_saves_partial_and_reraises(self):
+        cap = {}
+        with pytest.raises(asyncio.CancelledError):
+            await _run_invoke(
+                run_exc=asyncio.CancelledError(),
+                partial_history=["m1", "m2"],
+                capture=cap,
+                use_default=True,
+            )
+
+        cap["save"].assert_called_once()
+        save_kwargs = cap["save"].call_args.kwargs
+        assert save_kwargs["session_id"] == "test-agent-session-abc123"
+        assert save_kwargs["message_history"] == ["m1", "m2"]
+
+        cap["warning"].assert_called_once()
+        warn_text = cap["warning"].call_args.args[0]
+        assert "interrupted" in warn_text
+        assert "test-agent-session-abc123" in warn_text
+        assert "resume" in warn_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_grouped_cancellation_is_treated_as_interruption(self):
+        """Async teardown can wrap CancelledError in a BaseExceptionGroup."""
+        cap = {}
+        grouped = BaseExceptionGroup("teardown", [asyncio.CancelledError()])
+        with pytest.raises(BaseExceptionGroup):
+            await _run_invoke(
+                run_exc=grouped,
+                partial_history=["m1"],
+                capture=cap,
+                use_default=True,
+            )
+
+        cap["save"].assert_called_once()
+        cap["warning"].assert_called_once()
+        assert "interrupted" in cap["warning"].call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_zero_message_cancellation_reports_nothing_saved(self):
+        """A cancel before any turn completes has no history to persist."""
+        cap = {}
+        with pytest.raises(asyncio.CancelledError):
+            await _run_invoke(
+                run_exc=asyncio.CancelledError(),
+                partial_history=[],
+                capture=cap,
+                use_default=True,
+            )
+
+        cap["save"].assert_not_called()
+        warn_text = cap["warning"].call_args.args[0]
+        assert "no new messages" in warn_text
+        assert "test-agent-session-abc123" in warn_text
+
+    @pytest.mark.asyncio
+    async def test_ordinary_failure_still_returns_error_output(self):
+        """Non-cancellation crashes keep the existing failure-result contract."""
+        cap = {}
+        out = await _run_invoke(
+            run_raises=True,
+            partial_history=["m1", "m2"],
+            capture=cap,
+            use_default=True,
+        )
+
+        assert out.response is None
+        assert out.error is not None
+        cap["save"].assert_called_once()
+        cap["warning"].assert_not_called()


### PR DESCRIPTION
## Why this change

Cancelling a runaway subagent should stop the work; it should not erase the
only record that the work ever happened.

Before this change, interrupting an `invoke_agent` run discarded the partial
history and the session ID together:

- Subagent history was saved only after `temp_agent.run()` returned, or on the
  crash path guarded by `except Exception`.
- `asyncio.CancelledError` (what Ctrl-C raises) inherits from `BaseException`,
  so it slipped past `except Exception` entirely and no partial save ran.
- Async teardown can also wrap that cancellation in a `BaseExceptionGroup`,
  which was likewise treated as an ordinary crash.

The intended invariant: once a subagent has made progress, cancellation must not
make that progress untraceable.

## What changed

The invocation error handler is widened from `except Exception` to
`except BaseException`, and cancellation is classified explicitly:

1. Plain `CancelledError`/`KeyboardInterrupt`, and cancellation nested inside a
   `BaseExceptionGroup`, are treated as an interruption (not a crash).
2. On interruption the partial history is persisted through the existing session
   store, a resume hint naming the exact session ID is emitted, and the original
   exception is re-raised. Persistence never converts Ctrl-C into a successful
   return.
3. The partial-save logic is extracted into one shared helper used by both the
   interruption path and the ordinary-failure path (DRY).
4. Non-cancellation `BaseException`s (e.g. `SystemExit`) propagate untouched
   instead of being swallowed into a failure result.

Resume itself is unchanged and already supported: re-invoking with the same
`session_id` loads the saved history via the existing
`_load_session_history` / `_save_session_history` pair. The session ID's hash
suffix is baked in before saving, so the resumed session keeps the exact ID.

## Scope (intentionally minimal)

This is the minimum fix for the interruption-loses-work bug. It deliberately
does not add: a JSONL recovery journal, continuous atomic checkpointing, the
`/subagents list|show|resume` command surface, fork pre-start ID reservation,
panel/lifecycle-message plumbing, or the invocation-module split. Those are
separable enhancements and are not required to stop cancellation from erasing
work.

Known scope boundary: a cancellation that fires before any turn completes has no
history to persist, so it leaves only the on-screen resume hint (no on-disk
record yet). Reserving zero-message metadata up front is out of scope here.

## User-visible outcome

Interrupting a subagent now leaves a permanent message like:

```text
code-reviewer interrupted - 18 message(s) saved. Resume: invoke_agent(session_id='code-reviewer-session-a3f2b1')
```

Ctrl-C still cancels the work. It just stops deleting the record too.

## Testing

Focused regressions added to `tests/test_subagent_invocation_usage.py`
(`TestCancellationPersistence`):

- plain cancellation persists partial history and re-raises;
- grouped cancellation (`BaseExceptionGroup`) is treated as interruption;
- zero-message cancellation reports nothing saved;
- ordinary failure still returns the existing error result (no false warning).

```text
tests/test_subagent_invocation_usage.py .......................... 22 passed
tests/test_agent_tools_coverage.py + tests/agents/test_run_signals_cancel.py  40 passed
ruff check + ruff format: clean
```

Diff: +209 / -26 across 2 files.
