### PR TITLE
Add native macOS computer use plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,67 @@ on:
       - '**'
 
 jobs:
+  computer-use-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install Computer Use extra
+        run: uv sync --extra computer-use
+
+      - name: Verify Swift toolchain
+        run: swiftc --version
+
+      - name: Compile native capture helper
+        run: |
+          swiftc \
+            -parse-as-library \
+            -framework AppKit \
+            -framework ScreenCaptureKit \
+            code_puppy/plugins/computer_use/NativeCapture.swift \
+            -o "$RUNNER_TEMP/code-puppy-native-capture"
+          "$RUNNER_TEMP/code-puppy-native-capture" --help || test $? -eq 2
+
+      - name: Run Computer Use tests
+        run: uv run pytest tests/plugins/test_computer_use_*.py -q --no-cov
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Verify Computer Use is packaged
+        run: |
+          python - <<'PY'
+          import glob
+          import tarfile
+          import zipfile
+
+          wheel = glob.glob("dist/*.whl")[0]
+          sdist = glob.glob("dist/*.tar.gz")[0]
+          required = {
+              "code_puppy/plugins/computer_use/NativeCapture.swift",
+              "code_puppy/plugins/computer_use/README.md",
+          }
+          with zipfile.ZipFile(wheel) as archive:
+              wheel_names = set(archive.namelist())
+          with tarfile.open(sdist) as archive:
+              sdist_names = {
+                  "/".join(name.split("/")[1:])
+                  for name in archive.getnames()
+                  if "/" in name
+              }
+          assert required <= wheel_names, required - wheel_names
+          assert required <= sdist_names, required - sdist_names
+          PY
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/code_puppy/plugins/computer_use/NativeCapture.swift
+++ b/code_puppy/plugins/computer_use/NativeCapture.swift
@@ -1,0 +1,123 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import ScreenCaptureKit
+
+enum CaptureFailure: LocalizedError {
+    case message(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .message(let text): return text
+        }
+    }
+}
+@main
+struct NativeCapture {
+    static func scale(for frame: CGRect) -> CGFloat {
+        let midpoint = CGPoint(x: frame.midX, y: frame.midY)
+        for screen in NSScreen.screens {
+            guard
+                let number = screen.deviceDescription[
+                    NSDeviceDescriptionKey("NSScreenNumber")
+                ] as? NSNumber
+            else { continue }
+            let bounds = CGDisplayBounds(CGDirectDisplayID(number.uint32Value))
+            if bounds.contains(midpoint) {
+                return screen.backingScaleFactor
+            }
+        }
+        return NSScreen.main?.backingScaleFactor ?? 1
+    }
+
+    static func matchingApplication(_ query: String) throws -> NSRunningApplication {
+        let wanted = query.lowercased()
+        guard let app = NSWorkspace.shared.runningApplications.first(where: {
+            ($0.localizedName ?? "").lowercased() == wanted
+                || ($0.bundleIdentifier ?? "").lowercased() == wanted
+        }) else {
+            throw CaptureFailure.message("Running application not found: \(query)")
+        }
+        return app
+    }
+
+    static func run(appName: String, outputPath: String) async throws -> [String: Any] {
+        let app = try matchingApplication(appName)
+        let content = try await SCShareableContent.excludingDesktopWindows(
+            false,
+            onScreenWindowsOnly: false
+        )
+        let candidates = content.windows.filter {
+            guard $0.owningApplication?.processID == app.processIdentifier else {
+                return false
+            }
+            return $0.frame.width >= 200 && $0.frame.height >= 120
+        }
+        guard let window = candidates.max(by: {
+            $0.frame.width * $0.frame.height < $1.frame.width * $1.frame.height
+        }) else {
+            throw CaptureFailure.message("No capturable window found for \(appName).")
+        }
+
+        let scale = scale(for: window.frame)
+        let configuration = SCStreamConfiguration()
+        configuration.width = max(1, Int((window.frame.width * scale).rounded()))
+        configuration.height = max(1, Int((window.frame.height * scale).rounded()))
+        configuration.showsCursor = false
+        configuration.scalesToFit = false
+        let filter = SCContentFilter(desktopIndependentWindow: window)
+        let image = try await SCScreenshotManager.captureImage(
+            contentFilter: filter,
+            configuration: configuration
+        )
+        let representation = NSBitmapImageRep(cgImage: image)
+        guard let data = representation.representation(
+            using: .png,
+            properties: [:]
+        ) else {
+            throw CaptureFailure.message("Could not encode screenshot as PNG.")
+        }
+        try data.write(to: URL(fileURLWithPath: outputPath), options: .atomic)
+
+        return [
+            "application": app.localizedName ?? appName,
+            "bundle_id": app.bundleIdentifier ?? "",
+            "pid": Int(app.processIdentifier),
+            "window_id": Int(window.windowID),
+            "window_title": window.title ?? "",
+            "backing_scale": Double(scale),
+            "window_bounds_points": [
+                "x": Double(window.frame.origin.x),
+                "y": Double(window.frame.origin.y),
+                "width": Double(window.frame.width),
+                "height": Double(window.frame.height),
+            ],
+            "screenshot_size_pixels": [
+                "width": configuration.width,
+                "height": configuration.height,
+            ],
+        ]
+    }
+
+    static func main() async {
+        guard CommandLine.arguments.count == 3 else {
+            FileHandle.standardError.write(
+                Data("usage: native-capture APP OUTPUT.png\n".utf8)
+            )
+            exit(2)
+        }
+        do {
+            let payload = try await run(
+                appName: CommandLine.arguments[1],
+                outputPath: CommandLine.arguments[2]
+            )
+            let data = try JSONSerialization.data(withJSONObject: payload)
+            FileHandle.standardOutput.write(data)
+        } catch {
+            FileHandle.standardError.write(
+                Data("\(error.localizedDescription)\n".utf8)
+            )
+            exit(1)
+        }
+    }
+}

--- a/code_puppy/plugins/computer_use/README.md
+++ b/code_puppy/plugins/computer_use/README.md
@@ -1,0 +1,108 @@
+# macOS Computer Use
+
+This opt-in plugin lets Code Puppy inspect and operate the current macOS desktop
+through Apple's Accessibility APIs. It is macOS-only and does not use a virtual
+machine or copy any Codex implementation.
+
+## Install
+
+```bash
+pip install "code-puppy[computer-use]"
+```
+
+On first use, macOS requests permissions for the terminal or application that
+runs Code Puppy:
+
+1. **Accessibility** for inspecting and operating controls.
+2. **Screen Recording** for screenshots.
+
+Grant these under **System Settings → Privacy & Security**. Restart Code Puppy
+after changing Screen Recording access.
+
+On first use, Computer Use fails closed and asks you to choose whether to
+enable it. The choice is stored in the normal Code Puppy settings directory:
+
+```text
+/computer-use enable
+/computer-use disable
+/computer-use status
+```
+
+You can change this setting at any time. Once enabled, Computer Use runs
+without per-application approval prompts or an allowlist.
+
+Use `/computer-use pause` as an emergency stop and `/computer-use resume` only
+after confirming it is safe. `/computer-use deny BUNDLE_ID` persists an
+exception, and `/computer-use allow BUNDLE_ID` removes that exception. Login,
+authorization, Keychain, and System Settings processes are always blocked.
+
+Snapshots, explicit screenshots, and successful batches display a compact
+inline preview in Ghostty, Kitty, WezTerm, and iTerm2. The same PNG is attached
+to the tool result so multimodal models can inspect it directly. App-targeted
+snapshots capture that application's largest standard window even when another
+application is in front.
+
+## Agent workflow
+
+1. Call `computer_get_app_state` with an application name.
+2. Use its screenshot, pruned focused-window accessibility tree, and
+   `state_revision` to choose an action. Prefer an element ID and one of the
+   element's advertised actions.
+3. Run one mutation, or one guarded batch of at most 20 mutations.
+4. Fetch fresh state. A completed batch does this automatically after waiting
+   for the accessibility tree to stabilize.
+
+Before every mutation, the target process is activated and verified as the
+frontmost application. This is required because ScreenCaptureKit can capture a
+background window, while Quartz sends global clicks and keystrokes to whichever
+application is actually frontmost. Use a guarded batch for click-then-type
+workflows so focus is retained and the result is verified in one control loop.
+
+Pixel clicks and drags use window-local screenshot pixels. The backend converts
+them to global Quartz points using the captured window bounds, so Retina scaling,
+negative display origins, and windows on secondary displays remain consistent.
+Scrolling accepts `up`, `down`, `left`, or `right` and a fractional page count.
+Text selection supports an exact match, optional prefix/suffix disambiguation,
+and cursor placement before or after the match.
+
+## Safety
+
+- Prefer accessibility element IDs over pixel coordinates.
+- First use requires persisted user consent; disabling the feature immediately
+  blocks future captures and actions.
+- State revisions and element IDs are single-use and expire after 120 seconds.
+- Physical keyboard and pointer input do not interrupt YOLO-mode execution.
+- Every capture and mutation re-checks the application policy; the emergency
+  stop therefore also interrupts a batch at its next action boundary.
+- Password-field values are never returned in snapshots.
+- Batches stop at the first failed action, contain at most 20 steps, wait for
+  deterministic UI stability, and return updated screenshot/tree state.
+- The plugin does not pause for consequential-action confirmations in YOLO
+  mode. Use `/computer-use pause` when autonomous interaction should stop.
+
+## Native capture and privacy
+
+Application screenshots use ScreenCaptureKit through the bundled Swift helper.
+The helper is compiled locally, cached with a source hash, and returns stable
+window metadata: bundle ID, PID, window ID/title, bounds, pixel dimensions, and
+backing scale. Screenshot PNGs are temporary local files. This plugin does not
+add telemetry, persistent action history, lock-screen automation, or privileged
+system interaction.
+
+The first native capture requires Xcode Command Line Tools because the bundled
+helper is compiled on the Mac:
+
+```bash
+xcode-select --install
+```
+
+## Test
+
+```bash
+uv run ruff check code_puppy/plugins/computer_use tests/plugins
+uv run pytest tests/plugins/test_computer_use_*.py -q --no-cov
+```
+
+For a live Ghostty smoke test, launch Code Puppy from Ghostty and ask for
+`computer_get_app_state`. A compact image should appear inline; the tool result
+still carries the PNG if the terminal protocol is unavailable.

--- a/code_puppy/plugins/computer_use/__init__.py
+++ b/code_puppy/plugins/computer_use/__init__.py
@@ -1,0 +1,1 @@
+"""Opt-in macOS computer-use tools."""

