### PR TITLE
fix: guard ModelNameCompleter against None active_model and stale cache

### DIFF
--- a/code_puppy/command_line/model_picker_completion.py
+++ b/code_puppy/command_line/model_picker_completion.py
@@ -74,7 +74,6 @@ class ModelNameCompleter(Completer):
     def __init__(self, trigger: str = "/model", prefix: str = ""):
         self.trigger = trigger
         self.prefix = prefix
-        self.model_names = load_model_names()
 
     def get_completions(
         self, document: Document, complete_event
@@ -91,6 +90,7 @@ class ModelNameCompleter(Completer):
         from code_puppy.model_descriptions import get_model_description
 
         models_config = _load_models_config()
+        model_names = load_model_names()
 
         # --- Prefix mode (e.g. ``/fork @agent @mod``) ---
         if self.prefix:
@@ -112,7 +112,7 @@ class ModelNameCompleter(Completer):
             start_position = -len(text_after_prefix)
 
         # Filter model names based on what's typed (case-insensitive)
-        for model_name in self.model_names:
+        for model_name in model_names:
             if text_after_prefix and not query_matches_text(
                 text_after_prefix, model_name
             ):
@@ -120,7 +120,7 @@ class ModelNameCompleter(Completer):
 
             description = get_model_description(models_config, model_name)
             active_model_name = get_active_model()
-            if model_name.lower() == active_model_name.lower():
+            if active_model_name is not None and model_name.lower() == active_model_name.lower():
                 short = (
                     description[:45] + "..." if len(description) > 48 else description
                 )

--- a/tests/command_line/test_model_picker_completion.py
+++ b/tests/command_line/test_model_picker_completion.py
@@ -125,6 +125,28 @@ class TestModelNameCompleter:
             assert len(completions) == 1
             assert completions[0].text == "claude-3"
 
+    def test_no_active_model_does_not_crash(self):
+        """Regression test: get_completions must not crash when no model is
+        configured and get_active_model() returns None."""
+        from code_puppy.command_line.model_picker_completion import ModelNameCompleter
+
+        with (
+            patch(
+                "code_puppy.command_line.model_picker_completion._load_models_config",
+                return_value={"gpt-4": {}, "claude-3": {}},
+            ),
+            patch(
+                "code_puppy.command_line.model_picker_completion.get_active_model",
+                return_value=None,
+            ),
+        ):
+            c = ModelNameCompleter(trigger="/model")
+            completions = list(c.get_completions(self._make_doc("/model "), None))
+            assert len(completions) == 2
+            # None of the completions should be marked as active ✓
+            for comp in completions:
+                assert "✓" not in str(comp.display_meta)
+
 
 class TestFindMatchingModel:
     def test_exact_match(self):


### PR DESCRIPTION
## Changes

- Guard `get_active_model()` return against `None` before calling `.lower()` (fixes `AttributeError` crash)
- Remove stale `self.model_names` cache from `__init__`
- Load `model_names` fresh per completion invocation in `get_completions()`
- Add regression test for the no-model-configured scenario

## Issue

Closes #419

## Testing

```python
from unittest.mock import patch
from code_puppy.command_line.model_picker_completion import ModelNameCompleter
from prompt_toolkit.document import Document

with patch("..._load_models_config", return_value={"gpt-4": {}}), \
     patch("...get_active_model", return_value=None):
    completions = list(ModelNameCompleter().get_completions(Document("/model "), None))
    assert len(completions) > 0  # No crash!
```

**Credit:** Issue analysis and code pointers by @mpfaffenberger.