### PR TITLE
feat: cost_tracker plugin - /cost session spend estimates from billed…

### DIFF
--- a/code_puppy/plugins/cost_tracker/__init__.py
+++ b/code_puppy/plugins/cost_tracker/__init__.py
@@ -1,0 +1,1 @@
+"""Cost Tracker plugin - estimates dollar spend per session from billed token usage."""

--- a/code_puppy/plugins/cost_tracker/pricing.py
+++ b/code_puppy/plugins/cost_tracker/pricing.py
@@ -1,0 +1,308 @@
+"""Offline pricing lookup for the cost_tracker plugin.
+
+Resolves a Code Puppy model-config name (e.g. ``gpt-5``, ``qwen1``) to
+per-million-token prices using the **bundled** ``models_dev_api.json``
+database that ships with Code Puppy for the ``/add_model`` offline
+fallback.
+
+Design constraints:
+
+* **Never touches the network.** The project has a hard privacy
+  commitment; pricing lookups read only the bundled JSON that is already
+  on disk. If a model isn't in the bundle, its cost is simply reported
+  as *unknown* (tokens are still tracked).
+* **Deterministic.** The same model name always resolves to the same
+  price. When one model id exists under several providers with
+  different prices, the provider inferred from the model config's
+  ``type`` wins; otherwise the alphabetically-first provider id is used
+  and the result is (like everything here) labeled an estimate.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import pathlib
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# models.dev prices are USD per **million** tokens.
+_TOKENS_PER_PRICE_UNIT = 1_000_000
+
+# Model-config ``type`` values whose providers report usage
+# Anthropic-style: ``input_tokens`` EXCLUDES cache reads/writes (they are
+# billed separately at their own rates). Everything else is treated
+# OpenAI-style, where ``input_tokens`` INCLUDES the cached portion and the
+# cached portion is billed at the (discounted) cache-read rate instead of
+# the full input rate. Mirrors the semantics split already used by
+# ``model_factory`` for cache accounting.
+ANTHROPIC_STYLE_TYPES = frozenset(
+    {
+        "anthropic",
+        "custom_anthropic",
+        "claude_code",
+        "aws_bedrock",
+        "azure_foundry",
+    }
+)
+
+# Map Code Puppy model-config ``type`` -> models.dev provider id, used to
+# disambiguate when the same model id is listed under several providers.
+_TYPE_TO_PROVIDER: Dict[str, str] = {
+    "anthropic": "anthropic",
+    "custom_anthropic": "anthropic",
+    "claude_code": "anthropic",
+    "openai": "openai",
+    "chatgpt_oauth": "openai",
+    "azure_openai": "azure",
+    "gemini": "google",
+    "custom_gemini": "google",
+    "gemini_oauth": "google",
+    "cerebras": "cerebras",
+    "openrouter": "openrouter",
+    "copilot": "github-copilot",
+    "aws_bedrock": "amazon-bedrock",
+    "groq": "groq",
+    "mistral": "mistral",
+    "deepseek": "deepseek",
+}
+
+# Strip trailing date/version noise when an exact id match fails, e.g.
+# ``claude-sonnet-4-20250514`` -> ``claude-sonnet-4``.
+_DATE_SUFFIX_RE = re.compile(r"-(20\d{6}|latest|v\d+)$")
+
+
+@dataclass(frozen=True)
+class ModelPricing:
+    """Per-million-token USD prices for one (provider, model) pair."""
+
+    provider_id: str
+    model_id: str
+    input: Optional[float] = None
+    output: Optional[float] = None
+    cache_read: Optional[float] = None
+    cache_write: Optional[float] = None
+
+    @property
+    def has_any_price(self) -> bool:
+        return any(v is not None for v in (self.input, self.output, self.cache_read))
+
+
+# ---------------------------------------------------------------------------
+# Bundled DB loading + indexing (lazy, cached, offline-only)
+# ---------------------------------------------------------------------------
+_INDEX: Optional[Dict[str, List[Tuple[str, ModelPricing]]]] = None
+
+
+def _bundled_db_path() -> pathlib.Path:
+    import code_puppy
+
+    return pathlib.Path(code_puppy.__file__).parent / "models_dev_api.json"
+
+
+def _coerce_price(value: Any) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        price = float(value)
+        return price if price >= 0 else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_index() -> Dict[str, List[Tuple[str, ModelPricing]]]:
+    """Flatten the bundled models.dev DB into ``model_id -> candidates``.
+
+    Candidate lists are sorted by provider id so resolution is
+    deterministic regardless of JSON key order.
+    """
+    index: Dict[str, List[Tuple[str, ModelPricing]]] = {}
+    try:
+        with open(_bundled_db_path(), "r", encoding="utf-8") as f:
+            raw = json.load(f)
+    except Exception as exc:  # pragma: no cover - missing bundle is unusual
+        logger.warning(f"cost_tracker: could not load bundled pricing DB: {exc}")
+        return index
+
+    if not isinstance(raw, dict):
+        return index
+
+    for provider_id, provider_data in raw.items():
+        if not isinstance(provider_data, dict):
+            continue
+        models = provider_data.get("models", {})
+        if not isinstance(models, dict):
+            continue
+        for model_id, model_data in models.items():
+            if not isinstance(model_data, dict):
+                continue
+            cost = model_data.get("cost", {})
+            if not isinstance(cost, dict):
+                cost = {}
+            pricing = ModelPricing(
+                provider_id=str(provider_id),
+                model_id=str(model_id),
+                input=_coerce_price(cost.get("input")),
+                output=_coerce_price(cost.get("output")),
+                cache_read=_coerce_price(cost.get("cache_read")),
+                cache_write=_coerce_price(cost.get("cache_write")),
+            )
+            index.setdefault(str(model_id).lower(), []).append(
+                (str(provider_id), pricing)
+            )
+
+    for candidates in index.values():
+        candidates.sort(key=lambda pair: pair[0])
+    return index
+
+
+def _get_index() -> Dict[str, List[Tuple[str, ModelPricing]]]:
+    global _INDEX
+    if _INDEX is None:
+        _INDEX = _build_index()
+    return _INDEX
+
+
+def clear_pricing_cache() -> None:
+    """Testing hook: drop the cached index so it rebuilds on next use."""
+    global _INDEX
+    _INDEX = None
+
+
+# ---------------------------------------------------------------------------
+# Resolution: config name -> ModelPricing
+# ---------------------------------------------------------------------------
+def _lookup_candidates(model_id: str) -> List[Tuple[str, ModelPricing]]:
+    index = _get_index()
+    key = model_id.lower()
+    if key in index:
+        return index[key]
+    stripped = _DATE_SUFFIX_RE.sub("", key)
+    if stripped != key and stripped in index:
+        return index[stripped]
+    return []
+
+
+def _pick_candidate(
+    candidates: List[Tuple[str, ModelPricing]], model_type: str
+) -> Optional[ModelPricing]:
+    if not candidates:
+        return None
+    preferred_provider = _TYPE_TO_PROVIDER.get(model_type)
+    if preferred_provider:
+        for provider_id, pricing in candidates:
+            if provider_id == preferred_provider:
+                return pricing
+    # Deterministic fallback: alphabetically-first provider (list is sorted).
+    return candidates[0][1]
+
+
+def resolve_pricing(
+    model_name: str,
+    config: Optional[Dict[str, Any]] = None,
+    _depth: int = 0,
+) -> Tuple[Optional[ModelPricing], bool]:
+    """Resolve pricing for a Code Puppy model-config name.
+
+    Args:
+        model_name: The config key as reported by ``agent.get_model_name()``
+            (e.g. ``gpt-5``, ``qwen1``, ``my-round-robin``).
+        config: The full models config dict. When ``None`` it is loaded via
+            ``ModelFactory.load_config()``.
+        _depth: Internal recursion guard for round-robin indirection.
+
+    Returns:
+        ``(pricing, anthropic_style)``. ``pricing`` is ``None`` when the
+        model can't be found in the bundled DB (cost then reports as
+        unknown, tokens still tracked). ``anthropic_style`` describes how
+        cache tokens relate to input tokens for this model's provider.
+    """
+    if _depth > 3:
+        return None, False
+
+    if config is None:
+        try:
+            from code_puppy.model_factory import ModelFactory
+
+            config = ModelFactory.load_config()
+        except Exception as exc:
+            logger.debug(f"cost_tracker: could not load model config: {exc}")
+            config = {}
+
+    entry = config.get(model_name) if isinstance(config, dict) else None
+    entry = entry if isinstance(entry, dict) else {}
+    model_type = str(entry.get("type", "") or "")
+    anthropic_style = model_type in ANTHROPIC_STYLE_TYPES
+
+    # Round-robin models front several concrete models (typically the same
+    # underlying model split across API keys) - price via the first member.
+    if model_type == "round_robin":
+        members = entry.get("models") or []
+        if isinstance(members, list) and members:
+            return resolve_pricing(str(members[0]), config, _depth + 1)
+        return None, False
+
+    underlying = str(entry.get("name") or model_name)
+    candidates = _lookup_candidates(underlying)
+    if not candidates and underlying != model_name:
+        candidates = _lookup_candidates(model_name)
+
+    pricing = _pick_candidate(candidates, model_type)
+    if pricing is not None and not pricing.has_any_price:
+        pricing = None
+    return pricing, anthropic_style
+
+
+def estimate_cost_usd(
+    pricing: ModelPricing,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+    anthropic_style: bool = False,
+) -> float:
+    """Estimate USD cost for one run's billed token counts.
+
+    Two accounting styles:
+
+    * ``anthropic_style=True``: ``input_tokens`` excludes cache traffic, so
+      every bucket is billed at its own rate and simply summed.
+    * ``anthropic_style=False`` (OpenAI-style): ``input_tokens`` includes the
+      cached portion. The cached portion is billed at the cache-read rate
+      (when known) and subtracted from full-rate input; without a cache-read
+      rate the whole input bills at the input rate.
+
+    Reasoning/"thought" tokens are intentionally NOT billed separately:
+    every major provider already includes them in the billed output count,
+    so adding them again would double-charge.
+    """
+    input_tokens = max(int(input_tokens or 0), 0)
+    output_tokens = max(int(output_tokens or 0), 0)
+    cache_read_tokens = max(int(cache_read_tokens or 0), 0)
+    cache_write_tokens = max(int(cache_write_tokens or 0), 0)
+
+    in_rate = pricing.input or 0.0
+    out_rate = pricing.output or 0.0
+    cr_rate = pricing.cache_read
+    cw_rate = pricing.cache_write
+
+    if anthropic_style:
+        full_rate_input = input_tokens
+        cached_read_billed = cache_read_tokens
+    else:
+        if cr_rate is not None and cache_read_tokens:
+            full_rate_input = max(input_tokens - cache_read_tokens, 0)
+            cached_read_billed = min(cache_read_tokens, input_tokens)
+        else:
+            full_rate_input = input_tokens
+            cached_read_billed = 0
+
+    cost = full_rate_input * in_rate + output_tokens * out_rate
+    if cr_rate is not None:
+        cost += cached_read_billed * cr_rate
+    if cw_rate is not None:
+        cost += cache_write_tokens * cw_rate
+    return cost / _TOKENS_PER_PRICE_UNIT

--- a/code_puppy/plugins/cost_tracker/register_callbacks.py
+++ b/code_puppy/plugins/cost_tracker/register_callbacks.py
@@ -1,0 +1,155 @@
+"""Wire the cost tracker into agent runs and register the ``/cost`` command.
+
+* ``agent_run_end`` -> fold each run's billed usage into the session meter.
+  Fires for main-agent AND sub-agent runs; both cost real money and each
+  reports its own ``result.usage()``, so summing every event matches actual
+  API billing (see ``tracker`` module docstring).
+* ``/cost`` -> print the session spend report.
+* ``/cost reset`` -> zero the meter.
+
+Everything is estimate-labeled: prices come from the bundled models.dev
+database (no network), and provider billing has nuances (tiered pricing,
+batch discounts, free tiers) this deliberately does not model.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from code_puppy.callbacks import register_callback
+
+from .tracker import format_tokens, format_usd, get_tracker
+
+COMMAND_NAME = "cost"
+
+
+# ---------------------------------------------------------------------------
+# agent_run_end -> record spend
+# ---------------------------------------------------------------------------
+async def _on_agent_run_end(
+    agent_name: str,
+    model_name: str,
+    session_id: Optional[str] = None,
+    success: bool = True,
+    error: Optional[Exception] = None,
+    response_text: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Record the run's billed usage. Failed/cancelled runs still count -
+    whatever the API billed before the failure was still spent."""
+    get_tracker().record_run(model_name, metadata)
+
+
+# ---------------------------------------------------------------------------
+# /cost command
+# ---------------------------------------------------------------------------
+def _custom_help() -> List[Tuple[str, str]]:
+    return [
+        (
+            COMMAND_NAME,
+            "Show estimated dollar spend this session (per model); "
+            "'/cost reset' zeroes the meter",
+        )
+    ]
+
+
+def _render_report() -> str:
+    snap = get_tracker().snapshot()
+    if not snap.per_model:
+        return (
+            ":moneybag: [bold]Session cost[/bold]\n"
+            "No completed agent runs yet - nothing spent."
+        )
+
+    lines: List[str] = []
+    total = format_usd(snap.total_cost_usd) if snap.known_cost else "unknown"
+    lines.append(f":moneybag: [bold]Session cost (estimated): {total}[/bold]")
+
+    if snap.last_run_cost_usd is not None:
+        lines.append(
+            f"Last run: {format_usd(snap.last_run_cost_usd)} ({snap.last_run_model})"
+        )
+
+    lines.append("")
+    for spend in snap.per_model:
+        cost = format_usd(spend.cost_usd)
+        token_bits = [
+            f"in {format_tokens(spend.input_tokens)}",
+            f"out {format_tokens(spend.output_tokens)}",
+        ]
+        if spend.cache_read_tokens:
+            token_bits.append(f"cache-read {format_tokens(spend.cache_read_tokens)}")
+        if spend.cache_write_tokens:
+            token_bits.append(f"cache-write {format_tokens(spend.cache_write_tokens)}")
+        source = ""
+        if spend.pricing is not None:
+            source = (
+                f" [dim](priced as {spend.pricing.provider_id}/"
+                f"{spend.pricing.model_id})[/dim]"
+            )
+        lines.append(
+            f"  [cyan]{spend.model_name}[/cyan]: {cost} "
+            f"({', '.join(token_bits)}; {spend.runs} run"
+            f"{'s' if spend.runs != 1 else ''}){source}"
+        )
+
+    unknown = snap.unknown_models
+    if unknown:
+        lines.append("")
+        lines.append(
+            "[yellow]No pricing data for: "
+            + ", ".join(m.model_name for m in unknown)
+            + " - tokens tracked, cost excluded from the total.[/yellow]"
+        )
+
+    lines.append("")
+    lines.append(
+        "[dim]Estimates use bundled models.dev list prices; actual billing "
+        "may differ (tiers, discounts, free quotas).[/dim]"
+    )
+    return "\n".join(lines)
+
+
+def _handle_cost_command(command: str) -> bool:
+    from code_puppy.messaging import emit_info, emit_success, emit_warning
+
+    tokens = command.strip().split()
+    arg = tokens[1].lower() if len(tokens) > 1 else ""
+
+    if arg in ("--help", "-h", "help"):
+        emit_info(
+            "Usage: /cost            Show estimated session spend\n"
+            "       /cost reset      Zero the meter (pricing cache kept)"
+        )
+        return True
+    if arg == "reset":
+        get_tracker().reset()
+        emit_success(":moneybag: Cost meter reset to $0.00")
+        return True
+    if arg:
+        emit_warning(f"Unknown /cost subcommand: {arg} (try /cost --help)")
+        return True
+
+    emit_info(_render_report())
+    return True
+
+
+def _handle_custom_command(command: str, name: str) -> Optional[bool]:
+    if name != COMMAND_NAME:
+        return None
+    return _handle_cost_command(command)
+
+
+register_callback("agent_run_end", _on_agent_run_end)
+register_callback("custom_command_help", _custom_help)
+register_callback("custom_command", _handle_custom_command)
+
+
+__all__ = [
+    "COMMAND_NAME",
+    "_custom_help",
+    "_handle_custom_command",
+    "_handle_cost_command",
+    "_on_agent_run_end",
+    "_render_report",
+]

--- a/code_puppy/plugins/cost_tracker/tracker.py
+++ b/code_puppy/plugins/cost_tracker/tracker.py
@@ -1,0 +1,196 @@
+"""Session-wide spend accumulator for the cost_tracker plugin.
+
+Fed by the ``agent_run_end`` callback with the *real billed* usage counts
+that ``_runtime`` extracts from ``result.usage()`` (not the char-based
+estimates used elsewhere for context-window math). Sub-agent runs fire
+their own ``agent_run_end`` with their own usage, so summing every event
+matches what the APIs actually bill - no double counting, because a
+parent's usage never includes a sub-agent's own API calls.
+
+State is process-lifetime ("since startup"): ``/clear`` wipes conversation
+history but the money was still spent, so the meter keeps running.
+``/cost reset`` zeroes it explicitly.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from .pricing import ModelPricing, estimate_cost_usd, resolve_pricing
+
+
+@dataclass
+class ModelSpend:
+    """Accumulated usage + estimated cost for one model-config name."""
+
+    model_name: str
+    runs: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    cost_usd: Optional[float] = None  # None => pricing unknown
+    pricing: Optional[ModelPricing] = field(default=None, repr=False)
+
+
+@dataclass(frozen=True)
+class CostSnapshot:
+    """Immutable view of the tracker for rendering."""
+
+    total_cost_usd: float
+    known_cost: bool  # True when at least one run had known pricing
+    last_run_cost_usd: Optional[float]
+    last_run_model: Optional[str]
+    started_at: float
+    per_model: Tuple[ModelSpend, ...]
+
+    @property
+    def unknown_models(self) -> List[ModelSpend]:
+        return [m for m in self.per_model if m.cost_usd is None]
+
+
+def _usage_int(metadata: Dict[str, Any], key: str) -> int:
+    try:
+        value = metadata.get(key)
+        return max(int(value), 0) if value is not None else 0
+    except (TypeError, ValueError):
+        return 0
+
+
+class SessionCostTracker:
+    """Thread-safe accumulator; one instance per process (module singleton)."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._per_model: Dict[str, ModelSpend] = {}
+        self._pricing_cache: Dict[str, Tuple[Optional[ModelPricing], bool]] = {}
+        self._last_run_cost: Optional[float] = None
+        self._last_run_model: Optional[str] = None
+        self._started_at = time.time()
+
+    # -- recording ---------------------------------------------------------
+    def record_run(self, model_name: str, metadata: Optional[Dict[str, Any]]) -> None:
+        """Fold one finished agent run's billed usage into the totals.
+
+        Never raises: cost tracking must not be able to break a run.
+        """
+        try:
+            self._record_run(model_name, metadata)
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+    def _record_run(self, model_name: str, metadata: Optional[Dict[str, Any]]) -> None:
+        if not model_name or not isinstance(metadata, dict):
+            return
+        input_tokens = _usage_int(metadata, "usage_input_tokens")
+        output_tokens = _usage_int(metadata, "usage_output_tokens")
+        cache_read = _usage_int(metadata, "usage_cached_read_tokens")
+        cache_write = _usage_int(metadata, "usage_cached_write_tokens")
+        if not any((input_tokens, output_tokens, cache_read, cache_write)):
+            return  # cancelled/failed before any billing happened
+
+        pricing, anthropic_style = self._get_pricing(model_name)
+        run_cost: Optional[float] = None
+        if pricing is not None:
+            run_cost = estimate_cost_usd(
+                pricing,
+                input_tokens,
+                output_tokens,
+                cache_read,
+                cache_write,
+                anthropic_style=anthropic_style,
+            )
+
+        with self._lock:
+            spend = self._per_model.setdefault(
+                model_name, ModelSpend(model_name=model_name, pricing=pricing)
+            )
+            spend.runs += 1
+            spend.input_tokens += input_tokens
+            spend.output_tokens += output_tokens
+            spend.cache_read_tokens += cache_read
+            spend.cache_write_tokens += cache_write
+            if run_cost is not None:
+                spend.cost_usd = (spend.cost_usd or 0.0) + run_cost
+                spend.pricing = pricing
+            self._last_run_cost = run_cost
+            self._last_run_model = model_name
+
+    def _get_pricing(self, model_name: str) -> Tuple[Optional[ModelPricing], bool]:
+        with self._lock:
+            cached = self._pricing_cache.get(model_name)
+        if cached is not None:
+            return cached
+        resolved = resolve_pricing(model_name)
+        with self._lock:
+            self._pricing_cache[model_name] = resolved
+        return resolved
+
+    # -- reading -----------------------------------------------------------
+    def snapshot(self) -> CostSnapshot:
+        with self._lock:
+            per_model = tuple(
+                ModelSpend(
+                    model_name=m.model_name,
+                    runs=m.runs,
+                    input_tokens=m.input_tokens,
+                    output_tokens=m.output_tokens,
+                    cache_read_tokens=m.cache_read_tokens,
+                    cache_write_tokens=m.cache_write_tokens,
+                    cost_usd=m.cost_usd,
+                    pricing=m.pricing,
+                )
+                for m in sorted(self._per_model.values(), key=lambda m: m.model_name)
+            )
+            total = sum(m.cost_usd or 0.0 for m in per_model)
+            known = any(m.cost_usd is not None for m in per_model)
+            return CostSnapshot(
+                total_cost_usd=total,
+                known_cost=known,
+                last_run_cost_usd=self._last_run_cost,
+                last_run_model=self._last_run_model,
+                started_at=self._started_at,
+                per_model=per_model,
+            )
+
+    def reset(self) -> None:
+        with self._lock:
+            self._per_model.clear()
+            self._last_run_cost = None
+            self._last_run_model = None
+            self._started_at = time.time()
+            # Pricing cache survives reset on purpose - prices don't change
+            # mid-process, only the meter is being zeroed.
+
+
+_TRACKER = SessionCostTracker()
+
+
+def get_tracker() -> SessionCostTracker:
+    return _TRACKER
+
+
+def format_usd(value: Optional[float]) -> str:
+    """Render a dollar amount with sane precision for tiny values."""
+    if value is None:
+        return "unknown"
+    if value == 0:
+        return "$0.00"
+    if value < 0.01:
+        return f"${value:.4f}"
+    if value < 1:
+        return f"${value:.3f}"
+    return f"${value:,.2f}"
+
+
+def format_tokens(value: int) -> str:
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:.1f}M"
+    if value >= 10_000:
+        return f"{value / 1_000:.0f}k"
+    if value >= 1_000:
+        return f"{value / 1_000:.1f}k"
+    return str(value)

--- a/tests/plugins/test_cost_tracker.py
+++ b/tests/plugins/test_cost_tracker.py
@@ -1,0 +1,319 @@
+"""Tests for the cost_tracker plugin (pricing math, accumulation, /cost)."""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from code_puppy.plugins.cost_tracker import pricing as pricing_module
+from code_puppy.plugins.cost_tracker.pricing import (
+    ModelPricing,
+    estimate_cost_usd,
+    resolve_pricing,
+)
+from code_puppy.plugins.cost_tracker.register_callbacks import (
+    COMMAND_NAME,
+    _custom_help,
+    _handle_custom_command,
+    _on_agent_run_end,
+    _render_report,
+)
+from code_puppy.plugins.cost_tracker.tracker import (
+    SessionCostTracker,
+    format_tokens,
+    format_usd,
+    get_tracker,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_global_tracker():
+    """Zero the module-level tracker around every test."""
+    get_tracker().reset()
+    yield
+    get_tracker().reset()
+
+
+# ---------------------------------------------------------------------------
+# Cost math
+# ---------------------------------------------------------------------------
+def test_estimate_cost_openai_style_discounts_cached_input():
+    # $2/M in, $8/M out, $0.50/M cache-read (gpt-ish numbers).
+    p = ModelPricing("openai", "gpt-x", input=2.0, output=8.0, cache_read=0.5)
+    # 1M input INCLUDING 400k cached; 100k output.
+    cost = estimate_cost_usd(
+        p, 1_000_000, 100_000, cache_read_tokens=400_000, anthropic_style=False
+    )
+    # 600k @ $2/M + 400k @ $0.5/M + 100k @ $8/M = 1.2 + 0.2 + 0.8
+    assert cost == pytest.approx(2.2)
+
+
+def test_estimate_cost_anthropic_style_bills_buckets_separately():
+    # $3/M in, $15/M out, $0.30/M cache-read, $3.75/M cache-write.
+    p = ModelPricing(
+        "anthropic",
+        "claude-x",
+        input=3.0,
+        output=15.0,
+        cache_read=0.3,
+        cache_write=3.75,
+    )
+    # Anthropic-style: input EXCLUDES cache traffic - nothing subtracted.
+    cost = estimate_cost_usd(
+        p,
+        200_000,
+        50_000,
+        cache_read_tokens=1_000_000,
+        cache_write_tokens=100_000,
+        anthropic_style=True,
+    )
+    # 0.2M*3 + 0.05M*15 + 1M*0.3 + 0.1M*3.75 = 0.6 + 0.75 + 0.3 + 0.375
+    assert cost == pytest.approx(2.025)
+
+
+def test_estimate_cost_without_cache_rate_bills_full_input():
+    p = ModelPricing("x", "m", input=1.0, output=2.0, cache_read=None)
+    cost = estimate_cost_usd(
+        p, 1_000_000, 0, cache_read_tokens=999_999, anthropic_style=False
+    )
+    assert cost == pytest.approx(1.0)  # no subtraction without a cache rate
+
+
+def test_estimate_cost_clamps_negative_and_none_tokens():
+    p = ModelPricing("x", "m", input=1.0, output=1.0)
+    assert estimate_cost_usd(p, -5, None) == 0.0  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Pricing resolution against the bundled DB
+# ---------------------------------------------------------------------------
+def test_resolve_pricing_prefers_provider_from_type():
+    config = {"my-claude": {"type": "anthropic", "name": "claude-opus-4-0"}}
+    pricing, anthropic_style = resolve_pricing("my-claude", config)
+    assert pricing is not None
+    assert pricing.provider_id == "anthropic"
+    assert anthropic_style is True
+    assert pricing.input and pricing.output  # bundled DB has real prices
+
+
+def test_resolve_pricing_round_robin_uses_first_member():
+    config = {
+        "qwen1": {"type": "anthropic", "name": "claude-opus-4-0"},
+        "rr": {"type": "round_robin", "models": ["qwen1", "qwen2"]},
+    }
+    pricing, anthropic_style = resolve_pricing("rr", config)
+    assert pricing is not None
+    assert pricing.model_id == "claude-opus-4-0"
+    assert anthropic_style is True  # inherited from the member's type
+
+
+def test_resolve_pricing_unknown_model_returns_none():
+    config = {"mystery": {"type": "custom_openai", "name": "totally-not-real-9000"}}
+    pricing, _ = resolve_pricing("mystery", config)
+    assert pricing is None
+
+
+def test_resolve_pricing_strips_date_suffix():
+    # Only meaningful if the dateless id exists in the bundle; the exact-id
+    # miss must at minimum not crash and fall through deterministically.
+    config = {"m": {"type": "anthropic", "name": "claude-opus-4-0-20250522"}}
+    pricing, _ = resolve_pricing("m", config)
+    assert pricing is None or pricing.model_id == "claude-opus-4-0"
+
+
+def test_resolve_pricing_handles_empty_config_and_missing_entry():
+    pricing, anthropic_style = resolve_pricing("nonexistent-model", {})
+    # Must not raise; unpriced unless the raw name happens to exist upstream.
+    assert anthropic_style is False
+    assert pricing is None or pricing.model_id
+
+
+# ---------------------------------------------------------------------------
+# Tracker accumulation
+# ---------------------------------------------------------------------------
+def _meta(inp=0, out=0, cr=0, cw=0):
+    return {
+        "usage_input_tokens": inp,
+        "usage_output_tokens": out,
+        "usage_cached_read_tokens": cr,
+        "usage_cached_write_tokens": cw,
+    }
+
+
+def test_tracker_accumulates_runs_and_costs():
+    tracker = SessionCostTracker()
+    fixed = (ModelPricing("openai", "gpt-x", input=1.0, output=1.0), False)
+    with patch.object(SessionCostTracker, "_get_pricing", return_value=fixed):
+        tracker.record_run("gpt-x", _meta(inp=1_000_000, out=1_000_000))
+        tracker.record_run("gpt-x", _meta(inp=500_000))
+    snap = tracker.snapshot()
+    assert snap.total_cost_usd == pytest.approx(2.5)
+    assert snap.known_cost is True
+    assert snap.last_run_cost_usd == pytest.approx(0.5)
+    assert snap.last_run_model == "gpt-x"
+    (spend,) = snap.per_model
+    assert spend.runs == 2
+    assert spend.input_tokens == 1_500_000
+    assert spend.output_tokens == 1_000_000
+
+
+def test_tracker_tracks_tokens_for_unpriced_models():
+    tracker = SessionCostTracker()
+    with patch.object(SessionCostTracker, "_get_pricing", return_value=(None, False)):
+        tracker.record_run("mystery", _meta(inp=1000, out=2000))
+    snap = tracker.snapshot()
+    assert snap.total_cost_usd == 0.0
+    assert snap.known_cost is False
+    assert snap.last_run_cost_usd is None
+    (spend,) = snap.per_model
+    assert spend.cost_usd is None
+    assert spend.input_tokens == 1000
+    assert snap.unknown_models == [spend]
+
+
+def test_tracker_ignores_zero_usage_and_bad_metadata():
+    tracker = SessionCostTracker()
+    tracker.record_run("gpt-x", _meta())  # all zeros: cancelled pre-billing
+    tracker.record_run("gpt-x", None)
+    tracker.record_run("gpt-x", {"usage_input_tokens": "garbage"})
+    tracker.record_run("", _meta(inp=100))
+    assert tracker.snapshot().per_model == ()
+
+
+def test_tracker_reset_zeroes_meter():
+    tracker = SessionCostTracker()
+    fixed = (ModelPricing("openai", "gpt-x", input=1.0, output=1.0), False)
+    with patch.object(SessionCostTracker, "_get_pricing", return_value=fixed):
+        tracker.record_run("gpt-x", _meta(inp=1_000_000))
+    tracker.reset()
+    snap = tracker.snapshot()
+    assert snap.per_model == ()
+    assert snap.total_cost_usd == 0.0
+    assert snap.last_run_cost_usd is None
+
+
+def test_tracker_record_run_never_raises():
+    tracker = SessionCostTracker()
+    with patch.object(
+        SessionCostTracker, "_get_pricing", side_effect=RuntimeError("boom")
+    ):
+        tracker.record_run("gpt-x", _meta(inp=100))  # must swallow
+    assert tracker.snapshot().per_model == ()
+
+
+# ---------------------------------------------------------------------------
+# agent_run_end callback
+# ---------------------------------------------------------------------------
+def test_run_end_callback_records_usage():
+    fixed = (ModelPricing("openai", "gpt-x", input=1.0, output=1.0), False)
+    with patch.object(SessionCostTracker, "_get_pricing", return_value=fixed):
+        asyncio.run(
+            _on_agent_run_end(
+                agent_name="code-puppy",
+                model_name="gpt-x",
+                metadata={"model": "gpt-x", **_meta(inp=2_000_000)},
+            )
+        )
+    snap = get_tracker().snapshot()
+    assert snap.total_cost_usd == pytest.approx(2.0)
+
+
+def test_run_end_callback_counts_failed_runs_with_billing():
+    fixed = (ModelPricing("openai", "gpt-x", input=1.0, output=1.0), False)
+    with patch.object(SessionCostTracker, "_get_pricing", return_value=fixed):
+        asyncio.run(
+            _on_agent_run_end(
+                agent_name="code-puppy",
+                model_name="gpt-x",
+                success=False,
+                error=RuntimeError("mid-run explosion"),
+                metadata=_meta(inp=1_000_000),
+            )
+        )
+    assert get_tracker().snapshot().total_cost_usd == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# /cost command
+# ---------------------------------------------------------------------------
+def test_help_lists_cost():
+    entries = _custom_help()
+    assert any(name == COMMAND_NAME for name, _ in entries)
+
+
+def test_other_commands_are_not_ours():
+    assert _handle_custom_command("/woof hi", "woof") is None
+
+
+def test_cost_empty_session_report():
+    with patch("code_puppy.messaging.emit_info") as emit:
+        assert _handle_custom_command("/cost", "cost") is True
+    assert emit.called
+    assert "nothing spent" in str(emit.call_args).lower()
+
+
+def test_cost_report_shows_totals_and_unknowns():
+    tracker = get_tracker()
+    fixed = (ModelPricing("openai", "gpt-x", input=1.0, output=1.0), False)
+    with patch.object(SessionCostTracker, "_get_pricing", return_value=fixed):
+        tracker.record_run("gpt-x", _meta(inp=1_000_000))
+    with patch.object(SessionCostTracker, "_get_pricing", return_value=(None, False)):
+        tracker.record_run("mystery", _meta(inp=500))
+    report = _render_report()
+    assert "$1.00" in report
+    assert "gpt-x" in report
+    assert "mystery" in report
+    assert "No pricing data" in report
+    assert "models.dev" in report
+
+
+def test_cost_reset_subcommand():
+    fixed = (ModelPricing("openai", "gpt-x", input=1.0, output=1.0), False)
+    with patch.object(SessionCostTracker, "_get_pricing", return_value=fixed):
+        get_tracker().record_run("gpt-x", _meta(inp=1_000_000))
+    with patch("code_puppy.messaging.emit_success") as emit:
+        assert _handle_custom_command("/cost reset", "cost") is True
+    assert emit.called
+    assert get_tracker().snapshot().total_cost_usd == 0.0
+
+
+def test_cost_help_subcommand():
+    with patch("code_puppy.messaging.emit_info") as emit:
+        assert _handle_custom_command("/cost --help", "cost") is True
+    assert "Usage" in str(emit.call_args)
+
+
+def test_cost_unknown_subcommand_warns():
+    with patch("code_puppy.messaging.emit_warning") as emit:
+        assert _handle_custom_command("/cost frobnicate", "cost") is True
+    assert "frobnicate" in str(emit.call_args)
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+def test_format_usd_precision_bands():
+    assert format_usd(None) == "unknown"
+    assert format_usd(0) == "$0.00"
+    assert format_usd(0.0042) == "$0.0042"
+    assert format_usd(0.042) == "$0.042"
+    assert format_usd(1234.5) == "$1,234.50"
+
+
+def test_format_tokens_bands():
+    assert format_tokens(999) == "999"
+    assert format_tokens(1_500) == "1.5k"
+    assert format_tokens(25_000) == "25k"
+    assert format_tokens(3_400_000) == "3.4M"
+
+
+# ---------------------------------------------------------------------------
+# Bundled DB index sanity
+# ---------------------------------------------------------------------------
+def test_bundled_index_builds_and_is_sorted():
+    pricing_module.clear_pricing_cache()
+    index = pricing_module._get_index()
+    assert index, "bundled models_dev_api.json should produce a non-empty index"
+    some_candidates = next(iter(index.values()))
+    providers = [provider for provider, _ in some_candidates]
+    assert providers == sorted(providers)


### PR DESCRIPTION
## What

New built-in plugin: `/cost` shows estimated dollar spend for the current
session, broken down per model, with `/cost reset` to zero the meter.

```
💰 Session cost (estimated): $5.21
Last run: $0.525 (opus)

  opus: $5.21 (in 110k, out 25k, cache-read 500k, cache-write 50k; 2 runs) (priced as anthropic/claude-opus-4-0)

Estimates use bundled models.dev list prices; actual billing may differ (tiers, discounts, free quotas).
```

## Why

The models.dev integration already ships per-million-token prices
(`cost.input` / `cost.output` / `cost.cache_read` in the bundled
`models_dev_api.json`), and `_runtime` already extracts real billed usage
from `result.usage()` into the `agent_run_end` metadata
(`usage_input_tokens` etc.) — but nothing multiplies the two together.
For a tool whose README opens with anger at IDE pricing, spend visibility
felt like a natural fit.

## How

- `agent_run_end` callback folds each run's billed usage into a
  thread-safe process-lifetime accumulator. Sub-agent runs fire their own
  `agent_run_end` with their own `usage()`, so summing every event matches
  actual API billing — no double counting.
- Pricing resolves `config name → underlying model id → bundled models.dev
  entry`, preferring the provider implied by the config `type` when one id
  exists under several providers; `round_robin` models price via their
  first member. **Never touches the network** — bundled JSON only,
  matching the privacy commitment.
- Two cache-accounting styles, mirroring the split `model_factory` already
  uses: Anthropic-style (`input_tokens` excludes cache traffic; buckets
  summed at their own rates) vs OpenAI-style (cached portion subtracted
  from full-rate input and billed at the cache-read rate).
- Reasoning tokens are deliberately not billed separately (providers
  include them in billed output — adding them would double-charge).
- Models with no pricing data still get token tracking; they're listed
  separately and excluded from the total rather than guessed at.
- Failed/cancelled runs still count whatever was billed before the
  failure. Runs with all-zero usage (cancelled pre-billing) are skipped.
- `record_run` is wrapped so cost tracking can never break an agent run.

## Testing

- 26 new tests in `tests/plugins/test_cost_tracker.py`: cost math for both
  accounting styles, cache-rate fallback, bundled-DB resolution
  (provider preference, round-robin, date-suffix stripping, unknown
  models), accumulation/reset/thread-state, run-end callback including the
  failed-run path, `/cost` dispatch + `reset` + `--help` + unknown
  subcommand, formatting bands, index determinism.
- Full `tests/plugins/` suite passes (one pre-existing, unrelated failure
  in `test_chatgpt_oauth_core.py` reproduces on clean main).
- `ruff check` / `ruff format` clean under the CI-pinned 0.15.x.

## Notes / open questions

- Everything is labeled an estimate: list prices only, no tiers/batch/free
  quotas. Happy to add a config toggle to disable the plugin entirely if
  you'd prefer it opt-in.
- A statusline segment (running `$` next to the context indicator) would be
  a natural follow-up; kept out of this PR to keep it reviewable.

---

*This contribution was developed with AI assistance (Claude Fable 5 on Max effort); all tests and
lint were run against current main before submission.*