### PR TITLE
PUP-544: Scope per-run token usage/timing to invoke_agent_with_model only

### DIFF
--- a/code_puppy/plugins/statusline/payload.py
+++ b/code_puppy/plugins/statusline/payload.py
@@ -60,6 +60,8 @@ def detect_git_branch(cwd: str) -> Optional[str]:
                 stdout=out_f,
                 stderr=subprocess.DEVNULL,
                 timeout=5,
+                encoding="utf-8",
+                errors="replace",
             )
             if proc.returncode == 0:
                 out_f.seek(0)

--- a/code_puppy/tools/agent_tools.py
+++ b/code_puppy/tools/agent_tools.py
@@ -201,13 +201,24 @@ class ListAgentsOutput(BaseModel):
 
 
 class AgentInvokeOutput(BaseModel):
-    """Output for the invoke_agent tool.
+    """Output for the invoke_agent tool."""
 
-    The token-usage and timing fields are populated on the success path so
-    benchmarking/model-comparison callers can measure per-run cost without
-    reconstructing it from downstream telemetry. They are purely additive and
-    remain ``None`` on every error path, so existing callers that ignore them
-    are unaffected.
+    response: str | None
+    agent_name: str
+    session_id: str | None = None
+    model_name: str | None = None
+    error: str | None = None
+
+
+class AgentInvokeWithModelOutput(AgentInvokeOutput):
+    """Output for the invoke_agent_with_model tool.
+
+    Extends :class:`AgentInvokeOutput` with per-run token-usage and timing
+    fields, populated on the success path only, so benchmarking/
+    model-comparison callers that explicitly pin a model can measure per-run
+    cost without reconstructing it from downstream telemetry. These fields are
+    scoped to THIS tool only -- ``invoke_agent`` keeps the original five-field
+    contract untouched, with no functional or schema changes.
 
     Token accounting is normalized so the input buckets never overlap:
     ``input_tokens`` counts only regular (non-cached) input, while cached input