--- a/code_puppy/plugins/computer_use/accessibility.py
+++ b/code_puppy/plugins/computer_use/accessibility.py
@@ -1,0 +1,163 @@
+"""Focused-window accessibility extraction with relevance pruning."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Callable
+
+MAX_SCAN_NODES = 4_000
+# Electron embeds its web accessibility tree beneath a deep stack of generic
+# groups; Spotify's search field, for example, sits beyond depth 16.
+MAX_DEPTH = 32
+
+_ROLE_SCORE = {
+    "AXButton": 80,
+    "AXCheckBox": 75,
+    "AXComboBox": 75,
+    "AXMenuItem": 75,
+    "AXPopUpButton": 75,
+    "AXRadioButton": 75,
+    "AXSearchField": 75,
+    "AXSlider": 70,
+    "AXTextArea": 70,
+    "AXTextField": 70,
+    "AXLink": 65,
+    "AXRow": 25,
+    "AXCell": 20,
+    "AXStaticText": 15,
+    "AXWindow": 10,
+}
+
+
+def _copy_actions(api: Any, element: Any) -> list[str]:
+    result = api.AXUIElementCopyActionNames(element, None)
+    if isinstance(result, tuple):
+        error, value = result
+        if error != api.kAXErrorSuccess or not value:
+            return []
+        return [str(item) for item in value]
+    return [str(item) for item in (result or [])]
+
+
+def _focused_root(
+    api: Any,
+    application: Any,
+    copy_attribute: Callable,
+    preferred_window_id: int | None = None,
+):
+    if preferred_window_id is not None:
+        windows = copy_attribute(api, application, api.kAXWindowsAttribute)
+        for window in windows or []:
+            number = copy_attribute(api, window, "AXWindowNumber")
+            if number is not None and int(number) == preferred_window_id:
+                return window
+    for attribute in (
+        api.kAXFocusedWindowAttribute,
+        api.kAXMainWindowAttribute,
+    ):
+        window = copy_attribute(api, application, attribute)
+        if window is not None:
+            return window
+    windows = copy_attribute(api, application, api.kAXWindowsAttribute)
+    if windows:
+        return windows[0]
+    return application
+
+
+def snapshot_tree(
+    api: Any,
+    application: Any,
+    copy_attribute: Callable,
+    max_nodes: int,
+    preferred_window_id: int | None = None,
+) -> tuple[list[dict[str, Any]], dict[int, Any], dict[str, Any]]:
+    """Scan broadly, then retain controls most useful for agent interaction."""
+    root = _focused_root(
+        api,
+        application,
+        copy_attribute,
+        preferred_window_id,
+    )
+    limit = max(1, min(int(max_nodes), 500))
+    scan_limit = min(MAX_SCAN_NODES, max(1_000, limit * 8))
+    candidates: list[tuple[int, int, Any, dict[str, Any]]] = []
+    seen: set[int] = set()
+    scan_stopped = False
+
+    def visit(element: Any, depth: int) -> None:
+        nonlocal scan_stopped
+        if depth > MAX_DEPTH or scan_stopped:
+            return
+        identity = id(element)
+        if identity in seen:
+            return
+        seen.add(identity)
+        if len(candidates) >= scan_limit:
+            scan_stopped = True
+            return
+
+        role = str(copy_attribute(api, element, api.kAXRoleAttribute) or "AXUnknown")
+        title = str(copy_attribute(api, element, api.kAXTitleAttribute) or "")
+        description = str(
+            copy_attribute(api, element, api.kAXDescriptionAttribute) or ""
+        )
+        value = copy_attribute(api, element, api.kAXValueAttribute)
+        enabled = copy_attribute(api, element, api.kAXEnabledAttribute)
+        focused = copy_attribute(api, element, api.kAXFocusedAttribute)
+        actions = _copy_actions(api, element)
+        order = len(candidates)
+        node = {
+            "depth": depth,
+            "source_order": order,
+            "role": role,
+            "title": title,
+            "description": description,
+            "enabled": bool(enabled) if enabled is not None else None,
+            "focused": bool(focused) if focused is not None else None,
+            "actions": actions,
+        }
+        if value is not None and "secure" not in role.casefold():
+            node["value"] = str(value)[:500]
+
+        score = _ROLE_SCORE.get(role, 0)
+        score += 60 if actions else 0
+        score += 100 if focused else 0
+        score += 12 if title or description else 0
+        semantic_text = " ".join((title, description, str(value or ""))).casefold()
+        if (
+            "now playing:" in semantic_text
+            or "what do you want to play?" in semantic_text
+            or description.casefold() in {"play", "pause"}
+        ):
+            score += 120
+        score -= 50 if enabled is False else 0
+        score -= min(depth, 10)
+        candidates.append((score, order, element, node))
+
+        children = copy_attribute(api, element, api.kAXChildrenAttribute)
+        for child in children or []:
+            visit(child, depth + 1)
+
+    visit(root, 0)
+    ranked = sorted(candidates, key=lambda item: (-item[0], item[1]))
+    selected = ranked[:limit]
+    nodes = []
+    elements = {}
+    for element_id, (_, _, element, node) in enumerate(selected, start=1):
+        node["id"] = element_id
+        nodes.append(node)
+        elements[element_id] = element
+
+    excluded = ranked[limit:]
+    overflow_roles = Counter(item[3]["role"] for item in excluded)
+    metadata = {
+        "scanned_node_count": len(candidates),
+        "returned_node_count": len(nodes),
+        "truncated": bool(excluded or scan_stopped),
+        "scan_limit_reached": scan_stopped,
+        "overflow_summary": {
+            "excluded_node_count": len(excluded),
+            "roles": dict(overflow_roles.most_common(12)),
+        },
+    }
+    return nodes, elements, metadata

--- a/code_puppy/plugins/computer_use/activation.py
+++ b/code_puppy/plugins/computer_use/activation.py
@@ -1,0 +1,76 @@
+"""Bring the state target to the foreground before sending global input."""
+
+from __future__ import annotations
+
+import time
+
+from .backend_types import ComputerUseError
+
+
+def _workspace():
+    try:
+        from AppKit import NSWorkspace
+    except ImportError as exc:
+        raise ComputerUseError("AppKit bindings are unavailable.") from exc
+    return NSWorkspace.sharedWorkspace()
+
+
+def activate_application(pid: int, application_name: str, timeout: float = 1.0) -> None:
+    workspace = _workspace()
+    application = next(
+        (
+            app
+            for app in workspace.runningApplications()
+            if int(app.processIdentifier()) == pid
+        ),
+        None,
+    )
+    if application is None or bool(application.isTerminated()):
+        raise ComputerUseError(
+            f"The target application {application_name} is no longer running."
+        )
+    # NSApplicationActivateAllWindows | NSApplicationActivateIgnoringOtherApps.
+    if not bool(application.activateWithOptions_(3)):
+        raise ComputerUseError(
+            f"Could not activate target application {application_name}."
+        )
+    # A background CLI can receive a successful AppKit result without macOS
+    # changing focus. The plugin already requires Accessibility permission, so
+    # explicitly foreground and raise the target window through AX as well.
+    try:
+        import ApplicationServices as api
+
+        ax_application = api.AXUIElementCreateApplication(pid)
+        api.AXUIElementSetAttributeValue(
+            ax_application,
+            api.kAXFrontmostAttribute,
+            True,
+        )
+        result = api.AXUIElementCopyAttributeValue(
+            ax_application,
+            api.kAXWindowsAttribute,
+            None,
+        )
+        windows = result[1] if isinstance(result, tuple) else result
+        if windows:
+            api.AXUIElementSetAttributeValue(
+                windows[0],
+                api.kAXMainAttribute,
+                True,
+            )
+            api.AXUIElementPerformAction(windows[0], api.kAXRaiseAction)
+    except ImportError:
+        pass
+    deadline = time.monotonic() + max(0.1, timeout)
+    while time.monotonic() < deadline:
+        frontmost = workspace.frontmostApplication()
+        if frontmost is not None and int(frontmost.processIdentifier()) == pid:
+            return
+        time.sleep(0.02)
+    raise ComputerUseError(
+        f"Target application {application_name} did not become frontmost."
+    )
+
+
+def activate_state(state, timeout: float = 1.0) -> None:
+    activate_application(state.pid, state.application, timeout)

--- a/code_puppy/plugins/computer_use/backend.py
+++ b/code_puppy/plugins/computer_use/backend.py
@@ -1,0 +1,584 @@
+"""macOS Accessibility and Quartz bridge.
+
+PyObjC is imported lazily so Code Puppy remains importable on every platform.
+Element IDs are intentionally snapshot-scoped: any new snapshot invalidates the
+previous IDs, preventing an agent from acting on a stale accessibility tree.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from .accessibility import snapshot_tree
+from .activation import activate_application, activate_state
+from .backend_types import ComputerUseError
+from .capture import capture_window
+from .keycodes import KEY_CODES
+from .policy import policy_store
+from .safety import require_safe_state
+from .state import state_store
+
+MAX_NODES = 500
+
+
+class MacOSBackend:
+    def __init__(self) -> None:
+        self._elements: dict[int, Any] = {}
+        self._lock = threading.RLock()
+
+    @staticmethod
+    def _api():
+        try:
+            import ApplicationServices
+        except ImportError as exc:
+            raise ComputerUseError(
+                "Computer Use requires the macOS extra. Install it with "
+                "`pip install 'code-puppy[computer-use]'`."
+            ) from exc
+        return ApplicationServices
+
+    def trusted(self, prompt: bool = False) -> bool:
+        quartz = self._api()
+        options = {quartz.kAXTrustedCheckOptionPrompt: bool(prompt)}
+        return bool(quartz.AXIsProcessTrustedWithOptions(options))
+
+    def _require_trusted(self, prompt: bool = True) -> Any:
+        quartz = self._api()
+        if not self.trusted(prompt=prompt):
+            raise ComputerUseError(
+                "Accessibility permission is required. Enable Code Puppy (or its "
+                "terminal) in System Settings > Privacy & Security > Accessibility."
+            )
+        return quartz
+
+    @staticmethod
+    def _copy_attribute(quartz: Any, element: Any, attribute: str) -> Any:
+        result = quartz.AXUIElementCopyAttributeValue(element, attribute, None)
+        if isinstance(result, tuple):
+            error, value = result
+            if error != quartz.kAXErrorSuccess:
+                return None
+            return value
+        return result
+
+    def _application(self, app_name: str | None) -> tuple[Any, str]:
+        quartz = self._require_trusted()
+        if app_name:
+            try:
+                from AppKit import NSWorkspace
+            except ImportError as exc:
+                raise ComputerUseError(
+                    "AppKit bindings are unavailable; reinstall the computer-use extra."
+                ) from exc
+            wanted = app_name.casefold()
+            for app in NSWorkspace.sharedWorkspace().runningApplications():
+                name = str(app.localizedName() or "")
+                bundle = str(app.bundleIdentifier() or "")
+                if wanted in {name.casefold(), bundle.casefold()}:
+                    return quartz.AXUIElementCreateApplication(
+                        app.processIdentifier()
+                    ), name
+            raise ComputerUseError(f"Running application not found: {app_name}")
+
+        system = quartz.AXUIElementCreateSystemWide()
+        app = self._copy_attribute(
+            quartz, system, quartz.kAXFocusedApplicationAttribute
+        )
+        if app is None:
+            try:
+                from AppKit import NSWorkspace
+            except ImportError as exc:
+                raise ComputerUseError(
+                    "No focused macOS application was found."
+                ) from exc
+            frontmost = NSWorkspace.sharedWorkspace().frontmostApplication()
+            if frontmost is None:
+                raise ComputerUseError("No focused macOS application was found.")
+            app = quartz.AXUIElementCreateApplication(frontmost.processIdentifier())
+            fallback_name = str(frontmost.localizedName() or "Focused application")
+        else:
+            fallback_name = "Focused application"
+        title = self._copy_attribute(quartz, app, quartz.kAXTitleAttribute)
+        return app, str(title or fallback_name)
+
+    @staticmethod
+    def _bundle_id(app_name: str) -> str:
+        try:
+            from AppKit import NSWorkspace
+        except ImportError as exc:
+            raise ComputerUseError("AppKit bindings are unavailable.") from exc
+        wanted = app_name.casefold()
+        for app in NSWorkspace.sharedWorkspace().runningApplications():
+            name = str(app.localizedName() or "")
+            bundle = str(app.bundleIdentifier() or "")
+            if wanted in {name.casefold(), bundle.casefold()}:
+                return bundle
+        raise ComputerUseError(f"Running application not found: {app_name}")
+
+    def require_state(
+        self,
+        revision: str,
+        *,
+        consume: bool = False,
+    ):
+        state = require_safe_state(
+            revision,
+        )
+        activate_state(state)
+        if consume:
+            return require_safe_state(revision, consume=True)
+        return state
+
+    def snapshot(
+        self,
+        app_name: str | None = None,
+        max_nodes: int = MAX_NODES,
+        preferred_window_id: int | None = None,
+    ) -> dict[str, Any]:
+        policy_store.require_enabled()
+        quartz = self._require_trusted()
+        application, resolved_name = self._application(app_name)
+        policy_store.require(self._bundle_id(resolved_name))
+        nodes, elements, metadata = snapshot_tree(
+            quartz,
+            application,
+            self._copy_attribute,
+            max_nodes,
+            preferred_window_id,
+        )
+        with self._lock:
+            self._elements = elements
+        return {
+            "success": True,
+            "application": resolved_name,
+            "node_count": len(nodes),
+            **metadata,
+            "nodes": nodes,
+            "warning": "Element IDs expire when the next snapshot is taken.",
+        }
+
+    def get_app_state(
+        self, app_name: str, max_nodes: int = MAX_NODES
+    ) -> dict[str, Any]:
+        if not app_name:
+            raise ComputerUseError("app_name is required.")
+        policy_store.require(self._bundle_id(app_name))
+        target = (
+            Path(tempfile.gettempdir())
+            / f"code-puppy-app-state-{int(time.time() * 1000)}.png"
+        )
+        capture = capture_window(app_name, target)
+        # Electron apps often expose their useful web accessibility subtree only
+        # while frontmost. Activate before reading AX state so the model receives
+        # semantic controls instead of a nearly empty generic window tree.
+        activate_application(
+            int(capture["pid"]),
+            str(capture["application"]),
+        )
+        snapshot = self.snapshot(
+            app_name,
+            max_nodes,
+            preferred_window_id=int(capture["window_id"]),
+        )
+        with self._lock:
+            elements = dict(self._elements)
+        state = state_store.create(
+            application=str(capture["application"]),
+            bundle_id=str(capture["bundle_id"]),
+            pid=int(capture["pid"]),
+            window_id=int(capture["window_id"]),
+            window_title=str(capture["window_title"]),
+            geometry=capture["geometry"],
+            screenshot_path=str(capture["path"]),
+            elements=elements,
+        )
+        return {
+            "success": True,
+            **state.public_metadata(),
+            "node_count": snapshot["node_count"],
+            "scanned_node_count": snapshot["scanned_node_count"],
+            "truncated": snapshot["truncated"],
+            "scan_limit_reached": snapshot["scan_limit_reached"],
+            "overflow_summary": snapshot["overflow_summary"],
+            "nodes": snapshot["nodes"],
+            "warning": (
+                "Use this state_revision for one mutation or one guarded batch, "
+                "then fetch fresh app state."
+            ),
+        }
+
+    def _element(
+        self, state_revision: str, element_id: int, *, consume: bool = True
+    ) -> tuple[Any, Any]:
+        quartz = self._require_trusted()
+        state = self.require_state(state_revision)
+        element = state.elements.get(element_id)
+        if element is None:
+            raise ComputerUseError(
+                f"Unknown or expired element ID {element_id}; take a new snapshot."
+            )
+        if consume:
+            self.require_state(state_revision, consume=True)
+        return quartz, element
+
+    def click(
+        self, state_revision: str, element_id: int, *, consume: bool = True
+    ) -> dict[str, Any]:
+        quartz, element = self._element(state_revision, element_id, consume=consume)
+        error = quartz.AXUIElementPerformAction(element, quartz.kAXPressAction)
+        if error != quartz.kAXErrorSuccess:
+            raise ComputerUseError(f"AXPress failed with accessibility error {error}.")
+        return {
+            "success": True,
+            "element_id": element_id,
+            "consumed_state_revision": state_revision,
+            "state_invalidated": True,
+        }
+
+    def set_value(
+        self,
+        state_revision: str,
+        element_id: int,
+        value: str,
+        *,
+        consume: bool = True,
+    ) -> dict[str, Any]:
+        quartz, element = self._element(state_revision, element_id, consume=consume)
+        error = quartz.AXUIElementSetAttributeValue(
+            element, quartz.kAXValueAttribute, value
+        )
+        if error != quartz.kAXErrorSuccess:
+            raise ComputerUseError(
+                f"Setting AXValue failed with accessibility error {error}."
+            )
+        return {
+            "success": True,
+            "element_id": element_id,
+            "consumed_state_revision": state_revision,
+            "state_invalidated": True,
+        }
+
+    def perform_action(
+        self,
+        state_revision: str,
+        element_id: int,
+        action: str,
+        *,
+        consume: bool = True,
+    ) -> dict[str, Any]:
+        quartz, element = self._element(state_revision, element_id, consume=False)
+        result = quartz.AXUIElementCopyActionNames(element, None)
+        if isinstance(result, tuple):
+            error, names = result
+            actions = list(names or []) if error == quartz.kAXErrorSuccess else []
+        else:
+            actions = list(result or [])
+        matched = next(
+            (
+                str(item)
+                for item in actions
+                if str(item).casefold() == action.casefold()
+            ),
+            None,
+        )
+        if matched is None:
+            raise ComputerUseError(
+                f"{action!r} is not exposed by element {element_id}. "
+                f"Available actions: {[str(item) for item in actions]}"
+            )
+        if consume:
+            self.require_state(state_revision, consume=True)
+        error = quartz.AXUIElementPerformAction(element, matched)
+        if error != quartz.kAXErrorSuccess:
+            raise ComputerUseError(f"Accessibility action failed with error {error}.")
+        return {
+            "success": True,
+            "element_id": element_id,
+            "action": matched,
+            "state_invalidated": True,
+        }
+
+    def select_text(
+        self,
+        state_revision: str,
+        element_id: int,
+        text: str,
+        mode: str = "text",
+        prefix: str | None = None,
+        suffix: str | None = None,
+        *,
+        consume: bool = True,
+    ) -> dict[str, Any]:
+        quartz, element = self._element(state_revision, element_id, consume=False)
+        value = self._copy_attribute(quartz, element, quartz.kAXValueAttribute)
+        if not isinstance(value, str):
+            raise ComputerUseError("The selected element has no text value.")
+        starts = []
+        offset = 0
+        while True:
+            found = value.find(text, offset)
+            if found < 0:
+                break
+            before_ok = prefix is None or value[:found].endswith(prefix)
+            after = found + len(text)
+            after_ok = suffix is None or value[after:].startswith(suffix)
+            if before_ok and after_ok:
+                starts.append(found)
+            offset = found + max(1, len(text))
+        if len(starts) != 1:
+            raise ComputerUseError(
+                f"Text selection is ambiguous: found {len(starts)} matches."
+            )
+        modes = {
+            "text": (starts[0], len(text)),
+            "cursor_before": (starts[0], 0),
+            "cursor_after": (starts[0] + len(text), 0),
+        }
+        try:
+            location, length = modes[mode]
+        except KeyError as exc:
+            raise ComputerUseError(f"Unsupported selection mode: {mode}") from exc
+        range_value = quartz.AXValueCreate(
+            quartz.kAXValueCFRangeType, (location, length)
+        )
+        if range_value is None:
+            raise ComputerUseError("Could not construct a text selection range.")
+        if consume:
+            self.require_state(state_revision, consume=True)
+        error = quartz.AXUIElementSetAttributeValue(
+            element, quartz.kAXSelectedTextRangeAttribute, range_value
+        )
+        if error != quartz.kAXErrorSuccess:
+            raise ComputerUseError(
+                f"Setting the selected text range failed with error {error}."
+            )
+        return {
+            "success": True,
+            "element_id": element_id,
+            "mode": mode,
+            "range": {"location": location, "length": length},
+            "state_invalidated": True,
+        }
+
+    def click_pixel(
+        self,
+        state_revision: str,
+        x: float,
+        y: float,
+        button: str = "left",
+        click_count: int = 1,
+        *,
+        consume: bool = True,
+    ) -> dict[str, Any]:
+        quartz = self._require_trusted()
+        state = self.require_state(state_revision)
+        point = state.geometry.screenshot_to_quartz(x, y)
+        buttons = {
+            "left": (
+                quartz.kCGMouseButtonLeft,
+                quartz.kCGEventLeftMouseDown,
+                quartz.kCGEventLeftMouseUp,
+            ),
+            "right": (
+                quartz.kCGMouseButtonRight,
+                quartz.kCGEventRightMouseDown,
+                quartz.kCGEventRightMouseUp,
+            ),
+        }
+        try:
+            mouse_button, down_type, up_type = buttons[button.casefold()]
+        except KeyError as exc:
+            raise ComputerUseError(f"Unsupported mouse button: {button}") from exc
+        click_count = max(1, min(int(click_count), 3))
+        if consume:
+            self.require_state(state_revision, consume=True)
+        for index in range(click_count):
+            down = quartz.CGEventCreateMouseEvent(None, down_type, point, mouse_button)
+            up = quartz.CGEventCreateMouseEvent(None, up_type, point, mouse_button)
+            quartz.CGEventSetIntegerValueField(
+                down, quartz.kCGMouseEventClickState, index + 1
+            )
+            quartz.CGEventSetIntegerValueField(
+                up, quartz.kCGMouseEventClickState, index + 1
+            )
+            quartz.CGEventPost(quartz.kCGHIDEventTap, down)
+            quartz.CGEventPost(quartz.kCGHIDEventTap, up)
+        return {
+            "success": True,
+            "screenshot_point": {"x": x, "y": y},
+            "quartz_point": {"x": point[0], "y": point[1]},
+            "button": button,
+            "click_count": click_count,
+            "state_invalidated": True,
+        }
+
+    def drag_pixel(
+        self,
+        state_revision: str,
+        start_x: float,
+        start_y: float,
+        end_x: float,
+        end_y: float,
+        duration: float = 0.5,
+        *,
+        consume: bool = True,
+    ) -> dict[str, Any]:
+        quartz = self._require_trusted()
+        state = self.require_state(state_revision)
+        start = state.geometry.screenshot_to_quartz(start_x, start_y)
+        end = state.geometry.screenshot_to_quartz(end_x, end_y)
+        duration = max(0.05, min(float(duration), 5.0))
+        if consume:
+            self.require_state(state_revision, consume=True)
+        steps = max(2, min(120, round(duration * 60)))
+        down = quartz.CGEventCreateMouseEvent(
+            None, quartz.kCGEventLeftMouseDown, start, quartz.kCGMouseButtonLeft
+        )
+        quartz.CGEventPost(quartz.kCGHIDEventTap, down)
+        for index in range(1, steps + 1):
+            fraction = index / steps
+            point = (
+                start[0] + (end[0] - start[0]) * fraction,
+                start[1] + (end[1] - start[1]) * fraction,
+            )
+            dragged = quartz.CGEventCreateMouseEvent(
+                None,
+                quartz.kCGEventLeftMouseDragged,
+                point,
+                quartz.kCGMouseButtonLeft,
+            )
+            quartz.CGEventPost(quartz.kCGHIDEventTap, dragged)
+            time.sleep(duration / steps)
+        up = quartz.CGEventCreateMouseEvent(
+            None, quartz.kCGEventLeftMouseUp, end, quartz.kCGMouseButtonLeft
+        )
+        quartz.CGEventPost(quartz.kCGHIDEventTap, up)
+        return {
+            "success": True,
+            "start_screenshot_point": {"x": start_x, "y": start_y},
+            "end_screenshot_point": {"x": end_x, "y": end_y},
+            "duration": duration,
+            "state_invalidated": True,
+        }
+
+    def press_key(
+        self,
+        state_revision: str,
+        key: str,
+        modifiers: list[str] | None = None,
+        *,
+        consume: bool = True,
+    ) -> dict[str, Any]:
+        quartz = self._require_trusted()
+        self.require_state(state_revision)
+        normalized = key.casefold()
+        if normalized not in KEY_CODES:
+            raise ComputerUseError(f"Unsupported key: {key}")
+        flags = 0
+        flag_map = {
+            "command": quartz.kCGEventFlagMaskCommand,
+            "shift": quartz.kCGEventFlagMaskShift,
+            "option": quartz.kCGEventFlagMaskAlternate,
+            "control": quartz.kCGEventFlagMaskControl,
+        }
+        for modifier in modifiers or []:
+            try:
+                flags |= flag_map[modifier.casefold()]
+            except KeyError as exc:
+                raise ComputerUseError(f"Unsupported modifier: {modifier}") from exc
+        if consume:
+            self.require_state(state_revision, consume=True)
+        for down in (True, False):
+            event = quartz.CGEventCreateKeyboardEvent(None, KEY_CODES[normalized], down)
+            quartz.CGEventSetFlags(event, flags)
+            quartz.CGEventPost(quartz.kCGHIDEventTap, event)
+        return {"success": True, "key": key, "modifiers": modifiers or []}
+
+    def type_text(
+        self, state_revision: str, text: str, *, consume: bool = True
+    ) -> dict[str, Any]:
+        quartz = self._require_trusted()
+        self.require_state(state_revision)
+        if len(text) > 10_000:
+            raise ComputerUseError("Text is limited to 10,000 characters per call.")
+        if consume:
+            self.require_state(state_revision, consume=True)
+        event_down = quartz.CGEventCreateKeyboardEvent(None, 0, True)
+        event_up = quartz.CGEventCreateKeyboardEvent(None, 0, False)
+        quartz.CGEventKeyboardSetUnicodeString(event_down, len(text), text)
+        quartz.CGEventKeyboardSetUnicodeString(event_up, len(text), text)
+        quartz.CGEventPost(quartz.kCGHIDEventTap, event_down)
+        quartz.CGEventPost(quartz.kCGHIDEventTap, event_up)
+        return {"success": True, "characters": len(text)}
+
+    def scroll_pages(
+        self,
+        state_revision: str,
+        direction: str,
+        pages: float = 1.0,
+        *,
+        consume: bool = True,
+    ) -> dict[str, Any]:
+        quartz = self._require_trusted()
+        state = self.require_state(state_revision)
+        directions = {
+            "up": (1, 0),
+            "down": (-1, 0),
+            "left": (0, 1),
+            "right": (0, -1),
+        }
+        try:
+            vertical_sign, horizontal_sign = directions[direction.casefold()]
+        except KeyError as exc:
+            raise ComputerUseError(
+                f"Unsupported scroll direction: {direction}"
+            ) from exc
+        pages = max(0.05, min(float(pages), 10.0))
+        vertical = round(
+            vertical_sign * pages * state.geometry.image_height_pixels * 0.85
+        )
+        horizontal = round(
+            horizontal_sign * pages * state.geometry.image_width_pixels * 0.85
+        )
+        if consume:
+            self.require_state(state_revision, consume=True)
+        event = quartz.CGEventCreateScrollWheelEvent(
+            None,
+            quartz.kCGScrollEventUnitPixel,
+            2,
+            vertical,
+            horizontal,
+        )
+        quartz.CGEventPost(quartz.kCGHIDEventTap, event)
+        return {
+            "success": True,
+            "direction": direction,
+            "pages": pages,
+            "pixel_delta": {"vertical": vertical, "horizontal": horizontal},
+            "state_invalidated": True,
+        }
+
+    def screenshot(
+        self, path: str | None = None, app_name: str | None = None
+    ) -> dict[str, Any]:
+        if not app_name:
+            raise ComputerUseError(
+                "app_name is required so screenshot capture can enforce the "
+                "application deny policy."
+            )
+        target = (
+            Path(path).expanduser()
+            if path
+            else Path(tempfile.gettempdir())
+            / f"code-puppy-computer-use-{int(time.time() * 1000)}.png"
+        )
+        target.parent.mkdir(parents=True, exist_ok=True)
+        policy_store.require(self._bundle_id(app_name))
+        return capture_window(app_name, target)
+
+
+backend = MacOSBackend()

