### PR TITLE
Keep model catalog loads out of settings TUI repaints

### DIFF
--- a/code_puppy/command_line/model_settings_menu.py
+++ b/code_puppy/command_line/model_settings_menu.py
@@ -251,10 +251,23 @@ def _format_custom_pairs(pairs: Dict) -> str:
     return "; ".join(f"{k}={_format_custom_value(v)}" for k, v in pairs.items())
 
 
-def _load_all_model_names() -> List[str]:
+def _load_all_model_names(models_config: Optional[dict] = None) -> List[str]:
     """Load all available model names from config."""
-    models_config = ModelFactory.load_config()
+    if models_config is None:
+        models_config = ModelFactory.load_config()
     return list(models_config.keys())
+
+
+def _supports_setting(
+    model_name: str, setting: str, models_config: Optional[dict] = None
+) -> bool:
+    """Check capability against one preloaded model-catalog snapshot."""
+    try:
+        return model_supports_setting(model_name, setting, models_config=models_config)
+    except TypeError:
+        # Preserve compatibility with older plugin overrides/test doubles that
+        # still implement the historical two-argument callable.
+        return model_supports_setting(model_name, setting)
 
 
 # Per-model retry override keys are handled specially: they live in the dedicated
@@ -298,13 +311,15 @@ def _write_per_model_retry(model_name: str, menu_key: str, value) -> None:
         set_value(key, str(value))
 
 
-def _get_model_display_settings(model_name: str) -> Dict:
+def _get_model_display_settings(
+    model_name: str, models_config: Optional[dict] = None
+) -> Dict:
     """Get configured model settings plus model-specific display defaults."""
     settings = get_all_model_settings(model_name)
 
-    if model_supports_setting(model_name, "reasoning_context"):
+    if _supports_setting(model_name, "reasoning_context", models_config):
         settings.setdefault("reasoning_context", "all_turns")
-    if model_supports_setting(model_name, "reasoning_mode"):
+    if _supports_setting(model_name, "reasoning_mode", models_config):
         settings.setdefault("reasoning_mode", "standard")
     # Per-model retry overrides live in their own namespace, so inject their
     # current values here (only when actually set -- unset shows the default).