@@ -216,11 +227,6 @@ class AgentInvokeOutput(BaseModel):
     report a given bucket leaves that field ``None`` rather than a fabricated 0.
     """
 
-    response: str | None
-    agent_name: str
-    session_id: str | None = None
-    model_name: str | None = None
-    error: str | None = None
     input_tokens: int | None = None
     cache_read_input_tokens: int | None = None
     cache_creation_input_tokens: int | None = None
@@ -300,6 +306,7 @@ from code_puppy.tools.subagent_invocation import (  # noqa: E402
 __all__ = [
     "AgentInfo",
     "AgentInvokeOutput",
+    "AgentInvokeWithModelOutput",
     "ListAgentsOutput",
     "_active_subagent_tasks",
     "_generate_session_hash_suffix",

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -2,13 +2,12 @@
 
 import asyncio
 import inspect
-import math
 import time
 import traceback
 from contextlib import AsyncExitStack
 from datetime import datetime, timezone
 from functools import partial
-from typing import Any, Set
+from typing import Set
 
 from pydantic_ai import Agent, RunContext, UsageLimits
 
@@ -31,6 +30,7 @@ from code_puppy.messaging import (
 )
 from code_puppy.tools.agent_tools import (
     AgentInvokeOutput,
+    AgentInvokeWithModelOutput,
     _generate_session_hash_suffix,
     _load_session_history,
     _sanitize_for_session_id,
@@ -44,142 +44,13 @@ from code_puppy.tools.subagent_context import (
     get_subagent_model_name,
     subagent_context,
 )
+from code_puppy.tools.subagent_usage_metrics import (
+    _safe_usage_metrics,
+    build_invoke_output,
+)
 
 # Set to track active subagent invocation tasks
 _active_subagent_tasks: Set[asyncio.Task] = set()
-
-
-def _coerce_token_count(value: Any) -> int | None:
-    """Coerce a usage value to an ``int``, or ``None`` if it isn't usable.
-
-    Token/request counts are semantically integers. ``bool`` is rejected even
-    though it subclasses ``int`` (``True`` must not silently become ``1``), and
-    non-finite floats (``nan``/``inf``) are treated as missing. Anything that
-    is not a real number (e.g. a ``Mock``) is treated as missing too.
-    """
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        if not math.isfinite(value):
-            return None
-        return int(value)
-    return None
-
-
-def _pick_reported_tokens(
-    usage: Any, detail_keys: tuple[str, ...], attr: str
-) -> int | None:
-    """Return a reported token count, preferring the provider ``details`` dict.
-
-    The ``details`` dict only contains keys a provider actually sent, so when a
-    key is present it is the authoritative signal for presence: a key present
-    with value ``0`` is a genuine "provider reported zero" and is kept. The
-    normalized first-class attribute (e.g. ``cache_read_tokens``) is used as a
-    fallback, and only when it is positive, because its dataclass default of
-    ``0`` is indistinguishable from "not reported" -- so for providers that only
-    surface a bucket via the first-class attribute (OpenAI cache reads), a
-    genuine zero is reported as ``None`` rather than a fabricated ``0``.
-    """
-    details = getattr(usage, "details", None)
-    if isinstance(details, dict):
-        for key in detail_keys:
-            if key in details:
-                coerced = _coerce_token_count(details[key])
-                if coerced is not None:
-                    return coerced
-    fallback = _coerce_token_count(getattr(usage, attr, None))
-    if fallback is not None and fallback > 0:
-        return fallback
-    return None
-
-
-def _extract_usage_metrics(usage: Any) -> dict[str, int | None]:
-    """Map a pydantic-ai usage object to our schema fields, defensively.
-
-    Token buckets are normalized so they never overlap: pydantic-ai (via
-    genai-prices) folds cached tokens INTO ``input_tokens`` for every provider
-    we use (Anthropic, OpenAI/codex, Gemini), so we subtract the cache
-    components back out to keep ``input_tokens`` strictly non-cached. That way
-    ``input_tokens + cache_read_input_tokens + cache_creation_input_tokens``
-    reflects total input without double-counting.
-
-    Cache buckets are sourced per provider (verified against the installed
-    pydantic-ai + genai-prices):
-    - cache reads: Anthropic emits ``cache_read_input_tokens`` and Gemini emits
-      ``cached_content_tokens`` in the ``details`` dict; OpenAI only surfaces it
-      via the first-class ``cache_read_tokens`` attribute (its nested
-      ``prompt_tokens_details.cached_tokens`` is not copied into ``details``).
-    - cache creation: Anthropic ``cache_creation_input_tokens`` only
-      (also normalized to ``cache_write_tokens``); OpenAI and Gemini have no
-      such concept, so that field stays ``None``.
-    """
-    metrics: dict[str, int | None] = {
-        "input_tokens": None,
-        "cache_read_input_tokens": None,
-        "cache_creation_input_tokens": None,
-        "output_tokens": None,
-        "total_tokens": None,
-        "num_requests": None,
-    }
-    if usage is None:
-        return metrics
-
-    cache_read = _pick_reported_tokens(
-        usage,
-        ("cache_read_input_tokens", "cached_content_tokens"),
-        "cache_read_tokens",
-    )
-    cache_creation = _pick_reported_tokens(
-        usage, ("cache_creation_input_tokens",), "cache_write_tokens"
-    )
-
-    # pydantic-ai reports a combined input count that already includes the
-    # cached tokens; subtract them back out so the buckets don't overlap.
-    combined_input = _coerce_token_count(getattr(usage, "input_tokens", None))
-    if combined_input is None:
-        combined_input = _coerce_token_count(getattr(usage, "request_tokens", None))
-    input_tokens = combined_input
-    if combined_input is not None:
-        input_tokens = max(
-            combined_input - (cache_read or 0) - (cache_creation or 0), 0
-        )
-
-    output_tokens = _coerce_token_count(getattr(usage, "output_tokens", None))
-    if output_tokens is None:
-        output_tokens = _coerce_token_count(getattr(usage, "response_tokens", None))
-
-    total_tokens = _coerce_token_count(getattr(usage, "total_tokens", None))
-    if total_tokens is None:
-        parts = [
-            p
-            for p in (input_tokens, cache_read, cache_creation, output_tokens)
-            if p is not None
-        ]
-        if parts:
-            total_tokens = sum(parts)
-
-    metrics["input_tokens"] = input_tokens
-    metrics["cache_read_input_tokens"] = cache_read
-    metrics["cache_creation_input_tokens"] = cache_creation
-    metrics["output_tokens"] = output_tokens
-    metrics["total_tokens"] = total_tokens
-    metrics["num_requests"] = _coerce_token_count(getattr(usage, "requests", None))
-    return metrics
-
-
-def _safe_usage_metrics(result: Any) -> dict[str, int | None]:
-    """Best-effort ``result.usage()`` extraction that never breaks the run.
-
-    Usage is secondary metadata; a failure here must not prevent a successful
-    sub-agent invocation from returning its response.
-    """
-    try:
-        usage = result.usage()
-        return _extract_usage_metrics(usage)
-    except Exception:
-        return _extract_usage_metrics(None)
 
 
 def _subagent_recursion_blocked() -> bool:
@@ -221,8 +92,16 @@ async def _invoke_agent_impl(
     session_id: str | None = None,
     model_name: str | None = None,
     emit_response_message: bool = True,
+    include_usage_metrics: bool = False,
 ) -> AgentInvokeOutput:
-    """Invoke a sub-agent, optionally suppressing its standard response message."""
+    """Invoke a sub-agent, optionally suppressing its standard response message.
+
+    ``include_usage_metrics`` is set by ``invoke_agent_with_model`` only; it
+    gates BOTH the returned type (``AgentInvokeWithModelOutput`` vs the plain
+    ``AgentInvokeOutput``) and whether any timing/usage instrumentation runs
+    at all, so ``invoke_agent`` callers see zero behavioral or performance
+    change from before this instrumentation existed.
+    """
     from code_puppy.agents.agent_manager import load_agent
 
     group_id = generate_group_id("invoke_agent", agent_name)
@@ -239,7 +118,8 @@ async def _invoke_agent_impl(
 
     if error:
         emit_error(error, message_group=group_id)
-        return AgentInvokeOutput(
+        return build_invoke_output(
+            include_usage_metrics=include_usage_metrics,
             response=None,
             agent_name=agent_name,
             model_name=model_name,
@@ -253,7 +133,8 @@ async def _invoke_agent_impl(
         except ValueError as e:
             # Return error immediately if session_id is invalid
             emit_error(str(e), message_group=group_id)
-            return AgentInvokeOutput(
+            return build_invoke_output(
+                include_usage_metrics=include_usage_metrics,
                 response=None,
                 agent_name=agent_name,
                 model_name=model_name,
@@ -528,9 +409,16 @@ async def _invoke_agent_impl(
                     # user-observed latency, not just a single attempt.
                     # start_time/end_time are timezone-aware UTC ISO-8601
                     # strings; duration_ms uses a monotonic clock so it is
-                    # immune to wall-clock adjustments during the run.
-                    run_started = time.perf_counter()
-                    start_time = datetime.now(timezone.utc).isoformat()
+                    # immune to wall-clock adjustments during the run. This
+                    # instrumentation only runs for invoke_agent_with_model
+                    # (include_usage_metrics=True) -- invoke_agent skips it
+                    # entirely so its behavior/performance is unchanged.
+                    run_started = time.perf_counter() if include_usage_metrics else None
+                    start_time = (
+                        datetime.now(timezone.utc).isoformat()
+                        if include_usage_metrics
+                        else None
+                    )
                     task = asyncio.create_task(_run_subagent())
                     _active_subagent_tasks.add(task)
 
@@ -543,9 +431,14 @@ async def _invoke_agent_impl(
 
                     # Capture usage + latency as close to the run boundary as
                     # possible, before any rendering/history/emit bookkeeping.
-                    end_time = datetime.now(timezone.utc).isoformat()
-                    duration_ms = (time.perf_counter() - run_started) * 1000.0
-                    usage_metrics = _safe_usage_metrics(result)
+                    if include_usage_metrics:
+                        end_time = datetime.now(timezone.utc).isoformat()
+                        duration_ms = (time.perf_counter() - run_started) * 1000.0
+                        usage_metrics = _safe_usage_metrics(result)
+                    else:
+                        end_time = None
+                        duration_ms = None
+                        usage_metrics = None
 
                 # Still inside subagent_context: if high mode and streaming
                 # didn't produce any text, fall back to the one-shot renderer
@@ -594,19 +487,13 @@ async def _invoke_agent_impl(
                 f"✓ {agent_name} completed successfully", message_group=group_id
             )
 
-            return AgentInvokeOutput(
+            return build_invoke_output(
+                include_usage_metrics=include_usage_metrics,
                 response=response,
                 agent_name=agent_name,
                 session_id=session_id,
                 model_name=effective_model_name,
-                input_tokens=usage_metrics["input_tokens"],
-                cache_read_input_tokens=usage_metrics["cache_read_input_tokens"],
-                cache_creation_input_tokens=usage_metrics[
-                    "cache_creation_input_tokens"
-                ],
-                output_tokens=usage_metrics["output_tokens"],
-                total_tokens=usage_metrics["total_tokens"],
-                num_requests=usage_metrics["num_requests"],
+                usage_metrics=usage_metrics,
                 start_time=start_time,
                 end_time=end_time,
                 duration_ms=duration_ms,
@@ -642,7 +529,8 @@ async def _invoke_agent_impl(
         except Exception:
             pass
 
-        return AgentInvokeOutput(
+        return build_invoke_output(
+            include_usage_metrics=include_usage_metrics,
             response=None,
             agent_name=agent_name,
             session_id=session_id,
@@ -686,12 +574,7 @@ def register_invoke_agent(agent):
 
         Returns:
             AgentInvokeOutput: Contains response, agent_name, session_id,
-            effective model_name, and error fields. On a successful run it also
-            reports per-run token usage (non-cached input_tokens,
-            cache_read_input_tokens, cache_creation_input_tokens, output_tokens,
-            total_tokens, num_requests) and timing (start_time/end_time as UTC
-            ISO-8601 strings plus duration_ms); those fields are None on any
-            error path.
+            effective model_name, and error fields.
         """
         return await _invoke_agent_impl(
             context=context,
@@ -724,7 +607,7 @@ def register_invoke_agent_with_model(agent):
         prompt: str,
         model_name: str,
         session_id: str | None = None,
-    ) -> AgentInvokeOutput:
+    ) -> AgentInvokeWithModelOutput:
         """Invoke a sub-agent with an explicit one-call model override.
 
         Use this only when a model override is intentionally required. For
@@ -741,20 +624,22 @@ def register_invoke_agent_with_model(agent):
             session_id: Optional kebab-case session id for continuing memory.
 
         Returns:
-            AgentInvokeOutput: Contains response, agent_name, session_id,
-            effective model_name, and error fields. On a successful run it also
-            reports per-run token usage (non-cached input_tokens,
-            cache_read_input_tokens, cache_creation_input_tokens, output_tokens,
-            total_tokens, num_requests) and timing (start_time/end_time as UTC
-            ISO-8601 strings plus duration_ms); those fields are None on any
-            error path.
+            AgentInvokeWithModelOutput: Contains response, agent_name,
+            session_id, effective model_name, and error fields. On a
+            successful run it also reports per-run token usage (non-cached
+            input_tokens, cache_read_input_tokens, cache_creation_input_tokens,
+            output_tokens, total_tokens, num_requests) and timing
+            (start_time/end_time as UTC ISO-8601 strings plus duration_ms);
+            those fields are None on any error path. This extra usage/timing
+            reporting is scoped to invoke_agent_with_model only -- invoke_agent
+            is unaffected.
         """
         normalized_model_name = model_name.strip()
         if not normalized_model_name:
             group_id = generate_group_id("invoke_agent", agent_name)
             error_msg = "model_name cannot be empty"
             emit_error(error_msg, message_group=group_id)
