### PR TITLE
fix(security): make YOLO mode fail closed when unconfigured

### DIFF
--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -1303,7 +1303,16 @@ def get_cli_yolo_override() -> Optional[bool]:
 
 
 def get_yolo_mode() -> bool:
-    """Return effective YOLO mode using CLI > persisted config precedence."""
+    """Return effective YOLO mode using CLI > persisted config precedence.
+
+    YOLO mode bypasses every human-in-the-loop confirmation prompt
+    (file writes, deletes, destructive shell commands, force-pushes).
+    Because it is a safety *bypass*, it must fail closed: when the user
+    has not explicitly opted in via the CLI flag or a persisted
+    ``yolo_mode`` config value, we default to ``False`` so confirmation
+    gates stay ON. Defaulting to ``True`` here silently disabled the
+    confirmation guardrail for anyone who never touched the setting.
+    """
     if _cli_yolo_override is not None:
         return _cli_yolo_override
 
@@ -1311,7 +1320,7 @@ def get_yolo_mode() -> bool:
     cfg_val = get_value("yolo_mode")
     if cfg_val is not None:
         return str(cfg_val).strip().lower() in true_vals
-    return True
+    return False
 
 
 def get_safety_permission_level():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -576,10 +576,10 @@ class TestGetYoloMode:
             mock_get_value.assert_called_once_with("yolo_mode")
 
     @patch("code_puppy.config.get_value")
-    def test_get_yolo_mode_not_in_config_defaults_true(self, mock_get_value):
+    def test_get_yolo_mode_not_in_config_defaults_false(self, mock_get_value):
         mock_get_value.return_value = None
 
-        assert cp_config.get_yolo_mode() is True
+        assert cp_config.get_yolo_mode() is False
         mock_get_value.assert_called_once_with("yolo_mode")
 
 

--- a/tests/test_config_extended_part1.py
+++ b/tests/test_config_extended_part1.py
@@ -141,7 +141,7 @@ class TestConfigExtendedPart1:
             assert result is True  # Default should be True
 
     def test_get_yolo_mode_default(self, temp_config_dir):
-        """Test get_yolo_mode returns True when not set"""
+        """Test get_yolo_mode returns False when not set (fails closed)"""
         temp_dir, config_file = temp_config_dir
 
         # Create config without yolo_mode key
@@ -152,7 +152,7 @@ class TestConfigExtendedPart1:
 
         with patch("code_puppy.config.CONFIG_FILE", config_file):
             result = get_yolo_mode()
-            assert result is True  # Default should be True
+            assert result is False  # Default should be False (fail closed)
 
     def test_get_auto_save_session_default(self, temp_config_dir):
         """Test get_auto_save_session returns True when not set"""

--- a/tests/test_config_full_coverage.py
+++ b/tests/test_config_full_coverage.py
@@ -67,10 +67,11 @@ class TestBooleanGetters:
         cp_config.set_config_value("enable_streaming", "false")
         assert cp_config.get_enable_streaming() is False
 
-    def test_get_yolo_mode_default_true(self):
-        # yolo_mode defaults to True
+    def test_get_yolo_mode_default_false(self):
+        # yolo_mode is a safety bypass, so it must fail closed: when unset,
+        # confirmation prompts stay ON (yolo defaults to False).
         cp_config.reset_value("yolo_mode")
-        assert cp_config.get_yolo_mode() is True
+        assert cp_config.get_yolo_mode() is False
 
     def test_get_yolo_mode_off(self):
         cp_config.set_config_value("yolo_mode", "off")


### PR DESCRIPTION
## Summary
`get_yolo_mode()` defaulted to **`True`** when neither a CLI override nor a persisted `yolo_mode` config value was present. YOLO mode is a **safety bypass** — it skips every human-in-the-loop confirmation prompt (file writes, deletes, destructive shell commands, git force-push). Defaulting it ON meant the confirmation guardrail was **silently disabled for any user who never touched the setting**.

This surfaced when a `delete_file` ran with no confirmation prompt on a fresh setup that had no `yolo_mode` key in `puppy.cfg`.

## The fix
Change the fallback in `get_yolo_mode()` from `return True` to `return False` so the guardrail **fails closed**. Users must now explicitly opt in to YOLO via `--yolo` or a persisted config value. CLI-override and explicit-config precedence are unchanged.

## Why this is correct
A confirmation control for irreversible actions must fail *safe*. A safety bypass that defaults ON when unconfigured is the opposite of fail-safe — the secure default is to keep confirmation prompts enabled and require a deliberate opt-in to disable them.

## Tests
Updated the unit tests that asserted the old default-true behavior:
- `tests/test_config_full_coverage.py`: `test_get_yolo_mode_default_true` -> `test_get_yolo_mode_default_false`
- `tests/test_config.py`: `test_get_yolo_mode_not_in_config_defaults_true` -> `..._defaults_false`
- `tests/test_config_extended_part1.py`: `test_get_yolo_mode_default` now asserts `False`

Explicit-value tests (config set to true) are unaffected. Ran the config + yolo-CLI suites: **257 passed, 0 failed**.

## Behavior change note
Users who relied on the implicit default-on YOLO will now see confirmation prompts until they set `yolo_mode = true` (or pass `--yolo`). This is intentional and is the safer default.