@@ -323,7 +338,9 @@ def _get_model_display_settings(model_name: str) -> Dict:
 
 
 def _get_setting_choices(
-    setting_key: str, model_name: Optional[str] = None
+    setting_key: str,
+    model_name: Optional[str] = None,
+    models_config: Optional[dict] = None,
 ) -> List[str]:
     """Get the available choices for a setting, filtered by model capabilities.
 
@@ -344,7 +361,8 @@ def _get_setting_choices(
     base_choices = setting_def.get("choices", [])
 
     if setting_key == "reasoning_effort" and model_name:
-        models_config = ModelFactory.load_config()
+        if models_config is None:
+            models_config = ModelFactory.load_config()
         model_config = models_config.get(model_name, {})
         unsupported_choices = set()
         if not model_config.get("supports_xhigh_reasoning", False):
@@ -392,7 +410,15 @@ class ModelSettingsMenu:
 
     def __init__(self):
         """Initialize the settings menu."""
-        self.all_models = _load_all_model_names()
+        # Model config callbacks may perform network discovery. Snapshot once
+        # for this menu session; render/key paths must stay pure and immediate.
+        self.models_config = ModelFactory.load_config()
+        try:
+            self.all_models = _load_all_model_names(self.models_config)
+        except TypeError:
+            # Compatibility for older overrides/test doubles with no snapshot
+            # parameter. Production uses the one-load path above.
+            self.all_models = _load_all_model_names()
         self.current_model_name = get_global_model_name()
 
         # Navigation state
@@ -466,7 +492,7 @@ class ModelSettingsMenu:
             if (
                 setting_key == CUSTOM_MODEL_SETTING
                 or setting_key in _RETRY_MENU_KEYS
-                or model_supports_setting(model_name, setting_key)
+                or _supports_setting(model_name, setting_key, self.models_config)
             ):
                 supported.append(setting_key)
         return supported
@@ -475,7 +501,9 @@ class ModelSettingsMenu:
         """Load settings for a specific model."""
         self.selected_model = model_name
         self.supported_settings = self._get_supported_settings(model_name)
-        self.current_settings = _get_model_display_settings(model_name)
+        self.current_settings = _get_model_display_settings(
+            model_name, self.models_config
+        )
         self.custom_settings = get_custom_model_settings(model_name)
 
         self.setting_index = 0
@@ -539,8 +567,6 @@ class ModelSettingsMenu:
 
             from code_puppy.model_descriptions import get_model_description
 
-            models_config = ModelFactory.load_config()
-
             # Only render models on the current page
             for i, model_name in enumerate(self.models_on_page):
                 absolute_index = self.page_start + i
@@ -567,7 +593,7 @@ class ModelSettingsMenu:
                 lines.append(("", "\n"))
 
                 if is_selected:
-                    description = get_model_description(models_config, model_name)
+                    description = get_model_description(self.models_config, model_name)
                     lines.append(("class:tui.body", f"      {description}\n"))
 
             lines.append(("", "\n"))
@@ -730,7 +756,7 @@ class ModelSettingsMenu:
                 lines.append(("", "\n\n"))
 
             # Show current settings for this model
-            model_settings = _get_model_display_settings(model_name)
+            model_settings = _get_model_display_settings(model_name, self.models_config)
             if model_settings:
                 lines.append(("class:tui.label", "  Effective Settings:"))
                 lines.append(("", "\n"))
@@ -800,7 +826,9 @@ class ModelSettingsMenu:
                 lines.append(("class:tui.label", "  Options:"))
                 lines.append(("", "\n"))
                 # Get filtered choices based on model capabilities
-                choices = _get_setting_choices(setting_key, self.selected_model)
+                choices = _get_setting_choices(
+                    setting_key, self.selected_model, self.models_config
+                )
                 lines.append(
                     (
                         "class:tui.muted",
@@ -902,7 +930,9 @@ class ModelSettingsMenu:
             self.edit_value = current
         elif setting_def.get("type") == "choice":
             # For choice settings, start with the default (using filtered choices)
-            choices = _get_setting_choices(setting_key, self.selected_model)
+            choices = _get_setting_choices(
+                setting_key, self.selected_model, self.models_config
+            )
             resolved = _get_setting_default(setting_key, self.selected_model)
             self.edit_value = resolved or (choices[0] if choices else None)
         elif setting_def.get("type") == "boolean":
@@ -941,7 +971,9 @@ class ModelSettingsMenu:
 
         if setting_def.get("type") == "choice":
             # Cycle through filtered choices based on model capabilities
-            choices = _get_setting_choices(setting_key, self.selected_model)
+            choices = _get_setting_choices(
+                setting_key, self.selected_model, self.models_config
+            )
             current_idx = (
                 choices.index(self.edit_value) if self.edit_value in choices else 0
             )

--- a/code_puppy/command_line/model_settings_menu.py
+++ b/code_puppy/command_line/model_settings_menu.py
@@ -5,6 +5,7 @@ settings like temperature and seed on a per-model basis.
 """
 
 import sys
+import inspect
 import time
 from typing import Dict, List, Optional
 
@@ -262,12 +263,10 @@ def _supports_setting(
     model_name: str, setting: str, models_config: Optional[dict] = None
 ) -> bool:
     """Check capability against one preloaded model-catalog snapshot."""
-    try:
+    parameters = inspect.signature(model_supports_setting).parameters
+    if "models_config" in parameters:
         return model_supports_setting(model_name, setting, models_config=models_config)
-    except TypeError:
-        # Preserve compatibility with older plugin overrides/test doubles that
-        # still implement the historical two-argument callable.
-        return model_supports_setting(model_name, setting)
+    return model_supports_setting(model_name, setting)
 
 
 # Per-model retry override keys are handled specially: they live in the dedicated
@@ -413,11 +412,10 @@ class ModelSettingsMenu:
         # Model config callbacks may perform network discovery. Snapshot once
         # for this menu session; render/key paths must stay pure and immediate.
         self.models_config = ModelFactory.load_config()
-        try:
+        parameters = inspect.signature(_load_all_model_names).parameters
+        if "models_config" in parameters:
             self.all_models = _load_all_model_names(self.models_config)
-        except TypeError:
-            # Compatibility for older overrides/test doubles with no snapshot
-            # parameter. Production uses the one-load path above.
+        else:
             self.all_models = _load_all_model_names()
         self.current_model_name = get_global_model_name()
 

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -714,12 +714,18 @@ def reset_session_model():
     _SESSION_MODEL = None
 
 
