### PR TITLE
fix(mcp): a config can't be its own untrusted project twin (CWD == $HOME)

### DIFF
--- a/code_puppy/mcp_/project_config.py
+++ b/code_puppy/mcp_/project_config.py
@@ -25,6 +25,11 @@ Trust model (identical philosophy to ``code_puppy/plugins/trust.py``):
   ``allow``).
 * **Fail closed**: an unreadable store, malformed JSON, or an unhashable file
   all resolve to "not trusted" → the project config is silently ignored.
+* **A file can't be its own less-trusted twin**: the project candidate can
+  resolve to the very same file as ``config.MCP_SERVERS_FILE`` — the usual
+  way being ``<CWD> == $HOME`` under the default config location. That file
+  is already loaded as user-level (implicitly trusted), so there is nothing
+  to gate and :func:`get_project_mcp_servers_file` returns ``None``.
 """
 
 from __future__ import annotations
@@ -66,15 +71,47 @@ def get_project_mcp_servers_file(project_root: Optional[Path] = None) -> Optiona
 
     Like :func:`code_puppy.config.get_project_agents_directory`, this never
     creates anything — the team opts in by committing the file.
+
+    Returns ``None`` when the candidate resolves to the *same file* as
+    :data:`code_puppy.config.MCP_SERVERS_FILE`. That is the case whenever
+    ``<CWD>/.code_puppy/mcp_servers.json`` and the user-level config are one
+    path — most commonly ``CWD == $HOME`` under the default config location,
+    which is the normal state for anyone who just runs ``code-puppy`` from
+    their home directory. (With ``XDG_CONFIG_HOME`` set the user-level file
+    lives elsewhere and the two are ordinarily distinct — which is why the
+    check is against ``MCP_SERVERS_FILE`` itself, never against ``$HOME``.)
+
+    There is no second, less-trusted source to gate: the file is already
+    loaded as user-level (implicitly trusted). Reporting it as an untrusted
+    *project* config would be simply false — it told the user "its servers
+    are NOT loaded" while they were in fact loaded — and ``/mcp trust`` would
+    be ceremony over a decision the user already made by writing the file.
     """
     root = Path(project_root) if project_root is not None else Path.cwd()
     candidate = root / PROJECT_MCP_RELPATH
     try:
-        if candidate.is_file():
-            return candidate
+        if not candidate.is_file():
+            return None
+        if _is_user_level_config(candidate):
+            return None
+        return candidate
     except OSError:  # pragma: no cover - exotic filesystem errors
         return None
-    return None
+
+
+def _is_user_level_config(candidate: Path) -> bool:
+    """True when ``candidate`` IS the user-level MCP config file.
+
+    Compared with ``os.path.samefile`` so a symlink or bind-mount pointing at
+    the user-level config is recognized too, not just a literally equal path.
+    """
+    from code_puppy.config import MCP_SERVERS_FILE
+
+    try:
+        return candidate.samefile(MCP_SERVERS_FILE)
+    except OSError:
+        # User-level file absent/unreadable — then it isn't the same file.
+        return False
 
 
 # ---------- content hashing --------------------------------------------------

--- a/tests/mcp/test_project_config.py
+++ b/tests/mcp/test_project_config.py
@@ -144,6 +144,70 @@ def test_loader_ignores_untrusted_project(project, monkeypatch):
     assert merged == {"user_only": "u"}
 
 
