### PR TITLE
Fix the highlights

### DIFF
--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -110,6 +110,27 @@ def get_pack_agents_enabled() -> bool:
     return str(cfg_val).strip().lower() in {"1", "true", "yes", "on"}
 
 
+def get_selection_friendly_transcript() -> bool:
+    """Return True if transcript markdown should skip the theme fg override.
+
+    Default True. When True, ``_render_agent_response`` prints Markdown
+    WITHOUT forcing the theme's soft body foreground on every cell, so the
+    terminal's own text-selection highlight (typically a pale color) retains
+    contrast against the default terminal foreground.
+
+    When False, restores the pre-fix behavior of applying the theme fg to
+    all rendered markdown. This works around terminals that ignore OSC 10
+    (default-fg overrides), at the cost of low-contrast selection on any
+    terminal whose selection color is close in luminance to the theme fg.
+
+    Toggle via the ``selection_friendly_transcript`` config key.
+    """
+    cfg_val = get_value("selection_friendly_transcript")
+    if cfg_val is None:
+        return True  # Prefer selection contrast by default.
+    return str(cfg_val).strip().lower() in {"1", "true", "yes", "on"}
+
+
 def get_universal_constructor_enabled() -> bool:
     """Return True if the Universal Constructor is enabled (default True).
 

--- a/code_puppy/messaging/rich_renderer.py
+++ b/code_puppy/messaging/rich_renderer.py
@@ -1002,12 +1002,25 @@ class RichConsoleRenderer:
         # Content (markdown or plain)
         if msg.is_markdown:
             md = Markdown(msg.content)
-            # Give colorless Markdown styles (bold/headings) an explicit base
-            # foreground. Some terminals ignore OSC 10, making Rich resets leak
-            # the terminal profile's white into otherwise themed responses.
-            from code_puppy.callbacks import on_prompt_text_color
+            # Historically we applied the theme's foreground to every cell so
+            # that terminals which ignore OSC 10 wouldn't leak their profile's
+            # white through Rich resets. That was a cosmetic win for a few
+            # terminals but broke text-selection contrast for everyone: the
+            # theme's soft body color (e.g. Tokyo Night's #a9b1d6) has almost
+            # zero contrast against typical pale selection backgrounds, making
+            # highlighted text unreadable while dragging to copy.
+            #
+            # Default now: let the terminal keep its default fg so its own
+            # selection inversion works. Opt back in to the legacy behavior
+            # via ``selection_friendly_transcript = false`` in config.
+            from code_puppy.config import get_selection_friendly_transcript
 
-            self._console.print(md, style=on_prompt_text_color())
+            if get_selection_friendly_transcript():
+                self._console.print(md)
+            else:
+                from code_puppy.callbacks import on_prompt_text_color
+
+                self._console.print(md, style=on_prompt_text_color())
         else:
             self._console.print(msg.content)
 

--- a/tests/messaging/test_rich_renderer.py
+++ b/tests/messaging/test_rich_renderer.py
@@ -419,6 +419,47 @@ def test_render_agent_response_plain(renderer, console):
     renderer._render_agent_response(msg)
 
 
+@patch(
+    "code_puppy.config.get_selection_friendly_transcript",
+    return_value=True,
+)
+def test_render_agent_response_selection_friendly_skips_theme_fg(
+    mock_toggle, renderer, console
+):
+    """Selection-friendly default: no theme fg override on print().
+
+    The whole point of the toggle is that the terminal's own selection
+    inversion keeps contrast. That only works if we hand Rich the
+    Markdown *without* a hex-color base style, so we assert print() was
+    called with no ``style`` keyword.
+    """
+    msg = AgentResponseMessage(content="**hi**", is_markdown=True)
+    with patch.object(renderer._console, "print") as mock_print:
+        renderer._render_agent_response(msg)
+    # First call = banner header, second = markdown body (the one we care about).
+    markdown_call = mock_print.call_args_list[1]
+    assert "style" not in markdown_call.kwargs
+
+
+@patch(
+    "code_puppy.callbacks.on_prompt_text_color",
+    return_value="#a9b1d6",
+)
+@patch(
+    "code_puppy.config.get_selection_friendly_transcript",
+    return_value=False,
+)
+def test_render_agent_response_legacy_applies_theme_fg(
+    mock_toggle, mock_color, renderer, console
+):
+    """Opt-out path still applies the theme fg (OSC-10 workaround)."""
+    msg = AgentResponseMessage(content="**hi**", is_markdown=True)
+    with patch.object(renderer._console, "print") as mock_print:
+        renderer._render_agent_response(msg)
+    markdown_call = mock_print.call_args_list[1]
+    assert markdown_call.kwargs.get("style") == "#a9b1d6"
+
+
 @patch("code_puppy.messaging.rich_renderer.is_subagent", return_value=False)
 def test_render_subagent_invocation(mock_sub, renderer, console):
     msg = SubAgentInvocationMessage(


### PR DESCRIPTION
Currently, the users face an issue with the highlight which hides the content being highlighted due the highlight color and the rendered content font colors. 

Current:
<img width="852" height="217" alt="Screenshot 2026-08-03 at 2 17 33 PM" src="https://github.com/user-attachments/assets/0e2cfeb1-71b6-4428-890c-5b861a281617" />


<img width="589" height="204" alt="Screenshot 2026-08-03 at 2 19 20 PM" src="https://github.com/user-attachments/assets/f13b9c90-fb9d-497e-8733-202b8882e4a9" />


After the change:

<img width="897" height="309" alt="Screenshot 2026-08-03 at 2 17 47 PM" src="https://github.com/user-attachments/assets/4d509be6-551e-47c3-a9f3-d13b3402db94" />

Co-author: aditya.das@walmart.com