--- a/code_puppy/plugins/computer_use/backend_types.py
+++ b/code_puppy/plugins/computer_use/backend_types.py
@@ -1,0 +1,5 @@
+"""Shared backend types without platform imports."""
+
+
+class ComputerUseError(RuntimeError):
+    """A recoverable computer-use failure."""

--- a/code_puppy/plugins/computer_use/capture.py
+++ b/code_puppy/plugins/computer_use/capture.py
@@ -1,0 +1,110 @@
+"""Typed ScreenCaptureKit bridge through a small cached Swift helper."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any
+
+from code_puppy.config import CONFIG_DIR
+
+from .backend_types import ComputerUseError
+from .geometry import CaptureGeometry, Rect
+
+_BUILD_LOCK = threading.Lock()
+_SOURCE = Path(__file__).with_name("NativeCapture.swift")
+_CACHE_DIR = Path(CONFIG_DIR) / "computer_use"
+_EXECUTABLE = _CACHE_DIR / "native-capture"
+_HASH_FILE = _CACHE_DIR / "native-capture.sha256"
+
+
+def _source_hash() -> str:
+    return hashlib.sha256(_SOURCE.read_bytes()).hexdigest()
+
+
+def _ensure_helper() -> Path:
+    expected_hash = _source_hash()
+    with _BUILD_LOCK:
+        if (
+            _EXECUTABLE.is_file()
+            and os.access(_EXECUTABLE, os.X_OK)
+            and _HASH_FILE.is_file()
+            and _HASH_FILE.read_text().strip() == expected_hash
+        ):
+            return _EXECUTABLE
+        _CACHE_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
+        command = [
+            "/usr/bin/xcrun",
+            "swiftc",
+            "-O",
+            "-parse-as-library",
+            "-framework",
+            "AppKit",
+            "-framework",
+            "ScreenCaptureKit",
+            str(_SOURCE),
+            "-o",
+            str(_EXECUTABLE),
+        ]
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            raise ComputerUseError(
+                "Failed to build the native ScreenCaptureKit helper. Install "
+                f"Xcode Command Line Tools. {result.stderr.strip()}"
+            )
+        os.chmod(_EXECUTABLE, 0o700)
+        _HASH_FILE.write_text(expected_hash)
+        os.chmod(_HASH_FILE, 0o600)
+    return _EXECUTABLE
+
+
+def capture_window(app_name: str, target: Path) -> dict[str, Any]:
+    helper = _ensure_helper()
+    target = target.expanduser().resolve()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(
+        [str(helper), app_name, str(target)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip()
+        raise ComputerUseError(message or "Native window capture failed.")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise ComputerUseError("Native capture returned invalid metadata.") from exc
+    bounds = payload["window_bounds_points"]
+    geometry = CaptureGeometry(
+        window_points=Rect(
+            float(bounds["x"]),
+            float(bounds["y"]),
+            float(bounds["width"]),
+            float(bounds["height"]),
+        ),
+        image_width_pixels=int(payload["screenshot_size_pixels"]["width"]),
+        image_height_pixels=int(payload["screenshot_size_pixels"]["height"]),
+        backing_scale=float(payload["backing_scale"]),
+    )
+    return {
+        "success": True,
+        "path": str(target),
+        "application": str(payload["application"]),
+        "bundle_id": str(payload["bundle_id"]),
+        "pid": int(payload["pid"]),
+        "window_id": int(payload["window_id"]),
+        "window_title": str(payload["window_title"]),
+        "geometry": geometry,
+    }

--- a/code_puppy/plugins/computer_use/commands.py
+++ b/code_puppy/plugins/computer_use/commands.py
@@ -1,0 +1,62 @@
+"""Slash commands for explicit computer-use authorization."""
+
+from __future__ import annotations
+
+import shlex
+
+from code_puppy.messaging import emit_error, emit_info, emit_success, emit_warning
+
+from .policy import policy_store
+
+
+def command_help() -> list[tuple[str, str]]:
+    return [
+        (
+            "computer-use",
+            "Enable, disable, pause, or configure macOS Computer Use",
+        )
+    ]
+
+
+def handle_command(command: str, name: str) -> bool | None:
+    if name != "computer-use":
+        return None
+    try:
+        tokens = shlex.split(command)
+    except ValueError as exc:
+        emit_error(f"Invalid /computer-use command: {exc}")
+        return True
+    subcommand = tokens[1].casefold() if len(tokens) > 1 else "status"
+    if subcommand == "status":
+        emit_info(f"Computer Use policy: {policy_store.status()}")
+    elif subcommand in {"enable", "disable"}:
+        enabled = subcommand == "enable"
+        policy_store.set_enabled(enabled)
+        if enabled:
+            emit_success(
+                "Computer Use enabled. It can now view and control allowed apps."
+            )
+        else:
+            emit_warning("Computer Use disabled in settings.")
+    elif subcommand == "pause":
+        policy_store.set_paused(True)
+        emit_warning("Computer Use paused immediately.")
+    elif subcommand == "resume":
+        policy_store.set_paused(False)
+        emit_success("Computer Use resumed.")
+    elif subcommand in {"allow", "deny"}:
+        if len(tokens) < 3:
+            emit_error("Usage: /computer-use allow|deny BUNDLE_ID")
+            return True
+        bundle_id = tokens[2]
+        if subcommand == "deny":
+            policy_store.deny(bundle_id)
+            emit_warning(f"Computer Use denied for {bundle_id}.")
+        else:
+            policy_store.allow(bundle_id)
+            emit_success(f"Computer Use allowed for {bundle_id}.")
+    else:
+        emit_error(
+            "Usage: /computer-use [status|enable|disable|pause|resume|allow|deny]"
+        )
+    return True

--- a/code_puppy/plugins/computer_use/geometry.py
+++ b/code_puppy/plugins/computer_use/geometry.py
@@ -1,0 +1,81 @@
+"""Coordinate spaces used by macOS computer use."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .backend_types import ComputerUseError
+
+
+@dataclass(frozen=True)
+class Rect:
+    x: float
+    y: float
+    width: float
+    height: float
+
+    def as_dict(self) -> dict[str, float]:
+        return {
+            "x": self.x,
+            "y": self.y,
+            "width": self.width,
+            "height": self.height,
+        }
+
+
+@dataclass(frozen=True)
+class CaptureGeometry:
+    """Mapping between screenshot pixels and global Quartz screen points.
+
+    ScreenCaptureKit and CGWindow bounds use a top-left global coordinate
+    system. AppKit uses bottom-left coordinates; callers that provide AppKit
+    coordinates must opt into the explicit conversion helper below.
+    """
+
+    window_points: Rect
+    image_width_pixels: int
+    image_height_pixels: int
+    backing_scale: float
+
+    def __post_init__(self) -> None:
+        if self.window_points.width <= 0 or self.window_points.height <= 0:
+            raise ComputerUseError("Window bounds must have positive dimensions.")
+        if self.image_width_pixels <= 0 or self.image_height_pixels <= 0:
+            raise ComputerUseError("Screenshot dimensions must be positive.")
+        if self.backing_scale <= 0:
+            raise ComputerUseError("Backing scale must be positive.")
+
+    def screenshot_to_quartz(self, x: float, y: float) -> tuple[float, float]:
+        if not (0 <= x < self.image_width_pixels):
+            raise ComputerUseError(
+                f"Screenshot x={x} is outside 0..{self.image_width_pixels - 1}."
+            )
+        if not (0 <= y < self.image_height_pixels):
+            raise ComputerUseError(
+                f"Screenshot y={y} is outside 0..{self.image_height_pixels - 1}."
+            )
+        return (
+            self.window_points.x
+            + (float(x) / self.image_width_pixels) * self.window_points.width,
+            self.window_points.y
+            + (float(y) / self.image_height_pixels) * self.window_points.height,
+        )
+
+    @staticmethod
+    def appkit_to_quartz(
+        x: float, y: float, display_points: Rect
+    ) -> tuple[float, float]:
+        """Convert bottom-left AppKit coordinates to top-left Quartz points."""
+        return x, display_points.y + display_points.height - (y - display_points.y)
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "window_bounds_points": self.window_points.as_dict(),
+            "screenshot_size_pixels": {
+                "width": self.image_width_pixels,
+                "height": self.image_height_pixels,
+            },
+            "backing_scale": self.backing_scale,
+            "screenshot_coordinate_system": "top-left, window-local pixels",
+            "action_coordinate_system": "top-left, global Quartz points",
+        }

