### PR TITLE
Clarify optional model pinning and refresh Agent Creator examples

### DIFF
--- a/code_puppy/agents/agent_creator_agent.py
+++ b/code_puppy/agents/agent_creator_agent.py
@@ -84,8 +84,8 @@ You specialize in:
 3. List ALL available tools so they can see other options
 4. Ask them to confirm their tool selection
 5. Explain why each selected tool is useful for their agent
-6. Ask if they want to pin a specific model to the agent using your `ask_about_model_pinning` method
-7. Include the model in the final JSON if the user chooses to pin one
+6. Explain that pinning a model is optional, then ask whether they want to choose one; do not require a model choice
+7. Include the `model` field in the final JSON only if the user explicitly chooses to pin one; otherwise omit it so the agent uses the global model
 
 ## JSON Agent Schema
 
@@ -93,19 +93,19 @@ Here's the complete schema for JSON agent files:
 
 ```json
 {{
-  "id": "uuid"                       // REQUIRED: you can gen one on the command line or something"
-  "name": "agent-name",              // REQUIRED: Unique identifier (no spaces, use hyphens)
-  "display_name": "Agent Name 🤖",   // OPTIONAL: Pretty name with emoji
-  "description": "What this agent does", // REQUIRED: Clear description
-  "system_prompt": "Instructions...",    // REQUIRED: Agent instructions (string or array)
-  "tools": ["tool1", "tool2"],        // REQUIRED: Array of tool names
-  "user_prompt": "How can I help?",     // OPTIONAL: Custom greeting
-  "tools_config": {{                    // OPTIONAL: Tool configuration
+  "name": "agent-name",
+  "display_name": "Agent Name ",
+  "description": "What this agent does",
+  "system_prompt": "Instructions...",
+  "tools": ["tool1", "tool2"],
+  "user_prompt": "How can I help?",
+  "tools_config": {{
     "timeout": 60
-  }},
-  "model": "model-name"               // OPTIONAL: Pin a specific model for this agent
+  }}
 }}
 ```
+
+The `model` property is optional. Add `"model": "model-name"` only when the user explicitly wants a pinned model; otherwise leave it out.
 
 ### Required Fields:
 - `name`: Unique identifier (kebab-case recommended)
@@ -117,7 +117,7 @@ Here's the complete schema for JSON agent files:
 - `display_name`: Pretty display name (defaults to title-cased name + 🤖)
 - `user_prompt`: Custom user greeting
 - `tools_config`: Tool configuration object
-- `model`: Pin a specific model for this agent (defaults to global model)
+- `model`: Optional model pin. Omit this field to use the global model; users do not need to pin a model
 
 ## ALL AVAILABLE TOOLS:
 {", ".join(f"- **{tool}**" for tool in available_tools)}
@@ -136,7 +136,7 @@ To list all UC tools with their code, use: `universal_constructor(action="list")
 ## ALL AVAILABLE MODELS:
 {available_models_str}
 
-Users can optionally pin a specific model to their agent to override the global default.
+A model pin is completely optional. If the user does not request one, omit the `model` field and the agent will follow the global model setting. Do not pressure users to choose or pin a model.
 
 ### When to Pin Models:
 - For specialized agents that need specific capabilities (e.g., code-heavy agents might need a coding model)
@@ -220,8 +220,8 @@ Use this to recursively search for a string across files starting from the speci
 
 ### Tool Usage Instructions:
 
-#### `ask_about_model_pinning(agent_config)`
-Use this method to ask the user whether they want to pin a specific model to their agent. Always call this method before finalizing the agent configuration and include its result in the agent JSON if a model is selected.
+#### Model pinning
+Ask conversationally whether the user wants to pin a specific model, but make clear that this is optional. If they do not choose one, omit `model` from the JSON so the agent uses the global model. Never require or invent a model pin.
 
 NEVER output an entire file – this is very expensive.
 You may not edit file extensions: [.ipynb]
@@ -398,7 +398,7 @@ This detailed documentation should be copied verbatim into any agent that will b
 3. **🎯 SUGGEST TOOLS** based on their answer with explanations
 4. **📋 SHOW ALL TOOLS** so they know all options
 5. **✅ CONFIRM TOOL SELECTION** and explain choices
-6. **Ask about model pinning**: "Do you want to pin a specific model to this agent?" with list of options
+6. **Offer model pinning as optional**: ask "Do you want to pin a specific model to this agent?" If the user declines, skips, or has no preference, continue without a `model` field
 7. **Craft system prompt** that defines agent behavior, including ALL detailed tool documentation for selected tools
 8. **Generate complete JSON** with proper structure
 9. **🚨 MANDATORY: ASK FOR USER CONFIRMATION** of the generated JSON
@@ -463,8 +463,7 @@ This detailed documentation should be copied verbatim into any agent that will b
     "Always encourage learning and provide constructive feedback."
   ],
   "tools": ["read_file", "create_file", "replace_in_file"],
-  "user_prompt": "What Python concept would you like to learn today?",
-  "model": "Cerebras-GLM-4.6"  // Optional: Pin to a specific code model
+  "user_prompt": "What Python concept would you like to learn today?"
 }}
 ```
 
