### PR TITLE
fix: isolate retry hook callback diagnostics

### DIFF
--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -23,7 +23,7 @@ import signal
 import threading
 import uuid
 from contextlib import AsyncExitStack
-from typing import Any, Callable, Iterator, List, Optional, Sequence, Type, Union
+from typing import Any, Callable, List, Optional, Sequence, Type, Union
 
 import httpcore
 import httpx
@@ -59,7 +59,7 @@ try:  # pragma: no cover - pydantic-ai version dependent
 except ImportError:
     ModelAPIError = None  # type: ignore[misc,assignment]
 
-# Python 3.11+ builtin; graceful fallback for 3.10
+# Python 3.11+ builtin; graceful fallback for 3.10.
 try:
     from builtins import BaseExceptionGroup  # type: ignore[attr-defined]
 except ImportError:  # pragma: no cover - 3.10 only
@@ -81,6 +81,7 @@ from code_puppy.agents._run_signals import (
     sigint_should_cancel,
 )
 from code_puppy.agents.event_stream_handler import event_stream_handler
+from code_puppy.agents.exception_tree import walk_exception_tree
 from code_puppy.callbacks import (
     on_agent_exception,
     on_agent_run_cancel,
@@ -89,6 +90,7 @@ from code_puppy.callbacks import (
     on_agent_run_result,
     on_agent_run_start,
     on_should_skip_fallback_render,
+    on_streaming_retry_display_suffix,
     on_user_prompt_submit,
 )
 from code_puppy.config import (
@@ -187,34 +189,12 @@ def _embedded_http_status(text: str) -> Optional[int]:
     return int(match.group(1)) if match else None
 
 
-def _walk_cause_chain(
-    exc: BaseException, max_depth: int = 5
-) -> "Iterator[BaseException]":
-    """Yield ``exc`` and follow its ``__cause__`` / ``__context__`` chain.
-
-    Depth-capped and cycle-safe (tracked by ``id``) so a pathological
-    self-referencing chain can't loop forever. We walk both attributes because
-    Anthropic-SDK / pydantic-ai wrap the real transport error in ``__cause__``
-    (explicit ``raise X from Y``), while some libraries use the implicit
-    ``__context__`` set by ``except: raise``. Cost of a false-positive cause
-    match is at most 3 silent retries; cost of a false-negative is the 60-line
-    REPL traceback this whole helper exists to prevent.
-    """
-    seen: set[int] = set()
-    current: Optional[BaseException] = exc
-    for _ in range(max_depth):
-        if current is None or id(current) in seen:
-            return
-        seen.add(id(current))
-        yield current
-        current = current.__cause__ or current.__context__
-
-
 def _is_retryable_one(exc: BaseException) -> bool:
     """Per-exception predicate: is *this single* exception transient?
 
-    Intentionally does NOT walk the cause chain -- that's :func:`_walk_cause_chain`'s
-    job, kept as a separate concern so each piece stays independently testable.
+    Intentionally does NOT walk wrapped exceptions --
+    :func:`walk_exception_tree` owns that concern, keeping this predicate
+    independently testable.
     """
     if isinstance(exc, _RETRYABLE_EXCEPTIONS):
         return True
@@ -310,20 +290,6 @@ def _is_retryable_one(exc: BaseException) -> bool:
     return False
 
 
-def _group_members(exc: BaseException) -> tuple:
-    """Return an ExceptionGroup's sub-exceptions, or ``()`` for a plain error.
-
-    Guards against the 3.10 fallback where ``BaseExceptionGroup`` aliases
-    ``Exception`` -- there we'd otherwise treat *every* exception as a group.
-    On 3.11+ (and 3.10 with the backport) real groups expose ``.exceptions``.
-    """
-    if BaseExceptionGroup is Exception:  # 3.10 without exceptiongroup backport
-        return ()
-    if isinstance(exc, BaseExceptionGroup):
-        return tuple(exc.exceptions)
-    return ()
-
-
 def should_retry_streaming(exc: Exception) -> bool:
     """Decide whether ``exc`` (or anything it wraps) is a transient hiccup.
 
@@ -340,24 +306,10 @@ def should_retry_streaming(exc: Exception) -> bool:
     ``.exceptions``, so a retryable 5xx used to look opaque and crash the REPL
     with a full traceback instead of getting the slow spaced-out retry.
 
-    Returns ``True`` if *any* reachable exception is transient. Cycle-safe via
-    an ``id`` set; the per-chain depth cap of :func:`_walk_cause_chain` is
-    preserved (group membership is a separate traversal axis).
+    Returns ``True`` if *any* reachable exception is transient. Traversal is
+    cycle-safe and preserves a bounded cause/context depth for each group node.
     """
-    seen: set[int] = set()
-    stack: list[BaseException] = [exc]
-    while stack:
-        node = stack.pop()
-        if node is None or id(node) in seen:
-            continue
-        for link in _walk_cause_chain(node):
-            if id(link) in seen:
-                continue
-            seen.add(id(link))
-            if _is_retryable_one(link):
-                return True
-            stack.extend(_group_members(link))
-    return False
+    return any(_is_retryable_one(link) for link in walk_exception_tree(exc))
 
 
 # Default retry budget for the raw ``streaming_retry`` mechanism when called
@@ -494,11 +446,19 @@ def streaming_retry(
                         )
 
                         delay = MIN_DELAY_SECONDS
-                    emit_warning(
+                    suffix = on_streaming_retry_display_suffix(
+                        exc,
+                        delay=delay,
+                        total=total,
+                        streak=streak,
+                        max_attempts=max_attempts,
+                    )
+                    message = (
                         "\u26a1 Turn interrupted mid-stream, re-running from the "
                         f"last completed step in {delay}s... "
-                        f"(attempt {total}, streak {streak}/{max_attempts})"
+                        f"(attempt {total}, streak {streak}/{max_attempts}){suffix}"
                     )
+                    emit_warning(message)
                     await asyncio.sleep(delay)
 
         return runner

--- a/code_puppy/agents/exception_tree.py
+++ b/code_puppy/agents/exception_tree.py
@@ -1,0 +1,53 @@
+"""Shared traversal for wrapped and grouped model exceptions."""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+try:  # pragma: no cover - Python 3.11+ builtin, retained for embedders
+    from builtins import BaseExceptionGroup
+except ImportError:  # pragma: no cover - Python 3.10 only
+    BaseExceptionGroup = Exception  # type: ignore[misc,assignment]
+
+
+def _walk_cause_chain(
+    exc: BaseException, max_depth: int = 5
+) -> Iterator[BaseException]:
+    """Yield a depth-capped, cycle-safe cause/context chain from ``exc``."""
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    for _ in range(max_depth):
+        if current is None or id(current) in seen:
+            return
+        seen.add(id(current))
+        yield current
+        current = current.__cause__ or current.__context__
+
+
+def _group_members(exc: BaseException) -> tuple[BaseException, ...]:
+    """Return group members without treating every 3.10 exception as a group."""
+    if BaseExceptionGroup is Exception:  # pragma: no cover - Python 3.10 only
+        return ()
+    if isinstance(exc, BaseExceptionGroup):
+        return tuple(exc.exceptions)
+    return ()
+
+
+def walk_exception_tree(exc: BaseException) -> Iterator[BaseException]:
+    """Yield each reachable exception once across chains and exception groups.
+
+    The same traversal underpins retry classification and private provider
+    adapters, preventing subtle wrapping semantics from drifting between them.
+    """
+    seen: set[int] = set()
+    stack: list[BaseException] = [exc]
+    while stack:
+        node = stack.pop()
+        if id(node) in seen:
+            continue
+        for link in _walk_cause_chain(node):
+            if id(link) in seen:
+                continue
+            seen.add(id(link))
+            yield link
+            stack.extend(_group_members(link))

--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -176,6 +176,11 @@ def _get_disabled_plugins() -> Set[str]:
         return set()
 
 
+def _callback_name(callback: CallbackFunc) -> str:
+    """Return a stable diagnostic label for functions and callable objects."""
+    return getattr(callback, "__name__", type(callback).__name__)
+
+
 def register_callback(phase: PhaseType, func: CallbackFunc) -> None:
     if phase not in _callbacks:
         raise ValueError(
@@ -189,7 +194,7 @@ def register_callback(phase: PhaseType, func: CallbackFunc) -> None:
     # This can happen if plugins are accidentally loaded multiple times
     if func in _callbacks[phase]:
         logger.debug(
-            f"Callback {func.__name__} already registered for phase '{phase}', skipping"
+            f"Callback {_callback_name(func)} already registered for phase '{phase}', skipping"
         )
         return
 
@@ -199,7 +204,9 @@ def register_callback(phase: PhaseType, func: CallbackFunc) -> None:
     if _current_loading_plugin is not None:
         _callback_owners[func] = _current_loading_plugin
 
-    logger.debug(f"Registered async callback {func.__name__} for phase '{phase}'")
+    logger.debug(
+        f"Registered async callback {_callback_name(func)} for phase '{phase}'"
+    )
 
 
 def unregister_callback(phase: PhaseType, func: CallbackFunc) -> bool:
@@ -209,7 +216,7 @@ def unregister_callback(phase: PhaseType, func: CallbackFunc) -> bool:
     try:
         _callbacks[phase].remove(func)
         logger.debug(
-            f"Unregistered async callback {func.__name__} from phase '{phase}'"
+            f"Unregistered async callback {_callback_name(func)} from phase '{phase}'"
         )
         return True
     except ValueError:
@@ -619,6 +626,7 @@ def on_streaming_retry_display_suffix(
     """
     suffixes: list[str] = []
     for callback in get_callbacks("streaming_retry_display_suffix"):
+        callback_name = _callback_name(callback)
         try:
             result = callback(
                 exc,
@@ -633,18 +641,18 @@ def on_streaming_retry_display_suffix(
                 else:
                     logger.warning(
                         "Streaming retry display suffix %s returned an oversized value; ignoring it",
-                        callback.__name__,
+                        callback_name,
                     )
             elif result is not None:
                 logger.warning(
                     "Streaming retry display suffix %s returned %s; ignoring it",
-                    callback.__name__,
+                    callback_name,
                     type(result).__name__,
                 )
         except Exception as callback_exc:
             logger.error(
                 "Streaming retry display suffix %s failed: %s\n%s",
-                callback.__name__,
+                callback_name,
                 callback_exc,
                 traceback.format_exc(),
             )

--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -27,6 +27,7 @@ PhaseType = Literal[
     "pre_tool_call",
     "post_tool_call",
     "stream_event",
+    "streaming_retry_display_suffix",
     "thinking_display_filter",
     "termflow_style",
     "prompt_toolkit_style",
@@ -90,6 +91,7 @@ _callbacks: Dict[PhaseType, List[CallbackFunc]] = {
     "pre_tool_call": [],
     "post_tool_call": [],
     "stream_event": [],
+    "streaming_retry_display_suffix": [],
     "thinking_display_filter": [],
     "termflow_style": [],
     "prompt_toolkit_style": [],
@@ -598,6 +600,55 @@ async def on_post_tool_call(
     return await _trigger_callbacks(
         "post_tool_call", tool_name, tool_args, result, duration_ms, context
     )
+
+
+def on_streaming_retry_display_suffix(
+    exc: BaseException,
+    *,
+    delay: float,
+    total: int,
+    streak: int,
+    max_attempts: int,
+) -> str:
+    """Collect safe, additive plugin text for a streaming retry warning.
+
+    This synchronous hot-path hook runs immediately before each retry sleep.
+    Callbacks must be quick and non-blocking. Failures, non-string returns, and
+    oversized strings are ignored so plugins cannot interrupt retry behavior or
+    hide the core warning.
+    """
+    suffixes: list[str] = []
+    for callback in get_callbacks("streaming_retry_display_suffix"):
+        try:
+            result = callback(
+                exc,
+                delay=delay,
+                total=total,
+                streak=streak,
+                max_attempts=max_attempts,
+            )
+            if isinstance(result, str) and result:
+                if len(result) <= 256:
+                    suffixes.append(result)
+                else:
+                    logger.warning(
+                        "Streaming retry display suffix %s returned an oversized value; ignoring it",
+                        callback.__name__,
+                    )
+            elif result is not None:
+                logger.warning(
+                    "Streaming retry display suffix %s returned %s; ignoring it",
+                    callback.__name__,
+                    type(result).__name__,
+                )
+        except Exception as callback_exc:
+            logger.error(
+                "Streaming retry display suffix %s failed: %s\n%s",
+                callback.__name__,
+                callback_exc,
+                traceback.format_exc(),
+            )
+    return "".join(suffixes)
 
 
 def on_thinking_display_filter(

--- a/tests/agents/test_streaming_retry_e2e.py
+++ b/tests/agents/test_streaming_retry_e2e.py
@@ -10,6 +10,7 @@ to escape the classifier.
 import httpx
 import pytest
 
+from code_puppy.callbacks import register_callback
 from code_puppy.agents._runtime import streaming_retry
 
 
@@ -119,7 +120,51 @@ async def test_streaming_retry_does_not_retry_genuine_bugs():
     assert call_count["n"] == 1  # NO retries -- single attempt and done
 
 
-# --- Real reports from the field. These bodies are copy-pasted from user
+@pytest.mark.asyncio
+async def test_streaming_retry_warning_is_generic_without_suffix_plugin(monkeypatch):
+    warnings = []
+    monkeypatch.setattr("code_puppy.agents._runtime.emit_warning", warnings.append)
+
+    call_count = {"n": 0}
+
+    async def factory():
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise _make_anthropic_upstream_idle_timeout()
+        return "streamed-result"
+
+    result = await streaming_retry(max_attempts=3, delays=(0,))(factory)()
+
+    assert result == "streamed-result"
+    assert warnings[0].endswith(
+        "last completed step in 0s... (attempt 1, streak 1/3)"
+    )
+    assert "[resp_id:" not in warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_streaming_retry_suffix_plugin_is_additive_and_cannot_block_recovery(
+    monkeypatch,
+):
+    warnings = []
+    monkeypatch.setattr("code_puppy.agents._runtime.emit_warning", warnings.append)
+
+    def suffix(exc, **metadata):
+        assert metadata == {"delay": 0, "total": 1, "streak": 1, "max_attempts": 3}
+        return " [diagnostic]"
+
+    register_callback("streaming_retry_display_suffix", suffix)
+    call_count = {"n": 0}
+
+    async def factory():
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise _make_anthropic_upstream_idle_timeout()
+        return "streamed-result"
+
+    assert await streaming_retry(max_attempts=3, delays=(0,))(factory)() == "streamed-result"
+    assert call_count["n"] == 2
+    assert warnings[-1].endswith("[diagnostic]")
 # --- Teams messages so any future regression that breaks classification of
 # --- the actual shapes seen in production gets caught.
 

--- a/tests/agents/test_streaming_retry_e2e.py
+++ b/tests/agents/test_streaming_retry_e2e.py
@@ -136,9 +136,7 @@ async def test_streaming_retry_warning_is_generic_without_suffix_plugin(monkeypa
     result = await streaming_retry(max_attempts=3, delays=(0,))(factory)()
 
     assert result == "streamed-result"
-    assert warnings[0].endswith(
-        "last completed step in 0s... (attempt 1, streak 1/3)"
-    )
+    assert warnings[0].endswith("last completed step in 0s... (attempt 1, streak 1/3)")
     assert "[resp_id:" not in warnings[0]
 
 
@@ -162,9 +160,14 @@ async def test_streaming_retry_suffix_plugin_is_additive_and_cannot_block_recove
             raise _make_anthropic_upstream_idle_timeout()
         return "streamed-result"
 
-    assert await streaming_retry(max_attempts=3, delays=(0,))(factory)() == "streamed-result"
+    assert (
+        await streaming_retry(max_attempts=3, delays=(0,))(factory)()
+        == "streamed-result"
+    )
     assert call_count["n"] == 2
     assert warnings[-1].endswith("[diagnostic]")
+
+
 # --- Teams messages so any future regression that breaks classification of
 # --- the actual shapes seen in production gets caught.
 

--- a/tests/test_callbacks_extended.py
+++ b/tests/test_callbacks_extended.py
@@ -23,6 +23,7 @@ from code_puppy.callbacks import (
     on_replace_in_file,
     on_startup,
     on_stream_event,
+    on_streaming_retry_display_suffix,
     on_termflow_highlighter,
     on_termflow_style,
     register_callback,
@@ -42,6 +43,47 @@ class TestCallbacksExtended:
         register_callback("prompt_toolkit_style", lambda style: [*style, "menu"])
 
         assert on_prompt_toolkit_style(["base"]) == ["base", "theme", "menu"]
+
+    def test_streaming_retry_display_suffix_isolated_and_ordered(self, caplog):
+        seen = []
+
+        def first(exc, **metadata):
+            seen.append((exc, metadata))
+            return " [one]"
+
+        def broken(exc, **metadata):
+            raise RuntimeError("plugin boom")
+
+        def invalid(exc, **metadata):
+            return 42
+
+        def oversized(exc, **metadata):
+            return "x" * 257
+
+        def second(exc, **metadata):
+            return " [two]"
+
+        for callback in (first, broken, invalid, oversized, second):
+            register_callback("streaming_retry_display_suffix", callback)
+
+        error = RuntimeError("transient")
+        assert on_streaming_retry_display_suffix(
+            error, delay=5, total=2, streak=1, max_attempts=3
+        ) == " [one] [two]"
+        assert seen == [
+            (
+                error,
+                {"delay": 5, "total": 2, "streak": 1, "max_attempts": 3},
+            )
+        ]
+        assert "plugin boom" in caplog.text
+        assert "returned int" in caplog.text
+        assert "oversized value" in caplog.text
+
+    def test_streaming_retry_display_suffix_has_no_plugin_output(self):
+        assert on_streaming_retry_display_suffix(
+            RuntimeError("transient"), delay=5, total=1, streak=1, max_attempts=3
+        ) == ""
 
     def test_register_callback(self):
         """Test callback registration."""

--- a/tests/test_callbacks_extended.py
+++ b/tests/test_callbacks_extended.py
@@ -63,13 +63,27 @@ class TestCallbacksExtended:
         def second(exc, **metadata):
             return " [two]"
 
-        for callback in (first, broken, invalid, oversized, second):
+        class NamelessBrokenCallback:
+            def __call__(self, exc, **metadata):
+                raise RuntimeError("nameless plugin boom")
+
+        for callback in (
+            first,
+            broken,
+            invalid,
+            oversized,
+            NamelessBrokenCallback(),
+            second,
+        ):
             register_callback("streaming_retry_display_suffix", callback)
 
         error = RuntimeError("transient")
-        assert on_streaming_retry_display_suffix(
-            error, delay=5, total=2, streak=1, max_attempts=3
-        ) == " [one] [two]"
+        assert (
+            on_streaming_retry_display_suffix(
+                error, delay=5, total=2, streak=1, max_attempts=3
+            )
+            == " [one] [two]"
+        )
         assert seen == [
             (
                 error,
@@ -77,13 +91,17 @@ class TestCallbacksExtended:
             )
         ]
         assert "plugin boom" in caplog.text
+        assert "nameless plugin boom" in caplog.text
         assert "returned int" in caplog.text
         assert "oversized value" in caplog.text
 
     def test_streaming_retry_display_suffix_has_no_plugin_output(self):
-        assert on_streaming_retry_display_suffix(
-            RuntimeError("transient"), delay=5, total=1, streak=1, max_attempts=3
-        ) == ""
+        assert (
+            on_streaming_retry_display_suffix(
+                RuntimeError("transient"), delay=5, total=1, streak=1, max_attempts=3
+            )
+            == ""
+        )
 
     def test_register_callback(self):
         """Test callback registration."""


### PR DESCRIPTION
[CodePuppy Agent] - ## What

Add a synchronous `streaming_retry_display_suffix` callback seam to the streaming retry warning path.

## Why

Retry warnings can benefit from deployment-specific diagnostics without putting provider or enterprise details into the core harness.

## How

- Add a provider-neutral retry-warning suffix callback phase.
- Preserve generic warning output when no callback is registered.
- Collect additive suffixes in registration order.
- Isolate callback exceptions, invalid returns, and oversized values so plugins cannot interrupt retry recovery.
- Add `walk_exception_tree()` for shared traversal of wrapped causes, contexts, and `ExceptionGroup` members.
- Support callable objects safely in callback diagnostics rather than assuming callbacks always expose `__name__`.

## Testing

- `/pr-me` local gate: changed-file Ruff and formatter checks passed.
- `/pr-me` affected tests: 209 passed.
- `/pr-me` independent pre-PR review: clean.
- Full validation previously passed: `12,692 passed, 81 skipped, 1 xpassed`.
- i18n audit completed.

## Scope

Provider-neutral OSS infrastructure only. This PR contains no Walmart, Element, gateway response-body, or private diagnostic behavior.
