### PR TITLE
feat(herdr): add Windows named-pipe transport

### DIFF
--- a/code_puppy/plugins/herdr/client.py
+++ b/code_puppy/plugins/herdr/client.py
@@ -1,4 +1,4 @@
-"""Fire-and-forget client for the herdr pane socket.
+r"""Fire-and-forget client for the herdr pane socket.
 
 herdr (https://herdr.dev) is a terminal workspace manager for coding
 agents. When code-puppy runs inside a herdr pane, herdr injects three
@@ -30,9 +30,13 @@ always converges on the latest authoritative facts. Request ``id`` and
 order stays monotonic even when critical work overtakes decorative work;
 retries reuse the same serialized envelope (herdr dedupes on ``seq``).
 
-Windows named-pipe transport is intentionally out of scope; herdr's
-Windows build is beta and ``AF_UNIX`` is the contract everywhere else.
-When the socket is unavailable the client is simply inactive.
+Transport is ``AF_UNIX`` everywhere it exists. On Windows (where CPython
+still has no ``socket.AF_UNIX``), herdr's build -- via Rust's
+``interprocess`` crate -- maps the file-style ``HERDR_SOCKET_PATH`` onto a
+named pipe whose name *is* the full path (``\\.\pipe\C:\...\herdr.sock``),
+so plain stdlib file I/O on that pipe path gives the same bidirectional
+byte stream. When neither transport is available the client is simply
+inactive.
 """
 
 from __future__ import annotations
@@ -90,7 +94,7 @@ class HerdrClient:
             os.environ.get("HERDR_ENV") == "1"
             and self._socket_path
             and self._pane_id
-            and hasattr(socket, "AF_UNIX")
+            and (hasattr(socket, "AF_UNIX") or os.name == "nt")
         )
 
         # One condition guards every mailbox slot and the lifecycle flags.
@@ -289,16 +293,8 @@ class HerdrClient:
         last_exc: Optional[Exception] = None
         for attempt in range(_SEND_ATTEMPTS):
             try:
-                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
-                    sock.settimeout(_CONNECT_TIMEOUT_S)
-                    sock.connect(self._socket_path)  # type: ignore[arg-type]
-                    sock.sendall(payload)
-                    # Any nonempty response is an ack: herdr already treats the
-                    # report as taken (even a busy ``shown:false`` reply), so we
-                    # stop. No bytes (closed / timed-out) means it may not have
-                    # applied -> retry the identical envelope.
-                    if sock.recv(_ACK_BYTES):
-                        return
+                if self._deliver(payload):
+                    return
             except (OSError, ValueError) as exc:
                 last_exc = exc
             if attempt + 1 < _SEND_ATTEMPTS:
@@ -311,6 +307,38 @@ class HerdrClient:
             _SEND_ATTEMPTS,
             last_exc,
         )
+
+    def _deliver(self, payload: bytes) -> bool:
+        """One wire attempt. ``True`` means herdr acked the report.
+
+        Any nonempty response is an ack: herdr already treats the report as
+        taken (even a busy ``shown:false`` reply). No bytes (closed /
+        timed-out) means it may not have applied -> caller retries the
+        identical envelope.
+        """
+        if os.name == "nt":
+            return self._deliver_pipe(payload)
+        return self._deliver_unix(payload)
+
+    def _deliver_unix(self, payload: bytes) -> bool:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(_CONNECT_TIMEOUT_S)
+            sock.connect(self._socket_path)  # type: ignore[arg-type]
+            sock.sendall(payload)
+            return bool(sock.recv(_ACK_BYTES))
+
+    def _deliver_pipe(self, payload: bytes) -> bool:
+        # herdr's Windows build (Rust ``interprocess`` crate) exposes the
+        # named pipe ``\\.\pipe\<full HERDR_SOCKET_PATH>``; the .sock file
+        # itself is just a pid marker. CreateFile fails fast when herdr is
+        # gone (OSError -> retry lane). The ack read has no timeout, but
+        # replies are immediate in practice, the worker is a daemon thread,
+        # and ``release_and_close`` is caller-bounded, so a wedged herdr
+        # cannot hang the agent or its shutdown.
+        pipe_name = "\\\\.\\pipe\\" + str(self._socket_path)
+        with open(pipe_name, "r+b", buffering=0) as pipe:
+            pipe.write(payload)
+            return bool(pipe.readline(_ACK_BYTES))
 
 
 __all__ = ["HerdrClient", "SOURCE", "AGENT"]

--- a/tests/plugins/test_herdr_client.py
+++ b/tests/plugins/test_herdr_client.py
@@ -3,8 +3,10 @@
 Split out from ``test_herdr_plugin.py`` (which keeps the reporter state
 machine + core wiring) so each file stays well under the 600-line cap.
 
-Covers env-gated activation, a real ``AF_UNIX`` round-trip, seq
-monotonicity, retry-until-acked delivery, and the protocol-16 additions:
+Covers env-gated activation, a real ``AF_UNIX`` round-trip, the Windows
+named-pipe transport (activation without ``AF_UNIX`` plus a real pipe
+round-trip against a ctypes pipe server), seq monotonicity,
+retry-until-acked delivery, and the protocol-16 additions:
 coalescing critical/decorative lanes, wire-order seq assignment, pane
 metadata, and bounded idempotent release.
 """
@@ -89,6 +91,83 @@ def test_client_sends_report_over_socket(monkeypatch):
     assert params["state"] == "working"
     assert params["agent_session_id"] == "sess-42"
     assert isinstance(params["seq"], int)
+
+
+# --- Windows named-pipe transport -----------------------------------------
+
+_IS_WINDOWS = os.name == "nt"
+
+
+@pytest.mark.skipif(not _IS_WINDOWS, reason="named-pipe transport is windows-only")
+def test_client_active_on_windows_without_af_unix(monkeypatch):
+    """Windows has no ``socket.AF_UNIX``; the pipe transport must still arm."""
+    assert not hasattr(socket, "AF_UNIX")  # the premise of the whole feature
+    monkeypatch.setenv("HERDR_ENV", "1")
+    monkeypatch.setenv("HERDR_SOCKET_PATH", r"C:\nonexistent\herdr.sock")
+    monkeypatch.setenv("HERDR_PANE_ID", "w1:p1")
+    client = HerdrClient()
+    assert client.active is True
+    client.close()
+
+
+def _serve_one_pipe_request(pipe_name: str, received: list, ready: threading.Event):
+    """Minimal one-shot named-pipe server (what herdr's Windows build does)."""
+    import ctypes
+    from ctypes import wintypes
+
+    k32 = ctypes.windll.kernel32
+    k32.CreateNamedPipeW.restype = wintypes.HANDLE
+    PIPE_ACCESS_DUPLEX = 0x3
+    handle = k32.CreateNamedPipeW(
+        pipe_name, PIPE_ACCESS_DUPLEX, 0, 1, 65536, 65536, 0, None
+    )
+    assert handle not in (0, wintypes.HANDLE(-1).value), "CreateNamedPipeW failed"
+    ready.set()
+    k32.ConnectNamedPipe(wintypes.HANDLE(handle), None)
+    buf = ctypes.create_string_buffer(65536)
+    n = wintypes.DWORD()
+    k32.ReadFile(wintypes.HANDLE(handle), buf, 65536, ctypes.byref(n), None)
+    received.append(buf.raw[: n.value])
+    reply = b'{"result":{"type":"ok"}}\n'
+    k32.WriteFile(wintypes.HANDLE(handle), reply, len(reply), ctypes.byref(n), None)
+    k32.FlushFileBuffers(wintypes.HANDLE(handle))
+    k32.DisconnectNamedPipe(wintypes.HANDLE(handle))
+    k32.CloseHandle(wintypes.HANDLE(handle))
+
+
+@pytest.mark.skipif(not _IS_WINDOWS, reason="named-pipe transport is windows-only")
+def test_client_sends_report_over_named_pipe(monkeypatch):
+    """Full round-trip over the ``\\\\.\\pipe\\<HERDR_SOCKET_PATH>`` mapping."""
+    sock_path = os.path.join(tempfile.mkdtemp(), "herdr.sock")
+    pipe_name = "\\\\.\\pipe\\" + sock_path
+
+    received: list[bytes] = []
+    ready = threading.Event()
+    t = threading.Thread(
+        target=_serve_one_pipe_request, args=(pipe_name, received, ready), daemon=True
+    )
+    t.start()
+    assert ready.wait(timeout=2)
+
+    monkeypatch.setenv("HERDR_ENV", "1")
+    monkeypatch.setenv("HERDR_SOCKET_PATH", sock_path)
+    monkeypatch.setenv("HERDR_PANE_ID", "w1:p1")
+
+    client = HerdrClient()
+    assert client.active is True
+    client.report_state("working", agent_session_id="sess-42")
+
+    t.join(timeout=3)
+    assert received, "pipe server never received a report"
+
+    envelope = json.loads(received[0].decode("utf-8").strip().splitlines()[0])
+    assert envelope["method"] == "pane.report_agent"
+    params = envelope["params"]
+    assert params["pane_id"] == "w1:p1"
+    assert params["source"] == SOURCE
+    assert params["agent"] == AGENT
+    assert params["state"] == "working"
+    assert params["agent_session_id"] == "sess-42"
 
 
 def test_client_seq_strictly_increases(monkeypatch):
@@ -365,6 +444,9 @@ def test_release_and_close_is_idempotent(monkeypatch):
     assert c._release is first_release
 
 
+@pytest.mark.skipif(
+    not hasattr(socket, "AF_UNIX"), reason="AF_UNIX transport is unix-only"
+)
 def test_send_retries_reuse_one_seq(monkeypatch):
     """One ``_send`` assigns exactly one seq, however many attempts it makes."""
     monkeypatch.setattr(cl, "_SEND_BACKOFF_S", 0.0)


### PR DESCRIPTION
CPython still has no socket.AF_UNIX on Windows, so HerdrClient declared itself inactive there and panes never saw code-puppy agents. herdr's Windows build (Rust interprocess crate) exposes the file-style HERDR_SOCKET_PATH as a named pipe named after the full path (\\\\.\\pipe\\C:\\...\\herdr.sock), which plain stdlib file I/O can speak -- no new deps.