-            return AgentInvokeOutput(
+            return AgentInvokeWithModelOutput(
                 response=None,
                 agent_name=agent_name,
                 session_id=session_id,
@@ -767,6 +652,7 @@ def register_invoke_agent_with_model(agent):
             prompt=prompt,
             session_id=session_id,
             model_name=normalized_model_name,
+            include_usage_metrics=True,
         )
 
     return invoke_agent_with_model

--- a/code_puppy/tools/subagent_usage_metrics.py
+++ b/code_puppy/tools/subagent_usage_metrics.py
@@ -1,0 +1,203 @@
+"""Per-run token usage/latency extraction for ``invoke_agent_with_model``.
+
+This module is deliberately self-contained: pure functions that map a
+pydantic-ai usage object to our schema fields, plus the output-builder that
+decides which :class:`AgentInvokeOutput` subtype a caller gets back. None of
+this depends on the agent-run orchestration in ``subagent_invocation.py``, so
+it lives separately to keep both files focused and under the puppy bloat
+line.
+
+Scope reminder: this instrumentation is used ONLY by ``invoke_agent_with_model``
+(via ``include_usage_metrics=True`` in ``_invoke_agent_impl``). ``invoke_agent``
+never calls into this module at all -- see ``build_invoke_output``'s
+``include_usage_metrics=False`` branch, which returns a plain
+``AgentInvokeOutput`` without touching any of these helpers.
+"""
+
+from typing import Any
+
+from code_puppy.tools.agent_tools import AgentInvokeOutput, AgentInvokeWithModelOutput
+
+_EMPTY_USAGE_METRICS: dict[str, int | None] = {
+    "input_tokens": None,
+    "cache_read_input_tokens": None,
+    "cache_creation_input_tokens": None,
+    "output_tokens": None,
+    "total_tokens": None,
+    "num_requests": None,
+}
+
+
+def _coerce_token_count(value: Any) -> int | None:
+    """Coerce a usage value to an ``int``, or ``None`` if it isn't usable.
+
+    Token/request counts are semantically integers. ``bool`` is rejected even
+    though it subclasses ``int`` (``True`` must not silently become ``1``), and
+    non-finite floats (``nan``/``inf``) are treated as missing. Anything that
+    is not a real number (e.g. a ``Mock``) is treated as missing too.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        import math
+
+        if not math.isfinite(value):
+            return None
+        return int(value)
+    return None
+
+
+def _pick_reported_tokens(
+    usage: Any, detail_keys: tuple[str, ...], attr: str
+) -> int | None:
+    """Return a reported token count, preferring the provider ``details`` dict.
+
+    The ``details`` dict only contains keys a provider actually sent, so when a
+    key is present it is the authoritative signal for presence: a key present
+    with value ``0`` is a genuine "provider reported zero" and is kept. The
+    normalized first-class attribute (e.g. ``cache_read_tokens``) is used as a
+    fallback, and only when it is positive, because its dataclass default of
+    ``0`` is indistinguishable from "not reported" -- so for providers that only
+    surface a bucket via the first-class attribute (OpenAI cache reads), a
+    genuine zero is reported as ``None`` rather than a fabricated ``0``.
+    """
+    details = getattr(usage, "details", None)
+    if isinstance(details, dict):
+        for key in detail_keys:
+            if key in details:
+                coerced = _coerce_token_count(details[key])
+                if coerced is not None:
+                    return coerced
+    fallback = _coerce_token_count(getattr(usage, attr, None))
+    if fallback is not None and fallback > 0:
+        return fallback
+    return None
+
+
+def _extract_usage_metrics(usage: Any) -> dict[str, int | None]:
+    """Map a pydantic-ai usage object to our schema fields, defensively.
+
+    Token buckets are normalized so they never overlap: pydantic-ai (via
+    genai-prices) folds cached tokens INTO ``input_tokens`` for every provider
+    we use (Anthropic, OpenAI/codex, Gemini), so we subtract the cache
+    components back out to keep ``input_tokens`` strictly non-cached. That way
+    ``input_tokens + cache_read_input_tokens + cache_creation_input_tokens``
+    reflects total input without double-counting.
+
+    Cache buckets are sourced per provider (verified against the installed
+    pydantic-ai + genai-prices):
+    - cache reads: Anthropic emits ``cache_read_input_tokens`` and Gemini emits
+      ``cached_content_tokens`` in the ``details`` dict; OpenAI only surfaces it
+      via the first-class ``cache_read_tokens`` attribute (its nested
+      ``prompt_tokens_details.cached_tokens`` is not copied into ``details``).
+    - cache creation: Anthropic ``cache_creation_input_tokens`` only
+      (also normalized to ``cache_write_tokens``); OpenAI and Gemini have no
+      such concept, so that field stays ``None``.
+    """
+    metrics: dict[str, int | None] = dict(_EMPTY_USAGE_METRICS)
+    if usage is None:
+        return metrics
+
+    cache_read = _pick_reported_tokens(
+        usage,
+        ("cache_read_input_tokens", "cached_content_tokens"),
+        "cache_read_tokens",
+    )
+    cache_creation = _pick_reported_tokens(
+        usage, ("cache_creation_input_tokens",), "cache_write_tokens"
+    )
+
+    # pydantic-ai reports a combined input count that already includes the
+    # cached tokens; subtract them back out so the buckets don't overlap.
+    combined_input = _coerce_token_count(getattr(usage, "input_tokens", None))
+    if combined_input is None:
+        combined_input = _coerce_token_count(getattr(usage, "request_tokens", None))
+    input_tokens = combined_input
+    if combined_input is not None:
+        input_tokens = max(
+            combined_input - (cache_read or 0) - (cache_creation or 0), 0
+        )
+
+    output_tokens = _coerce_token_count(getattr(usage, "output_tokens", None))
+    if output_tokens is None:
+        output_tokens = _coerce_token_count(getattr(usage, "response_tokens", None))
+
+    total_tokens = _coerce_token_count(getattr(usage, "total_tokens", None))
+    if total_tokens is None:
+        parts = [
+            p
+            for p in (input_tokens, cache_read, cache_creation, output_tokens)
+            if p is not None
+        ]
+        if parts:
+            total_tokens = sum(parts)
+
+    metrics["input_tokens"] = input_tokens
+    metrics["cache_read_input_tokens"] = cache_read
+    metrics["cache_creation_input_tokens"] = cache_creation
+    metrics["output_tokens"] = output_tokens
+    metrics["total_tokens"] = total_tokens
+    metrics["num_requests"] = _coerce_token_count(getattr(usage, "requests", None))
+    return metrics
+
+
+def _safe_usage_metrics(result: Any) -> dict[str, int | None]:
+    """Best-effort ``result.usage()`` extraction that never breaks the run.
+
+    Usage is secondary metadata; a failure here must not prevent a successful
+    sub-agent invocation from returning its response.
+    """
+    try:
+        usage = result.usage()
+        return _extract_usage_metrics(usage)
+    except Exception:
+        return _extract_usage_metrics(None)
+
+
+def build_invoke_output(
+    *,
+    include_usage_metrics: bool,
+    response: str | None,
+    agent_name: str,
+    session_id: str | None = None,
+    model_name: str | None = None,
+    error: str | None = None,
+    usage_metrics: dict[str, int | None] | None = None,
+    start_time: str | None = None,
+    end_time: str | None = None,
+    duration_ms: float | None = None,
+) -> AgentInvokeOutput:
+    """Build the correct output type for the calling tool.
+
+    ``invoke_agent`` always gets a plain :class:`AgentInvokeOutput` -- the
+    original five-field contract, completely untouched. Only
+    ``invoke_agent_with_model`` (``include_usage_metrics=True``) gets the
+    extra token-usage/timing fields via :class:`AgentInvokeWithModelOutput`.
+    """
+    if not include_usage_metrics:
+        return AgentInvokeOutput(
+            response=response,
+            agent_name=agent_name,
+            session_id=session_id,
+            model_name=model_name,
+            error=error,
+        )
+    metrics = usage_metrics or _EMPTY_USAGE_METRICS
+    return AgentInvokeWithModelOutput(
+        response=response,
+        agent_name=agent_name,
+        session_id=session_id,
+        model_name=model_name,
+        error=error,
+        input_tokens=metrics["input_tokens"],
+        cache_read_input_tokens=metrics["cache_read_input_tokens"],
+        cache_creation_input_tokens=metrics["cache_creation_input_tokens"],
+        output_tokens=metrics["output_tokens"],
+        total_tokens=metrics["total_tokens"],
+        num_requests=metrics["num_requests"],
+        start_time=start_time,
+        end_time=end_time,
+        duration_ms=duration_ms,
+    )

--- a/tests/test_subagent_invocation_usage.py
+++ b/tests/test_subagent_invocation_usage.py
@@ -1,7 +1,10 @@
 """Tests for per-run usage/latency reporting in subagent_invocation.
 
-These cover the additive token-usage and timing fields added to
-``AgentInvokeOutput``:
+These cover the additive token-usage and timing fields on
+``AgentInvokeWithModelOutput`` -- scoped EXCLUSIVELY to
+``invoke_agent_with_model``. ``invoke_agent`` keeps returning the original,
+unmodified ``AgentInvokeOutput`` with no usage/timing fields at all; that
+contract is locked in by ``TestInvokeAgentUnaffected`` below.
 
 - success path populates every new field (non-cached input_tokens, cache read /
   creation buckets, output_tokens, total_tokens, num_requests, start_time,
@@ -10,6 +13,7 @@ These cover the additive token-usage and timing fields added to
   double-counted (Anthropic / OpenAI / Gemini shapes)
 - a failing ``result.usage()`` leaves token fields None but still times the run
 - an error path (the sub-agent run raises) leaves all new fields None
+- ``invoke_agent`` (no model override) never sees any of these fields
 
 The suite is intentionally isolated from ``test_agent_tools_coverage.py`` so the
 new behaviour stays focused and readable.
@@ -23,9 +27,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from code_puppy.tools.subagent_invocation import (
-    _extract_usage_metrics,
+    register_invoke_agent,
     register_invoke_agent_with_model,
 )
+from code_puppy.tools.subagent_usage_metrics import _extract_usage_metrics
 
 
 def _usage(**kwargs):
@@ -57,6 +62,20 @@ def _capture_invoke_with_model():
     return captured["func"]
 
 
+def _capture_invoke_default():
+    """Capture the registered invoke_agent (no model override) callable."""
+    mock_agent = MagicMock()
+    captured = {}
+
+    def capture_tool(func):
+        captured["func"] = func
+        return func
+
+    mock_agent.tool = capture_tool
+    register_invoke_agent(mock_agent)
+    return captured["func"]
+
+
 def _build_agent_config():
     config = MagicMock()
 
@@ -72,9 +91,16 @@ def _build_agent_config():
     return config
 
 
-async def _run_invoke(*, usage=None, usage_raises=False, run_raises=False, perf=None):
-    """Drive _invoke_agent_impl with a mocked temp agent and return the output."""
-    invoke = _capture_invoke_with_model()
+async def _run_invoke(
+    *, usage=None, usage_raises=False, run_raises=False, perf=None, use_default=False
+):
+    """Drive _invoke_agent_impl with a mocked temp agent and return the output.
+
+    ``use_default=True`` drives it through the plain ``invoke_agent`` tool
+    (no model override, no usage instrumentation) instead of
+    ``invoke_agent_with_model``.
+    """
+    invoke = _capture_invoke_default() if use_default else _capture_invoke_with_model()
     mock_context = MagicMock()
     agent_config = _build_agent_config()
 
@@ -192,6 +218,12 @@ async def _run_invoke(*, usage=None, usage_raises=False, run_raises=False, perf=
                 )
             )
 
+        if use_default:
+            return await invoke(
+                mock_context,
+                agent_name="test-agent",
+                prompt="Hello",
+            )
         return await invoke(
             mock_context,
             agent_name="test-agent",
@@ -461,3 +493,63 @@ class TestInvokeReportsUsageAndLatency:
         assert out.start_time is None
         assert out.end_time is None
         assert out.duration_ms is None
+
+
+class TestInvokeAgentUnaffected:
+    """Locks in that ``invoke_agent`` has ZERO functional/schema changes.
+
+    ``invoke_agent`` must keep returning a plain ``AgentInvokeOutput`` -- the
+    original five-field contract -- with no usage/timing fields present at
+    all (not even as ``None`` attributes), and must not pay the cost of
+    ``time.perf_counter()``/``datetime.now()``/``result.usage()`` calls.
+    """
+
+    @pytest.mark.asyncio
+    async def test_success_returns_plain_agent_invoke_output(self):
+        from code_puppy.tools.agent_tools import (
+            AgentInvokeOutput,
+            AgentInvokeWithModelOutput,
+        )
+
+        usage = _usage(input_tokens=120, output_tokens=60, total_tokens=180, requests=3)
+        out = await _run_invoke(usage=usage, use_default=True)
+
+        assert out.response == "subagent response"
+        assert out.error is None
+        assert type(out) is AgentInvokeOutput
+        assert not isinstance(out, AgentInvokeWithModelOutput)
+        # The usage/timing fields must not exist on this type at all.
+        for field in (
+            "input_tokens",
+            "cache_read_input_tokens",
+            "cache_creation_input_tokens",
+            "output_tokens",
+            "total_tokens",
+            "num_requests",
+            "start_time",
+            "end_time",
+            "duration_ms",
+        ):
+            assert not hasattr(out, field)
+
+    @pytest.mark.asyncio
+    async def test_error_path_returns_plain_agent_invoke_output(self):
+        from code_puppy.tools.agent_tools import AgentInvokeWithModelOutput
+
+        out = await _run_invoke(run_raises=True, use_default=True)
+
+        assert out.response is None
+        assert out.error is not None
+        assert not isinstance(out, AgentInvokeWithModelOutput)
+
+    @pytest.mark.asyncio
+    async def test_usage_and_clock_are_never_touched(self):
+        """invoke_agent must not pay for timing/usage instrumentation at all."""
+        usage = _usage(input_tokens=1, output_tokens=1, total_tokens=2, requests=1)
+        with patch(
+            "code_puppy.tools.subagent_invocation.time.perf_counter"
+        ) as mock_perf:
+            out = await _run_invoke(usage=usage, use_default=True)
+
+        assert out.response == "subagent response"
+        mock_perf.assert_not_called()


### PR DESCRIPTION
## Summary

PR #674 (merged) added per-run token-usage and timing fields directly onto
the shared `AgentInvokeOutput` model consumed by BOTH `invoke_agent` and
`invoke_agent_with_model`, and instrumented the shared `_invoke_agent_impl`
unconditionally. The intent, however, was to scope this feature to
`invoke_agent_with_model` **only** — `invoke_agent` was supposed to have zero
functional/schema changes.

This PR corrects the scope. **`invoke_agent` now has exactly the same
behavior and return type it had before #674 ever merged.**

Jira: **PUP-544** — https://jira.walmart.com/browse/PUP-544

## What changed

- **`code_puppy/tools/agent_tools.py`**
  - `AgentInvokeOutput` reverted to its original five-field shape (`response`,
    `agent_name`, `session_id`, `model_name`, `error`) with the original
    docstring. `invoke_agent` keeps returning this exact type.
  - New `AgentInvokeWithModelOutput(AgentInvokeOutput)` subclass carries the
    nine usage/timing fields (`input_tokens`, `cache_read_input_tokens`,
    `cache_creation_input_tokens`, `output_tokens`, `total_tokens`,
    `num_requests`, `start_time`, `end_time`, `duration_ms`), returned
    exclusively by `invoke_agent_with_model`.

- **`code_puppy/tools/subagent_invocation.py`**
  - `_invoke_agent_impl` gained an explicit `include_usage_metrics: bool =
    False` parameter. `invoke_agent`'s wrapper does not pass it (stays
    `False`); `invoke_agent_with_model`'s wrapper passes
    `include_usage_metrics=True`.
  - The timing/usage-capture block is gated behind `if include_usage_metrics:`
    — when `invoke_agent` calls in, `time.perf_counter()`, `datetime.now()`,
    and `result.usage()` are never invoked at all. Not just discarded —
    skipped entirely, so there's no perf cost either.
  - All four `return` sites in `_invoke_agent_impl` now go through a shared
    `build_invoke_output(...)` helper that picks the correct output type
    based on the flag, instead of constructing `AgentInvokeOutput` directly
    in each spot.
  - `register_invoke_agent`'s docstring reverted to the original wording (no
    mention of usage/timing fields). `register_invoke_agent_with_model`'s
    return type annotation changed to `AgentInvokeWithModelOutput`.