-def model_supports_setting(model_name: str, setting: str) -> bool:
+def model_supports_setting(
+    model_name: str,
+    setting: str,
+    models_config: Optional[dict[str, Any]] = None,
+) -> bool:
     """Check if a model supports a particular setting (e.g., 'temperature', 'seed').
 
     Args:
         model_name: The name of the model to check.
         setting: The setting name to check for (e.g., 'temperature', 'seed', 'top_p').
+        models_config: Optional preloaded model catalog. Callers checking several
+            settings should pass one snapshot to avoid repeated config loads.
 
     Returns:
         True if the model supports the setting, False otherwise.
@@ -747,7 +753,8 @@ def model_supports_setting(model_name: str, setting: str) -> bool:
     try:
         from code_puppy.model_factory import ModelFactory
 
-        models_config = ModelFactory.load_config()
+        if models_config is None:
+            models_config = ModelFactory.load_config()
         model_config = models_config.get(model_name, {})
         if setting in ("reasoning_context", "reasoning_mode"):
             underlying_name = str(model_config.get("name", "")).lower()

--- a/tests/command_line/test_model_settings_menu_latency.py
+++ b/tests/command_line/test_model_settings_menu_latency.py
@@ -1,0 +1,46 @@
+"""Regression coverage for network-backed model catalogs in /model_settings."""
+
+from unittest.mock import patch
+
+from code_puppy.command_line.model_settings_menu import ModelSettingsMenu
+
+
+def test_model_picker_repaints_do_not_reload_model_catalog():
+    catalog = {
+        "vizio-gpt-5.6-sol": {
+            "supported_settings": ["reasoning_effort", "summary", "verbosity"]
+        },
+        "vizio-claude-opus-5": {"supported_settings": ["extended_thinking", "effort"]},
+    }
+
+    with patch(
+        "code_puppy.command_line.model_settings_menu.ModelFactory.load_config",
+        return_value=catalog,
+    ) as load_config:
+        menu = ModelSettingsMenu()
+        loads_after_open = load_config.call_count
+
+        # Every arrow/Enter/Esc repaint calls both renderers. A load_model_config
+        # callback may perform HTTP discovery, so neither renderer may reload it.
+        for _ in range(3):
+            menu._render_main_list()
+            menu._render_details_panel()
+
+        assert load_config.call_count == loads_after_open
+
+
+def test_model_picker_capability_checks_use_catalog_snapshot():
+    catalog = {
+        "vizio-claude-opus-5": {"supported_settings": ["extended_thinking", "effort"]}
+    }
+
+    with patch(
+        "code_puppy.command_line.model_settings_menu.ModelFactory.load_config",
+        return_value=catalog,
+    ) as load_config:
+        menu = ModelSettingsMenu()
+        loads_after_open = load_config.call_count
+        supported = menu._get_supported_settings("vizio-claude-opus-5")
+
+        assert "effort" in supported
+        assert load_config.call_count == loads_after_open

--- a/tests/command_line/test_model_settings_menu_latency.py
+++ b/tests/command_line/test_model_settings_menu_latency.py
@@ -29,6 +29,28 @@ def test_model_picker_repaints_do_not_reload_model_catalog():
         assert load_config.call_count == loads_after_open
 
 
+def test_capability_type_error_is_not_retried_without_snapshot():
+    catalog = {"vizio-model": {"supported_settings": ["effort"]}}
+
+    def broken(model_name, setting, models_config=None):
+        raise TypeError("implementation bug")
+
+    with patch(
+        "code_puppy.command_line.model_settings_menu.model_supports_setting",
+        side_effect=broken,
+    ) as supports:
+        from code_puppy.command_line.model_settings_menu import _supports_setting
+
+        try:
+            _supports_setting("vizio-model", "effort", catalog)
+        except TypeError as error:
+            assert str(error) == "implementation bug"
+        else:
+            raise AssertionError("internal TypeError must propagate")
+
+        assert supports.call_count == 1
+
+
 def test_model_picker_capability_checks_use_catalog_snapshot():
     catalog = {
         "vizio-claude-opus-5": {"supported_settings": ["extended_thinking", "effort"]}


### PR DESCRIPTION
## Summary
- snapshot model configuration once per `/model_settings` session
- reuse the snapshot for names, descriptions, capability checks, defaults, and choices
- keep model-picker render and keypress paths free of config callbacks
- let `model_supports_setting` accept an optional preloaded catalog

## Reproduction
The model picker called `ModelFactory.load_config()` 16 times per repaint: once in the list and 15 times while deriving capabilities for the details panel. For network-backed model catalogs, a 0.9s config load made each arrow/Enter/Esc repaint take 14.89s. The inner settings view remained responsive because it reused its supported-settings list.

## Verification
- regression tests assert repeated picker repaints perform zero additional catalog loads
- internal `TypeError` propagation is covered (no exception-driven retry)
- focused model-settings suites: 131 passed on current upstream main
- Ruff and formatting clean
