### PR TITLE
fix(acp): stop Windows subprocess pipe-drain deadlock hanging tool turns

### DIFF
--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -2338,16 +2338,26 @@ def _detect_git_toplevel(path: str) -> Optional[str]:
         return None
     try:
         import subprocess
+        import tempfile
 
-        out = subprocess.run(
-            ["git", "-C", probe_dir, "rev-parse", "--show-toplevel"],
-            capture_output=True,
-            text=True,
-            timeout=0.5,
-        )
-        if out.returncode == 0:
-            root = out.stdout.strip()
-            return os.path.realpath(root) if root else None
+        # Windows hardening: capture_output=True uses reader threads, and if the
+        # spawned git (or a grandchild) keeps a pipe write-handle open,
+        # subprocess.run hangs FOREVER joining those threads -- even with a
+        # timeout -- which deadlocks the ACP event loop from post_tool_call.
+        # Route output through a temp file (no reader threads) and detach stdin
+        # from any inherited pipe so run() can never block on a thread join.
+        with tempfile.TemporaryFile() as out_f:
+            proc = subprocess.run(
+                ["git", "-C", probe_dir, "rev-parse", "--show-toplevel"],
+                stdin=subprocess.DEVNULL,
+                stdout=out_f,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+            )
+            if proc.returncode == 0:
+                out_f.seek(0)
+                root = out_f.read().decode("utf-8", "replace").strip()
+                return os.path.realpath(root) if root else None
     except Exception:
         return None
     return None

--- a/code_puppy/plugins/statusline/payload.py
+++ b/code_puppy/plugins/statusline/payload.py
@@ -41,20 +41,30 @@ def _agent_block() -> Optional[Dict[str, Any]]:
 
 
 def detect_git_branch(cwd: str) -> Optional[str]:
-    """Return the active git branch for cwd, or None outside a branch/repo."""
+    """Return the active git branch for cwd, or None outside a branch/repo.
+
+    Windows hardening: ``capture_output=True`` uses reader threads, and if the
+    spawned git (or a grandchild) keeps a pipe write-handle open, ``run`` hangs
+    forever joining them -- even with a timeout -- which deadlocks the ACP event
+    loop when this runs from a ``post_tool_call`` hook. Route stdout through a
+    temp file (no reader threads) and detach stdin from any inherited pipe.
+    """
     try:
-        out = subprocess.run(
-            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-            cwd=cwd,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",  # explicit UTF-8: prevents cp1252 crash on Windows
-            errors="replace",  # never raise UnicodeDecodeError on branch names
-            timeout=0.5,
-        )
-        if out.returncode == 0:
-            branch = out.stdout.strip()
-            return branch or None
+        import tempfile
+
+        with tempfile.TemporaryFile() as out_f:
+            proc = subprocess.run(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                cwd=cwd,
+                stdin=subprocess.DEVNULL,
+                stdout=out_f,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+            )
+            if proc.returncode == 0:
+                out_f.seek(0)
+                branch = out_f.read().decode("utf-8", "replace").strip()
+                return branch or None
     except Exception:
         return None
     return None


### PR DESCRIPTION
I use code-puppy on my own personal machine and hit this the moment I tried the ACP path on Windows. It was a hard blocker, so I dug into the root cause and fixed it. Sharing the fix in case it helps other Windows users.

quick_resume + statusline run blocking git subprocesses in the post_tool_call hook, on the ACP event loop. On Windows, subprocess.run(capture_output=True, timeout=) can hang forever in communicate() joining reader threads when a child/grandchild keeps a pipe write-handle open -- the timeout does not cover the post-kill drain. This deadlocked every ACP tool-executing turn (file created, but no completed/stopReason).

Fix: route git stdout through a temp file (no reader threads) with stdin=DEVNULL in _detect_git_toplevel (config.py) and detect_git_branch (statusline/payload.py). Verified: ACP create-file turn now completes with stopReason=end_turn.