### PR TITLE
Add xhigh to adaptive effort settings

### DIFF
--- a/code_puppy/command_line/model_settings_menu.py
+++ b/code_puppy/command_line/model_settings_menu.py
@@ -168,9 +168,9 @@ SETTING_DEFINITIONS: Dict[str, Dict] = {
     },
     "effort": {
         "name": "Effort",
-        "description": "Controls how much effort the model spends on its response (Opus 4-6 only). Low = fast, Max = most thorough.",
+        "description": "Controls how much effort adaptive models spend on their response. Low = fast, Max = most thorough.",
         "type": "choice",
-        "choices": ["low", "medium", "high", "max"],
+        "choices": ["low", "medium", "high", "xhigh", "max"],
         "default": "high",
     },
     "retry_main_strategy": {

--- a/tests/command_line/test_model_settings_menu.py
+++ b/tests/command_line/test_model_settings_menu.py
@@ -82,6 +82,12 @@ class TestSettingDefinitions:
         assert "high" in reason_def["choices"]
         assert "max" in reason_def["choices"]
 
+    def test_adaptive_effort_setting_includes_xhigh(self):
+        """Adaptive effort supports Anthropic's xhigh level."""
+        effort_def = SETTING_DEFINITIONS["effort"]
+        assert effort_def["type"] == "choice"
+        assert effort_def["choices"] == ["low", "medium", "high", "xhigh", "max"]
+
     def test_summary_setting_definition(self):
         """Test reasoning summary setting has correct choices."""
         summary_def = SETTING_DEFINITIONS["summary"]


### PR DESCRIPTION
## Summary
- add `xhigh` to the shared adaptive `effort` selector
- describe the setting generically for adaptive models rather than one Opus version
- add focused regression coverage for the complete effort vocabulary

## Why
Code Puppy already passes `effort` through to `output_config.effort` for adaptive models, and its Bedrock plugin already creates an `xhigh` Opus 4.7 variant. The interactive `/model_settings` selector was the odd one out: it only offered low/medium/high/max, so users could not select a value the existing request path and provider catalog already support.

## Verification
- `uv run ruff check code_puppy/command_line/model_settings_menu.py tests/command_line/test_model_settings_menu.py`
- `uv run ruff format --check code_puppy/command_line/model_settings_menu.py tests/command_line/test_model_settings_menu.py`
- `uv run pytest tests/command_line/test_model_settings_menu.py -q` (37 passed)
