### PR TITLE
refactor: remove dead `get_file_icon`.

### DIFF
--- a/code_puppy/tools/file_operations.py
+++ b/code_puppy/tools/file_operations.py
@@ -438,35 +438,6 @@ def _list_files(
         else:
             return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"
 
-    def get_file_icon(file_path):
-        ext = os.path.splitext(file_path)[1].lower()
-        if ext in [".py", ".pyw"]:
-            return "\U0001f40d"
-        elif ext in [".js", ".jsx", ".ts", ".tsx"]:
-            return "\U0001f4dc"
-        elif ext in [".html", ".htm", ".xml"]:
-            return "\U0001f310"
-        elif ext in [".css", ".scss", ".sass"]:
-            return "\U0001f3a8"
-        elif ext in [".md", ".markdown", ".rst"]:
-            return "\U0001f4dd"
-        elif ext in [".json", ".yaml", ".yml", ".toml"]:
-            return "\u2699\ufe0f"
-        elif ext in [".jpg", ".jpeg", ".png", ".gif", ".svg", ".webp"]:
-            return "\U0001f5bc\ufe0f"
-        elif ext in [".mp3", ".wav", ".ogg", ".flac"]:
-            return "\U0001f3b5"
-        elif ext in [".mp4", ".avi", ".mov", ".webm"]:
-            return "\U0001f3ac"
-        elif ext in [".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx"]:
-            return "\U0001f4c4"
-        elif ext in [".zip", ".tar", ".gz", ".rar", ".7z"]:
-            return "\U0001f4e6"
-        elif ext in [".exe", ".dll", ".so", ".dylib"]:
-            return "\u26a1"
-        else:
-            return "\U0001f4c4"
-
     # Count items in results
     dir_count = sum(1 for item in results if item.type == "directory")
     file_count = sum(1 for item in results if item.type == "file")


### PR DESCRIPTION
Refs issue #534.

---

### What
Removes `get_file_icon` off `code_puppy/tools/file_operations.py` — a zero-reference function.

---

### Why this isn't a "duplicate" (correcting original issue's classification)
#534 flagged this as a HIGH-confidence duplicate of `RichConsoleRenderer._get_file_icon`.
On inspection, these two are unrelated:

- `get_file_icon` does real extension-based icon dispatch (13 `elif` branches mapping file extensions to emoji).
 
- `_get_file_icon` is a stub that unconditionally returns `"-"` regardless of its `file_path` argument — docstring confirms this is intentional ("Return neutral marker used for files in tool output").

These don't overlap in behavior or intent. Shared name is coincidental.
`get_file_icon` is genuinely unused, but not for the reason issue #534 states.

---

### Verification
Results after running `rg 'get_file_icon|format_terminal_banner|get_verified|start_servers_with_blocking'`:

<img width="300" height="250" alt="image" src="https://github.com/user-attachments/assets/076ab73d-f99b-453c-9c85-f70f730b348b" />

Confirmed zero call sites via two independent methods:
- `rg 'get_file_icon'` — only match is the definition itself.
- PyCharm semantic Find Usages (AST-based) — "Nothing found in Project Files".

<img width="300" height="250" alt="image" src="https://github.com/user-attachments/assets/89fa1c33-9939-4133-866d-c40f93652997" />
<img width="300" height="250" alt="image" src="https://github.com/user-attachments/assets/c3d68651-0911-4686-a37e-396ad6ba0cd0" />

Full test suite: `uv run pytest tests/ -q --no-cov` — passes.

---

### Scope note
#### `get_file_icon`
This PR only touches `get_file_icon`.

#### `get_verified`
Issue #534 also flagged `get_verified` (same repo, `server_registry_catalog.py`) as unused — confirmed via the same two methods.

But I'm leaving that for a maintainer call — its only "test"
(`test_get_verified_servers`) reimplements the filter logic inline instead of calling `catalog.get_verified()`, so the method could either be removed,
or the test could be fixed to actually exercise it. Happy to open a follow-up PR for whichever direction you'd prefer.

#### `start_servers_with_blocking`
`start_servers_with_blocking`, also listed in #534, initially looked like a false positive (internal call at `blocking_startup.py:449`, three
"dedicated" tests). On closer inspection, both were misleading — line 449 is inside the function's *docstring* (an `Example:` block), not executable code, so `rg` matched documentation text rather than a real call site.

All three tests in `test_blocking_startup_coverage.py` construct a `StartupMonitor` directly and manually replicate the function's naming logic instead of calling `start_servers_with_blocking()` itself — one test's own comment says "we test the monitor part" since "actual server startup is complex."

So this candidate has zero real call sites and zero real test coverage, same as `get_file_icon` and `get_verified` — just harder to spot because the docstring example and test names made it look covered. Not including it in this PR's scope either; flagging the corrected finding for a maintainer call, same as `get_verified` above.