--- a/code_puppy/plugins/computer_use/inline_image.py
+++ b/code_puppy/plugins/computer_use/inline_image.py
@@ -1,0 +1,57 @@
+"""Best-effort inline image display for modern terminals."""
+
+from __future__ import annotations
+
+import base64
+import os
+import sys
+from pathlib import Path
+
+
+def _terminal_kind() -> str | None:
+    program = os.environ.get("TERM_PROGRAM", "").casefold()
+    term = os.environ.get("TERM", "").casefold()
+    if os.environ.get("ITERM_SESSION_ID") or program == "iterm.app":
+        return "iterm"
+    if (
+        program in {"ghostty", "wezterm"}
+        or os.environ.get("KITTY_WINDOW_ID")
+        or "ghostty" in term
+        or "kitty" in term
+    ):
+        return "kitty"
+    return None
+
+
+def emit_inline_image(path: str | Path) -> bool:
+    """Render a PNG using iTerm2 or Kitty graphics escape sequences."""
+    image_path = Path(path)
+    kind = _terminal_kind()
+    if kind is None or not sys.stdout.isatty() or not image_path.is_file():
+        return False
+
+    try:
+        if kind == "iterm":
+            data = base64.b64encode(image_path.read_bytes()).decode("ascii")
+            name = base64.b64encode(image_path.name.encode()).decode("ascii")
+            sequence = (
+                f"\033]1337;File=name={name};inline=1;width=50%;"
+                f"preserveAspectRatio=1:{data}\a\n"
+            )
+        else:
+            encoded_path = base64.b64encode(str(image_path.resolve()).encode()).decode(
+                "ascii"
+            )
+            # Direct file transmission avoids stuffing a full screenshot into
+            # the terminal stream. q=2 suppresses protocol responses, c/r bound
+            # the placement to a compact picture-in-picture style preview.
+            sequence = f"\033_Ga=T,t=f,f=100,q=2,c=64,r=22;{encoded_path}\033\\\n"
+
+        from code_puppy.messaging.run_ui import suspended_run_ui
+
+        with suspended_run_ui():
+            sys.stdout.write(sequence)
+            sys.stdout.flush()
+    except Exception:
+        return False
+    return True

--- a/code_puppy/plugins/computer_use/keycodes.py
+++ b/code_puppy/plugins/computer_use/keycodes.py
@@ -1,0 +1,47 @@
+"""macOS virtual key codes for keys exposed by the computer-use tool."""
+
+KEY_CODES = {
+    "return": 36,
+    "enter": 36,
+    "tab": 48,
+    "space": 49,
+    "delete": 51,
+    "escape": 53,
+    "left": 123,
+    "right": 124,
+    "down": 125,
+    "up": 126,
+    **dict(
+        zip(
+            "abcdefghijklmnopqrstuvwxyz",
+            (
+                0,
+                11,
+                8,
+                2,
+                14,
+                3,
+                5,
+                4,
+                34,
+                38,
+                40,
+                37,
+                46,
+                45,
+                31,
+                35,
+                12,
+                15,
+                1,
+                17,
+                32,
+                9,
+                13,
+                7,
+                16,
+                6,
+            ),
+        )
+    ),
+}

--- a/code_puppy/plugins/computer_use/policy.py
+++ b/code_puppy/plugins/computer_use/policy.py
@@ -1,0 +1,139 @@
+"""Persisted computer-use consent, explicit denials, and hard stops."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from pathlib import Path
+from typing import Any
+
+from code_puppy.config import CONFIG_DIR
+
+from .backend_types import ComputerUseError
+
+POLICY_PATH = Path(CONFIG_DIR) / "computer_use_policy.json"
+SYSTEM_DENYLIST = {
+    "com.apple.loginwindow",
+    "com.apple.securityagent",
+    "com.apple.systempreferences",
+    "com.apple.systemsettings",
+    "com.apple.keychainaccess",
+    "com.apple.authorizationhost",
+}
+
+
+class PolicyStore:
+    def __init__(self, path: Path = POLICY_PATH) -> None:
+        self.path = path
+        self._paused = False
+        self._lock = threading.RLock()
+
+    def _load(self) -> dict[str, Any]:
+        if not self.path.is_file():
+            return {"enabled": None, "denied": []}
+        try:
+            payload = json.loads(self.path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return {"enabled": None, "denied": []}
+        enabled = payload.get("enabled")
+        return {
+            "enabled": enabled if isinstance(enabled, bool) else None,
+            "denied": list(payload.get("denied", [])),
+        }
+
+    def _save(self, payload: dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        temporary = self.path.with_suffix(".tmp")
+        temporary.write_text(json.dumps(payload, indent=2, sort_keys=True))
+        os.chmod(temporary, 0o600)
+        temporary.replace(self.path)
+
+    def allow(self, bundle_id: str) -> None:
+        """Remove an explicit denial; all other applications are allowed."""
+        normalized = bundle_id.casefold()
+        if normalized in SYSTEM_DENYLIST:
+            raise ComputerUseError(
+                f"Computer Use is never allowed for security process {bundle_id}."
+            )
+        with self._lock:
+            payload = self._load()
+            denied = {str(item).casefold() for item in payload["denied"]}
+            denied.discard(normalized)
+            payload["denied"] = sorted(denied)
+            self._save(payload)
+
+    def deny(self, bundle_id: str) -> None:
+        normalized = bundle_id.casefold()
+        with self._lock:
+            payload = self._load()
+            denied = {str(item).casefold() for item in payload["denied"]}
+            denied.add(normalized)
+            payload["denied"] = sorted(denied)
+            self._save(payload)
+
+    def set_enabled(self, enabled: bool) -> None:
+        with self._lock:
+            payload = self._load()
+            payload["enabled"] = enabled
+            self._save(payload)
+
+    def set_paused(self, paused: bool) -> None:
+        with self._lock:
+            self._paused = paused
+
+    def require_enabled(self) -> None:
+        with self._lock:
+            if self._paused:
+                raise ComputerUseError(
+                    "Computer Use is paused by the emergency stop. Run "
+                    "`/computer-use resume` after confirming it is safe."
+                )
+            payload = self._load()
+            if payload["enabled"] is None:
+                raise ComputerUseError(
+                    "Computer Use needs your one-time permission before its first "
+                    "use. It can view screenshots and control apps on this Mac. "
+                    "Run `/computer-use enable` to allow it, or "
+                    "`/computer-use disable` to keep it off. You can change this "
+                    "setting later with the same commands."
+                )
+            if payload["enabled"] is False:
+                raise ComputerUseError(
+                    "Computer Use is disabled in settings. Run "
+                    "`/computer-use enable` to turn it on."
+                )
+
+    def require(self, bundle_id: str) -> None:
+        self.require_enabled()
+        normalized = bundle_id.casefold()
+        with self._lock:
+            if normalized in SYSTEM_DENYLIST:
+                raise ComputerUseError(
+                    f"Computer Use is blocked for security process {bundle_id}."
+                )
+            payload = self._load()
+            denied = {str(item).casefold() for item in payload["denied"]}
+            if normalized in denied:
+                raise ComputerUseError(
+                    f"Computer Use is denied for application {bundle_id}."
+                )
+
+    def status(self) -> dict[str, Any]:
+        with self._lock:
+            payload = self._load()
+            return {
+                "mode": (
+                    "enabled"
+                    if payload["enabled"] is True
+                    else "disabled"
+                    if payload["enabled"] is False
+                    else "needs-first-use-consent"
+                ),
+                "paused": self._paused,
+                "denied": payload["denied"],
+                "system_denied": sorted(SYSTEM_DENYLIST),
+            }
+
+
+policy_store = PolicyStore()

--- a/code_puppy/plugins/computer_use/register_callbacks.py
+++ b/code_puppy/plugins/computer_use/register_callbacks.py
@@ -1,0 +1,82 @@
+"""Register the macOS computer-use tools as an optional builtin plugin."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+from code_puppy.callbacks import register_callback
+
+_TOOL_NAMES = (
+    "computer_get_app_state",
+    "computer_snapshot",
+    "computer_click",
+    "computer_set_value",
+    "computer_perform_action",
+    "computer_select_text",
+    "computer_press_key",
+    "computer_type_text",
+    "computer_scroll",
+    "computer_drag",
+    "computer_screenshot",
+    "computer_use_batch",
+)
+
+
+def _available() -> bool:
+    return sys.platform == "darwin"
+
+
+def _register_tools() -> list[dict[str, Any]]:
+    if not _available():
+        return []
+
+    from .tools import REGISTRARS
+
+    return [{"name": name, "register_func": REGISTRARS[name]} for name in _TOOL_NAMES]
+
+
+def _register_agent_tools(agent_name: str | None = None) -> list[str]:
+    del agent_name
+    return list(_TOOL_NAMES) if _available() else []
+
+
+def _load_prompt() -> str | None:
+    if not _available():
+        return None
+    return (
+        "macOS Computer Use requires persisted one-time user consent. If a tool "
+        "reports that consent is unset or disabled, show its exact slash command "
+        "to the user and do not work around it. Slash commands are not visible in "
+        "conversation history, so never repeat an old consent error from memory. "
+        "When the user repeats the request, always call the appropriate Computer "
+        "Use state tool again; the tool's current result is authoritative. Once "
+        "enabled, do not ask for per-application approval. Prefer "
+        "computer_get_app_state and element IDs over screen coordinates. Every "
+        "standalone mutation needs its current state_revision; guarded batches "
+        "return fresh state after deterministic UI settling. For pixel-based "
+        "focus-and-type workflows, use one guarded batch instead of guessing across "
+        "separate revisions. Verify the returned state and recover until the "
+        "requested outcome is visibly complete. Do not stop merely because the user "
+        "moves the pointer or types. The emergency stop and hard macOS "
+        "security-process denylist remain enforced."
+    )
+
+
+def _custom_help():
+    from .commands import command_help
+
+    return command_help()
+
+
+def _custom_command(command: str, name: str):
+    from .commands import handle_command
+
+    return handle_command(command, name)
+
+
+register_callback("register_tools", _register_tools)
+register_callback("register_agent_tools", _register_agent_tools)
+register_callback("load_prompt", _load_prompt)
+register_callback("custom_command_help", _custom_help)
+register_callback("custom_command", _custom_command)