- **`code_puppy/tools/subagent_usage_metrics.py`** (NEW)
  - Extracted `_coerce_token_count`, `_pick_reported_tokens`,
    `_extract_usage_metrics`, `_safe_usage_metrics`, and the new
    `build_invoke_output(...)` helper into a self-contained module.
  - Reason: `subagent_invocation.py` was already at 601 lines on `main`
    before this feature touched it (a project style guideline targets ~600
    lines per file); layering the instrumentation + scope-correction logic
    in place would have pushed it to 842 lines. These helpers are pure
    functions over usage objects / output construction with no dependency on
    the agent-run orchestration, so this is a cohesive split.
  - Net: `subagent_invocation.py` is 659 lines, `subagent_usage_metrics.py`
    is 203 lines.

- **`tests/test_subagent_invocation_usage.py`**
  - Existing per-provider/timing/error tests unchanged in behavior (they
    already only drove `register_invoke_agent_with_model`).
  - New `TestInvokeAgentUnaffected` class locks in the contract:
    - success path asserts `type(out) is AgentInvokeOutput` (not the
      subclass) and that none of the nine new field names exist as
      attributes at all (`hasattr(out, field) is False`), not merely `None`.
    - error path also returns a plain `AgentInvokeOutput`.
    - `time.perf_counter` is mocked and asserted `not_called()` when going
      through `invoke_agent`, proving the instrumentation is skipped, not
      just discarded.

