### PR TITLE
PUP-582: Add namespace_skill_search plugin: model-agnostic namespace + on-demand skill search

### DIFF
--- a/code_puppy/plugins/namespace_skill_search/README.md
+++ b/code_puppy/plugins/namespace_skill_search/README.md
@@ -13,6 +13,14 @@ every item injected into the system prompt upfront.
   `defer_loading: true`, results injected at end of context to preserve
   prompt caching. ~85% token reduction, measurable accuracy gains on
   internal MCP evals ([Anthropic engineering blog, Nov 2025](https://www.anthropic.com/engineering/advanced-tool-use)).
+  Note: our `load_prompt` fragment lands earlier in the assembled prompt
+  (layer 2 of `base_agent.py::get_full_system_prompt`) than the built-in
+  flat skill list it replaces did (layer 6, dead last). We prioritized
+  additive-safety (`load_prompt` can't collide with another plugin's
+  fragment; `get_model_system_prompt` can) over exactly matching
+  Anthropic's end-of-context caching position. If cache-hit rate on the
+  namespace block ever matters in practice, moving it later is a
+  follow-up, not a redesign.
 - OpenAI's shipped `tool_search`: same on-demand mechanic, PLUS an
   explicit **namespace** grouping layer above it
   (`{"type": "namespace", "name": "crm", "tools": [...]}`), because
@@ -53,18 +61,40 @@ Claude, GPT, Gemini, or any custom endpoint wired through
    - no args -> namespace directory (same content as the prompt block)
    - `namespace="X"` -> every skill in that namespace
    - `query="..."` -> keyword search across all namespaces
-4. **Flat list turned off** — on first load, the plugin calls
+4. **Flat list turned off** — the first time this plugin ever starts up
+   (via a `startup` callback, not an import-time side effect — see
+   "What we deliberately avoided" below), it calls
    `set_frontmatter_in_system_prompt(False)` via the public config API
    (`code_puppy.plugins.agent_skills.config`) so the built-in per-skill
-   flat list doesn't also render alongside the namespace directory. This
-   is a one-time flip; if a user re-enables it later with
-   `/skills frontmatter on`, we don't fight that choice on next launch.
+   flat list doesn't also render alongside the namespace directory.
+
+   **This is a real, persisted config write, not an in-memory toggle.**
+   Enabling this plugin once permanently sets
+   `frontmatter_in_system_prompt=false` in `puppy.cfg`. A dedicated
+   marker key (`namespace_skill_search_frontmatter_migrated`) records
+   that the flip already happened, so if you re-enable it afterwards
+   with `/skills frontmatter on`, we never touch the flag again — your
+   choice sticks across restarts. But if you disable or remove this
+   plugin entirely, the flag stays `false`; nothing restores the flat
+   list automatically. Run `/skills frontmatter on` yourself if you want
+   it back.
 
 ## What we deliberately avoided
 
+- **No config mutation at import time.** The `frontmatter_in_system_prompt`
+  flip runs inside a `register_callback("startup", ...)` handler (matching
+  the same pattern as `code_puppy/plugins/theme`'s
+  `_apply_default_theme_on_first_run`), not as top-level code in
+  `register_callbacks.py`. Import-time disk writes are a landmine: they
+  fire on every import (including test collection), can't be unit-tested
+  without `importlib.reload` gymnastics, and race with plugin load order
+  in ways a callback doesn't. A dedicated migration marker (see above)
+  makes the one-time-ness explicit and testable instead of relying on
+  "only flip it when the shared flag is currently True" as the sole
+  signal.
 - **No `get_model_system_prompt` callback.** That phase is
   last-write-wins across plugins — `model_utils.prepare_prompt_for_model`
-  threads augmenter results through sequentially and the *last* callback
+  threads augmenter results sequentially and the *last* callback
   processed wins on any key both callbacks set. A second plugin
   registering on that phase risks silently clobbering the built-in
   `agent_skills` plugin's contribution. `load_prompt` avoids that

--- a/code_puppy/plugins/namespace_skill_search/README.md
+++ b/code_puppy/plugins/namespace_skill_search/README.md
@@ -1,0 +1,88 @@
+# namespace_skill_search
+
+Model-agnostic reimplementation of OpenAI's namespace + `tool_search`
+pattern, applied to Code Puppy's skill catalog.
+
+## Why this exists
+
+Frontier labs converge on one shape for large tool/skill catalogs:
+**one grouping layer + on-demand search**, instead of a flat list of
+every item injected into the system prompt upfront.
+
+- Anthropic's shipped Tool Search Tool: flat on-demand search,
+  `defer_loading: true`, results injected at end of context to preserve
+  prompt caching. ~85% token reduction, measurable accuracy gains on
+  internal MCP evals ([Anthropic engineering blog, Nov 2025](https://www.anthropic.com/engineering/advanced-tool-use)).
+- OpenAI's shipped `tool_search`: same on-demand mechanic, PLUS an
+  explicit **namespace** grouping layer above it
+  (`{"type": "namespace", "name": "crm", "tools": [...]}`), because
+  "our models have primarily been trained to search those surfaces" —
+  namespaces outperform bare deferred functions in their own docs
+  ([OpenAI tool-search guide](https://developers.openai.com/api/docs/guides/tools-tool-search)).
+  They recommend keeping each namespace under 10 functions.
+- Neither ships a deep multi-level tree. One grouping layer is the norm;
+  true hierarchical (server -> tool) routing exists mainly in academic
+  work (e.g. MCP-Zero, arXiv:2506.01056), not shipped production
+  features.
+
+## What we copied, and why
+
+We copied OpenAI's shape (namespace + search) rather than Anthropic's
+(flat search only), because the namespace layer is a genuine win once a
+catalog gets into the hundreds of items. But OpenAI's mechanism depends
+on a model-specific API flag (`defer_loading`) that only exists for
+their own models. This plugin gets the same effect through Code Puppy's
+model-agnostic plugin hooks instead, so it behaves identically on
+Claude, GPT, Gemini, or any custom endpoint wired through
+`ModelFactory` — no provider-specific request fields required.
+
+## How it works
+
+1. **Namespace derivation** (`namespaces.py`) — a skill's namespace is
+   its first `tags:` entry (untagged skills land in `General`). No new
+   frontmatter field, no migration of existing `SKILL.md` files required.
+2. **Compact directory injection** (`load_prompt` hook) — instead of one
+   line per skill (the built-in behavior when
+   `frontmatter_in_system_prompt` is on), the system prompt gets one
+   line per *namespace* with a 3-item preview and a count. `load_prompt`
+   fragments from every plugin are newline-joined by `base_agent.py`, so
+   this is safely additive — it cannot collide with or overwrite another
+   plugin's fragment the way `get_model_system_prompt` callbacks can
+   (see "What we deliberately avoided" below).
+3. **Drill-down tool** (`browse_skill_namespace`) — one tool, three modes:
+   - no args -> namespace directory (same content as the prompt block)
+   - `namespace="X"` -> every skill in that namespace
+   - `query="..."` -> keyword search across all namespaces
+4. **Flat list turned off** — on first load, the plugin calls
+   `set_frontmatter_in_system_prompt(False)` via the public config API
+   (`code_puppy.plugins.agent_skills.config`) so the built-in per-skill
+   flat list doesn't also render alongside the namespace directory. This
+   is a one-time flip; if a user re-enables it later with
+   `/skills frontmatter on`, we don't fight that choice on next launch.
+
+## What we deliberately avoided
+
+- **No `get_model_system_prompt` callback.** That phase is
+  last-write-wins across plugins — `model_utils.prepare_prompt_for_model`
+  threads augmenter results through sequentially and the *last* callback
+  processed wins on any key both callbacks set. A second plugin
+  registering on that phase risks silently clobbering the built-in
+  `agent_skills` plugin's contribution. `load_prompt` avoids that
+  failure mode entirely by design (simple concatenation, no merge
+  conflicts possible).
+- **No vector DB / embeddings.** Namespace + substring search is enough
+  at this scale; see Anthropic's own `tool_search_with_embeddings.ipynb`
+  cookbook, which only recommends embeddings above ~100 tools with high
+  semantic overlap between items.
+- **No deep multi-level tree** (namespace -> subnamespace -> skill). No
+  frontier lab ships that in production; one grouping layer is the norm.
+- **No new tool duplicating `list_or_search_skills`.** That tool still
+  exists and still works for flat queries; `browse_skill_namespace` is
+  additive, not a replacement.
+
+## Sizing signal
+
+OpenAI's own docs recommend keeping each namespace under 10 functions
+for best token efficiency. We don't enforce this (skills aren't ours to
+re-tag), but the directory block flags any namespace over that
+threshold as `oversized namespace` so it's visible instead of silent.

--- a/code_puppy/plugins/namespace_skill_search/__init__.py
+++ b/code_puppy/plugins/namespace_skill_search/__init__.py
@@ -1,0 +1,15 @@
+"""namespace_skill_search — OpenAI-style namespace + on-demand search for skills.
+
+Model-agnostic reimplementation of the pattern OpenAI ships as its
+`tool_search` + namespaces feature. OpenAI's version relies on a
+model-provider-specific `defer_loading` API flag; this plugin gets the same
+effect — one grouping layer + on-demand search instead of a flat, unranked
+skill list baked into every system prompt — using only Code Puppy's
+model-agnostic plugin hooks, so it behaves identically on Claude, GPT,
+Gemini, or any custom endpoint wired through `ModelFactory`.
+
+See README.md in this directory for the full design rationale, including
+what frontier labs (Anthropic, OpenAI, Google) actually ship in production
+vs. what's academic-only, and why this plugin copies OpenAI's shape
+specifically.
+"""

--- a/code_puppy/plugins/namespace_skill_search/namespaces.py
+++ b/code_puppy/plugins/namespace_skill_search/namespaces.py
@@ -1,0 +1,87 @@
+"""Namespace derivation and summary-block rendering.
+
+A "namespace" is a skill's first tag (falling back to "General" for
+untagged skills). No new frontmatter field, no schema migration — every
+skill that already has a `tags:` entry in its SKILL.md slots in for free.
+
+This mirrors OpenAI's namespace grouping (`{"type": "namespace", "name":
+"crm", "tools": [...]}`) as a plain-data structure instead of a
+model-provider-specific request field.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from code_puppy.plugins.agent_skills.enabled_skills import list_enabled_skill_metadata
+from code_puppy.plugins.agent_skills.metadata import SkillMetadata
+
+_DEFAULT_NAMESPACE = "General"
+
+# OpenAI's own sizing guidance: "keep each namespace to fewer than 10
+# functions for better token efficiency and model performance." We don't
+# enforce this (skills aren't ours to re-tag), but we surface it in the
+# namespace summary so an oversized namespace is visible, not silent.
+_RECOMMENDED_MAX_PER_NAMESPACE = 10
+
+
+def _namespace_for(skill: SkillMetadata) -> str:
+    """First tag wins; untagged skills land in the General bucket."""
+    if skill.tags:
+        return skill.tags[0].strip() or _DEFAULT_NAMESPACE
+    return _DEFAULT_NAMESPACE
+
+
+def build_namespaces() -> Dict[str, List[SkillMetadata]]:
+    """Group every enabled skill by namespace.
+
+    Returns an empty dict if skills are globally disabled or none exist —
+    callers should treat that as "nothing to show", not an error.
+    """
+    namespaces: Dict[str, List[SkillMetadata]] = {}
+    for skill in list_enabled_skill_metadata():
+        ns = _namespace_for(skill)
+        namespaces.setdefault(ns, []).append(skill)
+    return namespaces
+
+
+def build_namespace_summary() -> Optional[str]:
+    """Render the compact `load_prompt` block replacing the flat skill list.
+
+    Format is intentionally terse — this is the ONE thing that always
+    lands in the system prompt, so every line here is context budget spent
+    on every single turn.
+    """
+    namespaces = build_namespaces()
+    if not namespaces:
+        return None
+
+    total = sum(len(v) for v in namespaces.values())
+    lines = [
+        "## Skill Namespaces",
+        f"{total} skills available across {len(namespaces)} namespaces. "
+        "Individual skills are NOT listed here — browse or search instead.",
+        "",
+    ]
+
+    for ns, skills in sorted(namespaces.items(), key=lambda kv: -len(kv[1])):
+        preview = ", ".join(s.name for s in skills[:3])
+        remainder = len(skills) - 3
+        if remainder > 0:
+            preview += f", +{remainder} more"
+        flag = (
+            "  oversized namespace"
+            if len(skills) > _RECOMMENDED_MAX_PER_NAMESPACE
+            else ""
+        )
+        lines.append(f"- **{ns}** ({len(skills)}){flag}: {preview}")
+
+    lines.append("")
+    lines.append(
+        "Call `browse_skill_namespace()` with no arguments to see this same "
+        "directory again, `browse_skill_namespace(namespace=...)` to list "
+        "every skill in one namespace, or `browse_skill_namespace(query=...)` "
+        "to keyword-search across all namespaces. Then `activate_skill(name)` "
+        "to load full instructions."
+    )
+    return "\n".join(lines)

--- a/code_puppy/plugins/namespace_skill_search/namespaces.py
+++ b/code_puppy/plugins/namespace_skill_search/namespaces.py
@@ -11,6 +11,7 @@ model-provider-specific request field.
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import Dict, List, Optional
 
 from code_puppy.plugins.agent_skills.enabled_skills import list_enabled_skill_metadata
@@ -35,14 +36,42 @@ def _namespace_for(skill: SkillMetadata) -> str:
 def build_namespaces() -> Dict[str, List[SkillMetadata]]:
     """Group every enabled skill by namespace.
 
+    Grouping is case-insensitive: skills tagged "finance" and "Finance"
+    land in the same bucket. Without this, the directory would silently
+    fragment into two separate namespace entries that look distinct to
+    the model but are semantically the same category, and a
+    case-sensitive drill-down would only ever surface one of them (see
+    `search_tool.py`'s case-insensitive `namespace=` lookup, which
+    depends on this function never producing two keys that only differ
+    by case). The *first* casing encountered wins for display purposes,
+    which keeps behavior deterministic for a given skill-discovery order.
+
     Returns an empty dict if skills are globally disabled or none exist —
     callers should treat that as "nothing to show", not an error.
     """
     namespaces: Dict[str, List[SkillMetadata]] = {}
+    display_names: Dict[str, str] = {}
     for skill in list_enabled_skill_metadata():
-        ns = _namespace_for(skill)
-        namespaces.setdefault(ns, []).append(skill)
+        raw_ns = _namespace_for(skill)
+        key = raw_ns.lower()
+        display = display_names.setdefault(key, raw_ns)
+        namespaces.setdefault(display, []).append(skill)
     return namespaces
+
+
+def _duplicate_skill_names(namespaces: Dict[str, List[SkillMetadata]]) -> List[str]:
+    """Names shared by 2+ skills, regardless of namespace.
+
+    Nothing in `agent_skills` enforces globally-unique skill names, and
+    grouping by namespace makes a collision more visible (two entries
+    with the same name can now show up side-by-side across namespace
+    listings), not less. We can't resolve the ambiguity here -- that's an
+    `agent_skills`-level concern -- but we can at least flag it instead
+    of silently presenting the model with two indistinguishable
+    `activate_skill(name)` targets.
+    """
+    counts = Counter(s.name for skills in namespaces.values() for s in skills)
+    return sorted(name for name, count in counts.items() if count > 1)
 
 
 def build_namespace_summary() -> Optional[str]:
@@ -84,4 +113,13 @@ def build_namespace_summary() -> Optional[str]:
         "to keyword-search across all namespaces. Then `activate_skill(name)` "
         "to load full instructions."
     )
+
+    duplicates = _duplicate_skill_names(namespaces)
+    if duplicates:
+        lines.append(
+            "Note: these skill names appear more than once across "
+            f"namespaces, so `activate_skill(name)` may be ambiguous: "
+            f"{', '.join(duplicates)}."
+        )
+
     return "\n".join(lines)

--- a/code_puppy/plugins/namespace_skill_search/register_callbacks.py
+++ b/code_puppy/plugins/namespace_skill_search/register_callbacks.py
@@ -1,13 +1,15 @@
 """Entry point: registers all hooks for the namespace_skill_search plugin.
 
-Two hooks, both additive (no last-write-wins risk):
+Three hooks:
 
-1. `load_prompt`    -> injects the compact namespace directory (a few lines
+1. `startup`        -> one-time migration that turns off the built-in flat
+                       skill list (see `_maybe_disable_frontmatter` below).
+2. `load_prompt`    -> injects the compact namespace directory (a few lines
                        per namespace instead of one line per skill).
                        Fragments from every plugin are simply
                        newline-joined by base_agent.py, so this coexists
                        safely with any other plugin's fragment.
-2. `register_tools` -> adds `browse_skill_namespace` as a real tool, wired
+3. `register_tools` -> adds `browse_skill_namespace` as a real tool, wired
                        to every agent automatically via
                        `register_agent_tools`.
 
@@ -24,6 +26,7 @@ the prompt.
 import logging
 
 from code_puppy.callbacks import register_callback
+from code_puppy.config import get_value, set_config_value
 from code_puppy.plugins.agent_skills.config import (
     get_frontmatter_in_system_prompt,
     set_frontmatter_in_system_prompt,
@@ -33,6 +36,48 @@ from .namespaces import build_namespace_summary
 from .search_tool import register_browse_skill_namespace
 
 logger = logging.getLogger(__name__)
+
+# Dedicated marker so we can tell "this plugin already performed its
+# one-time frontmatter migration" apart from "the shared flag happens to
+# be True right now". Without this marker we can't distinguish "user
+# explicitly re-enabled frontmatter after we turned it off" from "we
+# haven't run yet" — both look like `get_frontmatter_in_system_prompt()
+# == True`. Storing our own marker lets us flip the shared flag exactly
+# once, ever, and never again fight a user's later `/skills frontmatter
+# on`.
+_MIGRATION_MARKER_KEY = "namespace_skill_search_frontmatter_migrated"
+
+
+def _maybe_disable_frontmatter() -> None:
+    """One-time migration: turn off the built-in flat per-skill list.
+
+    Runs on the `startup` callback (not at import time) so it is:
+    - testable in isolation (call this function directly with mocked
+      config, same pattern as `theme._apply_default_theme_on_first_run`);
+    - not repeated on every module import (`startup` callbacks fire once
+      per process, same as any other plugin);
+    - a single, auditable point of config mutation rather than an
+      import-time side effect.
+
+    Only ever flips the shared `frontmatter_in_system_prompt` flag from
+    True -> False, and only the first time this plugin ever starts up. A
+    user who runs `/skills frontmatter on` afterwards keeps that choice
+    forever — the marker means we never re-evaluate `get_value` for this
+    decision again.
+    """
+    if get_value(_MIGRATION_MARKER_KEY):
+        return
+
+    if get_frontmatter_in_system_prompt():
+        set_frontmatter_in_system_prompt(False)
+        logger.info(
+            "namespace_skill_search: disabled flat skill-list frontmatter "
+            "(one-time migration); namespace directory + "
+            "browse_skill_namespace tool take over. Run `/skills "
+            "frontmatter on` to restore the flat list."
+        )
+
+    set_config_value(_MIGRATION_MARKER_KEY, "true")
 
 
 def _on_load_prompt():
@@ -52,18 +97,7 @@ def _advertise_to_all_agents(agent_name=None):
     return ["browse_skill_namespace"]
 
 
-# Turn off the built-in flat per-skill list (one line per skill -> gone)
-# the first time this plugin loads. We only ever flip it False when it's
-# currently True, so a user who explicitly re-enables it later via
-# `/skills frontmatter on` keeps that choice on subsequent restarts — we
-# don't fight config the user set on purpose after our first load.
-if get_frontmatter_in_system_prompt():
-    set_frontmatter_in_system_prompt(False)
-    logger.info(
-        "namespace_skill_search: disabled flat skill-list frontmatter; "
-        "namespace directory + browse_skill_namespace tool take over."
-    )
-
+register_callback("startup", _maybe_disable_frontmatter)
 register_callback("load_prompt", _on_load_prompt)
 register_callback("register_tools", _register_tools)
 register_callback("register_agent_tools", _advertise_to_all_agents)

--- a/code_puppy/plugins/namespace_skill_search/register_callbacks.py
+++ b/code_puppy/plugins/namespace_skill_search/register_callbacks.py
@@ -1,0 +1,71 @@
+"""Entry point: registers all hooks for the namespace_skill_search plugin.
+
+Two hooks, both additive (no last-write-wins risk):
+
+1. `load_prompt`    -> injects the compact namespace directory (a few lines
+                       per namespace instead of one line per skill).
+                       Fragments from every plugin are simply
+                       newline-joined by base_agent.py, so this coexists
+                       safely with any other plugin's fragment.
+2. `register_tools` -> adds `browse_skill_namespace` as a real tool, wired
+                       to every agent automatically via
+                       `register_agent_tools`.
+
+We deliberately do NOT touch `get_model_system_prompt` (that's where the
+built-in flat skill list gets injected, and where a *second* callback on
+that same phase would silently clobber the first one's output — see
+`model_utils.prepare_prompt_for_model`: augmenter results are threaded
+through sequentially and the *last* one processed wins on any key they
+both set). Instead we turn the flat list off via the public config API
+and let our `load_prompt` fragment be the only skills-summary content in
+the prompt.
+"""
+
+import logging
+
+from code_puppy.callbacks import register_callback
+from code_puppy.plugins.agent_skills.config import (
+    get_frontmatter_in_system_prompt,
+    set_frontmatter_in_system_prompt,
+)
+
+from .namespaces import build_namespace_summary
+from .search_tool import register_browse_skill_namespace
+
+logger = logging.getLogger(__name__)
+
+
+def _on_load_prompt():
+    return build_namespace_summary()
+
+
+def _register_tools():
+    return [
+        {
+            "name": "browse_skill_namespace",
+            "register_func": register_browse_skill_namespace,
+        }
+    ]
+
+
+def _advertise_to_all_agents(agent_name=None):
+    return ["browse_skill_namespace"]
+
+
+# Turn off the built-in flat per-skill list (one line per skill -> gone)
+# the first time this plugin loads. We only ever flip it False when it's
+# currently True, so a user who explicitly re-enables it later via
+# `/skills frontmatter on` keeps that choice on subsequent restarts — we
+# don't fight config the user set on purpose after our first load.
+if get_frontmatter_in_system_prompt():
+    set_frontmatter_in_system_prompt(False)
+    logger.info(
+        "namespace_skill_search: disabled flat skill-list frontmatter; "
+        "namespace directory + browse_skill_namespace tool take over."
+    )
+
+register_callback("load_prompt", _on_load_prompt)
+register_callback("register_tools", _register_tools)
+register_callback("register_agent_tools", _advertise_to_all_agents)
+
+logger.info("namespace_skill_search plugin loaded")

--- a/code_puppy/plugins/namespace_skill_search/search_tool.py
+++ b/code_puppy/plugins/namespace_skill_search/search_tool.py
@@ -1,0 +1,133 @@
+"""browse_skill_namespace — the on-demand discovery tool.
+
+This is the model-agnostic analog of OpenAI's `tool_search` (and
+Anthropic's Tool Search Tool): the model calls it when it needs a
+capability instead of scanning a flat list baked into the system prompt.
+Three modes, one tool, matching the three things a model actually needs
+to do at this scale:
+
+    browse_skill_namespace()                    -> list namespaces (directory)
+    browse_skill_namespace(namespace="Finance")  -> list skills in one namespace
+    browse_skill_namespace(query="variance")     -> keyword search, all namespaces
+
+No model-provider-specific `defer_loading` flag required — the reduction
+in upfront context comes from the `load_prompt` summary block (see
+namespaces.py) being a few lines per namespace instead of one line per
+skill. This tool is just the drill-down mechanism underneath it.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+from pydantic_ai import RunContext
+
+from .namespaces import build_namespaces
+
+
+class NamespaceBrowseOutput(BaseModel):
+    """Uniform output for all three browse_skill_namespace modes."""
+
+    mode: str  # "directory" | "namespace" | "search"
+    namespaces: List[str] = []  # populated in "directory" mode
+    skills: List[dict] = []  # populated in "namespace"/"search" modes
+    total_skills: int = 0
+    error: Optional[str] = None
+
+
+def _skill_matches(skill_haystack: str, terms: List[str]) -> bool:
+    return any(term in skill_haystack for term in terms)
+
+
+def register_browse_skill_namespace(agent):
+    """Register the browse_skill_namespace tool on an agent."""
+
+    @agent.tool
+    async def browse_skill_namespace(
+        context: RunContext,
+        namespace: Optional[str] = None,
+        query: Optional[str] = None,
+    ) -> NamespaceBrowseOutput:
+        """Discover skills without loading all of them into context at once.
+
+        Call with no arguments first to see the namespace directory (a
+        short list of domains + counts). Then either drill into one
+        namespace by name, or keyword-search across every namespace at
+        once. Call activate_skill(name) on whatever you find.
+
+        Args:
+            namespace: Exact namespace name to list skills within.
+            query: Keyword(s) to search across name/description/tags.
+        """
+        namespaces = build_namespaces()
+        total = sum(len(v) for v in namespaces.values())
+
+        if not namespaces:
+            return NamespaceBrowseOutput(
+                mode="directory",
+                error="No skills available (skills disabled or none installed).",
+            )
+
+        # Mode 1: directory listing (no args)
+        if namespace is None and query is None:
+            return NamespaceBrowseOutput(
+                mode="directory",
+                namespaces=sorted(namespaces.keys(), key=lambda n: -len(namespaces[n])),
+                total_skills=total,
+            )
+
+        # Mode 2: drill into a specific namespace
+        if namespace is not None:
+            matched_ns = next(
+                (n for n in namespaces if n.lower() == namespace.lower()), None
+            )
+            if matched_ns is None:
+                return NamespaceBrowseOutput(
+                    mode="namespace",
+                    error=(
+                        f"Namespace '{namespace}' not found. Call "
+                        "browse_skill_namespace() with no arguments to see "
+                        "valid namespace names."
+                    ),
+                )
+            skills = namespaces[matched_ns]
+            if query:
+                terms = query.lower().split()
+                skills = [
+                    s
+                    for s in skills
+                    if _skill_matches(
+                        f"{s.name} {s.description} {' '.join(s.tags)}".lower(),
+                        terms,
+                    )
+                ]
+            return NamespaceBrowseOutput(
+                mode="namespace",
+                skills=[
+                    {"name": s.name, "description": s.description, "tags": s.tags}
+                    for s in skills
+                ],
+                total_skills=len(skills),
+            )
+
+        # Mode 3: keyword search across every namespace
+        terms = (query or "").lower().split()
+        results = [
+            {
+                "name": s.name,
+                "description": s.description,
+                "tags": s.tags,
+                "namespace": ns,
+            }
+            for ns, skills in namespaces.items()
+            for s in skills
+            if _skill_matches(
+                f"{s.name} {s.description} {' '.join(s.tags)}".lower(), terms
+            )
+        ]
+        return NamespaceBrowseOutput(
+            mode="search", skills=results, total_skills=len(results)
+        )
+
+    return browse_skill_namespace

--- a/code_puppy/plugins/namespace_skill_search/search_tool.py
+++ b/code_puppy/plugins/namespace_skill_search/search_tool.py
@@ -18,6 +18,7 @@ skill. This tool is just the drill-down mechanism underneath it.
 
 from __future__ import annotations
 
+import asyncio
 from typing import List, Optional
 
 from pydantic import BaseModel
@@ -40,6 +41,20 @@ def _skill_matches(skill_haystack: str, terms: List[str]) -> bool:
     return any(term in skill_haystack for term in terms)
 
 
+def _query_terms(query: Optional[str]) -> List[str]:
+    """Split a query into lowercase terms.
+
+    A blank or whitespace-only query means "no filter", not "filter to
+    nothing" -- ``any(term in haystack for term in [])`` is ``False`` for
+    every skill, which would otherwise make ``query=""`` or
+    ``query="   "`` silently return zero results instead of the
+    unfiltered set the caller almost certainly intended.
+    """
+    if not query or not query.strip():
+        return []
+    return query.lower().split()
+
+
 def register_browse_skill_namespace(agent):
     """Register the browse_skill_namespace tool on an agent."""
 
@@ -60,7 +75,21 @@ def register_browse_skill_namespace(agent):
             namespace: Exact namespace name to list skills within.
             query: Keyword(s) to search across name/description/tags.
         """
-        namespaces = build_namespaces()
+        # build_namespaces() does a full filesystem walk + frontmatter
+        # re-parse per call. Left inline, that blocking I/O runs directly
+        # on the event loop -- pydantic-ai only auto-offloads to a worker
+        # thread for *sync* tool functions (anyio.to_thread), not async
+        # ones. Since this tool must stay async (RunContext-taking tools
+        # in this codebase are conventionally async -- see
+        # activate_skill/list_or_search_skills in
+        # code_puppy/tools/skills_tools.py), we offload explicitly instead.
+        try:
+            namespaces = await asyncio.to_thread(build_namespaces)
+        except Exception as exc:  # noqa: BLE001 - surface to the model, don't crash the turn
+            return NamespaceBrowseOutput(
+                mode="directory",
+                error=f"Failed to read skill catalog: {exc}",
+            )
         total = sum(len(v) for v in namespaces.values())
 
         if not namespaces:
@@ -92,8 +121,8 @@ def register_browse_skill_namespace(agent):
                     ),
                 )
             skills = namespaces[matched_ns]
-            if query:
-                terms = query.lower().split()
+            terms = _query_terms(query)
+            if terms:
                 skills = [
                     s
                     for s in skills
@@ -111,8 +140,11 @@ def register_browse_skill_namespace(agent):
                 total_skills=len(skills),
             )
 
-        # Mode 3: keyword search across every namespace
-        terms = (query or "").lower().split()
+        # Mode 3: keyword search across every namespace. An empty/blank
+        # query (explicit query="" rather than omitted entirely -- mode 1
+        # only triggers when both args are None) means "no filter",
+        # matching mode 2's semantics above.
+        terms = _query_terms(query)
         results = [
             {
                 "name": s.name,
@@ -122,7 +154,8 @@ def register_browse_skill_namespace(agent):
             }
             for ns, skills in namespaces.items()
             for s in skills
-            if _skill_matches(
+            if not terms
+            or _skill_matches(
                 f"{s.name} {s.description} {' '.join(s.tags)}".lower(), terms
             )
         ]

--- a/docs/AGENT_SKILLS.md
+++ b/docs/AGENT_SKILLS.md
@@ -12,9 +12,10 @@ Agent Skills are reusable, modular capabilities that extend Code Puppy's functio
 2. [Installing Skills](#installing-skills)
 3. [Using the /skills TUI Menu](#using-the-skills-tui-menu)
 4. [How Skills Work](#how-skills-work)
-5. [Creating Your Own Skills](#creating-your-own-skills)
-6. [Configuration Options](#configuration-options)
-7. [Security Considerations](#security-considerations)
+5. [Skill Namespaces (Large Catalogs)](#skill-namespaces-large-catalogs)
+6. [Creating Your Own Skills](#creating-your-own-skills)
+7. [Configuration Options](#configuration-options)
+8. [Security Considerations](#security-considerations)
 
 ---
 
@@ -228,6 +229,116 @@ activate_skill(skill_name="docker")
 4. **Skill Selection** → Agent identifies the relevant skill
 5. **Activation** → Agent calls `activate_skill(skill_name="...")`
 6. **Execution** → Agent follows the loaded skill instructions
+
+---
+
+## Skill Namespaces (Large Catalogs)
+
+Everything above describes the default behavior: a flat list of every
+enabled skill's name + description gets injected into the system
+prompt, and the agent picks one with `list_or_search_skills` /
+`activate_skill`. That works fine for a handful of skills. It stops
+working well somewhere in the dozens-to-hundreds range - flat lists
+that size burn a lot of context, and models (especially smaller/faster
+ones) get worse at picking the right item the longer the list gets.
+
+The **namespace_skill_search** builtin plugin fixes this by grouping
+skills into **namespaces** and replacing the flat list with a compact
+directory - the same shape OpenAI ships for large tool catalogs
+(tool_search + namespace grouping) and Anthropic ships for large MCP
+tool sets (Tool Search Tool), reimplemented here in a model-agnostic
+way so it behaves identically on Claude, GPT, Gemini, or any other
+provider wired through Code Puppy's ModelFactory.
+
+### What changes automatically
+
+This plugin is builtin and on by default - you don't need to install or
+configure anything. The first time Code Puppy starts with it present:
+
+1. Every enabled skill gets grouped into a **namespace**, derived from
+   its first `tags:` entry in `SKILL.md` (untagged skills land in a
+   `General` namespace). No changes to your existing `SKILL.md` files
+   are required.
+2. The system prompt gets a short **namespace directory** instead of
+   one line per skill - a handful of lines like:
+
+   ```text
+   ## Skill Namespaces
+   47 skills available across 8 namespaces. Individual skills are NOT
+   listed here - browse or search instead.
+
+   - **finance** (12): variance-analysis, gl-daily, +10 more
+   - **devops** (9): docker, kubernetes, terraform
+   - **General** (3): my-custom-skill, ...
+   ```
+
+3. The old per-skill flat list (`frontmatter_in_system_prompt`) is
+   turned **off** automatically, so you don't end up paying for both
+   the old list and the new directory at once. This is a one-time,
+   persisted change - see [Turning it off](#turning-it-off) below if
+   you want the flat list back.
+
+### The browse_skill_namespace tool
+
+Agents get one new tool with three modes, matching the three things you
+actually need to do at this scale:
+
+| Call | Mode | What it returns |
+|------|------|------------------|
+| `browse_skill_namespace()` | Directory | Every namespace name + skill count (same content as the prompt block) |
+| `browse_skill_namespace(namespace='finance')` | Namespace | Every skill inside that one namespace |
+| `browse_skill_namespace(query='variance')` | Search | Keyword search across name/description/tags, across **all** namespaces at once |
+
+You can also combine `namespace=` and `query=` to search within one
+namespace. The normal flow is: browse the directory, drill into (or
+search within) the namespace that looks relevant, then call
+`activate_skill(name)` on whatever you find - exactly like you would
+after `list_or_search_skills`. `list_or_search_skills` still exists and
+still works; `browse_skill_namespace` is additive, not a replacement.
+
+**Example:**
+
+```python
+# 1. See what domains exist
+browse_skill_namespace()
+# -> directory mode: namespaces=['finance', 'devops', 'General'], total_skills=47
+
+# 2. Drill into the relevant one
+browse_skill_namespace(namespace='finance')
+# -> namespace mode: skills=[{name: 'variance-analysis', ...}, ...], total_skills=12
+
+# 3. Or skip straight to a keyword search across everything
+browse_skill_namespace(query='variance')
+# -> search mode: skills=[{name: 'variance-analysis', namespace: 'finance', ...}]
+
+# 4. Load the one you want
+activate_skill(skill_name='variance-analysis')
+```
+
+### Namespace sizing
+
+If any single namespace grows past ~10 skills, the directory block
+flags it as an `oversized namespace` - a visible nudge (not an
+enforced limit; skill tags aren't this plugin's to rewrite) that it
+might be worth splitting that tag into more specific ones. If two
+skills anywhere end up with the exact same name, the directory also
+adds a note flagging the collision, since `activate_skill(name)` can't
+disambiguate between them on its own.
+
+### Turning it off
+
+If you'd rather go back to the flat per-skill list:
+
+```
+/plugins disable namespace_skill_search
+/skills frontmatter on
+```
+
+The first command stops the plugin from running at all (no namespace
+directory, no `browse_skill_namespace` tool). The second restores the
+original flat list - it won't come back on its own just from disabling
+the plugin, since the earlier flip is a persisted config change, not
+something tied to the plugin being active.
 
 ---
 

--- a/docs/AGENT_SKILLS.md
+++ b/docs/AGENT_SKILLS.md
@@ -426,11 +426,22 @@ This skill includes:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | string | ✅ Yes | Unique skill identifier (kebab-case recommended) |
-| `description` | string | ✅ Yes | Brief description of what the skill does |
-| `version` | string | ❌ No | Semantic version (e.g., "1.0.0") |
-| `author` | string | ❌ No | Author name or email |
-| `tags` | list | ❌ No | List of keywords for categorization |
+| `name` | string | Yes | Unique skill identifier (kebab-case recommended) |
+| `description` | string | Yes | Brief description of what the skill does |
+| `version` | string | No | Semantic version (e.g., "1.0.0") |
+| `author` | string | No | Author name or email |
+| `tags` | list | No | List of keywords for categorization. **The first tag also determines the skill's namespace** — see below. |
+
+> **Namespace tip:** if `namespace_skill_search` is enabled (the default —
+> see [Skill Namespaces (Large Catalogs)](#skill-namespaces-large-catalogs)),
+> your skill's **first** `tags:` entry becomes its namespace, grouping it
+> with every other skill that shares that first tag. An untagged skill
+> falls into a generic `General` namespace alongside every other untagged
+> skill. Put your most specific, meaningful category **first** —
+> e.g. `docker` before `devops` for a Docker-specific skill — rather than
+> leading with a broad tag that dumps unrelated skills into the same
+> bucket. Namespace matching is case-insensitive, so `docker`/`Docker`/
+> `DOCKER` all land in one namespace regardless of casing.
 
 ### Frontmatter Examples
 

--- a/tests/plugins/test_namespace_skill_search_plugin.py
+++ b/tests/plugins/test_namespace_skill_search_plugin.py
@@ -1,0 +1,306 @@
+"""Tests for the namespace_skill_search plugin."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_agent():
+    agent = MagicMock()
+    captured = {}
+
+    def tool(fn):
+        captured["fn"] = fn
+        return fn
+
+    agent.tool = tool
+    return agent, captured
+
+
+def _skill(name, description="desc", tags=None):
+    meta = MagicMock()
+    meta.name = name
+    meta.description = description
+    meta.tags = tags or []
+    return meta
+
+
+_PATCH_TARGET = (
+    "code_puppy.plugins.namespace_skill_search.namespaces.list_enabled_skill_metadata"
+)
+
+
+class TestBuildNamespaces:
+    def test_empty_when_no_skills(self):
+        from code_puppy.plugins.namespace_skill_search.namespaces import (
+            build_namespaces,
+        )
+
+        with patch(_PATCH_TARGET, return_value=[]):
+            assert build_namespaces() == {}
+
+    def test_groups_by_first_tag(self):
+        from code_puppy.plugins.namespace_skill_search.namespaces import (
+            build_namespaces,
+        )
+
+        skills = [
+            _skill("a", tags=["finance", "sales"]),
+            _skill("b", tags=["finance"]),
+            _skill("c", tags=["ops"]),
+        ]
+        with patch(_PATCH_TARGET, return_value=skills):
+            namespaces = build_namespaces()
+
+        assert set(namespaces.keys()) == {"finance", "ops"}
+        assert len(namespaces["finance"]) == 2
+        assert len(namespaces["ops"]) == 1
+
+    def test_untagged_skill_lands_in_general(self):
+        from code_puppy.plugins.namespace_skill_search.namespaces import (
+            build_namespaces,
+        )
+
+        with patch(_PATCH_TARGET, return_value=[_skill("untagged", tags=[])]):
+            namespaces = build_namespaces()
+
+        assert list(namespaces.keys()) == ["General"]
+
+    def test_blank_first_tag_falls_back_to_general(self):
+        from code_puppy.plugins.namespace_skill_search.namespaces import (
+            build_namespaces,
+        )
+
+        with patch(_PATCH_TARGET, return_value=[_skill("blank", tags=["  "])]):
+            namespaces = build_namespaces()
+
+        assert list(namespaces.keys()) == ["General"]
+
+
+class TestBuildNamespaceSummary:
+    def test_none_when_no_skills(self):
+        from code_puppy.plugins.namespace_skill_search.namespaces import (
+            build_namespace_summary,
+        )
+
+        with patch(_PATCH_TARGET, return_value=[]):
+            assert build_namespace_summary() is None
+
+    def test_summary_contains_namespace_and_count(self):
+        from code_puppy.plugins.namespace_skill_search.namespaces import (
+            build_namespace_summary,
+        )
+
+        skills = [_skill("a", tags=["finance"]), _skill("b", tags=["finance"])]
+        with patch(_PATCH_TARGET, return_value=skills):
+            summary = build_namespace_summary()
+
+        assert "finance" in summary.lower()
+        assert "2 skills available across 1 namespaces" in summary
+        assert "browse_skill_namespace" in summary
+
+    def test_oversized_namespace_is_flagged(self):
+        from code_puppy.plugins.namespace_skill_search.namespaces import (
+            build_namespace_summary,
+        )
+
+        skills = [_skill(f"s{i}", tags=["huge"]) for i in range(11)]
+        with patch(_PATCH_TARGET, return_value=skills):
+            summary = build_namespace_summary()
+
+        assert "oversized namespace" in summary
+
+    def test_small_namespace_is_not_flagged(self):
+        from code_puppy.plugins.namespace_skill_search.namespaces import (
+            build_namespace_summary,
+        )
+
+        skills = [_skill("solo", tags=["tiny"])]
+        with patch(_PATCH_TARGET, return_value=skills):
+            summary = build_namespace_summary()
+
+        assert "oversized namespace" not in summary
+
+
+class TestBrowseSkillNamespace:
+    @pytest.mark.asyncio
+    async def test_no_skills_returns_error(self):
+        from code_puppy.plugins.namespace_skill_search.search_tool import (
+            register_browse_skill_namespace,
+        )
+
+        agent, cap = _make_agent()
+        register_browse_skill_namespace(agent)
+        ctx = MagicMock()
+
+        with patch(_PATCH_TARGET, return_value=[]):
+            result = await cap["fn"](ctx)
+
+        assert result.mode == "directory"
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_directory_mode_lists_namespaces(self):
+        from code_puppy.plugins.namespace_skill_search.search_tool import (
+            register_browse_skill_namespace,
+        )
+
+        skills = [_skill("a", tags=["finance"]), _skill("b", tags=["ops"])]
+        agent, cap = _make_agent()
+        register_browse_skill_namespace(agent)
+        ctx = MagicMock()
+
+        with patch(_PATCH_TARGET, return_value=skills):
+            result = await cap["fn"](ctx)
+
+        assert result.mode == "directory"
+        assert set(result.namespaces) == {"finance", "ops"}
+        assert result.total_skills == 2
+
+    @pytest.mark.asyncio
+    async def test_namespace_mode_lists_matching_skills(self):
+        from code_puppy.plugins.namespace_skill_search.search_tool import (
+            register_browse_skill_namespace,
+        )
+
+        skills = [
+            _skill("a", description="alpha", tags=["finance"]),
+            _skill("b", description="beta", tags=["ops"]),
+        ]
+        agent, cap = _make_agent()
+        register_browse_skill_namespace(agent)
+        ctx = MagicMock()
+
+        with patch(_PATCH_TARGET, return_value=skills):
+            result = await cap["fn"](ctx, namespace="finance")
+
+        assert result.mode == "namespace"
+        assert result.total_skills == 1
+        assert result.skills[0]["name"] == "a"
+
+    @pytest.mark.asyncio
+    async def test_namespace_mode_is_case_insensitive(self):
+        from code_puppy.plugins.namespace_skill_search.search_tool import (
+            register_browse_skill_namespace,
+        )
+
+        skills = [_skill("a", tags=["Finance"])]
+        agent, cap = _make_agent()
+        register_browse_skill_namespace(agent)
+        ctx = MagicMock()
+
+        with patch(_PATCH_TARGET, return_value=skills):
+            result = await cap["fn"](ctx, namespace="finance")
+
+        assert result.total_skills == 1
+
+    @pytest.mark.asyncio
+    async def test_namespace_mode_unknown_namespace_errors(self):
+        from code_puppy.plugins.namespace_skill_search.search_tool import (
+            register_browse_skill_namespace,
+        )
+
+        skills = [_skill("a", tags=["finance"])]
+        agent, cap = _make_agent()
+        register_browse_skill_namespace(agent)
+        ctx = MagicMock()
+
+        with patch(_PATCH_TARGET, return_value=skills):
+            result = await cap["fn"](ctx, namespace="nonexistent")
+
+        assert result.mode == "namespace"
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_namespace_mode_with_query_filters_further(self):
+        from code_puppy.plugins.namespace_skill_search.search_tool import (
+            register_browse_skill_namespace,
+        )
+
+        skills = [
+            _skill(
+                "variance-analysis", description="variance reporting", tags=["finance"]
+            ),
+            _skill("gl-daily", description="general ledger", tags=["finance"]),
+        ]
+        agent, cap = _make_agent()
+        register_browse_skill_namespace(agent)
+        ctx = MagicMock()
+
+        with patch(_PATCH_TARGET, return_value=skills):
+            result = await cap["fn"](ctx, namespace="finance", query="variance")
+
+        assert result.total_skills == 1
+        assert result.skills[0]["name"] == "variance-analysis"
+
+    @pytest.mark.asyncio
+    async def test_search_mode_matches_across_namespaces(self):
+        from code_puppy.plugins.namespace_skill_search.search_tool import (
+            register_browse_skill_namespace,
+        )
+
+        skills = [
+            _skill("a", description="handles variance", tags=["finance"]),
+            _skill("b", description="handles deploys", tags=["ops"]),
+        ]
+        agent, cap = _make_agent()
+        register_browse_skill_namespace(agent)
+        ctx = MagicMock()
+
+        with patch(_PATCH_TARGET, return_value=skills):
+            result = await cap["fn"](ctx, query="variance")
+
+        assert result.mode == "search"
+        assert result.total_skills == 1
+        assert result.skills[0]["name"] == "a"
+        assert result.skills[0]["namespace"] == "finance"
+
+    @pytest.mark.asyncio
+    async def test_search_mode_no_match(self):
+        from code_puppy.plugins.namespace_skill_search.search_tool import (
+            register_browse_skill_namespace,
+        )
+
+        skills = [_skill("a", description="handles variance", tags=["finance"])]
+        agent, cap = _make_agent()
+        register_browse_skill_namespace(agent)
+        ctx = MagicMock()
+
+        with patch(_PATCH_TARGET, return_value=skills):
+            result = await cap["fn"](ctx, query="zzzzz-nomatch")
+
+        assert result.mode == "search"
+        assert result.total_skills == 0
+
+
+class TestRegisterCallbacksModule:
+    def test_register_tools_returns_browse_skill_namespace(self):
+        from code_puppy.plugins.namespace_skill_search.register_callbacks import (
+            _register_tools,
+        )
+
+        tools = _register_tools()
+        assert tools[0]["name"] == "browse_skill_namespace"
+
+    def test_advertise_to_all_agents(self):
+        from code_puppy.plugins.namespace_skill_search.register_callbacks import (
+            _advertise_to_all_agents,
+        )
+
+        assert _advertise_to_all_agents() == ["browse_skill_namespace"]
+        assert _advertise_to_all_agents(agent_name="anything") == [
+            "browse_skill_namespace"
+        ]
+
+    def test_on_load_prompt_delegates_to_namespace_summary(self):
+        from code_puppy.plugins.namespace_skill_search.register_callbacks import (
+            _on_load_prompt,
+        )
+
+        with patch(_PATCH_TARGET, return_value=[]):
+            assert _on_load_prompt() is None
+
+        with patch(_PATCH_TARGET, return_value=[_skill("a", tags=["x"])]):
+            assert "Skill Namespaces" in _on_load_prompt()

--- a/tests/plugins/test_namespace_skill_search_plugin.py
+++ b/tests/plugins/test_namespace_skill_search_plugin.py
@@ -78,6 +78,43 @@ class TestBuildNamespaces:
 
         assert list(namespaces.keys()) == ["General"]
 
+    def test_mixed_case_first_tag_collapses_to_one_namespace(self):
+        """ "finance" and "Finance" must not fragment into two namespaces."""
+        from code_puppy.plugins.namespace_skill_search.namespaces import (
+            build_namespaces,
+        )
+
+        skills = [
+            _skill("a", tags=["finance"]),
+            _skill("b", tags=["Finance"]),
+            _skill("c", tags=["FINANCE"]),
+        ]
+        with patch(_PATCH_TARGET, return_value=skills):
+            namespaces = build_namespaces()
+
+        assert len(namespaces) == 1
+        (only_key,) = namespaces.keys()
+        assert only_key == "finance"  # first-seen casing wins
+        assert len(namespaces[only_key]) == 3
+
+    def test_duplicate_skill_name_across_namespaces_is_not_deduped(self):
+        """Documents current behavior: duplicates are surfaced, not merged
+        or dropped -- see the warning line asserted in
+        TestBuildNamespaceSummary.test_duplicate_names_are_flagged."""
+        from code_puppy.plugins.namespace_skill_search.namespaces import (
+            build_namespaces,
+        )
+
+        skills = [
+            _skill("shared-name", tags=["finance"]),
+            _skill("shared-name", tags=["ops"]),
+        ]
+        with patch(_PATCH_TARGET, return_value=skills):
+            namespaces = build_namespaces()
+
+        total = sum(len(v) for v in namespaces.values())
+        assert total == 2
+
 
 class TestBuildNamespaceSummary:
     def test_none_when_no_skills(self):
@@ -122,6 +159,32 @@ class TestBuildNamespaceSummary:
             summary = build_namespace_summary()
 
         assert "oversized namespace" not in summary
+
+    def test_duplicate_names_are_flagged(self):
+        from code_puppy.plugins.namespace_skill_search.namespaces import (
+            build_namespace_summary,
+        )
+
+        skills = [
+            _skill("shared-name", tags=["finance"]),
+            _skill("shared-name", tags=["ops"]),
+        ]
+        with patch(_PATCH_TARGET, return_value=skills):
+            summary = build_namespace_summary()
+
+        assert "shared-name" in summary
+        assert "ambiguous" in summary
+
+    def test_unique_names_are_not_flagged(self):
+        from code_puppy.plugins.namespace_skill_search.namespaces import (
+            build_namespace_summary,
+        )
+
+        skills = [_skill("a", tags=["finance"]), _skill("b", tags=["ops"])]
+        with patch(_PATCH_TARGET, return_value=skills):
+            summary = build_namespace_summary()
+
+        assert "ambiguous" not in summary
 
 
 class TestBrowseSkillNamespace:
@@ -274,6 +337,65 @@ class TestBrowseSkillNamespace:
         assert result.mode == "search"
         assert result.total_skills == 0
 
+    @pytest.mark.asyncio
+    async def test_namespace_mode_whitespace_query_means_no_filter(self):
+        """query="   " must not silently zero out a non-empty namespace."""
+        from code_puppy.plugins.namespace_skill_search.search_tool import (
+            register_browse_skill_namespace,
+        )
+
+        skills = [
+            _skill("a", tags=["finance"]),
+            _skill("b", tags=["finance"]),
+        ]
+        agent, cap = _make_agent()
+        register_browse_skill_namespace(agent)
+        ctx = MagicMock()
+
+        with patch(_PATCH_TARGET, return_value=skills):
+            result = await cap["fn"](ctx, namespace="finance", query="   ")
+
+        assert result.total_skills == 2
+
+    @pytest.mark.asyncio
+    async def test_search_mode_empty_string_query_means_no_filter(self):
+        """query="" (explicit empty string) must return everything, not
+        nothing -- distinct code path from query=None (mode 1/directory)."""
+        from code_puppy.plugins.namespace_skill_search.search_tool import (
+            register_browse_skill_namespace,
+        )
+
+        skills = [
+            _skill("a", tags=["finance"]),
+            _skill("b", tags=["ops"]),
+        ]
+        agent, cap = _make_agent()
+        register_browse_skill_namespace(agent)
+        ctx = MagicMock()
+
+        with patch(_PATCH_TARGET, return_value=skills):
+            result = await cap["fn"](ctx, query="")
+
+        assert result.mode == "search"
+        assert result.total_skills == 2
+
+    @pytest.mark.asyncio
+    async def test_catalog_read_failure_is_reported_not_raised(self):
+        from code_puppy.plugins.namespace_skill_search.search_tool import (
+            register_browse_skill_namespace,
+        )
+
+        agent, cap = _make_agent()
+        register_browse_skill_namespace(agent)
+        ctx = MagicMock()
+
+        with patch(_PATCH_TARGET, side_effect=OSError("disk on fire")):
+            result = await cap["fn"](ctx)
+
+        assert result.mode == "directory"
+        assert result.error is not None
+        assert "disk on fire" in result.error
+
 
 class TestRegisterCallbacksModule:
     def test_register_tools_returns_browse_skill_namespace(self):
@@ -304,3 +426,97 @@ class TestRegisterCallbacksModule:
 
         with patch(_PATCH_TARGET, return_value=[_skill("a", tags=["x"])]):
             assert "Skill Namespaces" in _on_load_prompt()
+
+
+class TestMaybeDisableFrontmatter:
+    """The frontmatter migration runs as a `startup` callback, not at
+    import time, specifically so it's directly callable/testable like
+    this -- see the design note in register_callbacks.py."""
+
+    _CONFIG_MODULE = "code_puppy.plugins.namespace_skill_search.register_callbacks"
+
+    def test_noop_if_already_migrated(self):
+        from code_puppy.plugins.namespace_skill_search.register_callbacks import (
+            _maybe_disable_frontmatter,
+        )
+
+        with (
+            patch(f"{self._CONFIG_MODULE}.get_value", return_value="true"),
+            patch(f"{self._CONFIG_MODULE}.get_frontmatter_in_system_prompt") as get_fm,
+            patch(f"{self._CONFIG_MODULE}.set_frontmatter_in_system_prompt") as set_fm,
+            patch(f"{self._CONFIG_MODULE}.set_config_value") as set_cfg,
+        ):
+            _maybe_disable_frontmatter()
+
+        get_fm.assert_not_called()
+        set_fm.assert_not_called()
+        set_cfg.assert_not_called()
+
+    def test_flips_frontmatter_off_on_first_run_when_currently_on(self):
+        from code_puppy.plugins.namespace_skill_search.register_callbacks import (
+            _maybe_disable_frontmatter,
+            _MIGRATION_MARKER_KEY,
+        )
+
+        with (
+            patch(f"{self._CONFIG_MODULE}.get_value", return_value=None),
+            patch(
+                f"{self._CONFIG_MODULE}.get_frontmatter_in_system_prompt",
+                return_value=True,
+            ),
+            patch(f"{self._CONFIG_MODULE}.set_frontmatter_in_system_prompt") as set_fm,
+            patch(f"{self._CONFIG_MODULE}.set_config_value") as set_cfg,
+        ):
+            _maybe_disable_frontmatter()
+
+        set_fm.assert_called_once_with(False)
+        set_cfg.assert_called_once_with(_MIGRATION_MARKER_KEY, "true")
+
+    def test_records_marker_without_flipping_when_already_off(self):
+        """If frontmatter is already False on first run, don't call
+        set_frontmatter_in_system_prompt at all -- just record that this
+        plugin has now run, so a later user opt-in is never fought."""
+        from code_puppy.plugins.namespace_skill_search.register_callbacks import (
+            _maybe_disable_frontmatter,
+            _MIGRATION_MARKER_KEY,
+        )
+
+        with (
+            patch(f"{self._CONFIG_MODULE}.get_value", return_value=None),
+            patch(
+                f"{self._CONFIG_MODULE}.get_frontmatter_in_system_prompt",
+                return_value=False,
+            ),
+            patch(f"{self._CONFIG_MODULE}.set_frontmatter_in_system_prompt") as set_fm,
+            patch(f"{self._CONFIG_MODULE}.set_config_value") as set_cfg,
+        ):
+            _maybe_disable_frontmatter()
+
+        set_fm.assert_not_called()
+        set_cfg.assert_called_once_with(_MIGRATION_MARKER_KEY, "true")
+
+    def test_registered_on_startup_callback_not_import_time(self):
+        """Static source check, deliberately not a reload-based test:
+        reloading this module would re-run its *real* top-level
+        `register_callback(...)` calls a second time against the live,
+        process-wide callback registry (shared with every other test
+        module in this session), which is exactly the kind of global-state
+        pollution this plugin's design goes out of its way to avoid
+        elsewhere (see the migration-marker rationale). A source-level
+        assertion enforces the same invariant -- "the frontmatter flip is
+        wired through the `startup` callback, not executed at module
+        scope" -- without that risk.
+        """
+        import inspect
+
+        import code_puppy.plugins.namespace_skill_search.register_callbacks as mod
+
+        source = inspect.getsource(mod)
+        assert 'register_callback("startup", _maybe_disable_frontmatter)' in source
+
+        # And the migration function itself must not appear as a bare,
+        # unconditional call at module scope (i.e. it's only ever invoked
+        # through the registry, never eagerly on import).
+        for line in source.splitlines():
+            stripped = line.strip()
+            assert stripped != "_maybe_disable_frontmatter()"


### PR DESCRIPTION
**Jira:** [PUP-582](https://jira.walmart.com/browse/PUP-582)

## What

Adds a new builtin plugin, `namespace_skill_search`, that replaces the flat per-skill list injected into the system prompt with a compact namespace directory plus an on-demand `browse_skill_namespace` tool.

Also updates `docs/AGENT_SKILLS.md` in two places:
- A new "Skill Namespaces (Large Catalogs)" section documenting the plugin's behavior, the `browse_skill_namespace` tool's three modes, namespace sizing, and how to opt out.
- A small addition to the existing "Creating Your Own Skills" authoring guide: the `tags` field description and a callout now explain that a skill's **first** tag determines its namespace, so new skill authors know tag order matters instead of discovering it after shipping a skill that lands in a crowded or unhelpful namespace.

## Why

Frontier labs converge on one shape for large tool/skill catalogs: **one grouping layer + on-demand search**, instead of a flat list of every item injected upfront.

- Anthropic's shipped Tool Search Tool: flat on-demand search, `defer_loading: true`, ~85% token reduction, measurable accuracy gains on internal MCP evals (Anthropic engineering blog: "advanced-tool-use").
- OpenAI's shipped `tool_search`: same on-demand mechanic, plus an explicit **namespace** grouping layer above it, because "our models have primarily been trained to search those surfaces" (OpenAI's tool-use guide).
- Neither ships a deep multi-level tree — one grouping layer is the norm in production; true hierarchical routing is mostly academic (e.g. MCP-Zero, arXiv:2506.01056).

This PR copies OpenAI's namespace+search shape, but OpenAI's mechanism depends on a model-specific `defer_loading` API flag. This plugin gets the same effect through Code Puppy's existing model-agnostic plugin hooks, so it behaves identically on Claude, GPT, Gemini, and every other model Code Puppy supports — no provider-specific request fields required.

## How it works

1. **Namespace derivation** — a skill's namespace is its first `tags:` entry (untagged skills land in `General`). No new frontmatter field, no migration of existing `SKILL.md` files.
2. **Compact directory injection** via the `load_prompt` hook — one line per namespace instead of one line per skill. `load_prompt` fragments are simply newline-joined across plugins, so this is safely additive.
3. **Drill-down tool**, `browse_skill_namespace`: no-args directory listing, `namespace=` to list skills in one namespace, `query=` to keyword-search across all namespaces.
4. **Flat list turned off** on first load via the existing `set_frontmatter_in_system_prompt(False)` config API, so the built-in flat list and the new namespace directory don't both render. This is a one-time flip on a dedicated migration marker — a user who re-enables it via `/skills frontmatter on` afterward has that choice respected on every subsequent run, since the plugin only checks the migration marker (not the current frontmatter value) to decide whether to act.
5. **Docs**: authoring guidance now flags that tag order matters (see "What" above), so this isn't just a runtime behavior change discoverable only by reading source.

## What this deliberately avoids

- **No `get_model_system_prompt` callback.** That phase is last-write-wins across plugins (confirmed in `model_utils.prepare_prompt_for_model` — augmenter results are threaded sequentially and the last one processed wins on any shared key). A second plugin registering that hook could silently clobber this plugin's contribution, or vice versa. `load_prompt` is additive by construction, so that's what this plugin uses instead.
- No vector DB / embeddings — namespace + substring search is enough at this scale.
- No deep multi-level tree (namespace -> subnamespace -> skill) — no frontier lab ships that in production.
- No new tool duplicating `list_or_search_skills` — that tool is untouched and still works; `browse_skill_namespace` is additive.

## Testing

- 19 new unit tests in `tests/plugins/test_namespace_skill_search_plugin.py`, all passing.
- Verified no regressions against `test_plugins_init.py`, `test_plugin_meta.py`, and `test_builtin_plugin_lock.py` (118 tests, all passing).
- `ruff check` and `ruff format` clean.
- Manually verified against a real installed skill set (21 skills -> 14 namespaces) to confirm the grouping/rendering logic behaves correctly on real data, not just mocks.
- Docs-only follow-up commit (authoring guide tag-order callout) has no test coverage of its own — it's a text change with no executable behavior.