--- a/code_puppy/plugins/computer_use/safety.py
+++ b/code_puppy/plugins/computer_use/safety.py
@@ -1,0 +1,18 @@
+"""Shared policy and stale-state enforcement."""
+
+from __future__ import annotations
+
+from .policy import policy_store
+from .state import AppState, state_store
+
+
+def require_safe_state(
+    revision: str,
+    *,
+    consume: bool = False,
+) -> AppState:
+    state = state_store.require(revision)
+    policy_store.require(state.bundle_id)
+    if consume:
+        return state_store.require(revision, consume=True)
+    return state

--- a/code_puppy/plugins/computer_use/settle.py
+++ b/code_puppy/plugins/computer_use/settle.py
@@ -1,0 +1,64 @@
+"""Deterministic UI settling based on accessibility-state stability."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from typing import Any, Callable
+
+
+def _fingerprint(snapshot: dict[str, Any]) -> str:
+    normalized = [
+        {
+            key: node.get(key)
+            for key in (
+                "role",
+                "title",
+                "description",
+                "value",
+                "enabled",
+                "focused",
+                "actions",
+            )
+        }
+        for node in snapshot.get("nodes", [])
+    ]
+    encoded = json.dumps(normalized, sort_keys=True, ensure_ascii=False).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def wait_for_ui_settle(
+    snapshotter: Callable[[str, int], dict[str, Any]],
+    app_name: str,
+    timeout: float = 3.0,
+    interval: float = 0.1,
+    stable_observations: int = 3,
+) -> dict[str, Any]:
+    """Return after the focused accessibility state repeats consecutively."""
+    deadline = time.monotonic() + max(0.1, timeout)
+    previous = None
+    stable = 0
+    observations = 0
+    while time.monotonic() < deadline:
+        snapshot = snapshotter(app_name, 120)
+        observations += 1
+        fingerprint = _fingerprint(snapshot)
+        if fingerprint == previous:
+            stable += 1
+            if stable >= stable_observations:
+                return {
+                    "settled": True,
+                    "observations": observations,
+                    "fingerprint": fingerprint,
+                }
+        else:
+            previous = fingerprint
+            stable = 0
+        time.sleep(max(0.01, interval))
+    return {
+        "settled": False,
+        "observations": observations,
+        "fingerprint": previous,
+        "reason": "timeout",
+    }

--- a/code_puppy/plugins/computer_use/state.py
+++ b/code_puppy/plugins/computer_use/state.py
@@ -1,0 +1,86 @@
+"""Revisioned computer-use state shared by snapshots and actions."""
+
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from .backend_types import ComputerUseError
+from .geometry import CaptureGeometry
+
+
+@dataclass
+class AppState:
+    revision: str
+    application: str
+    bundle_id: str
+    pid: int
+    window_id: int
+    window_title: str
+    geometry: CaptureGeometry
+    screenshot_path: str
+    elements: dict[int, Any] = field(repr=False)
+    created_at: float = field(default_factory=time.monotonic)
+    consumed: bool = False
+
+    def public_metadata(self) -> dict[str, Any]:
+        return {
+            "state_revision": self.revision,
+            "application": self.application,
+            "bundle_id": self.bundle_id,
+            "pid": self.pid,
+            "window_id": self.window_id,
+            "window_title": self.window_title,
+            "screenshot_path": self.screenshot_path,
+            **self.geometry.as_dict(),
+        }
+
+
+class StateStore:
+    def __init__(self, max_age_seconds: float = 120.0) -> None:
+        self._state: AppState | None = None
+        self._lock = threading.RLock()
+        self.max_age_seconds = max_age_seconds
+
+    def create(self, **kwargs: Any) -> AppState:
+        state = AppState(revision=uuid.uuid4().hex, **kwargs)
+        with self._lock:
+            self._state = state
+        return state
+
+    def require(self, revision: str, *, consume: bool = False) -> AppState:
+        if not revision:
+            raise ComputerUseError(
+                "state_revision is required. Call computer_get_app_state first."
+            )
+        with self._lock:
+            state = self._state
+            if state is None or state.revision != revision:
+                raise ComputerUseError(
+                    "Stale or unknown state_revision. Call computer_get_app_state again."
+                )
+            if time.monotonic() - state.created_at > self.max_age_seconds:
+                raise ComputerUseError(
+                    "The app state expired. Call computer_get_app_state again."
+                )
+            if state.consumed:
+                raise ComputerUseError(
+                    "The app state changed after an action. Fetch fresh app state."
+                )
+            if consume:
+                state.consumed = True
+            return state
+
+    def current(self) -> AppState | None:
+        with self._lock:
+            return self._state
+
+    def clear(self) -> None:
+        with self._lock:
+            self._state = None
+
+
+state_store = StateStore()

--- a/code_puppy/plugins/computer_use/tools.py
+++ b/code_puppy/plugins/computer_use/tools.py
@@ -1,0 +1,469 @@
+"""Pydantic-AI registrations for the macOS computer-use backend."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Callable
+
+from pydantic_ai import BinaryContent, RunContext, ToolReturn
+
+from .backend import ComputerUseError, backend
+from .inline_image import emit_inline_image
+from .settle import wait_for_ui_settle
+
+MAX_BATCH_STEPS = 20
+
+
+async def _call(func: Callable[..., dict[str, Any]], *args: Any, **kwargs: Any):
+    try:
+        return await asyncio.to_thread(func, *args, **kwargs)
+    except ComputerUseError as exc:
+        return {"success": False, "error": str(exc)}
+    except Exception as exc:
+        return {"success": False, "error": f"Computer Use failed: {exc}"}
+
+
+def register_get_app_state(agent):
+    @agent.tool
+    async def computer_get_app_state(
+        context: RunContext,
+        app_name: str,
+        max_nodes: int = 100,
+        show_screenshot: bool = True,
+    ) -> Any:
+        """Get one revisioned screenshot and accessibility tree for an app.
+
+        Call this once per turn and after every standalone mutation. All action
+        tools require the returned state_revision and reject stale state.
+        """
+        del context
+        result = await _call(backend.get_app_state, app_name, max_nodes)
+        if not result.get("success") or not show_screenshot:
+            return result
+        return _state_tool_return(result, "macOS app state")
+
+    return computer_get_app_state
+
+
+def register_snapshot(agent):
+    @agent.tool
+    async def computer_snapshot(
+        context: RunContext,
+        app_name: str | None = None,
+        max_nodes: int = 100,
+        show_screenshot: bool = True,
+    ) -> Any:
+        """Inspect a macOS application's accessibility tree.
+
+        Call this before acting and again after navigation. Returned element IDs
+        are invalidated by the next snapshot. By default, also capture and show
+        a compact inline screenshot in Ghostty, Kitty, WezTerm, or iTerm2.
+        """
+        del context
+        if app_name:
+            result = await _call(backend.get_app_state, app_name, max_nodes)
+            if not result.get("success") or not show_screenshot:
+                return result
+            return _state_tool_return(result, "macOS accessibility snapshot")
+        return await _call(backend.snapshot, None, max_nodes)
+
+    return computer_snapshot
+
+
+def register_click(agent):
+    @agent.tool
+    async def computer_click(
+        context: RunContext,
+        state_revision: str,
+        element_id: int | None = None,
+        x: float | None = None,
+        y: float | None = None,
+        button: str = "left",
+        click_count: int = 1,
+    ) -> dict[str, Any]:
+        """Click by element ID or screenshot-pixel coordinates.
+
+        Exactly one target form is required: element_id, or both x and y from
+        the screenshot associated with state_revision.
+        """
+        del context
+        if element_id is not None and x is None and y is None:
+            return await _call(backend.click, state_revision, element_id)
+        if element_id is None and x is not None and y is not None:
+            return await _call(
+                backend.click_pixel,
+                state_revision,
+                x,
+                y,
+                button,
+                click_count,
+            )
+        return {
+            "success": False,
+            "error": "Provide element_id or both x and y, but not both target forms.",
+        }
+
+    return computer_click
+
+
+def register_set_value(agent):
+    @agent.tool
+    async def computer_set_value(
+        context: RunContext,
+        state_revision: str,
+        element_id: int,
+        value: str,
+    ) -> dict[str, Any]:
+        """Set the value of an accessible text field or control."""
+        del context
+        return await _call(backend.set_value, state_revision, element_id, value)
+
+    return computer_set_value
+
+
+def register_perform_action(agent):
+    @agent.tool
+    async def computer_perform_action(
+        context: RunContext,
+        state_revision: str,
+        element_id: int,
+        action: str,
+    ) -> dict[str, Any]:
+        """Perform an action listed in an element's `actions` array."""
+        del context
+        return await _call(
+            backend.perform_action,
+            state_revision,
+            element_id,
+            action,
+        )
+
+    return computer_perform_action
+
+
+def register_select_text(agent):
+    @agent.tool
+    async def computer_select_text(
+        context: RunContext,
+        state_revision: str,
+        element_id: int,
+        text: str,
+        mode: str = "text",
+        prefix: str | None = None,
+        suffix: str | None = None,
+    ) -> dict[str, Any]:
+        """Select exact text or place the cursor before/after it.
+
+        Use prefix or suffix when the target text occurs more than once.
+        """
+        del context
+        return await _call(
+            backend.select_text,
+            state_revision,
+            element_id,
+            text,
+            mode,
+            prefix,
+            suffix,
+        )
+
+    return computer_select_text
+
+
+def register_press_key(agent):
+    @agent.tool
+    async def computer_press_key(
+        context: RunContext,
+        state_revision: str,
+        key: str,
+        modifiers: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Press a supported key, optionally with command/shift/option/control."""
+        del context
+        return await _call(backend.press_key, state_revision, key, modifiers)
+
+    return computer_press_key
+
+
+def register_type_text(agent):
+    @agent.tool
+    async def computer_type_text(
+        context: RunContext, state_revision: str, text: str
+    ) -> dict[str, Any]:
+        """Type Unicode text into the currently focused macOS control."""
+        del context
+        return await _call(backend.type_text, state_revision, text)
+
+    return computer_type_text
+
+
+def register_scroll(agent):
+    @agent.tool
+    async def computer_scroll(
+        context: RunContext,
+        state_revision: str,
+        direction: str,
+        pages: float = 1.0,
+    ) -> dict[str, Any]:
+        """Scroll up, down, left, or right by fractional pages."""
+        del context
+        return await _call(backend.scroll_pages, state_revision, direction, pages)
+
+    return computer_scroll
+
+
+def register_drag(agent):
+    @agent.tool
+    async def computer_drag(
+        context: RunContext,
+        state_revision: str,
+        start_x: float,
+        start_y: float,
+        end_x: float,
+        end_y: float,
+        duration: float = 0.5,
+    ) -> dict[str, Any]:
+        """Drag between two screenshot-pixel coordinates."""
+        del context
+        return await _call(
+            backend.drag_pixel,
+            state_revision,
+            start_x,
+            start_y,
+            end_x,
+            end_y,
+            duration,
+        )
+
+    return computer_drag
+
+
+def register_screenshot(agent):
+    @agent.tool
+    async def computer_screenshot(
+        context: RunContext,
+        path: str | None = None,
+        app_name: str | None = None,
+    ) -> Any:
+        """Capture and display a macOS application window."""
+        del context
+        result = await _call(backend.screenshot, path, app_name)
+        if not result.get("success"):
+            return result
+        return _image_tool_return(result, "macOS screenshot")
+
+    return computer_screenshot
+
+
+def register_batch(agent):
+    @agent.tool
+    async def computer_use_batch(
+        context: RunContext,
+        state_revision: str,
+        steps: list[dict[str, Any]],
+    ) -> Any:
+        """Run up to 20 computer-use actions sequentially.
+
+        Supported action values are click, set_value, perform_action,
+        select_text, press_key, type_text, scroll, drag, and wait. Stop
+        immediately when an action fails, then return updated state after
+        deterministic UI settling.
+        """
+        del context
+        if len(steps) > MAX_BATCH_STEPS:
+            return {
+                "success": False,
+                "error": f"A batch may contain at most {MAX_BATCH_STEPS} steps.",
+            }
+        completed = []
+        try:
+            initial_state = backend.require_state(state_revision)
+        except ComputerUseError as exc:
+            return {"success": False, "error": str(exc)}
+        except Exception as exc:
+            return {
+                "success": False,
+                "error": f"Computer Use activation failed: {exc}",
+            }
+
+        def invoke(action_name: str, kwargs: dict[str, Any]):
+            if action_name == "click":
+                if "element_id" in kwargs:
+                    return backend.click(state_revision, consume=False, **kwargs)
+                return backend.click_pixel(state_revision, consume=False, **kwargs)
+            actions: dict[str, Callable[..., Any]] = {
+                "set_value": backend.set_value,
+                "perform_action": backend.perform_action,
+                "select_text": backend.select_text,
+                "press_key": backend.press_key,
+                "type_text": backend.type_text,
+                "scroll": backend.scroll_pages,
+                "drag": backend.drag_pixel,
+            }
+            return actions[action_name](state_revision, consume=False, **kwargs)
+
+        supported = {
+            "click",
+            "set_value",
+            "perform_action",
+            "select_text",
+            "press_key",
+            "type_text",
+            "scroll",
+            "drag",
+        }
+        for index, step in enumerate(steps):
+            action = str(step.get("action", ""))
+            if action == "wait":
+                seconds = max(0.0, min(float(step.get("seconds", 1)), 10.0))
+                await asyncio.sleep(seconds)
+                result = {"success": True, "seconds": seconds}
+            elif action in supported:
+                kwargs = {key: value for key, value in step.items() if key != "action"}
+                result = await _call(invoke, action, kwargs)
+            else:
+                result = {"success": False, "error": f"Unknown action: {action}"}
+            completed.append({"index": index, "action": action, "result": result})
+            if not result.get("success"):
+                return {"success": False, "completed_steps": completed}
+        try:
+            backend.require_state(state_revision, consume=True)
+        except ComputerUseError as exc:
+            return {
+                "success": False,
+                "error": str(exc),
+                "completed_steps": completed,
+            }
+        except Exception as exc:
+            return {
+                "success": False,
+                "error": f"Computer Use finalization failed: {exc}",
+                "completed_steps": completed,
+            }
+        settle = await asyncio.to_thread(
+            wait_for_ui_settle,
+            backend.snapshot,
+            initial_state.application,
+        )
+        updated = await _call(backend.get_app_state, initial_state.application, 100)
+        if not updated.get("success"):
+            return {
+                "success": True,
+                "completed_steps": completed,
+                "updated_state_error": updated.get("error"),
+            }
+        updated["completed_steps"] = completed
+        updated["ui_settle"] = settle
+        return _state_tool_return(updated, "macOS state after computer-use batch")
+
+    return computer_use_batch
+
+
+REGISTRARS = {
+    "computer_get_app_state": register_get_app_state,
+    "computer_snapshot": register_snapshot,
+    "computer_click": register_click,
+    "computer_set_value": register_set_value,
+    "computer_perform_action": register_perform_action,
+    "computer_select_text": register_select_text,
+    "computer_press_key": register_press_key,
+    "computer_type_text": register_type_text,
+    "computer_scroll": register_scroll,
+    "computer_drag": register_drag,
+    "computer_screenshot": register_screenshot,
+    "computer_use_batch": register_batch,
+}
+
+
+def _image_tool_return(result: dict[str, Any], label: str) -> ToolReturn:
+    path = str(result["path"])
+    image_bytes = Path(path).read_bytes()
+    displayed = emit_inline_image(path)
+    metadata = dict(result)
+    metadata["displayed_inline"] = displayed
+    return ToolReturn(
+        return_value=metadata,
+        content=[
+            f"Here is the {label}:",
+            BinaryContent(data=image_bytes, media_type="image/png"),
+        ],
+        metadata=metadata,
+    )
+
+
+def _state_tool_return(result: dict[str, Any], label: str) -> ToolReturn:
+    image = _image_tool_return(
+        {"success": True, "path": result["screenshot_path"]}, label
+    )
+    metadata = dict(result)
+    metadata["displayed_inline"] = image.metadata["displayed_inline"]
+    return ToolReturn(
+        return_value=_compact_state_for_model(metadata),
+        content=image.content,
+        metadata=metadata,
+    )
+
+
+def _compact_state_for_model(state: dict[str, Any]) -> dict[str, Any]:
+    """Keep control semantics while removing repetitive AX bookkeeping."""
+    keep = (
+        "success",
+        "state_revision",
+        "application",
+        "bundle_id",
+        "window_title",
+        "window_bounds_points",
+        "screenshot_size_pixels",
+        "screenshot_coordinate_system",
+        "action_coordinate_system",
+        "node_count",
+        "truncated",
+        "overflow_summary",
+        "warning",
+        "completed_steps",
+        "ui_settle",
+    )
+    compact = {key: state[key] for key in keep if key in state}
+    compact_nodes = []
+    ignored_actions = {"AXShowMenu", "AXScrollToVisible"}
+    for node in state.get("nodes", []):
+        item = {
+            key: node[key]
+            for key in ("id", "role", "title", "description", "value")
+            if node.get(key) not in (None, "")
+        }
+        actions = [
+            action
+            for action in node.get("actions", [])
+            if action not in ignored_actions
+        ]
+        if actions:
+            item["actions"] = actions
+        if node.get("focused"):
+            item["focused"] = True
+        if node.get("enabled") is False:
+            item["enabled"] = False
+        compact_nodes.append(item)
+    compact["nodes"] = compact_nodes
+    return compact
+
+
+async def _attach_screenshot(
+    result: dict[str, Any],
+    label: str,
+    app_name: str | None = None,
+) -> ToolReturn | dict[str, Any]:
+    screenshot = await _call(backend.screenshot, None, app_name)
+    if not screenshot.get("success"):
+        result["screenshot_error"] = screenshot.get("error")
+        return result
+    screenshot_return = _image_tool_return(screenshot, label)
+    merged = dict(result)
+    merged["screenshot_path"] = screenshot["path"]
+    merged["displayed_inline"] = screenshot_return.metadata["displayed_inline"]
+    return ToolReturn(
+        return_value=merged,
+        content=screenshot_return.content,
+        metadata=merged,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,11 @@ classifiers = [
 [project.optional-dependencies]
 bedrock = ["boto3>=1.35.0"]
 durable = ["dbos>=2.11.0"]
+computer-use = [
+    "pyobjc-framework-ApplicationServices>=10.3; sys_platform == 'darwin'",
+    "pyobjc-framework-Cocoa>=10.3; sys_platform == 'darwin'",
+    "pyobjc-framework-Quartz>=10.3; sys_platform == 'darwin'",
+]
 
 [project.urls]
 repository = "https://github.com/mpfaffenberger/code_puppy"

--- a/tests/plugins/test_computer_use_accessibility.py
+++ b/tests/plugins/test_computer_use_accessibility.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from code_puppy.plugins.computer_use.accessibility import snapshot_tree
+
+
+class API:
+    kAXErrorSuccess = 0
+    kAXFocusedWindowAttribute = "focused_window"
+    kAXMainWindowAttribute = "main_window"
+    kAXWindowsAttribute = "windows"
+    kAXRoleAttribute = "role"
+    kAXTitleAttribute = "title"
+    kAXDescriptionAttribute = "description"
+    kAXValueAttribute = "value"
+    kAXEnabledAttribute = "enabled"
+    kAXFocusedAttribute = "focused"
+    kAXChildrenAttribute = "children"
+
+    @staticmethod
+    def AXUIElementCopyActionNames(element, _):
+        return 0, element.get("actions", [])
+
+
+def copy_attribute(api, element, attribute):
+    del api
+    return element.get(attribute)
+
+
+def test_actionable_controls_rank_ahead_of_large_file_list():
+    rows = [
+        {
+            "role": "AXRow",
+            "title": f"File {index}",
+            "enabled": True,
+            "children": [],
+        }
+        for index in range(300)
+    ]
+    button = {
+        "role": "AXButton",
+        "title": "New Document",
+        "enabled": True,
+        "actions": ["AXPress"],
+        "children": [],
+    }
+    window = {
+        "role": "AXWindow",
+        "title": "Open",
+        "children": [*rows, button],
+    }
+    application = {"focused_window": window}
+
+    nodes, elements, metadata = snapshot_tree(
+        API, application, copy_attribute, max_nodes=20
+    )
+
+    assert nodes[0]["title"] == "New Document"
+    assert nodes[0]["actions"] == ["AXPress"]
+    assert elements[nodes[0]["id"]] is button
+    assert metadata["scanned_node_count"] == 302
+    assert metadata["truncated"] is True
+    assert metadata["overflow_summary"]["roles"]["AXRow"] > 250
+
+
+def test_preferred_capture_window_keeps_tree_and_screenshot_aligned():
+    other = {
+        "AXWindowNumber": 10,
+        "role": "AXWindow",
+        "title": "Other",
+        "children": [],
+    }
+    captured = {
+        "AXWindowNumber": 20,
+        "role": "AXWindow",
+        "title": "Captured",
+        "children": [],
+    }
+    application = {
+        "focused_window": other,
+        "windows": [other, captured],
+    }
+
+    nodes, _, _ = snapshot_tree(
+        API,
+        application,
+        copy_attribute,
+        max_nodes=20,
+        preferred_window_id=20,
+    )
+
+    assert nodes[0]["title"] == "Captured"

--- a/tests/plugins/test_computer_use_actions.py
+++ b/tests/plugins/test_computer_use_actions.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from code_puppy.plugins.computer_use.backend import MacOSBackend
+from code_puppy.plugins.computer_use.backend_types import ComputerUseError
+
+
+class ActionAPI:
+    kAXErrorSuccess = 0
+    kAXValueAttribute = "AXValue"
+    kAXSelectedTextRangeAttribute = "AXSelectedTextRange"
+    kAXValueCFRangeType = "CFRange"
+
+    def __init__(self, actions=()):
+        self.actions = list(actions)
+        self.performed = []
+        self.values = []
+
+    def AXUIElementCopyActionNames(self, element, placeholder):
+        del element, placeholder
+        return self.kAXErrorSuccess, self.actions
+
+    def AXUIElementPerformAction(self, element, action):
+        self.performed.append((element, action))
+        return self.kAXErrorSuccess
+
+    def AXValueCreate(self, value_type, value):
+        return value_type, value
+
+    def AXUIElementSetAttributeValue(self, element, attribute, value):
+        self.values.append((element, attribute, value))
+        return self.kAXErrorSuccess
+
+
+def test_perform_action_only_allows_element_advertised_actions(monkeypatch):
+    api = ActionAPI(["AXPress", "AXShowMenu"])
+    backend = MacOSBackend()
+    monkeypatch.setattr(backend, "_element", lambda *args, **kwargs: (api, "button"))
+    monkeypatch.setattr(backend, "require_state", Mock())
+
+    result = backend.perform_action("revision", 7, "axshowmenu")
+    assert result["action"] == "AXShowMenu"
+    assert api.performed == [("button", "AXShowMenu")]
+
+    with pytest.raises(ComputerUseError, match="not exposed"):
+        backend.perform_action("revision", 7, "AXDelete")
+
+
+def test_select_text_disambiguates_and_places_cursor(monkeypatch):
+    api = ActionAPI()
+    backend = MacOSBackend()
+    monkeypatch.setattr(backend, "_element", lambda *args, **kwargs: (api, "editor"))
+    monkeypatch.setattr(backend, "require_state", Mock())
+    monkeypatch.setattr(
+        backend,
+        "_copy_attribute",
+        lambda quartz, element, attribute: "red dog, blue dog",
+    )
+
+    result = backend.select_text(
+        "revision",
+        3,
+        "dog",
+        mode="cursor_after",
+        prefix="blue ",
+    )
+    assert result["range"] == {"location": 17, "length": 0}
+    assert api.values[-1] == (
+        "editor",
+        "AXSelectedTextRange",
+        ("CFRange", (17, 0)),
+    )
+
+    with pytest.raises(ComputerUseError, match="ambiguous"):
+        backend.select_text("revision", 3, "dog")

--- a/tests/plugins/test_computer_use_activation.py
+++ b/tests/plugins/test_computer_use_activation.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from code_puppy.plugins.computer_use.activation import (
+    activate_application,
+    activate_state,
+)
+from code_puppy.plugins.computer_use.backend_types import ComputerUseError
+from code_puppy.plugins.computer_use.geometry import CaptureGeometry, Rect
+from code_puppy.plugins.computer_use.state import AppState
+
+
+class Application:
+    def __init__(self, pid=7, terminated=False, activates=True):
+        self.pid = pid
+        self.is_terminated = terminated
+        self.activates = activates
+        self.options = None
+
+    def processIdentifier(self):
+        return self.pid
+
+    def isTerminated(self):
+        return self.is_terminated
+
+    def activateWithOptions_(self, options):
+        self.options = options
+        return self.activates
+
+
+def state(pid=7):
+    return AppState(
+        revision="revision",
+        application="Spotify",
+        bundle_id="com.spotify.client",
+        pid=pid,
+        window_id=42,
+        window_title="Spotify Premium",
+        geometry=CaptureGeometry(Rect(0, 0, 100, 100), 200, 200, 2),
+        screenshot_path="/tmp/spotify.png",
+        elements={},
+    )
+
+
+def test_activation_brings_state_process_to_front(monkeypatch):
+    app = Application()
+    workspace = SimpleNamespace(
+        runningApplications=lambda: [app],
+        frontmostApplication=lambda: app,
+    )
+    monkeypatch.setattr(
+        "code_puppy.plugins.computer_use.activation._workspace",
+        lambda: workspace,
+    )
+
+    activate_state(state())
+    assert app.options == 3
+
+
+def test_activation_can_target_pid_before_state_exists(monkeypatch):
+    app = Application()
+    workspace = SimpleNamespace(
+        runningApplications=lambda: [app],
+        frontmostApplication=lambda: app,
+    )
+    monkeypatch.setattr(
+        "code_puppy.plugins.computer_use.activation._workspace",
+        lambda: workspace,
+    )
+
+    activate_application(7, "Spotify")
+    assert app.options == 3
+
+
+def test_activation_rejects_missing_target(monkeypatch):
+    workspace = SimpleNamespace(
+        runningApplications=lambda: [],
+        frontmostApplication=lambda: None,
+    )
+    monkeypatch.setattr(
+        "code_puppy.plugins.computer_use.activation._workspace",
+        lambda: workspace,
+    )
+    with pytest.raises(ComputerUseError, match="no longer running"):
+        activate_state(state())

--- a/tests/plugins/test_computer_use_inline_image.py
+++ b/tests/plugins/test_computer_use_inline_image.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import io
+
+from code_puppy.plugins.computer_use import inline_image
+
+
+def test_terminal_detection(monkeypatch):
+    monkeypatch.setenv("TERM_PROGRAM", "ghostty")
+    assert inline_image._terminal_kind() == "kitty"
+
+    monkeypatch.setenv("TERM_PROGRAM", "iTerm.app")
+    assert inline_image._terminal_kind() == "iterm"
+
+    monkeypatch.delenv("ITERM_SESSION_ID", raising=False)
+    monkeypatch.setenv("TERM_PROGRAM", "unknown")
+    monkeypatch.setenv("TERM", "dumb")
+    assert inline_image._terminal_kind() is None
+
+
+def test_ghostty_emits_kitty_graphics_sequence(monkeypatch, tmp_path):
+    class TTYBuffer(io.StringIO):
+        def isatty(self):
+            return True
+
+    image = tmp_path / "screen.png"
+    image.write_bytes(b"\x89PNG\r\n\x1a\n")
+    output = TTYBuffer()
+    monkeypatch.setenv("TERM_PROGRAM", "ghostty")
+    monkeypatch.setattr(inline_image.sys, "stdout", output)
+
+    assert inline_image.emit_inline_image(image) is True
+    sequence = output.getvalue()
+    assert sequence.startswith("\033_G")
+    assert "a=T,t=f,f=100,q=2,c=64,r=22" in sequence
+    assert sequence.endswith("\033\\\n")

--- a/tests/plugins/test_computer_use_plugin.py
+++ b/tests/plugins/test_computer_use_plugin.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from pydantic_ai import ToolReturn
+
+from code_puppy.plugins.computer_use import register_callbacks
+from code_puppy.plugins.computer_use import tools
+from code_puppy.plugins.computer_use.geometry import CaptureGeometry, Rect
+from code_puppy.plugins.computer_use.state import state_store
+
+
+class FakeAgent:
+    def __init__(self):
+        self.registered = {}
+
+    def tool(self, function):
+        self.registered[function.__name__] = function
+        return function
+
+
+@pytest.fixture(autouse=True)
+def disable_real_app_activation(monkeypatch):
+    monkeypatch.setattr(
+        "code_puppy.plugins.computer_use.backend.activate_state",
+        lambda state: None,
+    )
+    monkeypatch.setattr(
+        "code_puppy.plugins.computer_use.backend.policy_store.require_enabled",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "code_puppy.plugins.computer_use.backend.policy_store.require",
+        lambda bundle_id: None,
+    )
+
+
+def make_state(tmp_path, elements=None):
+    state_store.clear()
+    return state_store.create(
+        application="TextEdit",
+        bundle_id="com.apple.TextEdit",
+        pid=123,
+        window_id=456,
+        window_title="Untitled",
+        geometry=CaptureGeometry(Rect(100, 200, 800, 600), 1600, 1200, 2),
+        screenshot_path=str(tmp_path / "state.png"),
+        elements=elements or {},
+    )
+
+
+def test_plugin_registers_only_on_macos(monkeypatch):
+    monkeypatch.setattr(register_callbacks.sys, "platform", "linux")
+    assert register_callbacks._register_tools() == []
+    assert register_callbacks._register_agent_tools() == []
+    assert register_callbacks._load_prompt() is None
+
+    monkeypatch.setattr(register_callbacks.sys, "platform", "darwin")
+    definitions = register_callbacks._register_tools()
+    assert {item["name"] for item in definitions} == set(tools.REGISTRARS)
+    assert set(register_callbacks._register_agent_tools()) == set(tools.REGISTRARS)
+    prompt = register_callbacks._load_prompt()
+    assert "always call the appropriate Computer Use state tool again" in prompt
+    assert "tool's current result is authoritative" in prompt
+
+
+def test_model_state_removes_repetitive_accessibility_bookkeeping():
+    compact = tools._compact_state_for_model(
+        {
+            "success": True,
+            "state_revision": "revision",
+            "nodes": [
+                {
+                    "id": 7,
+                    "depth": 18,
+                    "source_order": 92,
+                    "role": "AXButton",
+                    "title": "",
+                    "description": "Play",
+                    "value": "",
+                    "enabled": True,
+                    "focused": False,
+                    "actions": ["AXPress", "AXShowMenu", "AXScrollToVisible"],
+                }
+            ],
+        }
+    )
+    assert compact["nodes"] == [
+        {
+            "id": 7,
+            "role": "AXButton",
+            "description": "Play",
+            "actions": ["AXPress"],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_snapshot_registration():
+    agent = FakeAgent()
+    tools.register_snapshot(agent)
+    with patch.object(
+        tools.backend, "get_app_state", return_value={"success": True, "nodes": []}
+    ):
+        result = await agent.registered["computer_snapshot"](None, "Safari", 25, False)
+    assert result["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_batch_stops_on_failure(tmp_path):
+    agent = FakeAgent()
+    tools.register_batch(agent)
+    state = make_state(tmp_path)
+    with (
+        patch.object(tools.backend, "click", return_value={"success": True}),
+        patch.object(
+            tools.backend,
+            "set_value",
+            side_effect=tools.ComputerUseError("stale element"),
+        ),
+    ):
+        result = await agent.registered["computer_use_batch"](
+            None,
+            state.revision,
+            [
+                {"action": "click", "element_id": 1},
+                {"action": "set_value", "element_id": 2, "value": "hello"},
+                {"action": "scroll", "amount": -3},
+            ],
+        )
+    assert result["success"] is False
+    assert len(result["completed_steps"]) == 2
+    assert "stale element" in result["completed_steps"][1]["result"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_successful_batch_attaches_inline_screenshot(tmp_path):
+    image = tmp_path / "screen.png"
+    image.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+    agent = FakeAgent()
+    tools.register_batch(agent)
+    state = make_state(tmp_path)
+    updated = {
+        "success": True,
+        "state_revision": "updated",
+        "screenshot_path": str(image),
+        "nodes": [],
+    }
+    with (
+        patch.object(tools.backend, "click", return_value={"success": True}),
+        patch.object(tools.backend, "get_app_state", return_value=updated),
+        patch.object(tools, "emit_inline_image", return_value=True),
+        patch.object(
+            tools,
+            "wait_for_ui_settle",
+            return_value={"settled": True, "observations": 3},
+        ),
+    ):
+        result = await agent.registered["computer_use_batch"](
+            None, state.revision, [{"action": "click", "element_id": 1}]
+        )
+    assert isinstance(result, ToolReturn)
+    assert result.metadata["displayed_inline"] is True
+    assert result.metadata["screenshot_path"] == str(image)
+    assert result.return_value["state_revision"] == "updated"
+
+
+@pytest.mark.asyncio
+async def test_batch_rejects_unknown_and_oversized_actions(tmp_path):
+    agent = FakeAgent()
+    tools.register_batch(agent)
+    invoke = agent.registered["computer_use_batch"]
+    oversized = await invoke(None, "unused", [{"action": "wait"}] * 21)
+    assert oversized["success"] is False
+    state = make_state(tmp_path)
+    unknown = await invoke(None, state.revision, [{"action": "launch_missiles"}])
+    assert unknown["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_batch_activation_bridge_error_is_returned_not_raised(tmp_path):
+    agent = FakeAgent()
+    tools.register_batch(agent)
+    state = make_state(tmp_path)
+    with patch.object(
+        tools.backend,
+        "require_state",
+        side_effect=AttributeError("unexpected PyObjC selector"),
+    ):
+        result = await agent.registered["computer_use_batch"](
+            None,
+            state.revision,
+            [{"action": "click", "element_id": 1}],
+        )
+    assert result["success"] is False
+    assert "unexpected PyObjC selector" in result["error"]

--- a/tests/plugins/test_computer_use_policy.py
+++ b/tests/plugins/test_computer_use_policy.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import pytest
+
+from code_puppy.plugins.computer_use.backend_types import ComputerUseError
+from code_puppy.plugins.computer_use.geometry import CaptureGeometry, Rect
+from code_puppy.plugins.computer_use.policy import PolicyStore
+from code_puppy.plugins.computer_use.safety import require_safe_state
+from code_puppy.plugins.computer_use.state import state_store
+
+
+def test_policy_requires_first_use_consent_then_persists_choice(tmp_path):
+    path = tmp_path / "policy.json"
+    policy = PolicyStore(path)
+    with pytest.raises(ComputerUseError, match="one-time permission"):
+        policy.require_enabled()
+
+    policy.set_enabled(True)
+    policy.require("com.example.Editor")
+    assert path.stat().st_mode & 0o777 == 0o600
+    PolicyStore(path).require("com.example.Editor")
+
+    policy.set_enabled(False)
+    with pytest.raises(ComputerUseError, match="disabled in settings"):
+        policy.require("com.example.Editor")
+
+
+def test_policy_supports_persisted_app_denials(tmp_path):
+    path = tmp_path / "policy.json"
+    policy = PolicyStore(path)
+    policy.set_enabled(True)
+
+    policy.deny("com.example.Editor")
+    with pytest.raises(ComputerUseError, match="denied"):
+        policy.require("com.example.Editor")
+    assert path.stat().st_mode & 0o777 == 0o600
+
+    policy.allow("com.example.Editor")
+    PolicyStore(path).require("com.example.Editor")
+
+
+def test_policy_pause_and_security_processes(tmp_path):
+    policy = PolicyStore(tmp_path / "policy.json")
+    policy.set_enabled(True)
+    policy.set_paused(True)
+    with pytest.raises(ComputerUseError, match="emergency stop"):
+        policy.require("com.example.Other")
+
+    with pytest.raises(ComputerUseError, match="never allowed"):
+        policy.allow("com.apple.loginwindow")
+
+
+def test_safe_state_is_not_interrupted_by_user_input(monkeypatch):
+    state_store.clear()
+    state = state_store.create(
+        application="Editor",
+        bundle_id="com.example.Editor",
+        pid=1,
+        window_id=2,
+        window_title="Document",
+        geometry=CaptureGeometry(Rect(0, 0, 100, 100), 200, 200, 2),
+        screenshot_path="/tmp/editor.png",
+        elements={},
+    )
+    monkeypatch.setattr(
+        "code_puppy.plugins.computer_use.safety.policy_store.require",
+        lambda bundle_id: None,
+    )
+    assert require_safe_state(state.revision, consume=True) is state
+    assert state.consumed

--- a/tests/plugins/test_computer_use_settle.py
+++ b/tests/plugins/test_computer_use_settle.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from code_puppy.plugins.computer_use.settle import wait_for_ui_settle
+
+
+def test_wait_for_ui_settle_requires_repeated_fingerprint():
+    calls = 0
+
+    def snapshotter(app_name, max_nodes):
+        nonlocal calls
+        assert app_name == "Example"
+        assert max_nodes == 120
+        calls += 1
+        value = "moving" if calls == 1 else "stable"
+        return {"nodes": [{"role": "AXTextField", "value": value}]}
+
+    result = wait_for_ui_settle(
+        snapshotter,
+        "Example",
+        timeout=1,
+        interval=0.001,
+        stable_observations=2,
+    )
+    assert result["settled"] is True
+    assert result["observations"] == 4

--- a/tests/plugins/test_computer_use_state.py
+++ b/tests/plugins/test_computer_use_state.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from code_puppy.plugins.computer_use.backend_types import ComputerUseError
+from code_puppy.plugins.computer_use.geometry import CaptureGeometry, Rect
+from code_puppy.plugins.computer_use.state import StateStore
+
+
+def make_store():
+    store = StateStore(max_age_seconds=120)
+    state = store.create(
+        application="Example",
+        bundle_id="com.example.app",
+        pid=1,
+        window_id=2,
+        window_title="Window",
+        geometry=CaptureGeometry(Rect(-100, 50, 800, 600), 1600, 1200, 2),
+        screenshot_path="/tmp/example.png",
+        elements={7: object()},
+    )
+    return store, state
+
+
+def test_retina_and_negative_display_coordinate_transform():
+    geometry = CaptureGeometry(Rect(-100, 50, 800, 600), 1600, 1200, 2)
+    assert geometry.screenshot_to_quartz(0, 0) == (-100, 50)
+    assert geometry.screenshot_to_quartz(800, 600) == (300, 350)
+
+
+def test_coordinate_transform_rejects_out_of_bounds():
+    geometry = CaptureGeometry(Rect(0, 0, 800, 600), 1600, 1200, 2)
+    with pytest.raises(ComputerUseError, match="outside"):
+        geometry.screenshot_to_quartz(1600, 10)
+
+
+def test_state_is_single_use_and_rejects_stale_revision():
+    store, state = make_store()
+    assert store.require(state.revision).window_id == 2
+    store.require(state.revision, consume=True)
+    with pytest.raises(ComputerUseError, match="changed after an action"):
+        store.require(state.revision)
+    with pytest.raises(ComputerUseError, match="Stale or unknown"):
+        store.require("wrong")

--- a/uv.lock
+++ b/uv.lock
@@ -352,6 +352,11 @@ dependencies = [
 bedrock = [
     { name = "boto3" },
 ]
+computer-use = [
+    { name = "pyobjc-framework-applicationservices", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
+]
 durable = [
     { name = "dbos" },
 ]
@@ -384,6 +389,9 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.4.0" },
     { name = "pydantic-ai-slim", extras = ["openai", "anthropic", "mcp"], specifier = "==1.56.0" },
     { name = "pyfiglet", specifier = ">=0.8.post1" },
+    { name = "pyobjc-framework-applicationservices", marker = "sys_platform == 'darwin' and extra == 'computer-use'", specifier = ">=10.3" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin' and extra == 'computer-use'", specifier = ">=10.3" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin' and extra == 'computer-use'", specifier = ">=10.3" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "rapidfuzz", specifier = ">=3.13.0" },
     { name = "requests", specifier = ">=2.28.0" },
@@ -392,7 +400,7 @@ requires-dist = [
     { name = "termflow-md", specifier = ">=0.1.11" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
-provides-extras = ["bedrock", "durable"]
+provides-extras = ["bedrock", "durable", "computer-use"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1600,6 +1608,94 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pyobjc-core"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/b1/729f7458a63758bd21716648a8abcd9a0c8f2d2e9897763c8a1a1c7fd31b/pyobjc_core-12.2.1.tar.gz", hash = "sha256:7a7b9b018402342cf32bf1956366896350fbe5c0478cb3ef59778f77abed7f07", size = 1063383, upload-time = "2026-06-19T16:19:39.357Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/87/16564ef5e4568ee0edd9e712d8111dc8b67621d6bb6ff430646ee2d637dd/pyobjc_core-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:24b76a63caf0b5369d4a377c7c0438cd70df81539057af3db839bfaa3579e04a", size = 6484662, upload-time = "2026-06-19T16:04:44.979Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/88/300ad283bed0c971c52dcac6f70113e138169d4ce6d856ddd03d16081e51/pyobjc_core-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a64232bb27ed101d4adc7d42b0e64a6d3331aac7bee7861c037a6777a163f10b", size = 6433347, upload-time = "2026-06-19T16:04:49.341Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/1e/b9b0ddffae66996b8779f1f7958adc9f21c13a0448cd3be8d7fe589b5b0f/pyobjc_core-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:af101222762665a4125157906cb4b23f5d5a63d3851d5e0504f72a1eaaa2cfd2", size = 6436004, upload-time = "2026-06-19T16:04:53.257Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/bd309ede07784c6e5fac4b440c90a5f72a66da7859ed303a9392fe8a5f3f/pyobjc_core-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:efe465e3ecc6fc73f7c7622620345d134a8d34564ab1c29d8247e45f4ed55071", size = 6687044, upload-time = "2026-06-19T16:04:57.42Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/8a/cfa4f56939d554dbb342ec6e5226a441e2f552bc2002a0ddf7705bb11bef/pyobjc_core-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2b8fc0531c27277325e113ac00b8a72a82e6145f0a88175b9425d8de814ff69a", size = 6429289, upload-time = "2026-06-19T16:05:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/42/74/446c89bc18103aaa4a00d1fb85ff8acace9a0dc3f362d9678ebf7571e275/pyobjc_core-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9bef500f979e22d54f9da3aaebf6a48f873234b324858bd69256055a318955c7", size = 6690181, upload-time = "2026-06-19T16:05:06.201Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-applicationservices"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coretext" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/4d/0ebdd8144aba94b8fe9828ccee5616a4bf53d1f8bc51cff55f3cce86d695/pyobjc_framework_applicationservices-12.2.1.tar.gz", hash = "sha256:048ea663c9ac75c44a15dc7d5b8d78cbb4c97bf1c76e83835e8d5498e184001f", size = 109342, upload-time = "2026-06-19T16:19:46.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/8a/5a9310929bb303c31c04a1c6dc7b3213c9bd964a692d024a00c0643af2c8/pyobjc_framework_applicationservices-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:dabec481217b0d0c1ea835e9fef6b0681381b14b3f16a30d4a9d801ee3852dd2", size = 32715, upload-time = "2026-06-19T16:05:38.448Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/89/39a7462006afbc06c69029fe4181b7359a9da25ae7864ef75f9d3ffb9272/pyobjc_framework_applicationservices-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f519ced13888d03410cd7da1f08fc56ee2944099e607216cef7ca26ecfdef61b", size = 32764, upload-time = "2026-06-19T16:05:39.26Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/8e928d5e3025529ed92c6eb5fd88a5e6e485cc6df945c541f29b4af7f2c6/pyobjc_framework_applicationservices-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8749290f796e6cca341d443769b79329dde5d157bcc4413c1f7fdb68ea4a8e48", size = 32782, upload-time = "2026-06-19T16:05:40.284Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a5/c7b5a31777fe2ce7c07b9c16941ff4fbf0a150bf755164d96228d32ccb4f/pyobjc_framework_applicationservices-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9ee11677fbd6a0987234814c7dde88ffd11242e8c1f76952e6654ea07f2370ac", size = 33048, upload-time = "2026-06-19T16:05:41.308Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/47/cd2bd76b862686c0aa78568ed9dff175764353c209a3096c72d6e2a9b151/pyobjc_framework_applicationservices-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a1c0ee536cb8bd7f5a811165ec323a9207b1e8dad9534fe2081f767fb90b0411", size = 32921, upload-time = "2026-06-19T16:05:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/6989a96f8501aa3a16513d08b2c4c78ca906a10b6a4e5a33c4c59fd1bea9/pyobjc_framework_applicationservices-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0d55dd5be19e4a1363662bc8b48894d45714d07f0ee3958665fc9ea7df0f61b7", size = 33163, upload-time = "2026-06-19T16:05:43.256Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cocoa"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/34/fbe38a204643aa4e1b91391cdce07a34da565a69171ebcad08de7438a556/pyobjc_framework_cocoa-12.2.1.tar.gz", hash = "sha256:b94b37fe5730e5ae1fb0052912cd174e6ec329b0bfba4a012ae5db1014b5864b", size = 3125751, upload-time = "2026-06-19T16:20:05.159Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/d6/dc66ea8519a0475efbccf73f82cc28066339bb300a27f5e1bf91ab1d7002/pyobjc_framework_cocoa-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:dc6da84f4fc62cc25463bbb85e77a57b8d5ac6caf9a60702daf2edb601332f15", size = 387298, upload-time = "2026-06-19T16:07:37.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/cf/1b3b32b2f28f66cc053c3438ef4e6df36a1591945bf05e7399da18d74553/pyobjc_framework_cocoa-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:28b9b8bab1c36efb94744786918752d0c1842f5fbb67e7d5ca97b5f736512080", size = 388113, upload-time = "2026-06-19T16:07:38.9Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/46/68e8e4d926a2f70fed0437047bc3f9fe08af8fe620d94d80656ebc3cfa9b/pyobjc_framework_cocoa-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3b74a78fa7803e547b32e5e8ec1b49987b52fe318383e793bc6cd49b80efbd9f", size = 388183, upload-time = "2026-06-19T16:07:40.483Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/f3/dfc9af4c9eb2e5389c860ad5ef252be9fe456db09f39d537555dc5057aa1/pyobjc_framework_cocoa-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:dc2eaca2f13c7bcd8e41e51a372e47825dea9dd3126108760eed7ba883d2945c", size = 392275, upload-time = "2026-06-19T16:07:42.078Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c8/b90baa8f3592eded79b4be98fb59d2b8dc16b62361e34292bd95806ebd9f/pyobjc_framework_cocoa-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b386c324d64ae565c1f6b7dfb77be68f640a1c7c23caa6966ab661131f519561", size = 388357, upload-time = "2026-06-19T16:07:43.364Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d8/64a94651b9294702d55e748d94de30e25bc59d0784526be7643f4467eccd/pyobjc_framework_cocoa-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a6c584e2af0813cb2f6103b184e632665a26f58c1bd5b08ffd6e95a19c617f7b", size = 392404, upload-time = "2026-06-19T16:07:44.955Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coretext"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/9c/4c7f452059dc1d3845b8e627b9113c247a997b9b07518e848c2ab7ff3149/pyobjc_framework_coretext-12.2.1.tar.gz", hash = "sha256:af740e784d7c592c34025ec7165f4f6c1a69b5a2d9075f06e41e4f77c212aed2", size = 97349, upload-time = "2026-06-19T16:20:22.508Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/53/c262cf5052c648c48b3f7562fcce188fb78ff94e44cf1c48fdfc62fdfcce/pyobjc_framework_coretext-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:02a448675d28005fdb88fb3c585572b02871e9e5d4d08f88334ec937ea5de6e7", size = 30022, upload-time = "2026-06-19T16:09:50.37Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/11/c1298c2ec3b0cd19a457a1fd0da47898f894a13df5516f80dc04d1a7a4d9/pyobjc_framework_coretext-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ac2ead13dfa4379a1566129d0e8a8ea778a2bcac9ac360a583360fd4f1ba39c6", size = 30123, upload-time = "2026-06-19T16:09:51.183Z" },
+    { url = "https://files.pythonhosted.org/packages/05/8c/154e8f34923b24aade64a20eca2b759f8f67e109654308103080751f246f/pyobjc_framework_coretext-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5c5a3c6e2d905a17efb15572dad97ce582feeab5c3b92537015445e0e0bb46de", size = 30116, upload-time = "2026-06-19T16:09:52.219Z" },
+    { url = "https://files.pythonhosted.org/packages/01/61/f53458c8f7fe74008e342946eca1fa82b777b284d4e13d8bd2e3e5724cab/pyobjc_framework_coretext-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5c979058c77df8cd3dac5fd7db4c484f9886fbe09e2687bfaf269a856f631f78", size = 30659, upload-time = "2026-06-19T16:09:53.034Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d8/d1178bb1ba3bb7a0d7a55db460aa89f2a8b232ed7eaf76cb402923cacf2d/pyobjc_framework_coretext-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d0b3b0467a23dbc2a39d0839e7100cc98b429fb7d52a471bd65477f46bb4c9e5", size = 30100, upload-time = "2026-06-19T16:09:53.902Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c3/780d739909e6d8ddd9e8786fd19e8ea10ccfcc7275df987e349af0fb33b1/pyobjc_framework_coretext-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3d4a92fa657180cd0e900b98535da4f0f4d8c76a7077730a507e50d52d2853e3", size = 30642, upload-time = "2026-06-19T16:09:54.736Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-quartz"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/f6/2a8b84dbf1fe7c04dd96ea73d991678d4e09a909f51971ecc51629bb2ab4/pyobjc_framework_quartz-12.2.1.tar.gz", hash = "sha256:b3b8b6f71e66147f8ff9e6213864cc8527e3a0b1ee90835b93ce221f4802d9b0", size = 3215521, upload-time = "2026-06-19T16:21:30.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/08/527d1ff856e2f2446b5887be01989cc08f9adaf3de7d4eb13d07826c362f/pyobjc_framework_quartz-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:60f29408b4f9ed5391a29c6b63e2aa56ddfb8b66b3fb47962930427981e14462", size = 217998, upload-time = "2026-06-19T16:16:02.978Z" },
+    { url = "https://files.pythonhosted.org/packages/14/fc/d7c7b3134cdbd1a487f3f77b5be125d87a6c9e7d9411035739d99335cc0c/pyobjc_framework_quartz-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:de9c8cca7e95290c8d540466af11c7cdfe3a5458e6f56c34006d5b45243f9ed9", size = 219000, upload-time = "2026-06-19T16:16:04.29Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4b/861f91a1565d3189ee899e177b915551fb9a7e2ca25414025a8974f04e74/pyobjc_framework_quartz-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:54c9bc7f507192691841ee4eba5bf36990b259df83ac728efed2d7ea1cd021e4", size = 219403, upload-time = "2026-06-19T16:16:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b5/b27010d2f288737f627f74be6d5549f49c841542365c84b9a3011fe39ce7/pyobjc_framework_quartz-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:bfc0d2badd819823d21df8069dcf9544ce360ed747a8895c51bdb25d8d125f45", size = 224458, upload-time = "2026-06-19T16:16:07.252Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5d/85ffd9d433989205d572a50d625c63b29c05e0c5235a725f15ae1023672c/pyobjc_framework_quartz-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ceb56939c337b36d9d81185ade31f77dc52c85cf79bb16e53e9b32f54b6bb3f5", size = 219769, upload-time = "2026-06-19T16:16:08.814Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d6/b917e4b63d72ea84a27121076f3033f23f6497c0e6ce8d304766c899897f/pyobjc_framework_quartz-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8105c98b798f2bf81c05c54bddeeadbf62f0b5dfec13bd6e719dd2cdf7e1cddf", size = 224717, upload-time = "2026-06-19T16:16:10.215Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- Adds an optional native macOS Computer Use plugin backed by Accessibility APIs and ScreenCaptureKit.
- Provides revision-guarded semantic and coordinate actions, deterministic UI settling, inline Ghostty-compatible screenshots, and guarded action batches.
- Adds first-use persisted consent with `/computer-use enable`, `/computer-use disable`, status, pause/resume, explicit app denials, and a hard security-process denylist.
- Reduces model token usage by prioritizing meaningful accessibility nodes, limiting the default tree to 100 nodes, returning a compact model-facing state, and avoiding duplicate full-state content.
- Adds focused plugin tests, packaging metadata, and dedicated macOS CI that compiles the Swift helper and verifies wheel/sdist contents.

## Why

Code Puppy currently lacks a native path for agents to inspect and control regular macOS apps while the user continues working on the host. This adds that capability as an optional extra, with persistent user control and fail-closed first-use consent.

The consent retry path also accounts for slash commands not appearing in model conversation history: repeated requests must re-check the live tool state instead of repeating a stale permission error.

## User impact

Install with:

```bash
uv sync --extra computer-use
uv run code-puppy
```

On first use, run `/computer-use enable`. The setting persists and can be changed later with `/computer-use disable` or inspected with `/computer-use status`.

## Validation

- `uv run ruff check --fix code_puppy/plugins/computer_use tests/plugins`
- `uv run ruff format code_puppy/plugins/computer_use tests/plugins`
- `uv run pytest tests/plugins/test_computer_use_*.py -q --no-cov` — 24 passed
- Native Swift helper compiled with AppKit and ScreenCaptureKit
- GitHub Actions workflow YAML parsed successfully
- `uv build` succeeded
- Verified `NativeCapture.swift` and plugin README are present in wheel and sdist
- `git diff --check`
