### PR TITLE
perf(messaging): decouple from code_puppy.tools (import messaging −239ms / −62%)

### DIFF
--- a/code_puppy/agents/event_stream_handler.py
+++ b/code_puppy/agents/event_stream_handler.py
@@ -32,7 +32,7 @@ from code_puppy.config import (
     get_suppress_thinking_messages,
 )
 from code_puppy.tools.display import erase_progress_line
-from code_puppy.tools.subagent_context import is_subagent
+from code_puppy.subagent_context import is_subagent
 
 logger = logging.getLogger(__name__)
 

--- a/code_puppy/agents/run_stats.py
+++ b/code_puppy/agents/run_stats.py
@@ -50,7 +50,7 @@ from pydantic_ai.messages import (
     ToolCallPartDelta,
 )
 
-from code_puppy.tools.subagent_context import is_subagent
+from code_puppy.subagent_context import is_subagent
 
 
 class AgentRunStats:

--- a/code_puppy/messaging/rich_renderer.py
+++ b/code_puppy/messaging/rich_renderer.py
@@ -25,8 +25,18 @@ from code_puppy.config import (
     get_suppress_informational_messages,
     get_suppress_thinking_messages,
 )
-from code_puppy.tools.common import format_diff_with_colors
-from code_puppy.tools.subagent_context import is_subagent
+from code_puppy.subagent_context import is_subagent
+
+# NOTE: ``format_diff_with_colors`` is intentionally NOT imported here.
+# It lives in ``code_puppy.tools.common``, and importing anything from
+# ``code_puppy.tools`` executes ``code_puppy/tools/__init__.py`` — which
+# eagerly loads the full tool registry (browser->playwright,
+# image_tools->PIL, agent_tools->rapidfuzz, and dozens more). That drags
+# ~1000 modules into every plugin's import path via this renderer.
+#
+# The function is only called inside ``_render_diff_message`` (a
+# post-tool-call rendering path). Importing it there keeps the
+# discovery-time cost of ``code_puppy.messaging`` at a bare minimum.
 
 from .bus import MessageBus
 from .commands import (
@@ -873,7 +883,11 @@ class RichConsoleRenderer:
         if not msg.diff_lines:
             return
 
-        # Reconstruct unified diff text from diff_lines for format_diff_with_colors
+        # Reconstruct unified diff text from diff_lines for format_diff_with_colors.
+        # See the module-level note: importing this function is deferred to
+        # keep ``code_puppy.messaging`` off the ``code_puppy.tools`` import path.
+        from code_puppy.tools.common import format_diff_with_colors
+
         diff_text_lines = []
         for line in msg.diff_lines:
             if line.type == "add":

--- a/code_puppy/messaging/spinner/__init__.py
+++ b/code_puppy/messaging/spinner/__init__.py
@@ -100,11 +100,13 @@ def update_spinner_context(info: str) -> None:
     doesn't apply to a status row that describes the main context.
     (Sub-agent status lives on the panel rows via ``set_panel_lines``.)
     """
-    try:
-        from code_puppy.subagent_context import is_subagent
-    except ImportError:
-        is_subagent = None
-    if is_subagent is not None and is_subagent():
+    # Skip sub-agent contexts entirely — status rows describe the main
+    # context; sub-agent status lives on panel rows via ``set_panel_lines``.
+    # Function-scope import keeps ``code_puppy.messaging`` off the tools
+    # graph at discovery time (see ``rich_renderer.py`` module note).
+    from code_puppy.subagent_context import is_subagent
+
+    if is_subagent():
         return
     try:
         from code_puppy.messaging.bottom_bar import get_bottom_bar

--- a/code_puppy/messaging/spinner/__init__.py
+++ b/code_puppy/messaging/spinner/__init__.py
@@ -101,7 +101,7 @@ def update_spinner_context(info: str) -> None:
     (Sub-agent status lives on the panel rows via ``set_panel_lines``.)
     """
     try:
-        from code_puppy.tools.subagent_context import is_subagent
+        from code_puppy.subagent_context import is_subagent
     except ImportError:
         is_subagent = None
     if is_subagent is not None and is_subagent():

--- a/code_puppy/plugins/subagent_panel/register_callbacks.py
+++ b/code_puppy/plugins/subagent_panel/register_callbacks.py
@@ -478,7 +478,7 @@ async def _on_agent_run_end(
     if not _runtime_enabled():
         return
     try:
-        from code_puppy.tools.subagent_context import is_subagent
+        from code_puppy.subagent_context import is_subagent
 
         if is_subagent():
             return  # a sub-agent finishing -- leave the live tree intact

--- a/code_puppy/plugins/wiggum/judge.py
+++ b/code_puppy/plugins/wiggum/judge.py
@@ -23,7 +23,7 @@ from code_puppy.agents._history import stringify_part
 from code_puppy.agents.agent_manager import load_agent
 from code_puppy.model_factory import ModelFactory, make_model_settings
 from code_puppy.model_utils import prepare_prompt_for_model
-from code_puppy.tools.subagent_context import subagent_context
+from code_puppy.subagent_context import subagent_context
 
 from .judge_config import DEFAULT_JUDGE_PROMPT, JudgeConfig
 

--- a/code_puppy/subagent_context.py
+++ b/code_puppy/subagent_context.py
@@ -1,0 +1,208 @@
+"""Sub-agent context management with async-safe state tracking.
+
+This module provides context-aware tracking of sub-agent execution state using
+Python's contextvars for async-safe isolation. This ensures that sub-agent state
+is properly isolated across different async tasks and execution contexts.
+
+## Why ContextVars?
+
+ContextVars provide automatic context isolation in async environments:
+- Each async task gets its own copy of the context
+- State changes in one task don't affect others
+- Perfect for tracking execution depth in nested agent calls
+- Token-based reset ensures proper cleanup even with exceptions
+
+## Usage Example:
+
+```python
+from code_puppy.tools.subagent_context import subagent_context, is_subagent
+
+# Main agent
+print(is_subagent())  # False
+
+async def run_subagent():
+    with subagent_context("retriever"):
+        print(is_subagent())  # True
+        print(get_subagent_name())  # "retriever"
+        print(get_subagent_depth())  # 1
+
+        # Nested sub-agent
+        with subagent_context("terrier"):
+            print(get_subagent_depth())  # 2
+            print(get_subagent_name())  # "terrier"
+
+        # Back to parent sub-agent
+        print(get_subagent_name())  # "retriever"
+        print(get_subagent_depth())  # 1
+
+# After context exits
+print(is_subagent())  # False
+```
+
+## Benefits:
+
+1. **Async Safety**: Multiple sub-agents can run concurrently without interference
+2. **Nested Support**: Properly handles sub-agents calling other sub-agents
+3. **Clean Restoration**: Token-based reset ensures state is restored even on errors
+4. **Zero Overhead**: When not in a sub-agent context, minimal performance impact
+"""
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Generator
+
+__all__ = [
+    "subagent_context",
+    "is_subagent",
+    "get_subagent_name",
+    "get_subagent_chain",
+    "get_subagent_depth",
+    "get_subagent_model_name",
+]
+
+# Track sub-agent depth (0 = main agent, 1+ = sub-agent)
+_subagent_depth: ContextVar[int] = ContextVar("subagent_depth", default=0)
+
+# Track current sub-agent name (None = main agent)
+_subagent_name: ContextVar[str | None] = ContextVar("subagent_name", default=None)
+_subagent_model_name: ContextVar[str | None] = ContextVar(
+    "subagent_model_name", default=None
+)
+
+# Track the full call chain of sub-agent names. Stored as an
+# immutable tuple so each context-manager push is a cheap snapshot. The
+# tuple is empty in the main-agent context and `(deepest_name,)` for a
+# single-level sub-agent. For ``code-puppy -> A -> B`` it is ``("A", "B")``.
+_subagent_chain: ContextVar[tuple[str, ...]] = ContextVar("subagent_chain", default=())
+
+
+@contextmanager
+def subagent_context(
+    agent_name: str, model_name: str | None = None
+) -> Generator[None, None, None]:
+    """Context manager for tracking sub-agent execution.
+
+    Increments the sub-agent depth and sets the current agent name on entry,
+    then restores the previous state on exit. Uses token-based reset for
+    proper async isolation and exception safety.
+
+    Args:
+        agent_name: Name of the sub-agent being executed (e.g., "retriever", "code-puppy")
+
+    Yields:
+        None
+
+    Example:
+        >>> with subagent_context("retriever"):
+        ...     assert is_subagent() is True
+        ...     assert get_subagent_name() == "retriever"
+        >>> assert is_subagent() is False
+
+    Note:
+        Token-based reset ensures that even if an exception occurs, the context
+        is properly restored. This is especially important in async environments
+        where multiple tasks may be running concurrently.
+    """
+    # Get current depth for incrementing
+    current_depth = _subagent_depth.get()
+    current_chain = _subagent_chain.get()
+
+    # Set new values and save tokens for restoration
+    depth_token = _subagent_depth.set(current_depth + 1)
+    name_token = _subagent_name.set(agent_name)
+    model_token = _subagent_model_name.set(model_name)
+    chain_token = _subagent_chain.set(current_chain + (agent_name,))
+
+    try:
+        yield
+    finally:
+        # Use token-based reset for proper async isolation
+        # This ensures the context is restored even if an exception occurs
+        _subagent_depth.reset(depth_token)
+        _subagent_name.reset(name_token)
+        _subagent_model_name.reset(model_token)
+        _subagent_chain.reset(chain_token)
+
+
+def is_subagent() -> bool:
+    """Check if currently executing within a sub-agent context.
+
+    Returns:
+        True if depth > 0 (inside a sub-agent), False otherwise (main agent)
+
+    Example:
+        >>> is_subagent()
+        False
+        >>> with subagent_context("retriever"):
+        ...     is_subagent()
+        True
+    """
+    return _subagent_depth.get() > 0
+
+
+def get_subagent_name() -> str | None:
+    """Get the name of the current sub-agent.
+
+    Returns:
+        Current sub-agent name, or None if in main agent context
+
+    Example:
+        >>> get_subagent_name()
+        None
+        >>> with subagent_context("code-puppy"):
+        ...     get_subagent_name()
+        'code-puppy'
+    """
+    return _subagent_name.get()
+
+
+def get_subagent_model_name() -> str | None:
+    """Return the model running the current sub-agent."""
+    return _subagent_model_name.get()
+
+
+def get_subagent_depth() -> int:
+    """Get the current sub-agent nesting depth.
+
+    Returns:
+        Current depth level (0 = main agent, 1 = first-level sub-agent,
+        2 = nested sub-agent, etc.)
+
+    Example:
+        >>> get_subagent_depth()
+        0
+        >>> with subagent_context("retriever"):
+        ...     get_subagent_depth()
+        1
+        ...     with subagent_context("terrier"):
+        ...         get_subagent_depth()
+        2
+    """
+    return _subagent_depth.get()
+
+
+def get_subagent_chain() -> tuple[str, ...]:
+    """Return the full sub-agent invocation chain, outermost first.
+
+    The main agent is not part of the chain — it is implicit. Use this
+    when you need to know the *immediate* parent sub-agent rather than
+    just the current name.
+
+    This is used to attribute token spend to the agent that actually
+    initiated the call vs. the one one level up the call stack.
+
+    Returns:
+        An immutable tuple of sub-agent names, deepest last. ``()`` when
+        running in the main agent context.
+
+    Example:
+        >>> get_subagent_chain()
+        ()
+        >>> with subagent_context("retriever"):
+        ...     get_subagent_chain()
+        ('retriever',)
+        ...     with subagent_context("terrier"):
+        ...         get_subagent_chain()
+        ('retriever', 'terrier')
+    """
+    return _subagent_chain.get()

--- a/code_puppy/subagent_context.py
+++ b/code_puppy/subagent_context.py
@@ -15,7 +15,7 @@ ContextVars provide automatic context isolation in async environments:
 ## Usage Example:
 
 ```python
-from code_puppy.tools.subagent_context import subagent_context, is_subagent
+from code_puppy.subagent_context import subagent_context, is_subagent
 
 # Main agent
 print(is_subagent())  # False

--- a/code_puppy/tools/subagent_context.py
+++ b/code_puppy/tools/subagent_context.py
@@ -1,55 +1,32 @@
-"""Sub-agent context management with async-safe state tracking.
+"""Compatibility shim.
 
-This module provides context-aware tracking of sub-agent execution state using
-Python's contextvars for async-safe isolation. This ensures that sub-agent state
-is properly isolated across different async tasks and execution contexts.
+The real implementation lives at :mod:`code_puppy.subagent_context` — a
+top-level, stdlib-only module. It was moved out of :mod:`code_puppy.tools`
+because importing anything from ``code_puppy.tools`` forces Python to
+execute ``code_puppy/tools/__init__.py``, which eagerly imports the full
+tool registry (browser -> playwright, image_tools -> PIL, agent_tools ->
+rapidfuzz, and dozens more). That import chain was the single largest
+source of Code Puppy's cold-start cost.
 
-## Why ContextVars?
+``subagent_context`` has no reason to be coupled to the tool registry —
+it's pure ``contextvars`` bookkeeping. Callers should prefer the new
+canonical location:
 
-ContextVars provide automatic context isolation in async environments:
-- Each async task gets its own copy of the context
-- State changes in one task don't affect others
-- Perfect for tracking execution depth in nested agent calls
-- Token-based reset ensures proper cleanup even with exceptions
+    from code_puppy.subagent_context import is_subagent  # preferred
 
-## Usage Example:
-
-```python
-from code_puppy.tools.subagent_context import subagent_context, is_subagent
-
-# Main agent
-print(is_subagent())  # False
-
-async def run_subagent():
-    with subagent_context("retriever"):
-        print(is_subagent())  # True
-        print(get_subagent_name())  # "retriever"
-        print(get_subagent_depth())  # 1
-
-        # Nested sub-agent
-        with subagent_context("terrier"):
-            print(get_subagent_depth())  # 2
-            print(get_subagent_name())  # "terrier"
-
-        # Back to parent sub-agent
-        print(get_subagent_name())  # "retriever"
-        print(get_subagent_depth())  # 1
-
-# After context exits
-print(is_subagent())  # False
-```
-
-## Benefits:
-
-1. **Async Safety**: Multiple sub-agents can run concurrently without interference
-2. **Nested Support**: Properly handles sub-agents calling other sub-agents
-3. **Clean Restoration**: Token-based reset ensures state is restored even on errors
-4. **Zero Overhead**: When not in a sub-agent context, minimal performance impact
+This shim is retained so existing external plugin authors (and tests
+that patch this exact string path) keep working. Prefer the canonical
+location for new code.
 """
 
-from contextlib import contextmanager
-from contextvars import ContextVar
-from typing import Generator
+from code_puppy.subagent_context import (  # noqa: F401
+    get_subagent_chain,
+    get_subagent_depth,
+    get_subagent_model_name,
+    get_subagent_name,
+    is_subagent,
+    subagent_context,
+)
 
 __all__ = [
     "subagent_context",
@@ -59,150 +36,3 @@ __all__ = [
     "get_subagent_depth",
     "get_subagent_model_name",
 ]
-
-# Track sub-agent depth (0 = main agent, 1+ = sub-agent)
-_subagent_depth: ContextVar[int] = ContextVar("subagent_depth", default=0)
-
-# Track current sub-agent name (None = main agent)
-_subagent_name: ContextVar[str | None] = ContextVar("subagent_name", default=None)
-_subagent_model_name: ContextVar[str | None] = ContextVar(
-    "subagent_model_name", default=None
-)
-
-# Track the full call chain of sub-agent names. Stored as an
-# immutable tuple so each context-manager push is a cheap snapshot. The
-# tuple is empty in the main-agent context and `(deepest_name,)` for a
-# single-level sub-agent. For ``code-puppy -> A -> B`` it is ``("A", "B")``.
-_subagent_chain: ContextVar[tuple[str, ...]] = ContextVar("subagent_chain", default=())
-
-
-@contextmanager
-def subagent_context(
-    agent_name: str, model_name: str | None = None
-) -> Generator[None, None, None]:
-    """Context manager for tracking sub-agent execution.
-
-    Increments the sub-agent depth and sets the current agent name on entry,
-    then restores the previous state on exit. Uses token-based reset for
-    proper async isolation and exception safety.
-
-    Args:
-        agent_name: Name of the sub-agent being executed (e.g., "retriever", "code-puppy")
-
-    Yields:
-        None
-
-    Example:
-        >>> with subagent_context("retriever"):
-        ...     assert is_subagent() is True
-        ...     assert get_subagent_name() == "retriever"
-        >>> assert is_subagent() is False
-
-    Note:
-        Token-based reset ensures that even if an exception occurs, the context
-        is properly restored. This is especially important in async environments
-        where multiple tasks may be running concurrently.
-    """
-    # Get current depth for incrementing
-    current_depth = _subagent_depth.get()
-    current_chain = _subagent_chain.get()
-
-    # Set new values and save tokens for restoration
-    depth_token = _subagent_depth.set(current_depth + 1)
-    name_token = _subagent_name.set(agent_name)
-    model_token = _subagent_model_name.set(model_name)
-    chain_token = _subagent_chain.set(current_chain + (agent_name,))
-
-    try:
-        yield
-    finally:
-        # Use token-based reset for proper async isolation
-        # This ensures the context is restored even if an exception occurs
-        _subagent_depth.reset(depth_token)
-        _subagent_name.reset(name_token)
-        _subagent_model_name.reset(model_token)
-        _subagent_chain.reset(chain_token)
-
-
-def is_subagent() -> bool:
-    """Check if currently executing within a sub-agent context.
-
-    Returns:
-        True if depth > 0 (inside a sub-agent), False otherwise (main agent)
-
-    Example:
-        >>> is_subagent()
-        False
-        >>> with subagent_context("retriever"):
-        ...     is_subagent()
-        True
-    """
-    return _subagent_depth.get() > 0
-
-
-def get_subagent_name() -> str | None:
-    """Get the name of the current sub-agent.
-
-    Returns:
-        Current sub-agent name, or None if in main agent context
-
-    Example:
-        >>> get_subagent_name()
-        None
-        >>> with subagent_context("code-puppy"):
-        ...     get_subagent_name()
-        'code-puppy'
-    """
-    return _subagent_name.get()
-
-
-def get_subagent_model_name() -> str | None:
-    """Return the model running the current sub-agent."""
-    return _subagent_model_name.get()
-
-
-def get_subagent_depth() -> int:
-    """Get the current sub-agent nesting depth.
-
-    Returns:
-        Current depth level (0 = main agent, 1 = first-level sub-agent,
-        2 = nested sub-agent, etc.)
-
-    Example:
-        >>> get_subagent_depth()
-        0
-        >>> with subagent_context("retriever"):
-        ...     get_subagent_depth()
-        1
-        ...     with subagent_context("terrier"):
-        ...         get_subagent_depth()
-        2
-    """
-    return _subagent_depth.get()
-
-
-def get_subagent_chain() -> tuple[str, ...]:
-    """Return the full sub-agent invocation chain, outermost first.
-
-    The main agent is not part of the chain — it is implicit. Use this
-    when you need to know the *immediate* parent sub-agent rather than
-    just the current name.
-
-    This is used to attribute token spend to the agent that actually
-    initiated the call vs. the one one level up the call stack.
-
-    Returns:
-        An immutable tuple of sub-agent names, deepest last. ``()`` when
-        running in the main agent context.
-
-    Example:
-        >>> get_subagent_chain()
-        ()
-        >>> with subagent_context("retriever"):
-        ...     get_subagent_chain()
-        ('retriever',)
-        ...     with subagent_context("terrier"):
-        ...         get_subagent_chain()
-        ('retriever', 'terrier')
-    """
-    return _subagent_chain.get()

--- a/code_puppy/tools/subagent_context.py
+++ b/code_puppy/tools/subagent_context.py
@@ -17,6 +17,11 @@ canonical location:
 This shim is retained so existing external plugin authors (and tests
 that patch this exact string path) keep working. Prefer the canonical
 location for new code.
+
+Note: only the public API (``__all__``) is re-exported. The private
+``_subagent_*`` ContextVar objects are intentionally NOT re-exported —
+reach into them via :mod:`code_puppy.subagent_context` directly if you
+really need to poke at internals.
 """
 
 from code_puppy.subagent_context import (  # noqa: F401

--- a/perf/bench/README.md
+++ b/perf/bench/README.md
@@ -1,0 +1,55 @@
+# Cold-start perf benchmarks
+
+Scripts used to measure the impact of PR #681 (messaging↔tools decoupling).
+Kept in-repo so future perf work has a starting point and so cited numbers
+are verifiably reproducible.
+
+## Scripts
+
+### `bench_messaging_only.py`
+
+Measures the cost of a single `import code_puppy.messaging` in a fresh
+subprocess. This is the tightest, most honest number for the messaging
+package's own transitive-import cost.
+
+```bash
+python perf/bench/bench_messaging_only.py
+```
+
+**Baseline (main, commit 25266787):** ~386ms wall, 1017 new modules.
+**After PR #681:** ~147ms wall, 392 new modules.
+**Delta: −239ms (−62%), −625 modules (−61%).** Reproducible run-to-run.
+
+### `bench_full_cold_start.py`
+
+Simulates the plugin-discovery phase of a real Code Puppy launch: registers
+all 51 built-in plugins in one Python process, reports wall-time
+distribution across 3 warmup + 15 measurement runs per repo, and asserts
+plugin-load parity between the two trees.
+
+```bash
+python perf/bench/bench_full_cold_start.py
+```
+
+Prints a per-tree median / stdev / min / max table and a **noise-floor
+verdict**: if `|Δmedian| < combined stdev`, the delta is inside run-to-run
+jitter and should NOT be headlined. This is how the round-2 review caught
+the (retracted) −12.4% cache-warmth artifact in PR #681.
+
+## Editing before running
+
+Both scripts hard-code `MAIN` / `WORK` repo paths and the venv Python at
+the top of the file. Adjust for your machine before running against your
+own before/after pair.
+
+## Adding new benchmarks
+
+Prefer the same shape as `bench_full_cold_start.py`:
+
+1. **Warmup runs discarded** (page cache, JIT caches).
+2. **N ≥ 7 measurement runs**, ideally 15+, in fresh subprocesses.
+3. **Report the distribution** (median + stdev + min + max), not just the mean.
+4. **Compute a noise-floor verdict** when comparing two trees. If the delta
+   is smaller than the combined stddev, say so out loud — don't headline
+   noise as a win.
+5. **Parity assertions** where relevant (e.g. same plugin set loaded).

--- a/perf/bench/README.md
+++ b/perf/bench/README.md
@@ -4,52 +4,99 @@ Scripts used to measure the impact of PR #681 (messaging↔tools decoupling).
 Kept in-repo so future perf work has a starting point and so cited numbers
 are verifiably reproducible.
 
+## Common invocation
+
+Both scripts compare two Code Puppy checkouts and take the same core args:
+
+```bash
+python perf/bench/<script>.py \
+    --before /path/to/baseline-checkout \
+    --after  /path/to/candidate-checkout
+```
+
+Optional:
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--runs N` | script-specific | measurement runs per tree |
+| `--warmup N` | script-specific | warmup runs per tree (discarded) |
+| `--python PATH` | `sys.executable` | Python used for subprocesses |
+
+Whichever Python you point at (or `sys.executable` by default) needs to
+be able to `import code_puppy` from *each* of the two trees — usually
+a venv with Code Puppy's dependencies installed. The scripts don't
+install anything and don't modify the checkouts.
+
 ## Scripts
 
 ### `bench_messaging_only.py`
 
 Measures the cost of a single `import code_puppy.messaging` in a fresh
-subprocess. This is the tightest, most honest number for the messaging
-package's own transitive-import cost.
+subprocess. Tightest, most honest number for the messaging package's
+own transitive-import cost.
+
+Defaults: `--runs 7`, `--warmup 1`.
 
 ```bash
-python perf/bench/bench_messaging_only.py
+python perf/bench/bench_messaging_only.py \
+    --before ../code_puppy-oss \
+    --after  .
 ```
 
-**Baseline (main, commit 25266787):** ~386ms wall, 1017 new modules.
-**After PR #681:** ~147ms wall, 392 new modules.
-**Delta: −239ms (−62%), −625 modules (−61%).** Reproducible run-to-run.
+Output format:
+
+```
+import code_puppy.messaging  (7 fresh subprocesses each)
+
+           wall (mean)     wall (min)    new_modules
+-------------------------------------------------------
+BEFORE          386.0ms        384.5ms         1017
+AFTER           147.1ms        146.7ms          392
+
+Delta wall (mean): -238.9ms  (-61.9%)
+Delta modules:     -625  (-61.5%)
+```
 
 ### `bench_full_cold_start.py`
 
-Simulates the plugin-discovery phase of a real Code Puppy launch: registers
-all 51 built-in plugins in one Python process, reports wall-time
-distribution across 3 warmup + 15 measurement runs per repo, and asserts
-plugin-load parity between the two trees.
+Simulates the plugin-discovery phase of a real Code Puppy launch:
+registers all built-in plugins in one Python process per subprocess,
+reports the wall-time **distribution** across warmup + measurement
+runs, and asserts plugin-load parity between the two trees.
+
+Defaults: `--runs 15`, `--warmup 3`.
 
 ```bash
-python perf/bench/bench_full_cold_start.py
+python perf/bench/bench_full_cold_start.py \
+    --before ../code_puppy-oss \
+    --after  .
 ```
 
-Prints a per-tree median / stdev / min / max table and a **noise-floor
-verdict**: if `|Δmedian| < combined stdev`, the delta is inside run-to-run
-jitter and should NOT be headlined. This is how the round-2 review caught
-the (retracted) −12.4% cache-warmth artifact in PR #681.
+Prints a per-tree median / stdev / min / max table and a
+**noise-floor verdict**: if `|Δmedian| < combined stdev`, the delta is
+inside run-to-run jitter and should NOT be headlined. This is how the
+adversarial round-2 review of PR #681 caught the (retracted) −12.4%
+cache-warmth artifact.
 
-## Editing before running
+Exit codes:
 
-Both scripts hard-code `MAIN` / `WORK` repo paths and the venv Python at
-the top of the file. Adjust for your machine before running against your
-own before/after pair.
+- `0` — benchmark completed
+- `2` — plugin-load parity violation (different plugins loaded across trees,
+  or plugins loaded inconsistently within a tree)
+- `3` — insufficient successful samples (see stderr)
 
 ## Adding new benchmarks
 
 Prefer the same shape as `bench_full_cold_start.py`:
 
-1. **Warmup runs discarded** (page cache, JIT caches).
+1. **Warmup runs discarded** — page cache, JIT caches, filesystem caches.
 2. **N ≥ 7 measurement runs**, ideally 15+, in fresh subprocesses.
 3. **Report the distribution** (median + stdev + min + max), not just the mean.
 4. **Compute a noise-floor verdict** when comparing two trees. If the delta
    is smaller than the combined stddev, say so out loud — don't headline
    noise as a win.
-5. **Parity assertions** where relevant (e.g. same plugin set loaded).
+5. **Parity assertions** where relevant (same plugin set loaded, same test
+   set executed, same subprocess exit codes, etc).
+6. **No hardcoded paths.** Take repo paths as `--before` / `--after` CLI
+   args; take the Python interpreter as `--python` with `sys.executable`
+   as the default.

--- a/perf/bench/bench_full_cold_start.py
+++ b/perf/bench/bench_full_cold_start.py
@@ -1,0 +1,177 @@
+"""Realistic cold-start bench — round 2 with proper distribution reporting.
+
+Runs plugin discovery in one Python process per subprocess invocation.
+Discards warmup runs, does many measurement runs, and reports median +
+stddev + min + max so cache-warmth artifacts stand out. Also asserts
+that both trees loaded the same set of plugins so silent plugin-load
+failures cannot skew the comparison.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import subprocess
+import sys
+
+VENV = "/Users/t0w0oqh/projects/code_puppy-oss/.venv/bin/python"
+
+SNIPPET = """
+import os, sys, time, json
+os.environ['NO_VERSION_UPDATE'] = '1'
+sys.path.insert(0, {repo!r})
+t0 = time.perf_counter()
+sys.stdout = open(os.devnull, 'w')
+from code_puppy.callbacks import register_callback  # noqa
+from code_puppy import plugins as plugins_pkg  # noqa
+from pathlib import Path
+PLUGINS_DIR = Path({repo!r}) / 'code_puppy' / 'plugins'
+loaded = []
+failed = []
+for p in sorted(PLUGINS_DIR.iterdir()):
+    if not p.is_dir():
+        continue
+    if not (p / 'register_callbacks.py').exists():
+        continue
+    try:
+        __import__(f'code_puppy.plugins.{{p.name}}.register_callbacks')
+        loaded.append(p.name)
+    except Exception as e:
+        failed.append((p.name, type(e).__name__))
+dt = time.perf_counter() - t0
+n_mod = len(sys.modules)
+sys.stdout = sys.__stdout__
+print(json.dumps({{
+    'wall_ms': round(dt * 1000, 2),
+    'n_modules': n_mod,
+    'loaded': loaded,
+    'failed': failed,
+}}))
+"""
+
+
+def run(repo: str, n: int) -> list[dict]:
+    results = []
+    for _ in range(n):
+        r = subprocess.run(
+            [VENV, "-c", SNIPPET.format(repo=repo)],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if r.returncode != 0:
+            print(f"FAIL: {r.stderr[-300:]}", file=sys.stderr)
+            continue
+        for line in reversed(r.stdout.strip().splitlines()):
+            try:
+                results.append(json.loads(line))
+                break
+            except json.JSONDecodeError:
+                continue
+    return results
+
+
+MAIN = "/Users/t0w0oqh/projects/code_puppy-oss"
+WORK = "/Users/t0w0oqh/projects/code_puppy-oss/.worktrees/perf-messaging-tools-decouple"
+
+WARMUPS = 3
+N = 15
+
+print(f"Warmup: {WARMUPS} runs per repo (discarded)")
+run(MAIN, n=WARMUPS)
+run(WORK, n=WARMUPS)
+
+print(f"Measuring: {N} runs per repo\n")
+main = run(MAIN, n=N)
+work = run(WORK, n=N)
+
+# --- Sample-count guard: fail loud if too many subprocesses errored ---
+if len(main) < 2 or len(work) < 2:
+    print(
+        f"insufficient samples (main={len(main)}, work={len(work)}); "
+        f"stddev is undefined with <2 runs and the noise-floor verdict "
+        f"would be meaningless.",
+        file=sys.stderr,
+    )
+    sys.exit(3)
+
+# --- Parity assertion (fail loud if plugin-load sets differ) ---
+main_loaded = set(main[0]["loaded"])
+work_loaded = set(work[0]["loaded"])
+main_only = main_loaded - work_loaded
+work_only = work_loaded - main_loaded
+if main_only or work_only:
+    print("!!! PLUGIN-LOAD PARITY VIOLATION !!!", file=sys.stderr)
+    print(f"  loaded only on MAIN:     {sorted(main_only)}", file=sys.stderr)
+    print(f"  loaded only on WORKTREE: {sorted(work_only)}", file=sys.stderr)
+    sys.exit(2)
+
+# Also assert every run loaded the same set as its first
+for label, rows in (("MAIN", main), ("WORKTREE", work)):
+    baseline = set(rows[0]["loaded"])
+    for i, r in enumerate(rows):
+        if set(r["loaded"]) != baseline:
+            print(
+                f"!!! {label} run {i} loaded a different plugin set than run 0",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
+n_loaded = len(main_loaded)
+print(
+    f"Plugin-load parity: both trees loaded the SAME {n_loaded} plugins on every run\n"
+)
+
+
+def stats(rows: list[dict]) -> dict:
+    t = [r["wall_ms"] for r in rows]
+    m = [r["n_modules"] for r in rows]
+    return {
+        "mean_ms": statistics.mean(t),
+        "median_ms": statistics.median(t),
+        "stdev_ms": statistics.stdev(t),
+        "min_ms": min(t),
+        "max_ms": max(t),
+        "modules": statistics.median(m),
+    }
+
+
+ms = stats(main)
+ws = stats(work)
+
+
+def fmt(s: dict) -> str:
+    return (
+        f"mean {s['mean_ms']:>7.1f}ms  "
+        f"median {s['median_ms']:>7.1f}ms  "
+        f"stdev {s['stdev_ms']:>5.1f}ms  "
+        f"min {s['min_ms']:>7.1f}ms  "
+        f"max {s['max_ms']:>7.1f}ms  "
+        f"modules {s['modules']:>6.0f}"
+    )
+
+
+print(f"MAIN     : {fmt(ms)}")
+print(f"WORKTREE : {fmt(ws)}")
+
+d_mean = ws["mean_ms"] - ms["mean_ms"]
+d_median = ws["median_ms"] - ms["median_ms"]
+d_min = ws["min_ms"] - ms["min_ms"]
+
+print(f"\nDelta mean   : {d_mean:+.1f}ms  ({100 * d_mean / ms['mean_ms']:+.2f}%)")
+print(f"Delta median : {d_median:+.1f}ms  ({100 * d_median / ms['median_ms']:+.2f}%)")
+print(f"Delta min    : {d_min:+.1f}ms  ({100 * d_min / ms['min_ms']:+.2f}%)")
+
+# Noise-floor check: is the delta larger than the combined stddev?
+combined_stdev = (ms["stdev_ms"] ** 2 + ws["stdev_ms"] ** 2) ** 0.5
+print(f"\nCombined stdev: {combined_stdev:.1f}ms")
+if abs(d_median) < combined_stdev:
+    print(
+        "VERDICT: |delta| < combined stdev  --> "
+        "delta is INSIDE the noise floor. Do not headline this number."
+    )
+else:
+    print(
+        "VERDICT: |delta| >= combined stdev  --> "
+        "delta is above the noise floor. Report it with the stddev."
+    )

--- a/perf/bench/bench_full_cold_start.py
+++ b/perf/bench/bench_full_cold_start.py
@@ -1,20 +1,41 @@
-"""Realistic cold-start bench — round 2 with proper distribution reporting.
+"""Realistic full-plugin cold-start bench with proper distribution reporting.
 
 Runs plugin discovery in one Python process per subprocess invocation.
 Discards warmup runs, does many measurement runs, and reports median +
-stddev + min + max so cache-warmth artifacts stand out. Also asserts
-that both trees loaded the same set of plugins so silent plugin-load
-failures cannot skew the comparison.
+stddev + min + max so cache-warmth artifacts stand out. Asserts both
+trees loaded the same set of plugins on every run so silent plugin-load
+failures cannot skew the comparison. Prints an explicit noise-floor
+verdict so it's obvious when the delta is inside run-to-run jitter.
+
+Usage
+-----
+Compare two checkouts (typically ``main`` vs a feature branch)::
+
+    python perf/bench/bench_full_cold_start.py \\
+        --before /path/to/checkout-before \\
+        --after  /path/to/checkout-after
+
+Optional flags:
+
+    --runs N       measurement runs per tree (default 15)
+    --warmup N     discarded warmup runs per tree (default 3)
+    --python PATH  Python interpreter to spawn subprocesses with
+                   (default: the interpreter running this script)
+
+Exit codes:
+    0  benchmark completed
+    2  plugin-load parity violation between the two trees
+    3  insufficient successful samples (see stderr)
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import statistics
 import subprocess
 import sys
-
-VENV = "/Users/t0w0oqh/projects/code_puppy-oss/.venv/bin/python"
+from pathlib import Path
 
 SNIPPET = """
 import os, sys, time, json
@@ -50,17 +71,20 @@ print(json.dumps({{
 """
 
 
-def run(repo: str, n: int) -> list[dict]:
-    results = []
+def run(python: str, repo: str, n: int) -> list[dict]:
+    results: list[dict] = []
     for _ in range(n):
         r = subprocess.run(
-            [VENV, "-c", SNIPPET.format(repo=repo)],
+            [python, "-c", SNIPPET.format(repo=repo)],
             capture_output=True,
             text=True,
             timeout=120,
         )
         if r.returncode != 0:
-            print(f"FAIL: {r.stderr[-300:]}", file=sys.stderr)
+            print(
+                f"[bench] subprocess failed (repo={repo}): {r.stderr[-300:]}",
+                file=sys.stderr,
+            )
             continue
         for line in reversed(r.stdout.strip().splitlines()):
             try:
@@ -69,58 +93,6 @@ def run(repo: str, n: int) -> list[dict]:
             except json.JSONDecodeError:
                 continue
     return results
-
-
-MAIN = "/Users/t0w0oqh/projects/code_puppy-oss"
-WORK = "/Users/t0w0oqh/projects/code_puppy-oss/.worktrees/perf-messaging-tools-decouple"
-
-WARMUPS = 3
-N = 15
-
-print(f"Warmup: {WARMUPS} runs per repo (discarded)")
-run(MAIN, n=WARMUPS)
-run(WORK, n=WARMUPS)
-
-print(f"Measuring: {N} runs per repo\n")
-main = run(MAIN, n=N)
-work = run(WORK, n=N)
-
-# --- Sample-count guard: fail loud if too many subprocesses errored ---
-if len(main) < 2 or len(work) < 2:
-    print(
-        f"insufficient samples (main={len(main)}, work={len(work)}); "
-        f"stddev is undefined with <2 runs and the noise-floor verdict "
-        f"would be meaningless.",
-        file=sys.stderr,
-    )
-    sys.exit(3)
-
-# --- Parity assertion (fail loud if plugin-load sets differ) ---
-main_loaded = set(main[0]["loaded"])
-work_loaded = set(work[0]["loaded"])
-main_only = main_loaded - work_loaded
-work_only = work_loaded - main_loaded
-if main_only or work_only:
-    print("!!! PLUGIN-LOAD PARITY VIOLATION !!!", file=sys.stderr)
-    print(f"  loaded only on MAIN:     {sorted(main_only)}", file=sys.stderr)
-    print(f"  loaded only on WORKTREE: {sorted(work_only)}", file=sys.stderr)
-    sys.exit(2)
-
-# Also assert every run loaded the same set as its first
-for label, rows in (("MAIN", main), ("WORKTREE", work)):
-    baseline = set(rows[0]["loaded"])
-    for i, r in enumerate(rows):
-        if set(r["loaded"]) != baseline:
-            print(
-                f"!!! {label} run {i} loaded a different plugin set than run 0",
-                file=sys.stderr,
-            )
-            sys.exit(2)
-
-n_loaded = len(main_loaded)
-print(
-    f"Plugin-load parity: both trees loaded the SAME {n_loaded} plugins on every run\n"
-)
 
 
 def stats(rows: list[dict]) -> dict:
@@ -136,10 +108,6 @@ def stats(rows: list[dict]) -> dict:
     }
 
 
-ms = stats(main)
-ws = stats(work)
-
-
 def fmt(s: dict) -> str:
     return (
         f"mean {s['mean_ms']:>7.1f}ms  "
@@ -151,27 +119,124 @@ def fmt(s: dict) -> str:
     )
 
 
-print(f"MAIN     : {fmt(ms)}")
-print(f"WORKTREE : {fmt(ws)}")
-
-d_mean = ws["mean_ms"] - ms["mean_ms"]
-d_median = ws["median_ms"] - ms["median_ms"]
-d_min = ws["min_ms"] - ms["min_ms"]
-
-print(f"\nDelta mean   : {d_mean:+.1f}ms  ({100 * d_mean / ms['mean_ms']:+.2f}%)")
-print(f"Delta median : {d_median:+.1f}ms  ({100 * d_median / ms['median_ms']:+.2f}%)")
-print(f"Delta min    : {d_min:+.1f}ms  ({100 * d_min / ms['min_ms']:+.2f}%)")
-
-# Noise-floor check: is the delta larger than the combined stddev?
-combined_stdev = (ms["stdev_ms"] ** 2 + ws["stdev_ms"] ** 2) ** 0.5
-print(f"\nCombined stdev: {combined_stdev:.1f}ms")
-if abs(d_median) < combined_stdev:
-    print(
-        "VERDICT: |delta| < combined stdev  --> "
-        "delta is INSIDE the noise floor. Do not headline this number."
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--before",
+        required=True,
+        type=Path,
+        help="path to the baseline code_puppy checkout",
     )
-else:
-    print(
-        "VERDICT: |delta| >= combined stdev  --> "
-        "delta is above the noise floor. Report it with the stddev."
+    p.add_argument(
+        "--after",
+        required=True,
+        type=Path,
+        help="path to the candidate code_puppy checkout",
     )
+    p.add_argument("--runs", type=int, default=15, help="measurement runs per tree")
+    p.add_argument(
+        "--warmup", type=int, default=3, help="warmup runs per tree (discarded)"
+    )
+    p.add_argument(
+        "--python",
+        default=sys.executable,
+        help="Python interpreter used to spawn subprocesses (default: sys.executable)",
+    )
+    args = p.parse_args()
+
+    before = args.before.resolve()
+    after = args.after.resolve()
+    for label, path in (("--before", before), ("--after", after)):
+        if not (path / "code_puppy").is_dir():
+            print(
+                f"[bench] {label}: {path} does not look like a code_puppy checkout "
+                "(no code_puppy/ subdir)",
+                file=sys.stderr,
+            )
+            return 2
+
+    print(f"[bench] python:  {args.python}")
+    print(f"[bench] before:  {before}")
+    print(f"[bench] after:   {after}")
+    print(f"[bench] warmup={args.warmup}, runs={args.runs}\n")
+
+    print(f"Warmup: {args.warmup} runs per repo (discarded)")
+    run(args.python, str(before), n=args.warmup)
+    run(args.python, str(after), n=args.warmup)
+
+    print(f"Measuring: {args.runs} runs per repo\n")
+    before_rows = run(args.python, str(before), n=args.runs)
+    after_rows = run(args.python, str(after), n=args.runs)
+
+    # --- Sample-count guard: fail loud if too many subprocesses errored ---
+    if len(before_rows) < 2 or len(after_rows) < 2:
+        print(
+            f"[bench] insufficient samples "
+            f"(before={len(before_rows)}, after={len(after_rows)}); "
+            f"stddev is undefined with <2 runs and the noise-floor verdict "
+            f"would be meaningless.",
+            file=sys.stderr,
+        )
+        return 3
+
+    # --- Parity assertion (fail loud if plugin-load sets differ) ---
+    before_loaded = set(before_rows[0]["loaded"])
+    after_loaded = set(after_rows[0]["loaded"])
+    before_only = before_loaded - after_loaded
+    after_only = after_loaded - before_loaded
+    if before_only or after_only:
+        print("!!! PLUGIN-LOAD PARITY VIOLATION !!!", file=sys.stderr)
+        print(f"  loaded only in BEFORE: {sorted(before_only)}", file=sys.stderr)
+        print(f"  loaded only in AFTER:  {sorted(after_only)}", file=sys.stderr)
+        return 2
+
+    # Intra-tree drift check: every run must load the same set as run 0.
+    for label, rows in (("BEFORE", before_rows), ("AFTER", after_rows)):
+        baseline = set(rows[0]["loaded"])
+        for i, r in enumerate(rows):
+            if set(r["loaded"]) != baseline:
+                print(
+                    f"!!! {label} run {i} loaded a different plugin set than run 0",
+                    file=sys.stderr,
+                )
+                return 2
+
+    n_loaded = len(before_loaded)
+    print(
+        f"Plugin-load parity: both trees loaded the SAME {n_loaded} plugins "
+        f"on every run\n"
+    )
+
+    bs = stats(before_rows)
+    as_ = stats(after_rows)
+
+    print(f"BEFORE : {fmt(bs)}")
+    print(f"AFTER  : {fmt(as_)}")
+
+    d_mean = as_["mean_ms"] - bs["mean_ms"]
+    d_median = as_["median_ms"] - bs["median_ms"]
+    d_min = as_["min_ms"] - bs["min_ms"]
+
+    print(f"\nDelta mean   : {d_mean:+.1f}ms  ({100 * d_mean / bs['mean_ms']:+.2f}%)")
+    print(
+        f"Delta median : {d_median:+.1f}ms  ({100 * d_median / bs['median_ms']:+.2f}%)"
+    )
+    print(f"Delta min    : {d_min:+.1f}ms  ({100 * d_min / bs['min_ms']:+.2f}%)")
+
+    combined_stdev = (bs["stdev_ms"] ** 2 + as_["stdev_ms"] ** 2) ** 0.5
+    print(f"\nCombined stdev: {combined_stdev:.1f}ms")
+    if abs(d_median) < combined_stdev:
+        print(
+            "VERDICT: |delta| < combined stdev  --> "
+            "delta is INSIDE the noise floor. Do not headline this number."
+        )
+    else:
+        print(
+            "VERDICT: |delta| >= combined stdev  --> "
+            "delta is above the noise floor. Report it with the stddev."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/perf/bench/bench_messaging_only.py
+++ b/perf/bench/bench_messaging_only.py
@@ -1,14 +1,37 @@
-"""Measure the cost of `import code_puppy.messaging` in isolation.
+"""Measure the cost of ``import code_puppy.messaging`` in isolation.
 
 This is the tightest, most honest number: how many modules and how much
-wall time does a plugin pay JUST to bring in the messaging package?
+wall time does a caller pay JUST to bring in the messaging package?
+
+Usage
+-----
+Compare two checkouts (typically ``main`` vs a feature branch)::
+
+    python perf/bench/bench_messaging_only.py \\
+        --before /path/to/checkout-before \\
+        --after  /path/to/checkout-after
+
+Optional flags:
+
+    --runs N       measurement runs per tree (default 7)
+    --warmup N     discarded warmup runs per tree (default 1)
+    --python PATH  Python interpreter to spawn subprocesses with
+                   (default: the interpreter running this script)
+
+The script only reads from the two checkouts; it doesn't modify them,
+doesn't install anything, and doesn't need them to share a venv --
+whatever ``--python`` points at (``sys.executable`` by default) needs
+to be able to import ``code_puppy`` from each of the two trees.
 """
 
+from __future__ import annotations
+
+import argparse
 import json
 import statistics
 import subprocess
-
-VENV = "/Users/t0w0oqh/projects/code_puppy-oss/.venv/bin/python"
+import sys
+from pathlib import Path
 
 SNIPPET = """
 import os, sys, time, json
@@ -25,15 +48,22 @@ print(json.dumps({{'wall_ms': round(dt * 1000, 2), 'new_modules': len(new)}}))
 """
 
 
-def run(repo, n=7):
-    times, mods = [], []
+def run(python: str, repo: str, n: int) -> tuple[list[float], list[int]]:
+    times: list[float] = []
+    mods: list[int] = []
     for _ in range(n):
         r = subprocess.run(
-            [VENV, "-c", SNIPPET.format(repo=repo)],
+            [python, "-c", SNIPPET.format(repo=repo)],
             capture_output=True,
             text=True,
             timeout=60,
         )
+        if r.returncode != 0:
+            print(
+                f"[bench] subprocess failed (repo={repo}): {r.stderr[-300:]}",
+                file=sys.stderr,
+            )
+            continue
         for line in reversed(r.stdout.strip().splitlines()):
             try:
                 d = json.loads(line)
@@ -41,31 +71,89 @@ def run(repo, n=7):
                 mods.append(d["new_modules"])
                 break
             except json.JSONDecodeError:
-                pass
+                continue
     return times, mods
 
 
-MAIN = "/Users/t0w0oqh/projects/code_puppy-oss"
-WORK = "/Users/t0w0oqh/projects/code_puppy-oss/.worktrees/perf-messaging-tools-decouple"
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--before",
+        required=True,
+        type=Path,
+        help="path to the baseline code_puppy checkout",
+    )
+    p.add_argument(
+        "--after",
+        required=True,
+        type=Path,
+        help="path to the candidate code_puppy checkout",
+    )
+    p.add_argument("--runs", type=int, default=7, help="measurement runs per tree")
+    p.add_argument(
+        "--warmup", type=int, default=1, help="warmup runs per tree (discarded)"
+    )
+    p.add_argument(
+        "--python",
+        default=sys.executable,
+        help="Python interpreter used to spawn subprocesses (default: sys.executable)",
+    )
+    args = p.parse_args()
 
-# discard warmup
-run(MAIN, n=1)
-run(WORK, n=1)
-mt, mm = run(MAIN, n=7)
-wt, wm = run(WORK, n=7)
+    before = args.before.resolve()
+    after = args.after.resolve()
+    for label, path in (("--before", before), ("--after", after)):
+        if not (path / "code_puppy").is_dir():
+            print(
+                f"[bench] {label}: {path} does not look like a code_puppy checkout "
+                "(no code_puppy/ subdir)",
+                file=sys.stderr,
+            )
+            return 2
 
-print("import code_puppy.messaging  (7 fresh subprocesses each)\n")
-print(f"{'':<10} {'wall (mean)':>14} {'wall (min)':>14} {'new_modules':>14}")
-print("-" * 55)
-print(
-    f"{'MAIN':<10} {statistics.mean(mt):>12.1f}ms {min(mt):>12.1f}ms {statistics.mean(mm):>12.0f}"
-)
-print(
-    f"{'WORKTREE':<10} {statistics.mean(wt):>12.1f}ms {min(wt):>12.1f}ms {statistics.mean(wm):>12.0f}"
-)
-print(
-    f"\nDelta wall (mean): {statistics.mean(wt) - statistics.mean(mt):+.1f}ms  ({100 * (statistics.mean(wt) / statistics.mean(mt) - 1):+.1f}%)"
-)
-print(
-    f"Delta modules:     {statistics.mean(wm) - statistics.mean(mm):+.0f}  ({100 * (statistics.mean(wm) / statistics.mean(mm) - 1):+.1f}%)"
-)
+    print(f"[bench] python:  {args.python}")
+    print(f"[bench] before:  {before}")
+    print(f"[bench] after:   {after}")
+    print(f"[bench] runs={args.runs}, warmup={args.warmup}\n")
+
+    # discard warmup
+    run(args.python, str(before), n=args.warmup)
+    run(args.python, str(after), n=args.warmup)
+
+    bt, bm = run(args.python, str(before), n=args.runs)
+    at, am = run(args.python, str(after), n=args.runs)
+
+    if len(bt) < 1 or len(at) < 1:
+        print(
+            f"[bench] insufficient samples (before={len(bt)}, after={len(at)})",
+            file=sys.stderr,
+        )
+        return 3
+
+    print(f"import code_puppy.messaging  ({args.runs} fresh subprocesses each)\n")
+    print(f"{'':<10} {'wall (mean)':>14} {'wall (min)':>14} {'new_modules':>14}")
+    print("-" * 55)
+    print(
+        f"{'BEFORE':<10} {statistics.mean(bt):>12.1f}ms "
+        f"{min(bt):>12.1f}ms {statistics.mean(bm):>12.0f}"
+    )
+    print(
+        f"{'AFTER':<10} {statistics.mean(at):>12.1f}ms "
+        f"{min(at):>12.1f}ms {statistics.mean(am):>12.0f}"
+    )
+
+    d_wall = statistics.mean(at) - statistics.mean(bt)
+    d_mods = statistics.mean(am) - statistics.mean(bm)
+    print(
+        f"\nDelta wall (mean): {d_wall:+.1f}ms  "
+        f"({100 * (statistics.mean(at) / statistics.mean(bt) - 1):+.1f}%)"
+    )
+    print(
+        f"Delta modules:     {d_mods:+.0f}  "
+        f"({100 * (statistics.mean(am) / statistics.mean(bm) - 1):+.1f}%)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/perf/bench/bench_messaging_only.py
+++ b/perf/bench/bench_messaging_only.py
@@ -1,0 +1,71 @@
+"""Measure the cost of `import code_puppy.messaging` in isolation.
+
+This is the tightest, most honest number: how many modules and how much
+wall time does a plugin pay JUST to bring in the messaging package?
+"""
+
+import json
+import statistics
+import subprocess
+
+VENV = "/Users/t0w0oqh/projects/code_puppy-oss/.venv/bin/python"
+
+SNIPPET = """
+import os, sys, time, json
+os.environ['NO_VERSION_UPDATE'] = '1'
+sys.path.insert(0, {repo!r})
+sys.stdout = open(os.devnull, 'w')
+before = set(sys.modules)
+t0 = time.perf_counter()
+import code_puppy.messaging  # noqa
+dt = time.perf_counter() - t0
+new = set(sys.modules) - before
+sys.stdout = sys.__stdout__
+print(json.dumps({{'wall_ms': round(dt * 1000, 2), 'new_modules': len(new)}}))
+"""
+
+
+def run(repo, n=7):
+    times, mods = [], []
+    for _ in range(n):
+        r = subprocess.run(
+            [VENV, "-c", SNIPPET.format(repo=repo)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        for line in reversed(r.stdout.strip().splitlines()):
+            try:
+                d = json.loads(line)
+                times.append(d["wall_ms"])
+                mods.append(d["new_modules"])
+                break
+            except json.JSONDecodeError:
+                pass
+    return times, mods
+
+
+MAIN = "/Users/t0w0oqh/projects/code_puppy-oss"
+WORK = "/Users/t0w0oqh/projects/code_puppy-oss/.worktrees/perf-messaging-tools-decouple"
+
+# discard warmup
+run(MAIN, n=1)
+run(WORK, n=1)
+mt, mm = run(MAIN, n=7)
+wt, wm = run(WORK, n=7)
+
+print("import code_puppy.messaging  (7 fresh subprocesses each)\n")
+print(f"{'':<10} {'wall (mean)':>14} {'wall (min)':>14} {'new_modules':>14}")
+print("-" * 55)
+print(
+    f"{'MAIN':<10} {statistics.mean(mt):>12.1f}ms {min(mt):>12.1f}ms {statistics.mean(mm):>12.0f}"
+)
+print(
+    f"{'WORKTREE':<10} {statistics.mean(wt):>12.1f}ms {min(wt):>12.1f}ms {statistics.mean(wm):>12.0f}"
+)
+print(
+    f"\nDelta wall (mean): {statistics.mean(wt) - statistics.mean(mt):+.1f}ms  ({100 * (statistics.mean(wt) / statistics.mean(mt) - 1):+.1f}%)"
+)
+print(
+    f"Delta modules:     {statistics.mean(wm) - statistics.mean(mm):+.0f}  ({100 * (statistics.mean(wm) / statistics.mean(mm) - 1):+.1f}%)"
+)

--- a/tests/messaging/spinner/test_spinner_shim.py
+++ b/tests/messaging/spinner/test_spinner_shim.py
@@ -90,7 +90,7 @@ def test_update_spinner_context_dropped_for_subagents(monkeypatch):
     bar = bottom_bar_mod.BottomBar(stream=tty, get_size=lambda: (80, 24))
     bottom_bar_mod.reset_bottom_bar()
     bottom_bar_mod._bottom_bar = bar
-    monkeypatch.setattr("code_puppy.tools.subagent_context.is_subagent", lambda: True)
+    monkeypatch.setattr("code_puppy.subagent_context.is_subagent", lambda: True)
     try:
         bar.start()
         bar.set_status("main agent context")

--- a/tests/messaging/test_medium_mode_audit.py
+++ b/tests/messaging/test_medium_mode_audit.py
@@ -601,10 +601,10 @@ class TestChecklist7_NoNewOutput:
         from code_puppy.messaging.spinner import pause_all_spinners, resume_all_spinners
 
         # The spinner imports is_subagent lazily from subagent_context,
-        # so we patch at the source module.
+        # so we patch at the source (canonical) module.
         with (
             patch(
-                "code_puppy.tools.subagent_context.is_subagent",
+                "code_puppy.subagent_context.is_subagent",
                 return_value=True,
             ),
             patch(

--- a/tests/test_rich_renderer.py
+++ b/tests/test_rich_renderer.py
@@ -1,9 +1,6 @@
 """Tests for the rich console renderer."""
 
-import sys
-import types
 from io import StringIO
-from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
@@ -14,25 +11,26 @@ from rich.panel import Panel
 from rich.rule import Rule
 from rich.text import Text
 
-ROOT = Path(__file__).resolve().parents[1]
-MESSAGING_PATH = ROOT / "code_puppy" / "messaging"
-TOOLS_PATH = ROOT / "code_puppy" / "tools"
+# NOTE: This file previously stubbed ``code_puppy.messaging``,
+# ``code_puppy.tools`` and ``code_puppy.tools.common`` via
+# ``sys.modules.setdefault`` to keep the tools import chain out of the
+# renderer's module load. That was already load-order-dependent — it
+# only worked because ``rich_renderer`` used to eagerly import
+# ``code_puppy.tools.common.format_diff_with_colors`` at module scope,
+# so the real ``code_puppy.tools`` package (and its transitively-loaded
+# submodules) was already in ``sys.modules`` before this file ran.
+#
+# ``rich_renderer`` now defers that import to the ``_render_diff`` call
+# site (see the module-level note in ``rich_renderer.py``). With the
+# eager import gone, the leftover stubs would shadow the real
+# ``code_puppy.tools.common`` and any subsequent access (e.g. through
+# ``azure_foundry``’s conftest hook loading ``command_runner``) would
+# hit the stub instead. The stubs are therefore removed — the real
+# modules are cheap enough for a single test file and correctness now
+# doesn't depend on import ordering.
 
-messaging_pkg = types.ModuleType("code_puppy.messaging")
-messaging_pkg.__path__ = [str(MESSAGING_PATH)]
-sys.modules.setdefault("code_puppy.messaging", messaging_pkg)
-
-tools_pkg = types.ModuleType("code_puppy.tools")
-tools_pkg.__path__ = [str(TOOLS_PATH)]
-sys.modules.setdefault("code_puppy.tools", tools_pkg)
-
-common_stub = types.ModuleType("code_puppy.tools.common")
-common_stub.format_diff_with_colors = lambda diff_text: diff_text
-sys.modules.setdefault("code_puppy.tools.common", common_stub)
-
-from code_puppy.messaging import rich_renderer as rich_renderer_module  # noqa: E402
-from code_puppy.messaging.bus import MessageBus  # noqa: E402
-from code_puppy.messaging.messages import (  # noqa: E402
+from code_puppy.messaging.bus import MessageBus
+from code_puppy.messaging.messages import (
     AgentReasoningMessage,
     ConfirmationRequest,
     DiffLine,
@@ -123,8 +121,14 @@ def test_render_diff_uses_formatter(monkeypatch: pytest.MonkeyPatch) -> None:
     renderer, console = _make_renderer()
     renderer._get_banner_color = Mock(return_value="blue")
 
+    # ``format_diff_with_colors`` is imported inside ``_render_diff`` (lazy)
+    # to keep ``code_puppy.messaging`` off the ``code_puppy.tools`` import
+    # path. Patch it at its canonical location so the deferred ``from ...
+    # import`` picks up the mock.
+    import code_puppy.tools.common as tools_common
+
     monkeypatch.setattr(
-        rich_renderer_module,
+        tools_common,
         "format_diff_with_colors",
         lambda diff_text: f"FORMATTED:{diff_text}",
     )

--- a/tests/tools/test_subagent_context.py
+++ b/tests/tools/test_subagent_context.py
@@ -32,20 +32,42 @@ class TestShimReExport:
     strings baked into other codebases rely on the shim resolving to
     the *same* objects as the canonical module."""
 
-    def test_public_api_object_identity(self) -> None:
-        from code_puppy import subagent_context as canonical
-        from code_puppy.tools import subagent_context as shim
-
-        for name in (
+    @pytest.mark.parametrize(
+        "name",
+        [
             "subagent_context",
             "is_subagent",
             "get_subagent_name",
             "get_subagent_chain",
             "get_subagent_depth",
             "get_subagent_model_name",
+        ],
+    )
+    def test_shim_symbol_is_canonical(self, name: str) -> None:
+        from code_puppy import subagent_context as canonical
+        from code_puppy.tools import subagent_context as shim
+
+        assert getattr(shim, name) is getattr(canonical, name), (
+            f"shim '{name}' must be the same object as canonical "
+            f"(monkeypatch strings baked into external callers depend "
+            f"on this)"
+        )
+
+    def test_shim_does_not_re_export_private_names(self) -> None:
+        """Private ContextVars are intentionally NOT proxied — documented
+        in the shim docstring. Assert the contract holds so a well-meaning
+        ‘clean-up’ doesn't quietly start re-exporting them."""
+        from code_puppy.tools import subagent_context as shim
+
+        for private in (
+            "_subagent_depth",
+            "_subagent_name",
+            "_subagent_chain",
+            "_subagent_model_name",
         ):
-            assert getattr(shim, name) is getattr(canonical, name), (
-                f"shim '{name}' must be the same object as canonical"
+            assert not hasattr(shim, private), (
+                f"shim should not expose private '{private}'; "
+                f"reach into code_puppy.subagent_context directly"
             )
 
 

--- a/tests/tools/test_subagent_context.py
+++ b/tests/tools/test_subagent_context.py
@@ -1,31 +1,52 @@
-"""Tests for code_puppy.tools.subagent_context.
+"""Tests for :mod:`code_puppy.subagent_context`.
 
 This module tests the sub-agent context management functionality including
 ContextVar state tracking, context manager behavior, and async isolation.
+
+Historically these tests loaded ``code_puppy/tools/subagent_context.py`` via
+``importlib.util.spec_from_file_location`` to sidestep the tools-package
+import chain. That file is now a re-export shim onto
+:mod:`code_puppy.subagent_context`, so loading it off-disk would just wrap
+the canonical module in an extra namespace and pretend to give isolation
+that doesn't actually exist (state is shared via the shared ContextVar
+objects). Import directly from the canonical module instead — that's the
+real contract we ship.
 """
 
 import asyncio
-import importlib.util
-from pathlib import Path
 
 import pytest
 
-# Import directly from the module file
-spec = importlib.util.spec_from_file_location(
-    "subagent_context_module",
-    Path(__file__).parent.parent.parent
-    / "code_puppy"
-    / "tools"
-    / "subagent_context.py",
+from code_puppy.subagent_context import (
+    get_subagent_chain,
+    get_subagent_depth,
+    get_subagent_name,
+    is_subagent,
+    subagent_context,
 )
-subagent_context_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(subagent_context_module)
 
-subagent_context = subagent_context_module.subagent_context
-is_subagent = subagent_context_module.is_subagent
-get_subagent_name = subagent_context_module.get_subagent_name
-get_subagent_depth = subagent_context_module.get_subagent_depth
-get_subagent_chain = subagent_context_module.get_subagent_chain
+
+class TestShimReExport:
+    """The old ``code_puppy.tools.subagent_context`` path must remain
+    a fully-transparent re-export — external callers and monkeypatch
+    strings baked into other codebases rely on the shim resolving to
+    the *same* objects as the canonical module."""
+
+    def test_public_api_object_identity(self) -> None:
+        from code_puppy import subagent_context as canonical
+        from code_puppy.tools import subagent_context as shim
+
+        for name in (
+            "subagent_context",
+            "is_subagent",
+            "get_subagent_name",
+            "get_subagent_chain",
+            "get_subagent_depth",
+            "get_subagent_model_name",
+        ):
+            assert getattr(shim, name) is getattr(canonical, name), (
+                f"shim '{name}' must be the same object as canonical"
+            )
 
 
 class TestSubagentChain:


### PR DESCRIPTION
## Why

Before this PR, the first plugin to import from `code_puppy.messaging` dragged in ~625 modules (`pydantic_ai`, `playwright`, `prompt_toolkit`, `rich`, `httpx`, ...) because `messaging.rich_renderer` imported two symbols from `code_puppy.tools` at module scope, which forced `code_puppy/tools/__init__.py` to execute the full static tool registry (`browser`→playwright, `image_tools`→PIL, `agent_tools`→rapidfuzz, and dozens more). Subsequent plugins got those modules for free from `sys.modules`, so the marginal cost per additional plugin was ~0 — but the messaging-touching plugin that lost the race paid the full 625.

## What

This change breaks the coupling without touching the tools registry:

1. **Move `subagent_context` out of `code_puppy.tools/`** to `code_puppy/`, since it's pure `contextvars` bookkeeping with zero tool dependencies.
2. **Leave a re-export shim at the old path** so existing external plugins and monkeypatch-based tests keep working. Only the public `__all__` is proxied — private ContextVar objects intentionally aren't.
3. **Update the module-scope import triggers** in `messaging/rich_renderer`, `messaging/spinner`, `agents/event_stream_handler`, `agents/run_stats`, and the two `plugins/` callers to point at the new canonical location.
4. **Defer the one remaining `tools.common` symbol** (`format_diff_with_colors`) to the `_render_diff` call site — it's only used inside a single post-tool-call render path.

The tools registry itself is unchanged — this is a *decoupling*, not a lazy-import refactor of the registry. Follow-up work can lazy-load individual tools.

## Measured impact — honest, with methodology

### The reproducible win: `import code_puppy.messaging` in isolation

This is the cost a caller pays *just to bring in the messaging package*. This is what actually changed.

| | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Wall time (mean of 7 fresh subprocesses) | 386ms | 147ms | **−239ms (−62%)** |
| New modules loaded | 1017 | 392 | **−625 (−61%)** |

Reproducible across repeat runs, both trees, same venv, same Python (`cpython-3.13.5-macos-aarch64`). Bench script: `/tmp/bench_messaging_only.py`.

### The non-win: full 51-plugin single-process cold-start

Re-ran with 3 warmup runs + 15 measurement runs per repo (`/tmp/bench_realistic_v2.py`) and asserted plugin-load parity (both trees loaded the same 51 plugins on every run):

| | Median | Stdev | Min | Max |
| --- | ---: | ---: | ---: | ---: |
| MAIN | 1271.5ms | 10.9ms | 1259.5ms | 1290.0ms |
| WORKTREE | 1269.6ms | 11.9ms | 1259.6ms | 1309.5ms |

**Delta median: −1.9ms (−0.15%). Combined stdev: 16.1ms. Verdict: INSIDE the noise floor.**

An earlier revision of this PR body claimed a **−183ms / −12.4%** full-cold-start win. That number was **cache-warmth artifact** from an under-warmed benchmark and has been retracted. The PR narrative already predicted this outcome ("tool-heavy plugins pull the graph anyway") — I just failed to notice the headline number contradicted the narrative until an adversarial review re-ran the bench.

**So who does this PR help?** Any caller that touches `code_puppy.messaging` without going through the full plugin-discovery path: individual plugins that never invoke a tool, subprocess helpers, tests, downstream ports of the messaging package. It also makes cold-start module ordering less dependent on eager-load side effects — the failure mode that used to hide a test-isolation bug in `tests/test_rich_renderer.py` (see below) can no longer happen.

Also removed the previous "**−10,252 modules (−38%)** summed across per-subprocess plugin measurements" framing — that number double-counted modules that would be shared via `sys.modules` in a real single-process launch. Not defensible.

## Backward compatibility

- `code_puppy.tools.subagent_context` still resolves — it now re-exports from `code_puppy.subagent_context`. **Same object identity** across both paths, verified by a parametrised `TestShimReExport` (six tests, one per public symbol).
- Only the public `__all__` symbols are re-exported. The private `_subagent_depth` / `_subagent_name` / `_subagent_chain` / `_subagent_model_name` ContextVar objects are intentionally **not** proxied. Documented in the shim's docstring and locked by `test_shim_does_not_re_export_private_names`.
- External plugins that do `from code_puppy.tools.subagent_context import is_subagent` keep working; new code should prefer `from code_puppy.subagent_context import is_subagent`.
- Plugin trust hashes are unaffected — this PR touches only `code_puppy/*` core, no user- or project-scoped plugin dirs.

## Test bookkeeping

- **`tests/test_rich_renderer.py`** previously stubbed `code_puppy.tools.common` via `sys.modules.setdefault`. That stubbing only worked by accident on `main` because `rich_renderer`'s own eager import of `tools.common` ran first and populated the real module. With the eager import gone, the incomplete stub would shadow the real module. Removed the stubs and added a module-level explanatory comment.
- **`tests/messaging/spinner/test_spinner_shim.py`** and **`tests/messaging/test_medium_mode_audit.py`** point their `monkeypatch`/`patch` calls at the new canonical `is_subagent` location. Both call sites use function-scope `from ... import`, so they pick up the mock.
- **`tests/tools/test_subagent_context.py`** used `importlib.util.spec_from_file_location` to load the tools/-side file off-disk for per-test isolation. With that file now being a re-export shim, the pattern just wrapped the canonical module in an extra namespace and pretended to give isolation that no longer exists. Rewrote to import from the canonical module directly, and added a `TestShimReExport` class (six parametrised identity tests + one private-names contract test).

## Test results

Same test-file set on both trees:

| | MAIN | WORKTREE | Delta |
| --- | ---: | ---: | ---: |
| Collected | 2036 | 2043 | **+7** |
| Passing | 2036 | 2043 | **+7** |

The +7 breaks down as: 6 parametrised `TestShimReExport.test_shim_symbol_is_canonical` tests + 1 `test_shim_does_not_re_export_private_names`. A previous version of this PR body claimed "+21 from parametrisation across six symbols" — that number was wrong (came from comparing different test-file sets across runs) and has been corrected.

## Files touched

- **New:** `code_puppy/subagent_context.py` (real implementation, moved from `code_puppy/tools/`)
- **Modified:** `code_puppy/tools/subagent_context.py` (now a re-export compat shim)
- **Modified:** `code_puppy/messaging/rich_renderer.py` (swap import path, defer `format_diff_with_colors`)
- **Modified:** `code_puppy/messaging/spinner/__init__.py` (swap import path, remove defensive-import theatre)
- **Modified:** `code_puppy/agents/event_stream_handler.py` (swap import path)
- **Modified:** `code_puppy/agents/run_stats.py` (swap import path)
- **Modified:** `code_puppy/plugins/wiggum/judge.py` (swap import path)
- **Modified:** `code_puppy/plugins/subagent_panel/register_callbacks.py` (swap import path)
- **Modified:** `tests/test_rich_renderer.py` (drop obsolete `sys.modules.setdefault` stubs)
- **Modified:** `tests/messaging/spinner/test_spinner_shim.py` (patch new canonical path)
- **Modified:** `tests/messaging/test_medium_mode_audit.py` (patch new canonical path)
- **Modified:** `tests/tools/test_subagent_context.py` (import canonical + parametrised shim-identity + private-names contract)

## Follow-ups (not this PR)

- Reproducibility: the two bench scripts used for the numbers above are now committed at `perf/bench/`.
- Lazy-load individual tools in `code_puppy/tools/__init__.py` — the tools registry itself is still an eager-load monolith. That's the next big-win piece; it's larger scope and higher risk than this PR, hence separate.
- Async version check (see the scoping report).
