### PR TITLE
Fix invalid summary message part for OpenAI Responses

### DIFF
--- a/code_puppy/agents/_compaction.py
+++ b/code_puppy/agents/_compaction.py
@@ -20,8 +20,8 @@ from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
     ModelResponse,
-    TextPart,
     ThinkingPart,
+    UserPromptPart,
 )
 
 from code_puppy.agents._history import (
@@ -218,7 +218,9 @@ def _run_summarization_core(
     # Splice ONLY the summary output into context — not the summarization
     # run's request/response envelope (which would drag the prompt + full
     # history right back into the window we just tried to shrink).
-    new_messages: List[ModelMessage] = [ModelRequest([TextPart(str(summary_text))])]
+    new_messages: List[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content=str(summary_text))])
+    ]
 
     compacted: List[ModelMessage] = [system_message] + list(new_messages)
     compacted.extend(msg for msg in protected_messages if msg is not system_message)

--- a/tests/agents/test_compaction.py
+++ b/tests/agents/test_compaction.py
@@ -13,6 +13,9 @@ from __future__ import annotations
 from typing import List
 from unittest.mock import patch
 
+from pydantic_ai.models import ModelRequestParameters
+from pydantic_ai.models.openai import OpenAIResponsesModel
+from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
@@ -598,7 +601,7 @@ class TestSummarize:
         assert result == msgs, "failure must return original messages unchanged"
         assert dropped == []
 
-    def test_non_list_output_is_wrapped(self):
+    async def test_non_list_output_is_wrapped(self):
         """If summarizer returns a string, it should be wrapped into a message."""
         msgs = _build_long_history(n_turns=10)
 
@@ -617,3 +620,15 @@ class TestSummarize:
         assert len(summary_request.parts) == 1
         assert isinstance(summary_request.parts[0], UserPromptPart)
         assert summary_request.parts[0].content == "summary as string"
+
+        # Exercise the provider mapper that previously raised assert_never()
+        # for TextPart inside a ModelRequest. No API request is made.
+        model = OpenAIResponsesModel(
+            "gpt-5", provider=OpenAIProvider(api_key="test")
+        )
+        _, mapped = await model._map_messages(
+            result,
+            {},
+            ModelRequestParameters(),
+        )
+        assert mapped[1] == {"role": "user", "content": "summary as string"}

--- a/tests/agents/test_compaction.py
+++ b/tests/agents/test_compaction.py
@@ -609,6 +609,11 @@ class TestSummarize:
         ):
             result, dropped = summarize(msgs, protected_tokens=500)
 
-        # Must still compact; string got wrapped into a ModelRequest
+        # Must still compact; string got wrapped into a valid request part.
         assert len(result) < len(msgs)
         assert result[0] is msgs[0]  # system preserved
+        summary_request = result[1]
+        assert isinstance(summary_request, ModelRequest)
+        assert len(summary_request.parts) == 1
+        assert isinstance(summary_request.parts[0], UserPromptPart)
+        assert summary_request.parts[0].content == "summary as string"

--- a/tests/agents/test_compaction.py
+++ b/tests/agents/test_compaction.py
@@ -623,9 +623,7 @@ class TestSummarize:
 
         # Exercise the provider mapper that previously raised assert_never()
         # for TextPart inside a ModelRequest. No API request is made.
-        model = OpenAIResponsesModel(
-            "gpt-5", provider=OpenAIProvider(api_key="test")
-        )
+        model = OpenAIResponsesModel("gpt-5", provider=OpenAIProvider(api_key="test"))
         _, mapped = await model._map_messages(
             result,
             {},


### PR DESCRIPTION
## Summary
- Construct compaction summaries with `UserPromptPart` instead of `TextPart` inside `ModelRequest`
- Exercise pydantic-ai's OpenAI Responses mapper in the regression test
- Verify the mapped summary is emitted as a user input item

## Problem
The summarization fallback created `ModelRequest([TextPart(...)])`. `TextPart` is a response-only part, so pydantic-ai's OpenAI Responses mapper reached `assert_never(part)` and crashed on the next model call.

## Validation
- `uv run pytest -q tests/agents/test_compaction.py -o addopts=` (31 passed)\n- `uv run ruff check code_puppy/agents/_compaction.py tests/agents/test_compaction.py`\n- `git diff --check`\n- Confirmed the old `TextPart` shape reproduces the reported `AssertionError`; the new test exercises the same mapper path and passes.