## Behavior contract (corrected)

- **`invoke_agent`**: always returns `AgentInvokeOutput` — response,
  agent_name, session_id, model_name, error. Identical to pre-#674 behavior.
  Zero performance cost from this feature.
- **`invoke_agent_with_model`**: returns `AgentInvokeWithModelOutput` on
  every path. Success populates all nine usage/timing fields; any error path
  leaves them all `None`. Unchanged from #674's original intent, just now
  correctly isolated to this tool.

## Testing

- `pytest tests/test_subagent_invocation_usage.py` → 18 passed (15 original +
  3 new `TestInvokeAgentUnaffected` tests)
- `pytest tests/test_agent_tools_coverage.py tests/test_agent_tools_full_coverage.py
  tests/test_agent_tools.py tests/tools/test_agent_tools.py
  tests/tools/test_subagent_recursion_limit.py tests/tools/test_subagent_no_agents_md.py
  tests/agents/test_run_stats.py tests/plugins/subagent_panel/test_post_tool_call_completion.py
  tests/test_tools_registration.py tests/test_coverage_agents_gaps.py` → 259 passed
- Full repo suite: 12,488 passed, 81 skipped, 1 xpassed, 2 failed. The 2
  failures (`tests/test_http_utils.py::TestResolveProxyConfig::*`) are
  pre-existing and environment-caused (local proxy env vars), verified
  identical on a clean `origin/main` checkout — unrelated to this change.
- `ruff check` + `ruff format --check` → clean

## Notes / follow-ups

- No Jira key in source (only PR metadata + commit body).
- `code_puppy/agents/agent_creator_agent.py` (~lines 270-280) still documents
  the `invoke_agent_with_model` return shape without the new fields — this
  was already flagged as out-of-scope in #674 and remains a follow-up.
- Supersedes the scope of #674 (merged) — does not touch anything else that
  PR changed.