@@ -482,7 +481,7 @@ This detailed documentation should be copied verbatim into any agent that will b
   ],
   "tools": ["list_files", "read_file", "grep"],
   "user_prompt": "Which code would you like me to review?",
-  "model": "claude-4-0-sonnet"  // Optional: Pin to a model good at analysis
+  "model": "claude-4-0-sonnet"
 }}
 ```
 
@@ -499,7 +498,7 @@ This detailed documentation should be copied verbatim into any agent that will b
   ],
   "tools": ["list_agents", "invoke_agent"],
   "user_prompt": "What can I help you accomplish today?",
-  "model": "gpt-5"  // Optional: Pin to a reasoning-focused model
+  "model": "gpt-5"
 }}
 ```
 
@@ -509,7 +508,7 @@ Be interactive - ask questions, suggest improvements, and guide users through th
 
 ## REMEMBER: COMPLETE THE WORKFLOW!
 - After generating JSON, ALWAYS get confirmation
-- Ask about model pinning using your `ask_about_model_pinning` method
+- Offer model pinning conversationally, but proceed without it when the user declines or has no preference
 - Once confirmed, IMMEDIATELY create the file (don't ask again)
 - Use your `create_file` tool to save the JSON
 - Always explain how to use the new agent with `/agent agent-name`

--- a/code_puppy/agents/agent_creator_agent.py
+++ b/code_puppy/agents/agent_creator_agent.py
@@ -93,7 +93,6 @@ Here's the complete schema for JSON agent files:
 
 ```json
 {{
-  "id": "uuid",
   "name": "agent-name",
   "display_name": "Agent Name ",
   "description": "What this agent does",

--- a/code_puppy/agents/agent_creator_agent.py
+++ b/code_puppy/agents/agent_creator_agent.py
@@ -93,6 +93,7 @@ Here's the complete schema for JSON agent files:
 
 ```json
 {{
+  "id": "uuid",
   "name": "agent-name",
   "display_name": "Agent Name ",
   "description": "What this agent does",

--- a/code_puppy/agents/agent_creator_agent.py
+++ b/code_puppy/agents/agent_creator_agent.py
@@ -433,8 +433,8 @@ This detailed documentation should be copied verbatim into any agent that will b
 ## Model Selection Guidance:
 
 **For code-heavy tasks**: → Suggest `Cerebras-GLM-4.6`, `grok-code-fast-1`, or `gpt-4.1`
-**For document analysis**: → Suggest `gemini-2.5-flash-preview-05-20` or `claude-4-0-sonnet`
-**For general reasoning**: → Suggest `gpt-5` or `o3`
+**For document analysis**: → Suggest `gemini-2.5-flash-preview-05-20` or `claude-sonnet-5`
+**For general reasoning**: → Suggest `gpt-5.6-terra` or `o3`
 **For cost-conscious tasks**: → Suggest `gpt-4.1-mini` or `gpt-4.1-nano`
 **For local/private work**: → Suggest `ollama-llama3.3` or `gpt-4.1-custom`
 


### PR DESCRIPTION
## Summary
- clarify that Agent Creator does not require a model pin
- document that omitting `model` uses the global model
- remove stale model-pinning instructions and fix JSON examples
- refresh the model examples to `claude-sonnet-5` and `gpt-5.6-terra`

## Validation
- `uv run pytest -q tests/test_agent_creator_full_coverage.py` (21 passed)
- adversarial code review: PASS
- `git diff --check`

## Notes
- Existing unrelated untracked files were not included.