+# ---------- CWD == $HOME: the config is its own "project" file ----------------
+#
+# Run `code-puppy` from your home directory and CWD == $HOME, so
+# <CWD>/.code_puppy/mcp_servers.json IS ~/.code_puppy/mcp_servers.json. The
+# gate used to flag that single file as an untrusted *project* config and warn
+# "its servers are NOT loaded" — while the very same file was already loaded as
+# user-level. One file cannot be its own less-trusted twin.
+
+
+def test_config_that_is_the_user_level_file_is_not_a_project_config(
+    project, monkeypatch
+):
+    cfg = _write_project_config(project, {"some-server": {"type": "sse"}})
+    monkeypatch.setattr(cp_config, "MCP_SERVERS_FILE", str(cfg))
+
+    assert pc.get_project_mcp_servers_file() is None
+    assert pc.is_project_mcp_trusted() is False  # nothing to trust
+    assert pc.load_project_mcp_server_configs() == {}
+
+
+def test_no_untrusted_warning_when_config_is_the_user_level_file(project, monkeypatch):
+    """The warning claimed servers were not loaded. They were."""
+    cfg = _write_project_config(project, {"some-server": {"type": "sse", "url": "u"}})
+    monkeypatch.setattr(cp_config, "MCP_SERVERS_FILE", str(cfg))
+
+    warnings = []
+    monkeypatch.setattr(pc, "_warn_untrusted", lambda *a, **k: warnings.append(a))
+
+    merged = cp_config.load_mcp_server_configs()
+
+    # Loaded via the user-level source — so no "NOT loaded" warning is honest.
+    assert merged == {"some-server": {"type": "sse", "url": "u"}}
+    assert warnings == []
+
+
+def test_symlink_to_user_level_config_is_not_a_project_config(
+    project, monkeypatch, tmp_path
+):
+    """samefile(), not path equality — a symlink is the same file too."""
+    real = tmp_path / "real_mcp.json"
+    real.write_text(json.dumps({"mcp_servers": {"s": "v"}}))
+    monkeypatch.setattr(cp_config, "MCP_SERVERS_FILE", str(real))
+
+    cfg_dir = project / ".code_puppy"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "mcp_servers.json").symlink_to(real)
+
+    assert pc.get_project_mcp_servers_file() is None
+
+
+def test_a_genuinely_separate_project_config_is_still_gated(project, monkeypatch):
+    """The real gate must keep working — this fix must not widen it."""
+    user_file = project / "user_mcp.json"
+    user_file.write_text(json.dumps({"mcp_servers": {"user_only": "u"}}))
+    monkeypatch.setattr(cp_config, "MCP_SERVERS_FILE", str(user_file))
+
+    _write_project_config(project, {"proj_only": {"type": "stdio", "command": "x"}})
+
+    assert pc.get_project_mcp_servers_file() is not None
+    assert cp_config.load_mcp_server_configs() == {"user_only": "u"}  # gated
+    assert pc.trust_project_mcp() is True
+    assert "proj_only" in cp_config.load_mcp_server_configs()  # honored once trusted
+
+
 # ---------- parse helper -----------------------------------------------------
 
 


### PR DESCRIPTION
Run `code-puppy` from your home directory and every launch warns about a file it already loaded:

```
> hi
Project MCP config '/home/you/.code_puppy/mcp_servers.json' is not trusted yet;
its servers are NOT loaded. Review it, then run '/mcp trust' to accept
```

### The two "sources" are the same file

When `CWD == $HOME`, the project candidate and the user-level config resolve to one path:

| source | path |
|---|---|
| user-level (implicitly trusted) | `~/.code_puppy/mcp_servers.json` |
| "project" (trust-gated) | `<CWD>/.code_puppy/mcp_servers.json` |

`get_project_mcp_servers_file()` returns that path as a project candidate, so the gate flags the user-level config as an untrusted stranger — while `load_mcp_server_configs()` has *already* merged its servers in via the user-level source. Measured:

```
load_mcp_server_configs()  → ['some-server']   ← loaded
get_trust_status(...)      → untrusted         ← warns "NOT loaded"
```

### Why this is worse than cosmetic noise

The warning is **false in the direction that costs trust**: it tells users their MCP tools are unavailable while they are working fine. Someone who believes it goes debugging a non-existent problem; someone who learns to ignore it has been trained to ignore the trust gate — which is the one message here that should carry weight.

It also fires on *every* launch, because the remedy never gets applied: `/mcp trust` is ceremony over a decision the user already made by writing the file, so nothing lands in `trusted_mcp.json` and the warning returns forever.

Not an exotic setup, incidentally — `cd ~ && code-puppy` is enough. Anything that runs the agent with `CWD=$HOME` (containers, sandboxes, headless/autonomous runs) hits it on every start, and an unattended run has nobody available to type `/mcp trust` anyway.

### Fix

`get_project_mcp_servers_file()` returns `None` when the candidate **is** the user-level config. There is no second, less-trusted source to gate, so there is nothing to ask about.

Compared with `samefile()` rather than path equality, so a symlink or bind-mount pointing at the user-level config is recognized too. The check targets `config.MCP_SERVERS_FILE` and never `$HOME`, so it stays correct when `XDG_CONFIG_HOME` relocates the user-level config out of `~/.code_puppy`.

Deliberately one chokepoint: `get_trust_status()`, `load_project_mcp_server_configs()` and `/mcp trust` all already handle "no project file" correctly, so a single guard fixes the whole path without adding a second code path.

### The real gate is untouched

A genuinely separate project config is still withheld until trusted — asserted in both directions, so the test fails if this fix ever widens into a bypass:

```python
assert cp_config.load_mcp_server_configs() == {"user_only": "u"}   # gated
assert pc.trust_project_mcp() is True
assert "proj_only" in cp_config.load_mcp_server_configs()          # honored
```

### Verification

- 4 tests added; **3 fail without the change** (14 → 17 in `tests/mcp/test_project_config.py`).
- `ruff check` and `ruff format --check` clean.
- Branch is cut from current `main`, so the diff is exactly these two files.

Context: `project_config.py` arrived in #615; the fix is against `if candidate.is_file(): return candidate` in the discovery helper.
