### PR TITLE
PUP-581: Split code-puppy-agent skill into topic reference docs, add namespace_skill_search coverage

### DIFF
--- a/code_puppy/plugins/code_puppy_agent/AGENTS_AND_TOOLS.md
+++ b/code_puppy/plugins/code_puppy_agent/AGENTS_AND_TOOLS.md
@@ -1,0 +1,155 @@
+# Agent & Tool System
+
+> Part of the `code-puppy-agent` skill. Read this when you need to
+> understand how agents are structured/discovered, or how tools get
+> registered and wired to an agent. See `SKILL.md` for the overview and
+> the full reference map.
+
+---
+
+## Agent System
+
+### BaseAgent (`agents/base_agent.py`)
+
+All agents inherit from `BaseAgent` (ABC). Key interface:
+
+| Member | Purpose |
+|--------|---------|
+| `name` (abstract property) | Stable machine identifier, e.g. `"code-puppy"` |
+| `display_name` (abstract property) | Human name with emoji |
+| `description` (abstract property) | One-line summary |
+| `get_system_prompt()` (abstract) | The authored system prompt (identity is appended separately at runtime) |
+| `get_available_tools()` (abstract) | List of tool-name strings from `TOOL_REGISTRY` |
+| `get_model_name()` | Effective model: runtime override > pinned > global |
+| `get_full_system_prompt()` | Authored prompt + `load_prompt` plugin fragments + identity ID |
+
+`BaseAgent` is a **thin conductor**. Real logic lives in sibling modules:
+- `_builder.py` — builds the pydantic-ai `Agent`, wires MCP toolsets
+- `_runtime.py` — `run_with_mcp()` orchestration, cancellation, retries
+- `_history.py` — token estimation, hashing, orphan pruning
+- `_compaction.py` — summarization/truncation when context overflows
+
+### Agent Types
+
+**Python agents** — classes in `agents/` discovered automatically by
+`agent_manager._discover_agents()` via `pkgutil.iter_modules`. Any
+`BaseAgent` subclass (excluding `JSONAgent` itself) in a non-underscore
+module gets registered.
+
+**JSON agents** — `JSONAgent` loads from `~/.code_puppy/agents/*.json`
+(user) and `<CWD>/.code_puppy/agents/*.json` (project). Project overrides
+user on name collision. Required fields: `name`, `description`,
+`system_prompt`, `tools`. Optional: `display_name`, `user_prompt`,
+`tools_config`, `model`, `mcp_servers`.
+
+**Plugin agents** — registered via the `register_agents` callback, which
+returns `[{"name": "...", "class": SomeAgentClass}]` (or
+`{"name": ..., "json_path": ".../agent.json"}`).
+
+**Discovery & precedence** — `_discover_agents()` runs three phases:
+
+1. Builtin Python classes (`pkgutil` scan of `agents/`).
+2. JSON agents via `discover_json_agents()`: the **user** dir is scanned
+   first, then the **project** dir overwrites it on collision, so **project
+   wins over user**. Both are skipped if a builtin Python agent already owns
+   the name (builtin beats JSON).
+3. Plugin-registered agents via `on_register_agents()` — these overwrite
+   `_AGENT_REGISTRY` **unconditionally**, so a plugin agent can shadow a
+   builtin. Register under a unique name.
+
+Net precedence: **builtin Python > JSON project > JSON user**; plugin
+agents are last-writer-wins (handled after the others, no collision guard).
+
+### Agent Manager (`agents/agent_manager.py`)
+
+- `get_current_agent()` — returns the active `BaseAgent` instance
+- `set_current_agent(name)` — switches agent, preserves history
+- `get_available_agents()` — dict of `name → display_name`
+- `clone_agent()` — creates a copy of the current agent
+
+Agent selection persists per **terminal session** (keyed by PPID) in
+`terminal_sessions.json` so different terminals can run different agents.
+
+---
+
+## Tool System
+
+### TOOL_REGISTRY (`tools/__init__.py`)
+
+A flat dict mapping tool-name strings to registration functions:
+
+```python
+TOOL_REGISTRY = {
+    "read_file": register_read_file,
+    "create_file": register_create_file,
+    "replace_in_file": register_replace_in_file,
+    # ... 60+ tools
+}
+```
+
+Each `register_*` function takes a pydantic-ai `agent` and calls
+`@agent.tool` to wire the tool's JSON schema.
+
+### How tools are assigned
+
+`register_tools_for_agent(agent, tool_names, agent_name=...)` is called
+during agent build. It:
+
+1. Loads plugin-registered tools via `on_register_tools()` → merges into `TOOL_REGISTRY`
+2. Merges plugin-advertised tools via `on_register_agent_tools(agent_name)` → unions into the requested list
+3. Expands compound tools (e.g. `"edit_file"` → `["create_file", "replace_in_file", "delete_snippet"]`)
+4. Registers each tool by calling its `register_func(agent)`
+
+### Built-in tool categories
+
+| Category | Tools |
+|----------|-------|
+| **File ops** | `list_files`, `read_file`, `grep` |
+| **File mods** | `create_file`, `replace_in_file`, `delete_snippet`, `delete_file` |
+| **Shell** | `agent_run_shell_command`, `agent_share_your_reasoning` |
+| **Sub-agents** | `list_agents`, `invoke_agent`, `invoke_agent_with_model` |
+| **Skills** | `activate_skill`, `list_or_search_skills` |
+| **User** | `ask_user_question`, `load_image_for_analysis` |
+| **Browser** | 30+ `browser_*` tools (Playwright-backed) |
+| **Models** | `list_available_models` |
+| **UC** | `universal_constructor` (dynamic tool factory) |
+
+### Plugin tools: two hooks, both required
+
+```python
+# 1. Define the tool (adds to TOOL_REGISTRY)
+def _register_tools():
+    return [{"name": "my_tool", "register_func": register_my_tool}]
+register_callback("register_tools", _register_tools)
+
+# 2. Advertise it to agents (adds to agent's tool list)
+def _advertise(agent_name=None):
+    return ["my_tool"]
+register_callback("register_agent_tools", _advertise)
+```
+
+Step 1 makes the tool *exist*; step 2 makes agents *see* it. Both are
+needed. `namespace_skill_search` (`code_puppy/plugins/namespace_skill_search/`)
+is a small, complete example of this pattern for a single tool
+(`browse_skill_namespace`) — see `SKILLS_SYSTEM.md` for what it does and
+`PLUGINS_AND_CALLBACKS.md` for the callback-safety reasoning behind how
+it's wired.
+
+### Async tool functions and blocking I/O
+
+Tool functions taking a `RunContext` (`activate_skill`,
+`list_or_search_skills`, `browse_skill_namespace`) are conventionally
+`async def` in this codebase. That matters for one non-obvious reason:
+pydantic-ai only auto-offloads **synchronous** tool functions to a worker
+thread (via `anyio.to_thread`); an `async def` tool runs directly on the
+event loop. If your async tool does blocking filesystem/network I/O
+(e.g. scanning a large directory tree), wrap the blocking call
+explicitly:
+
+```python
+result = await asyncio.to_thread(blocking_function, *args)
+```
+
+`namespace_skill_search/search_tool.py` does exactly this around its
+`build_namespaces()` call — a good reference implementation if you're
+writing a new async tool with real I/O in it.

--- a/code_puppy/plugins/code_puppy_agent/MODELS_AND_MCP.md
+++ b/code_puppy/plugins/code_puppy_agent/MODELS_AND_MCP.md
@@ -1,0 +1,104 @@
+# Model System & MCP Integration
+
+> Part of the `code-puppy-agent` skill. Read this when working with model
+> selection/config, or external MCP tool servers. See `SKILL.md` for the
+> overview and the full reference map.
+
+---
+
+## Model System
+
+### ModelFactory (`model_factory.py`)
+
+Resolves a model-name string into a pydantic-ai `Model` object.
+Supports providers: OpenAI, Anthropic, Gemini, Cerebras, OpenRouter,
+Azure, and custom OpenAI/Anthropic/Gemini-compatible endpoints.
+
+### Model configuration
+
+Models are defined in three places (merged at runtime):
+
+1. **Built-in defaults** — hardcoded in the factory
+2. **`~/.code_puppy/extra_models.json`** — user-defined custom models
+3. **Plugin injection** — `load_models_config` callback returns a dict
+
+Example `extra_models.json`:
+```json
+{
+  "my-model": {
+    "type": "custom_openai",
+    "name": "gpt-4o",
+    "custom_endpoint": {
+      "url": "https://api.example.com/v1",
+      "api_key": "$MY_API_KEY"
+    },
+    "context_length": 128000
+  }
+}
+```
+
+### Model types
+
+| Type | Provider |
+|------|----------|
+| `openai` / `openai_responses` | OpenAI |
+| `anthropic` | Anthropic (Claude) |
+| `gemini` | Google Gemini |
+| `cerebras` | Cerebras (via CerebrasProvider) |
+| `custom_openai` | Any OpenAI-compatible endpoint |
+| `custom_anthropic` | Anthropic-compatible endpoint |
+| `round_robin` | Cycle through N models (rate-limit mitigation) |
+| Plugin types | Registered via `register_model_type` callback |
+
+### Model selection precedence
+
+For any agent: **runtime override > agent-pinned model > agent's `model`
+field (JSON agents) > global model name**.
+
+The global model is set via `/model` and stored in config.
+
+---
+
+## MCP Integration
+
+### MCP Manager (`mcp_/manager.py`)
+
+Code Puppy manages external MCP (Model Context Protocol) servers that
+provide additional tools to agents. Key components:
+
+- **Registry** (`mcp_/registry.py`) — server definitions (stdio/SSE/streamable-http)
+- **Manager** (`mcp_/manager.py`) — lifecycle: start, stop, health checks
+- **Agent bindings** (`mcp_/agent_bindings.py`) — which agents get which servers
+- **Circuit breaker** (`mcp_/circuit_breaker.py`) — auto-disables flaky servers
+
+### How MCP servers attach to agents
+
+Servers can be:
+1. **Globally started** — available to all agents
+2. **Agent-bound** — declared in a JSON agent's `mcp_servers` field, or
+   bound via the `/mcp bind` menu
+3. **Auto-started** — bound servers with `auto_start: true` start when the
+   agent runs
+
+The `pre_mcp_autostart` hook fires before auto-start, letting plugins
+refresh tokens or mint credentials.
+
+### Managing MCP servers
+
+Use `/mcp` in the TUI:
+- `/mcp list` — show configured servers
+- `/mcp start <name>` / `/mcp stop <name>`
+- `/mcp status` — health dashboard
+- `/mcp bind` — attach servers to agents
+
+### MCP servers as skill providers — a known gap, not yet implemented
+
+Skills today are discovered only by filesystem scan (see
+`SKILLS_SYSTEM.md`) or via the `register_skills` callback. There is
+currently **no** mechanism for a bound MCP server to advertise skills of
+its own (e.g. a hypothetical `skill_provider` capability exposing
+`list_skills`/`get_skill`/`search_skills`) — skills served that way would
+just look like ordinary tool results, not first-class skills appearing in
+`/skills list` or `activate_skill`-able. If you're evaluating whether to
+build this, that's new platform work, not something `namespace_skill_search`
+or the existing skill-discovery code already covers.

--- a/code_puppy/plugins/code_puppy_agent/PLUGINS_AND_CALLBACKS.md
+++ b/code_puppy/plugins/code_puppy_agent/PLUGINS_AND_CALLBACKS.md
@@ -1,0 +1,147 @@
+# Plugin & Callback System
+
+> Part of the `code-puppy-agent` skill. Read this before writing a new
+> plugin, or when debugging why a hook isn't firing / is being
+> overwritten. See `SKILL.md` for the overview and the full reference map.
+
+---
+
+## Plugin discovery (three tiers)
+
+| Tier | Location | Load order |
+|------|----------|------------|
+| **Builtin** | `code_puppy/plugins/<name>/register_callbacks.py` | 1st |
+| **User** | `~/.code_puppy/plugins/<name>/register_callbacks.py` | 2nd |
+| **Project** | `<CWD>/.code_puppy/plugins/<name>/register_callbacks.py` | 3rd (highest precedence) |
+
+Each plugin is a directory containing `register_callbacks.py`. The loader
+auto-discovers it. Project plugins shadow user plugins on name collision.
+
+## The callback hook system
+
+`register_callback(phase, func)` at module scope. The callback engine
+(`callbacks.py`) stores functions per phase and fires them at the right
+time. All hooks accept sync or async functions.
+
+**Most important hooks for extending Code Puppy:**
+
+| Hook | When | Return value |
+|------|------|-------------|
+| `startup` | Once, at process start | (no return value used) — do one-time setup/migrations here, NOT at module import time (see below) |
+| `register_tools` | Tool registration | `list[dict]` with `name`, `register_func` |
+| `register_agent_tools` | Per-agent tool advertisement | `list[str]` of tool names |
+| `register_skills` | Skill catalogue | `list[dict]` with `name` + `skill_md`/`skill_md_path`/`frontmatter`+`body` |
+| `register_agents` | Agent catalogue | `list[dict]` with `name`, `class` |
+| `load_prompt` | System prompt assembly | `str` fragment or `None` |
+| `get_model_system_prompt` | Per-model prompt patch | `dict` with `instructions`/`handled` or `None` |
+| `custom_command` | Unknown `/slash` command | `True` (handled), `str` (message), or `None` (not mine) |
+| `pre_tool_call` | Before tool executes | Can modify args |
+| `post_tool_call` | After tool finishes | Observes result + duration |
+| `run_shell_command` | Before shell exec | Return `{"blocked": True}` to block |
+| `file_permission` | Before file op | `bool` — allow/deny |
+| `agent_run_start` / `agent_run_end` | Agent lifecycle | Observes name, model, session |
+
+The full list is in `callbacks.py` — `PhaseType` has ~45 phases.
+
+## Minimal plugin example
+
+```
+my_plugin/
+  __init__.py          # (can be empty)
+  register_callbacks.py
+```
+
+```python
+from code_puppy.callbacks import register_callback
+
+def _on_load_prompt():
+    return "\n## Project Rules\nAlways use type hints."
+
+register_callback("load_prompt", _on_load_prompt)
+```
+
+That's it. The loader handles discovery, import, and registration.
+
+---
+
+## Two gotchas that will bite you, both discovered building `namespace_skill_search`
+
+`namespace_skill_search` (`code_puppy/plugins/namespace_skill_search/`)
+groups skills into namespaces and replaces the flat per-skill list in the
+system prompt with a compact directory + a `browse_skill_namespace` tool
+(see `SKILLS_SYSTEM.md` for what it does from a user's perspective). It's
+also a good reference implementation for two hook-system pitfalls that
+are easy to hit and don't fail loudly when you do:
+
+### 1. `get_model_system_prompt` is last-write-wins, not additive
+
+If two plugins register a `get_model_system_prompt` callback, the second
+one processed can silently overwrite the first one's `instructions` —
+`model_utils.prepare_prompt_for_model` threads augmenter results through
+sequentially, and whichever callback runs last on a given key wins. This
+is *not* a merge; the built-in `agent_skills` plugin's own contribution
+(the flat skill list) can be clobbered by a badly-timed second callback
+on the same phase.
+
+**If you need to add content to the system prompt, use `load_prompt`
+instead whenever possible.** `load_prompt` fragments from every plugin
+are simply newline-joined by `base_agent.py::get_full_system_prompt` —
+there's no merge conflict possible, by construction. This is exactly why
+`namespace_skill_search` injects its namespace directory via
+`load_prompt` and explicitly avoids `get_model_system_prompt`, even
+though the content it's replacing (the flat skill list) is itself
+injected through `get_model_system_prompt`.
+
+### 2. Don't mutate config (or do any other real work) at import time
+
+A plugin's `register_callbacks.py` module body runs once, at import —
+which happens during every plugin scan, including in test collection.
+Anything at module scope that does real work (writes to
+`~/.code_puppy/puppy.cfg`, hits the filesystem, calls out to a network)
+is:
+
+- **Hard to test** — you'd need `importlib.reload()` gymnastics to
+  exercise it in isolation, and reloading re-runs *every* top-level
+  statement in the module, not just the one you wanted to test.
+- **Not observable** — it just happens silently whenever the module
+  happens to get imported, with no log line tied to a specific lifecycle
+  event.
+- **A pattern already solved by the `startup` callback.** See
+  `code_puppy/plugins/theme/register_callbacks.py`'s
+  `_apply_default_theme_on_first_run`, registered via
+  `register_callback("startup", _apply_default_theme_on_first_run)`.
+
+`namespace_skill_search` follows this pattern for its one piece of real
+setup work (turning off the built-in flat skill list the first time it
+ever runs): the config mutation lives in a plain function,
+`_maybe_disable_frontmatter()`, registered on `startup` — not executed
+as a bare statement in the module body. That function is directly
+callable and testable with mocked config, exactly like the theme
+plugin's equivalent.
+
+If you're doing a **one-time migration** (config flip, cache rebuild,
+etc.), also consider a dedicated marker config key to record "this
+plugin already ran its migration," independent of whatever value the
+thing you migrated currently holds — otherwise you can't distinguish
+"never ran yet" from "user changed it back after we ran." See
+`_MIGRATION_MARKER_KEY` in `namespace_skill_search/register_callbacks.py`
+for a worked example.
+
+---
+
+## Plugin structure convention
+
+```
+my_plugin/
+├── __init__.py              # docstring (can be minimal)
+├── register_callbacks.py    # entry point: register_callback() calls
+├── helpers.py               # optional: logic split out
+└── README.md                # optional: documentation
+```
+
+For a plugin that also ships a builtin skill via `register_skills`
+(rather than, or in addition to, tools/prompt fragments), see
+`code_puppy/plugins/code_puppy_agent/` (this skill's own plugin) or
+`namespace_skill_search`'s README for a fuller worked example of
+justifying design decisions in-repo rather than only in a PR
+description.

--- a/code_puppy/plugins/code_puppy_agent/SESSIONS_AND_HISTORY.md
+++ b/code_puppy/plugins/code_puppy_agent/SESSIONS_AND_HISTORY.md
@@ -1,0 +1,39 @@
+# Session & History System
+
+> Part of the `code-puppy-agent` skill. Read this when debugging context
+> window / compaction issues, or working with session save/load. See
+> `SKILL.md` for the overview and the full reference map.
+
+---
+
+## Message history
+
+Each `BaseAgent` maintains `_message_history` — a list of pydantic-ai
+`ModelMessage` objects (alternating `ModelRequest`/`ModelResponse`).
+History is the conversation context sent to the LLM on each turn.
+
+## Context window management
+
+When the conversation grows too large:
+1. **Token estimation** (`_history.py`) — estimates tokens per message
+2. **Compaction** (`_compaction.py`) — summarizes older messages using a
+   dedicated summarization agent, preserving recent messages
+3. **Protected tokens** — the most recent N tokens are never compacted
+   (configurable via `protected_token_count`)
+
+## Session persistence
+
+Sessions are saved as pickle files in the state directory:
+- `session_storage.py` handles serialization
+- `/save <name>` and `/load <name>` commands
+- Auto-save on exit
+
+## Useful history commands
+
+| Command | Effect |
+|---------|--------|
+| `/save <name>` | Save current session |
+| `/load <name>` | Load a saved session |
+| `/pop [N]` | Remove N most recent messages |
+| `/truncate <N>` | Keep only N most recent messages |
+| `/prune` | Interactive context pruning UI |

--- a/code_puppy/plugins/code_puppy_agent/SKILL.md
+++ b/code_puppy/plugins/code_puppy_agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-puppy-agent
-description: How Code Puppy itself is built — its internal architecture, structure, codebase layout, and source modules. Explains agents, tools, the plugin/callback hook system, models, MCP, sessions and history/context windows, skills, slash commands, config, messaging/UI, system-prompt assembly, and i18n. Activate for ANY question about how Code Puppy works internally, why it behaves a certain way, where something lives in the code, how a feature is implemented, or how to navigate, debug, or extend the codebase (add a tool, agent, plugin, command, skill, model, or MCP server).
-version: "1.1"
+description: How Code Puppy itself is built — its internal architecture, structure, codebase layout, and source modules. Explains agents, tools, the plugin/callback hook system, models, MCP, sessions and history/context windows, skills (including skill namespaces for large catalogs), slash commands, config, messaging/UI, system-prompt assembly, and i18n. Activate for ANY question about how Code Puppy works internally, why it behaves a certain way, where something lives in the code, how a feature is implemented, or how to navigate, debug, or extend the codebase (add a tool, agent, plugin, command, skill, model, or MCP server).
+version: "2.0"
 author: code-puppy
 tags:
   - code-puppy
@@ -22,6 +22,7 @@ tags:
   - sessions
   - history
   - skills
+  - namespaces
   - commands
   - config
   - messaging
@@ -42,9 +43,16 @@ codebase, debug issues, and extend the product without guessing.
 > `code_puppy/callbacks.py`. Don't edit `code_puppy/command_line/` or core
 > agent files unless a hook genuinely doesn't exist.
 
+This skill is split across multiple files so activating it doesn't force
+the full ~30KB of internals into context on every use — this SKILL.md is
+the index. **Read the reference file for the topic you actually need**;
+each one is self-contained and cites real file paths so you can jump
+straight to source. All reference files are plain repo paths under
+`code_puppy/plugins/code_puppy_agent/` — read them with `read_file`.
+
 ---
 
-## 1. Layered Architecture
+## Layered Architecture
 
 ```
 ┌──────────────────────────────────────────────────┐
@@ -76,509 +84,44 @@ Plugins hook into every stage via callbacks.
 
 ---
 
-## 2. Agent System
+## Reference Map
 
-### 2.1 BaseAgent (`agents/base_agent.py`)
+| File | Read this for |
+|------|----------------|
+| `AGENTS_AND_TOOLS.md` | How agents are structured/discovered (Python, JSON, plugin agents, precedence). How tools get registered and wired to an agent. Async-tool blocking-I/O gotcha. |
+| `PLUGINS_AND_CALLBACKS.md` | Plugin discovery tiers, the full callback hook table, a minimal plugin example, and **two hook-system gotchas** (`get_model_system_prompt` last-write-wins; don't do real work at import time) worth reading before writing any new plugin. |
+| `MODELS_AND_MCP.md` | ModelFactory, model config precedence, model types. MCP server lifecycle, agent bindings, and a known gap (MCP servers can't yet provide skills). |
+| `SESSIONS_AND_HISTORY.md` | Message history, context-window compaction, session save/load commands. |
+| `SKILLS_SYSTEM.md` | Skill discovery/activation, bundled-resource-file gotcha for plugin-registered skills, and **skill namespaces** — how `namespace_skill_search` groups large skill catalogs and replaces the flat prompt list. |
+| `SYSTEM_PROMPT_CONFIG_AND_I18N.md` | Exact system-prompt assembly order (which layer skills/rules/patches land in), `puppy.cfg` + key directories, the messaging bus, and an i18n quick-reference (full guide: `docs/I18N.md`). |
 
-All agents inherit from `BaseAgent` (ABC). Key interface:
-
-| Member | Purpose |
-|--------|---------|
-| `name` (abstract property) | Stable machine identifier, e.g. `"code-puppy"` |
-| `display_name` (abstract property) | Human name with emoji |
-| `description` (abstract property) | One-line summary |
-| `get_system_prompt()` (abstract) | The authored system prompt (identity is appended separately at runtime) |
-| `get_available_tools()` (abstract) | List of tool-name strings from `TOOL_REGISTRY` |
-| `get_model_name()` | Effective model: runtime override > pinned > global |
-| `get_full_system_prompt()` | Authored prompt + `load_prompt` plugin fragments + identity ID |
-
-`BaseAgent` is a **thin conductor**. Real logic lives in sibling modules:
-- `_builder.py` — builds the pydantic-ai `Agent`, wires MCP toolsets
-- `_runtime.py` — `run_with_mcp()` orchestration, cancellation, retries
-- `_history.py` — token estimation, hashing, orphan pruning
-- `_compaction.py` — summarization/truncation when context overflows
-
-### 2.2 Agent Types
-
-**Python agents** — classes in `agents/` discovered automatically by
-`agent_manager._discover_agents()` via `pkgutil.iter_modules`. Any
-`BaseAgent` subclass (excluding `JSONAgent` itself) in a non-underscore
-module gets registered.
-
-**JSON agents** — `JSONAgent` loads from `~/.code_puppy/agents/*.json`
-(user) and `<CWD>/.code_puppy/agents/*.json` (project). Project overrides
-user on name collision. Required fields: `name`, `description`,
-`system_prompt`, `tools`. Optional: `display_name`, `user_prompt`,
-`tools_config`, `model`, `mcp_servers`.
-
-**Plugin agents** — registered via the `register_agents` callback, which
-returns `[{"name": "...", "class": SomeAgentClass}]` (or
-`{"name": ..., "json_path": ".../agent.json"}`).
-
-**Discovery & precedence** — `_discover_agents()` runs three phases:
-
-1. Builtin Python classes (`pkgutil` scan of `agents/`).
-2. JSON agents via `discover_json_agents()`: the **user** dir is scanned
-   first, then the **project** dir overwrites it on collision, so **project
-   wins over user**. Both are skipped if a builtin Python agent already owns
-   the name (builtin beats JSON).
-3. Plugin-registered agents via `on_register_agents()` — these overwrite
-   `_AGENT_REGISTRY` **unconditionally**, so a plugin agent can shadow a
-   builtin. Register under a unique name.
-
-Net precedence: **builtin Python > JSON project > JSON user**; plugin
-agents are last-writer-wins (handled after the others, no collision guard).
-
-### 2.3 Agent Manager (`agents/agent_manager.py`)
-
-- `get_current_agent()` — returns the active `BaseAgent` instance
-- `set_current_agent(name)` — switches agent, preserves history
-- `get_available_agents()` — dict of `name → display_name`
-- `clone_agent()` — creates a copy of the current agent
-
-Agent selection persists per **terminal session** (keyed by PPID) in
-`terminal_sessions.json` so different terminals can run different agents.
+Don't guess which file has what you need — the table above is exhaustive
+for this skill's scope. If a question doesn't map cleanly to one row, it's
+probably answered by combining two (e.g. "why did my plugin's prompt
+addition get silently dropped" is a `PLUGINS_AND_CALLBACKS.md` +
+`SYSTEM_PROMPT_CONFIG_AND_I18N.md` question).
 
 ---
 
-## 3. Tool System
+## Development Conventions
 
-### 3.1 TOOL_REGISTRY (`tools/__init__.py`)
-
-A flat dict mapping tool-name strings to registration functions:
-
-```python
-TOOL_REGISTRY = {
-    "read_file": register_read_file,
-    "create_file": register_create_file,
-    "replace_in_file": register_replace_in_file,
-    # ... 60+ tools
-}
-```
-
-Each `register_*` function takes a pydantic-ai `agent` and calls
-`@agent.tool` to wire the tool's JSON schema.
-
-### 3.2 How tools are assigned
-
-`register_tools_for_agent(agent, tool_names, agent_name=...)` is called
-during agent build. It:
-
-1. Loads plugin-registered tools via `on_register_tools()` → merges into `TOOL_REGISTRY`
-2. Merges plugin-advertised tools via `on_register_agent_tools(agent_name)` → unions into the requested list
-3. Expands compound tools (e.g. `"edit_file"` → `["create_file", "replace_in_file", "delete_snippet"]`)
-4. Registers each tool by calling its `register_func(agent)`
-
-### 3.3 Built-in tool categories
-
-| Category | Tools |
-|----------|-------|
-| **File ops** | `list_files`, `read_file`, `grep` |
-| **File mods** | `create_file`, `replace_in_file`, `delete_snippet`, `delete_file` |
-| **Shell** | `agent_run_shell_command`, `agent_share_your_reasoning` |
-| **Sub-agents** | `list_agents`, `invoke_agent`, `invoke_agent_with_model` |
-| **Skills** | `activate_skill`, `list_or_search_skills` |
-| **User** | `ask_user_question`, `load_image_for_analysis` |
-| **Browser** | 30+ `browser_*` tools (Playwright-backed) |
-| **Models** | `list_available_models` |
-| **UC** | `universal_constructor` (dynamic tool factory) |
-
-### 3.4 Plugin tools
-
-Plugins register tools via two complementary hooks:
-
-```python
-# 1. Define the tool (adds to TOOL_REGISTRY)
-def _register_tools():
-    return [{"name": "my_tool", "register_func": register_my_tool}]
-register_callback("register_tools", _register_tools)
-
-# 2. Advertise it to agents (adds to agent's tool list)
-def _advertise(agent_name=None):
-    return ["my_tool"]
-register_callback("register_agent_tools", _advertise)
-```
-
-Step 1 makes the tool *exist*; step 2 makes agents *see* it. Both are
-needed.
-
----
-
-## 4. Plugin & Callback System
-
-### 4.1 Plugin discovery (three tiers)
-
-| Tier | Location | Load order |
-|------|----------|------------|
-| **Builtin** | `code_puppy/plugins/<name>/register_callbacks.py` | 1st |
-| **User** | `~/.code_puppy/plugins/<name>/register_callbacks.py` | 2nd |
-| **Project** | `<CWD>/.code_puppy/plugins/<name>/register_callbacks.py` | 3rd (highest precedence) |
-
-Each plugin is a directory containing `register_callbacks.py`. The loader
-auto-discovers it. Project plugins shadow user plugins on name collision.
-
-### 4.2 The callback hook system
-
-`register_callback(phase, func)` at module scope. The callback engine
-(`callbacks.py`) stores functions per phase and fires them at the right
-time. All hooks accept sync or async functions.
-
-**Most important hooks for extending Code Puppy:**
-
-| Hook | When | Return value |
-|------|------|-------------|
-| `register_tools` | Tool registration | `list[dict]` with `name`, `register_func` |
-| `register_agent_tools` | Per-agent tool advertisement | `list[str]` of tool names |
-| `register_skills` | Skill catalogue | `list[dict]` with `name` + `skill_md`/`skill_md_path`/`frontmatter`+`body` |
-| `register_agents` | Agent catalogue | `list[dict]` with `name`, `class` |
-| `load_prompt` | System prompt assembly | `str` fragment or `None` |
-| `get_model_system_prompt` | Per-model prompt patch | `dict` with `instructions`/`handled` or `None` |
-| `custom_command` | Unknown `/slash` command | `True` (handled), `str` (message), or `None` (not mine) |
-| `pre_tool_call` | Before tool executes | Can modify args |
-| `post_tool_call` | After tool finishes | Observes result + duration |
-| `run_shell_command` | Before shell exec | Return `{"blocked": True}` to block |
-| `file_permission` | Before file op | `bool` — allow/deny |
-| `agent_run_start` / `agent_run_end` | Agent lifecycle | Observes name, model, session |
-
-The full list is in `callbacks.py` — `PhaseType` has ~45 phases.
-
-### 4.3 Minimal plugin example
-
-```
-my_plugin/
-  __init__.py          # (can be empty)
-  register_callbacks.py
-```
-
-```python
-from code_puppy.callbacks import register_callback
-
-def _on_load_prompt():
-    return "\n## Project Rules\nAlways use type hints."
-
-register_callback("load_prompt", _on_load_prompt)
-```
-
-That's it. The loader handles discovery, import, and registration.
-
----
-
-## 5. Model System
-
-### 5.1 ModelFactory (`model_factory.py`)
-
-Resolves a model-name string into a pydantic-ai `Model` object.
-Supports providers: OpenAI, Anthropic, Gemini, Cerebras, OpenRouter,
-Azure, and custom OpenAI/Anthropic/Gemini-compatible endpoints.
-
-### 5.2 Model configuration
-
-Models are defined in three places (merged at runtime):
-
-1. **Built-in defaults** — hardcoded in the factory
-2. **`~/.code_puppy/extra_models.json`** — user-defined custom models
-3. **Plugin injection** — `load_models_config` callback returns a dict
-
-Example `extra_models.json`:
-```json
-{
-  "my-model": {
-    "type": "custom_openai",
-    "name": "gpt-4o",
-    "custom_endpoint": {
-      "url": "https://api.example.com/v1",
-      "api_key": "$MY_API_KEY"
-    },
-    "context_length": 128000
-  }
-}
-```
-
-### 5.3 Model types
-
-| Type | Provider |
-|------|----------|
-| `openai` / `openai_responses` | OpenAI |
-| `anthropic` | Anthropic (Claude) |
-| `gemini` | Google Gemini |
-| `cerebras` | Cerebras (via CerebrasProvider) |
-| `custom_openai` | Any OpenAI-compatible endpoint |
-| `custom_anthropic` | Anthropic-compatible endpoint |
-| `round_robin` | Cycle through N models (rate-limit mitigation) |
-| Plugin types | Registered via `register_model_type` callback |
-
-### 5.4 Model selection precedence
-
-For any agent: **runtime override > agent-pinned model > agent's `model`
-field (JSON agents) > global model name**.
-
-The global model is set via `/model` and stored in config.
-
----
-
-## 6. MCP Integration
-
-### 6.1 MCP Manager (`mcp_/manager.py`)
-
-Code Puppy manages external MCP (Model Context Protocol) servers that
-provide additional tools to agents. Key components:
-
-- **Registry** (`mcp_/registry.py`) — server definitions (stdio/SSE/streamable-http)
-- **Manager** (`mcp_/manager.py`) — lifecycle: start, stop, health checks
-- **Agent bindings** (`mcp_/agent_bindings.py`) — which agents get which servers
-- **Circuit breaker** (`mcp_/circuit_breaker.py`) — auto-disables flaky servers
-
-### 6.2 How MCP servers attach to agents
-
-Servers can be:
-1. **Globally started** — available to all agents
-2. **Agent-bound** — declared in a JSON agent's `mcp_servers` field, or
-   bound via the `/mcp bind` menu
-3. **Auto-started** — bound servers with `auto_start: true` start when the
-   agent runs
-
-The `pre_mcp_autostart` hook fires before auto-start, letting plugins
-refresh tokens or mint credentials.
-
-### 6.3 Managing MCP servers
-
-Use `/mcp` in the TUI:
-- `/mcp list` — show configured servers
-- `/mcp start <name>` / `/mcp stop <name>`
-- `/mcp status` — health dashboard
-- `/mcp bind` — attach servers to agents
-
----
-
-## 7. Session & History System
-
-### 7.1 Message history
-
-Each `BaseAgent` maintains `_message_history` — a list of pydantic-ai
-`ModelMessage` objects (alternating `ModelRequest`/`ModelResponse`).
-History is the conversation context sent to the LLM on each turn.
-
-### 7.2 Context window management
-
-When the conversation grows too large:
-1. **Token estimation** (`_history.py`) — estimates tokens per message
-2. **Compaction** (`_compaction.py`) — summarizes older messages using a
-   dedicated summarization agent, preserving recent messages
-3. **Protected tokens** — the most recent N tokens are never compacted
-   (configurable via `protected_token_count`)
-
-### 7.3 Session persistence
-
-Sessions are saved as pickle files in the state directory:
-- `session_storage.py` handles serialization
-- `/save <name>` and `/load <name>` commands
-- Auto-save on exit
-
-### 7.4 Useful history commands
-
-| Command | Effect |
-|---------|--------|
-| `/save <name>` | Save current session |
-| `/load <name>` | Load a saved session |
-| `/pop [N]` | Remove N most recent messages |
-| `/truncate <N>` | Keep only N most recent messages |
-| `/prune` | Interactive context pruning UI |
-
----
-
-## 8. Skills System
-
-### 8.1 How skills work
-
-A skill is a directory containing a `SKILL.md` with YAML frontmatter
-(`name`, `description`, optional `version`, `author`, `tags`) and
-markdown body. The body is the instruction set loaded into context when
-the skill is activated.
-
-### 8.2 Skill discovery (`plugins/agent_skills/discovery.py`)
-
-Scans these directories (first-discovered wins on name collision):
-1. `~/.code_puppy/skills/`
-2. `<CWD>/.code_puppy/skills/`
-3. `<CWD>/skills/`
-4. Plugin-registered skills (via `register_skills` callback)
-
-### 8.3 Skill activation flow
-
-1. The model calls `activate_skill("skill-name")` or the user types
-   `/<skill-name>`
-2. The tool reads the full `SKILL.md` from disk
-3. Content is injected into the model's context as a tool result
-4. The model follows the instructions in its next response
-
-Skills are **opt-in** — the model sees a one-line summary in its system
-prompt (name + description) and must explicitly activate to get full
-instructions.
-
-### 8.4 Managing skills
-
-| Command | Effect |
-|---------|--------|
-| `/skills` | Interactive TUI menu |
-| `/skills list` | Text list of all skills |
-| `/skills enable` / `disable` | Toggle skills globally |
-| `/skills frontmatter on/off` | Toggle skill summaries in system prompt |
-| `/skills install` | Browse & install from remote catalog |
-
----
-
-## 9. System Prompt Assembly
-
-Assembled in two stages: `get_full_system_prompt()` builds the base
-(`base_agent.py`), then `_assemble_instructions()` (`_builder.py`)
-appends rules and runs the per-model patcher.
-
-`get_full_system_prompt()` layers:
-
-```
-1. Authored prompt   (agent.get_system_prompt())
-2. load_prompt fragments (plugin-injected: kennel memory, permission
-   rules, …)
-3. Identity ID        (agent name + UUID prefix)
-```
-
-`_assemble_instructions()` then appends:
-
-```
-4. AGENTS.md puppy_rules  (global ~/.code_puppy/AGENTS.md, then project
-   <CWD>/.code_puppy/AGENTS.md, then ./AGENTS.md fallback — concatenated,
-   not first-wins)
-5. Extended-thinking note  (only if active for the resolved model)
-6. Per-model patches       (get_model_system_prompt callbacks, via
-   prepare_prompt_for_model) — this is where the **skills block**
-   (available-skills summary) is appended, by the agent_skills plugin
-```
-
-> The skills summary is **not** a `load_prompt` fragment — it's injected
-> through `get_model_system_prompt`, so it lands *after* identity and rules.
-
-Layers 2–6 are **runtime-only** — recomputed every run, never persisted
-into static agent definitions. This prevents stale timestamps, dead file
-paths, and baked-in session IDs from leaking into cloned agents.
-
----
-
-## 10. Configuration System (`config.py`)
-
-All settings live in `~/.code_puppy/puppy.cfg` (INI format) managed via:
-- `get_value(key)` / `set_value(key, value)`
-- `/set <key> <value>` slash command
-
-Key directories:
-- **Config root**: `~/.code_puppy/`
-- **State/sessions**: `~/.code_puppy/state/` (or platform cache dir)
-- **Cache**: `~/.code_puppy/cache/`
-- **Agents**: `~/.code_puppy/agents/`
-- **Skills**: `~/.code_puppy/skills/`
-- **Plugins**: `~/.code_puppy/plugins/`
-- **Extra models**: `~/.code_puppy/extra_models.json`
-
-AGENTS.md rules files are loaded from `~/.code_puppy/AGENTS.md` (global),
-`<CWD>/.code_puppy/AGENTS.md` (project), and `./AGENTS.md` (fallback).
-
----
-
-## 11. Messaging & UI
-
-### 11.1 Message bus (`messaging/`)
-
-Plugins emit UI messages through the message bus rather than printing
-directly:
-
-```python
-from code_puppy.messaging import emit_info, emit_success, emit_warning, emit_error
-emit_info("Something happened")
-```
-
-These are rendered by the TUI's event handler, so they work in both
-interactive and streaming contexts.
-
-### 11.2 Event streaming (`agents/event_stream_handler.py`)
-
-The agent's streaming response is handled by `event_stream_handler`,
-which processes pydantic-ai streaming events (text deltas, tool calls,
-tool returns) and emits UI messages. The `stream_event` callback lets
-plugins observe these events.
-
----
-
-## 12. Internationalization (i18n)
-
-User-facing CLI/TUI text is localizable via the `code_puppy/i18n/` package
-(stdlib-only; no Babel). Full guide: **`docs/I18N.md`**. Epic: PUP-473.
-
-### 12.1 Call sites
-
-```python
-from code_puppy.i18n import t, ngettext, lazy
-emit_info(t("startup.welcome", name=owner))     # simple, interpolated
-emit_info(ngettext("files.deleted", count=n))   # plural-aware
-emit_info(lazy("startup.ready"))                 # resolved at render time
-```
-
-- Keys are dotted IDs; **interpolation uses `{name}` only** — no f-strings,
-  no `str.format` on catalog text (attribute/index access and format specs are
-  deliberately unsupported; catalogs are untrusted input).
-- A missing key echoes the key back — resolution **never raises**.
-
-### 12.2 Catalogs & locales
-
-- JSON per locale: `i18n/locales/<locale>.json` (dotted-key → string, or a
-  plural dict `{"one": ..., "other": ...}`).
-- Shipped: `en-US` (source), `es` (Latin American `es-419` folded in), and
-  `fr-CA`. Regional catalogs are added only when reviewed translations exist.
-- **Fallback chain**: plain BCP-47 truncation, `es-AR → es → en-US` (see
-  `i18n.locale.fallback_chain`). `i18n.locale.PARENT_LOCALES` is a currently-
-  empty CLDR override seam for non-truncation parents. Plugins / the private
-  fork can register extra catalog dirs via `i18n.catalog.add_catalog_dir()`.
-
-### 12.3 How it wires in
-
-- **Choke point**: `messaging/message_queue.py::emit_message` resolves a
-  `LazyTranslation` to a string; plain strings pass through unchanged.
-- **Locale**: `config.get_locale()` is the single source of truth (delegates
-  to the i18n translator), seeded `CODE_PUPPY_LOCALE` › `locale` config key ›
-  POSIX env › `en-US`. `/set locale <tag>` persists it.
-- **Formatting**: `i18n.format_number` / `i18n.format_datetime` (locale-aware).
-
-### 12.4 Rules
-
-- **Model-facing system prompts are OUT of scope** — translating them changes
-  LLM behavior. Don't run them through the seam.
-- Extraction goes behind the coverage/pseudolocale CI gate
-  (`tests/i18n/test_i18n_coverage.py`): every translated key must exist in the
-  `en-US` source, and a pseudolocale (`en-XA`) run must emit only bracketed
-  text (catches un-externalized strings).
-- **Find what's left to extract** with the static audit:
-  `python -m code_puppy.i18n.audit --top 15` lists the worst files;
-  `--list` shows every raw `emit_*`/`console.print` site, `--json` is
-  machine-readable, and `--fail-under PCT` is a CI gate. Use it to pick the
-  next module, then the pseudolocale test above to prove it's fully migrated.
-
----
-
-## 13. Development Conventions
-
-### 13.1 Golden rules
+### Golden rules
 
 1. **Plugins over core** — if a callback hook exists, use it. Don't edit
    `command_line/` or core agent files.
 2. **One `register_callbacks.py` per plugin** — register at module scope.
-3. **600-line hard cap** per file — split into submodules.
+3. **600-line hard cap** per file — split into submodules. (This very
+   skill was split for exactly this reason — it was 632 lines as one file.)
 4. **Fail gracefully** — plugins must never crash the app. Wrap external
    calls in try/except.
 5. **Return `None`** from hooks/commands you don't own.
 6. **Always run linters** — `ruff check --fix`, `ruff format .`
-7. **Wrap user-facing strings** in `t()`/`ngettext` (see §12) — don't hardcode
-   English display text.
+7. **Wrap user-facing strings** in `t()`/`ngettext` (see
+   `SYSTEM_PROMPT_CONFIG_AND_I18N.md`) — don't hardcode English display
+   text. Model-facing system prompt content is explicitly exempt.
 8. **Never allow a Claude co-author commit.**
 
-### 13.2 Plugin structure
+### Plugin structure
 
 ```
 my_plugin/
@@ -588,7 +131,7 @@ my_plugin/
 └── README.md                # optional: documentation
 ```
 
-### 13.3 Zen of Code Puppy
+### Zen of Code Puppy
 
 - Simple is better than complex.
 - Flat is better than nested.
@@ -598,7 +141,7 @@ my_plugin/
 
 ---
 
-## 14. Quick Reference: Key File Map
+## Quick Reference: Key File Map
 
 | File | Responsibility |
 |------|---------------|
@@ -616,6 +159,7 @@ my_plugin/
 | `mcp_/manager.py` | MCP server lifecycle |
 | `session_storage.py` | Session pickle save/load |
 | `plugins/agent_skills/` | Skills discovery, activation, UI |
+| `plugins/namespace_skill_search/` | Namespace grouping + on-demand browse tool for large skill catalogs |
 | `i18n/` | Internationalization: catalogs, `t()`/`ngettext`, locale detection, formatting |
 | `i18n/locales/*.json` | Message catalogs (source of truth: `en-US.json`) |
 | `pydantic_patches.py` | Startup monkey-patches (clipboard fix, etc.) |
@@ -627,6 +171,10 @@ my_plugin/
 Activate this skill when you need to:
 - Understand **how a feature works internally** before modifying it
 - **Create a new plugin** and need to know which hooks to use
-- **Debug** an agent, tool, model, or MCP issue
+- **Debug** an agent, tool, model, skill, or MCP issue
 - **Navigate the codebase** and need to find the right file
 - **Extend Code Puppy** with custom tools, agents, skills, or commands
+
+Then read the specific reference file(s) from the map above — don't try
+to hold all six in context at once unless the question is genuinely
+that broad.

--- a/code_puppy/plugins/code_puppy_agent/SKILLS_SYSTEM.md
+++ b/code_puppy/plugins/code_puppy_agent/SKILLS_SYSTEM.md
@@ -1,0 +1,136 @@
+# Skills System
+
+> Part of the `code-puppy-agent` skill. Read this when working with
+> skill discovery/activation, or extending how skills are presented to
+> the model. See `SKILL.md` for the overview and the full reference map.
+
+---
+
+## How skills work
+
+A skill is a directory containing a `SKILL.md` with YAML frontmatter
+(`name`, `description`, optional `version`, `author`, `tags`) and
+markdown body. The body is the instruction set loaded into context when
+the skill is activated.
+
+## Skill discovery (`plugins/agent_skills/discovery.py`)
+
+Scans these directories (first-discovered wins on name collision):
+1. `~/.code_puppy/skills/`
+2. `<CWD>/.code_puppy/skills/`
+3. `<CWD>/skills/`
+4. Plugin-registered skills (via `register_skills` callback)
+
+## Skill activation flow
+
+1. The model calls `activate_skill("skill-name")` or the user types
+   `/<skill-name>`
+2. The tool reads the full `SKILL.md` from disk
+3. Content is injected into the model's context as a tool result
+4. The model follows the instructions in its next response
+
+Skills are **opt-in** — by default the model sees a one-line summary in
+its system prompt (name + description) and must explicitly activate to
+get full instructions. At small catalog sizes (a handful to a few dozen
+skills) this flat list is fine. It stops scaling well before a few
+hundred skills — see "Skill namespaces" below.
+
+### Bundled resource files: filesystem skills vs. plugin-registered skills
+
+`activate_skill` returns a `resources: List[str]` field listing files
+bundled alongside `SKILL.md` (via `get_skill_resources()`), which the
+model can then `read_file()` on demand instead of everything being
+force-loaded on activation. This works cleanly for a **filesystem**
+skill (a real directory under one of the scanned paths above) — any
+sibling file just shows up.
+
+It does **not** work the same way for a skill registered via the
+`register_skills` callback with `skill_md_path` (like this skill,
+`code-puppy-agent`, and `namespace_skill_search` originally considered
+before dropping the idea): the discovery loader materializes only
+`SKILL.md` itself into a cache directory (plus an optional `scripts_dir`
+entry, and even that isn't surfaced through `get_skill_resources` since
+it lands as a subdirectory, not a file). **If you want a plugin-owned
+skill to reference sibling docs, put real repo paths in the SKILL.md
+prose and let the model `read_file()` them directly** — don't rely on
+the `resources` field to surface them. This document you're reading
+right now is exactly that pattern: `SKILL.md` names this file by its
+real path in the repo rather than expecting it to appear as a
+`resources` entry.
+
+## Managing skills
+
+| Command | Effect |
+|---------|--------|
+| `/skills` | Interactive TUI menu |
+| `/skills list` | Text list of all skills |
+| `/skills enable` / `disable` | Toggle skills globally |
+| `/skills frontmatter on/off` | Toggle skill summaries in system prompt |
+| `/skills install` | Browse & install from remote catalog |
+
+---
+
+## Skill namespaces (large catalogs)
+
+The **`namespace_skill_search`** builtin plugin
+(`code_puppy/plugins/namespace_skill_search/`) addresses the
+flat-list-doesn't-scale problem above. It's the reference
+implementation to look at if you're extending how skills are surfaced
+to the model, or building something in the same spirit for another
+large catalog (tools, MCP servers, etc.).
+
+**Shape:** groups skills into **namespaces** — each skill's namespace is
+its first `tags:` entry (untagged skills fall back to a `General`
+namespace) — and replaces the flat per-skill system-prompt list with a
+compact namespace directory, plus a new `browse_skill_namespace` tool
+with three modes (no-args directory listing, `namespace=` drill-down,
+`query=` keyword search across everything). This mirrors OpenAI's
+shipped `tool_search` + namespace-grouping pattern and Anthropic's
+shipped Tool Search Tool, reimplemented in a model-agnostic way (no
+provider-specific request fields) using only Code Puppy's existing
+plugin hooks.
+
+**User-facing docs:** `docs/AGENT_SKILLS.md` → "Skill Namespaces (Large
+Catalogs)" section — what changes automatically, the tool's three
+modes with examples, and how to opt back out
+(`/plugins disable namespace_skill_search` + `/skills frontmatter on`).
+
+**Design rationale + what was deliberately not built:**
+`code_puppy/plugins/namespace_skill_search/README.md` — full writeup of
+what was copied from OpenAI/Anthropic, why namespace-per-first-tag was
+chosen over a vector DB or a deep multi-level tree, and the two hook-
+system gotchas it was built to avoid (see `PLUGINS_AND_CALLBACKS.md` in
+this reference set for those gotchas explained in general terms, not
+tied to this one plugin).
+
+**Implementation details worth knowing if you're extending it:**
+- Namespace grouping is **case-insensitive at build time** — skills
+  tagged `finance`/`Finance`/`FINANCE` merge into one namespace, keyed
+  by first-seen casing. This isn't optional; the tool's `namespace=`
+  lookup is case-insensitive, so case-sensitive grouping would let two
+  namespaces silently fragment while looking like a single one from the
+  tool's perspective.
+- A blank/whitespace-only `query` means "no filter," not "match
+  nothing" — a naive `any(term in haystack for term in
+  query.lower().split())` degrades to `any([])` (`False`) for every
+  skill on an empty query, which is a genuinely easy trap to fall into
+  with keyword-filter code in general, not specific to this plugin.
+- Duplicate skill names across namespaces are flagged in the directory
+  output (not deduped or resolved) — `activate_skill(name)` has no way
+  to disambiguate between two skills sharing a name, and that's an
+  `agent_skills`-level gap this plugin surfaces more visibly rather than
+  causes.
+
+## When to reach for `list_or_search_skills` / `activate_skill` vs. `browse_skill_namespace`
+
+Both exist simultaneously and are not mutually exclusive:
+- `list_or_search_skills` — the original, flat, always-available tool.
+  Fine for small catalogs or when you already roughly know the skill
+  name.
+- `browse_skill_namespace` — better when the catalog is large enough
+  that `namespace_skill_search` has replaced the flat prompt block with
+  a namespace directory, and you want to browse by domain or search
+  across everything without scanning a huge flat list yourself.
+
+Either way, the terminal step is the same: `activate_skill(name)` to
+load the full instructions.

--- a/code_puppy/plugins/code_puppy_agent/SYSTEM_PROMPT_CONFIG_AND_I18N.md
+++ b/code_puppy/plugins/code_puppy_agent/SYSTEM_PROMPT_CONFIG_AND_I18N.md
@@ -1,0 +1,160 @@
+# System Prompt Assembly, Configuration, Messaging & i18n
+
+> Part of the `code-puppy-agent` skill. Read this when debugging what
+> ends up in the system prompt (and in what order), working with
+> `puppy.cfg`, emitting UI messages from a plugin, or wrapping
+> user-facing strings for i18n. See `SKILL.md` for the overview and the
+> full reference map.
+
+---
+
+## System Prompt Assembly
+
+Assembled in two stages: `get_full_system_prompt()` builds the base
+(`base_agent.py`), then `_assemble_instructions()` (`_builder.py`)
+appends rules and runs the per-model patcher.
+
+`get_full_system_prompt()` layers:
+
+```
+1. Authored prompt   (agent.get_system_prompt())
+2. load_prompt fragments (plugin-injected: kennel memory, permission
+   rules, namespace_skill_search's namespace directory, …)
+3. Identity ID        (agent name + UUID prefix)
+```
+
+`_assemble_instructions()` then appends:
+
+```
+4. AGENTS.md puppy_rules  (global ~/.code_puppy/AGENTS.md, then project
+   <CWD>/.code_puppy/AGENTS.md, then ./AGENTS.md fallback — concatenated,
+   not first-wins)
+5. Extended-thinking note  (only if active for the resolved model)
+6. Per-model patches       (get_model_system_prompt callbacks, via
+   prepare_prompt_for_model) — this is where the **skills block**
+   (available-skills summary) is appended, by the agent_skills plugin
+```
+
+> The skills summary is **not** a `load_prompt` fragment — it's injected
+> through `get_model_system_prompt`, so it lands *after* identity and
+> rules. **This is exactly the phase `namespace_skill_search` avoids
+> registering a second callback on** — see `PLUGINS_AND_CALLBACKS.md`
+> for why (`get_model_system_prompt` is last-write-wins across plugins,
+> not additive like `load_prompt`).
+
+Layers 2–6 are **runtime-only** — recomputed every run, never persisted
+into static agent definitions. This prevents stale timestamps, dead file
+paths, and baked-in session IDs from leaking into cloned agents.
+
+---
+
+## Configuration System (`config.py`)
+
+All settings live in `~/.code_puppy/puppy.cfg` (INI format) managed via:
+- `get_value(key)` / `set_value(key, value)`
+- `/set <key> <value>` slash command
+
+Key directories:
+- **Config root**: `~/.code_puppy/`
+- **State/sessions**: `~/.code_puppy/state/` (or platform cache dir)
+- **Cache**: `~/.code_puppy/cache/`
+- **Agents**: `~/.code_puppy/agents/`
+- **Skills**: `~/.code_puppy/skills/`
+- **Plugins**: `~/.code_puppy/plugins/`
+- **Extra models**: `~/.code_puppy/extra_models.json`
+
+AGENTS.md rules files are loaded from `~/.code_puppy/AGENTS.md` (global),
+`<CWD>/.code_puppy/AGENTS.md` (project), and `./AGENTS.md` (fallback).
+
+### Disabling a plugin
+
+`/plugins disable <name>` writes to the `disabled_plugins` config key
+(JSON list) via `code_puppy/plugins/config.py`. A disabled plugin's
+callbacks are skipped entirely — but any *persisted config change* the
+plugin already made before being disabled (e.g. `namespace_skill_search`
+turning off `frontmatter_in_system_prompt` on its first run) does **not**
+automatically revert. Disabling the plugin and undoing what it already
+did to your config are two separate actions.
+
+---
+
+## Messaging & UI
+
+### Message bus (`messaging/`)
+
+Plugins emit UI messages through the message bus rather than printing
+directly:
+
+```python
+from code_puppy.messaging import emit_info, emit_success, emit_warning, emit_error
+emit_info("Something happened")
+```
+
+These are rendered by the TUI's event handler, so they work in both
+interactive and streaming contexts.
+
+### Event streaming (`agents/event_stream_handler.py`)
+
+The agent's streaming response is handled by `event_stream_handler`,
+which processes pydantic-ai streaming events (text deltas, tool calls,
+tool returns) and emits UI messages. The `stream_event` callback lets
+plugins observe these events.
+
+---
+
+## Internationalization (i18n)
+
+User-facing CLI/TUI text is localizable via the `code_puppy/i18n/` package
+(stdlib-only; no Babel). **Full guide: `docs/I18N.md`.** Epic: PUP-473.
+This section is a quick-reference cheat sheet, not a replacement for that
+doc.
+
+### Call sites
+
+```python
+from code_puppy.i18n import t, ngettext, lazy
+emit_info(t("startup.welcome", name=owner))     # simple, interpolated
+emit_info(ngettext("files.deleted", count=n))   # plural-aware
+emit_info(lazy("startup.ready"))                 # resolved at render time
+```
+
+- Keys are dotted IDs; **interpolation uses `{name}` only** — no f-strings,
+  no `str.format` on catalog text (attribute/index access and format specs are
+  deliberately unsupported; catalogs are untrusted input).
+- A missing key echoes the key back — resolution **never raises**.
+
+### Catalogs & locales
+
+- JSON per locale: `i18n/locales/<locale>.json` (dotted-key → string, or a
+  plural dict `{"one": ..., "other": ...}`).
+- Shipped: `en-US` (source), `es` (Latin American `es-419` folded in), and
+  `fr-CA`. Regional catalogs are added only when reviewed translations exist.
+- **Fallback chain**: plain BCP-47 truncation, `es-AR → es → en-US` (see
+  `i18n.locale.fallback_chain`). `i18n.locale.PARENT_LOCALES` is a currently-
+  empty CLDR override seam for non-truncation parents. Plugins / the private
+  fork can register extra catalog dirs via `i18n.catalog.add_catalog_dir()`.
+
+### How it wires in
+
+- **Choke point**: `messaging/message_queue.py::emit_message` resolves a
+  `LazyTranslation` to a string; plain strings pass through unchanged.
+- **Locale**: `config.get_locale()` is the single source of truth (delegates
+  to the i18n translator), seeded `CODE_PUPPY_LOCALE` › `locale` config key ›
+  POSIX env › `en-US`. `/set locale <tag>` persists it.
+- **Formatting**: `i18n.format_number` / `i18n.format_datetime` (locale-aware).
+
+### Rules
+
+- **Model-facing system prompts are OUT of scope** — translating them changes
+  LLM behavior. Don't run them through the seam. (This is why
+  `namespace_skill_search`'s namespace-directory prompt fragment is plain,
+  un-wrapped English — it's model-facing content, not user-facing UI text.)
+- Extraction goes behind the coverage/pseudolocale CI gate
+  (`tests/i18n/test_i18n_coverage.py`): every translated key must exist in the
+  `en-US` source, and a pseudolocale (`en-XA`) run must emit only bracketed
+  text (catches un-externalized strings).
+- **Find what's left to extract** with the static audit:
+  `python -m code_puppy.i18n.audit --top 15` lists the worst files;
+  `--list` shows every raw `emit_*`/`console.print` site, `--json` is
+  machine-readable, and `--fail-under PCT` is a CI gate. Use it to pick the
+  next module, then the pseudolocale test above to prove it's fully migrated.

--- a/code_puppy/plugins/code_puppy_agent/register_callbacks.py
+++ b/code_puppy/plugins/code_puppy_agent/register_callbacks.py
@@ -1,10 +1,27 @@
 """Register the built-in ``code-puppy-agent`` skill.
 
-The skill's full SKILL.md lives alongside this file.  We register it via
-the ``register_skills`` callback so the agent_skills plugin materializes
-it into the plugin-skill cache and it shows up in ``/skills list``,
-``activate_skill``, and the system-prompt skill block — just like any
-user-installed skill.
+The skill's SKILL.md lives alongside this file and is an *index* into a
+set of topic-specific reference files (``AGENTS_AND_TOOLS.md``,
+``PLUGINS_AND_CALLBACKS.md``, ``MODELS_AND_MCP.md``,
+``SESSIONS_AND_HISTORY.md``, ``SKILLS_SYSTEM.md``,
+``SYSTEM_PROMPT_CONFIG_AND_I18N.md``) in the same directory. This keeps
+any single activation cheap while still covering the full internals
+surface -- see SKILL.md's "Reference Map" for which file answers which
+question.
+
+We register it via the ``register_skills`` callback so the agent_skills
+plugin materializes it into the plugin-skill cache and it shows up in
+``/skills list``, ``activate_skill``, and the system-prompt skill block --
+just like any user-installed skill.
+
+Note: only ``skill_md_path`` is registered below, not the reference
+files. Plugin-registered skills (``skill_md_path``/``skill_md``/
+``frontmatter``+``body``) only ever materialize ``SKILL.md`` itself into
+the runtime cache -- sibling files are NOT auto-discovered as
+``resources`` the way they would be for a real filesystem skill
+directory. That's why SKILL.md references the other files by their real
+repo paths in prose (for the model to ``read_file`` on demand) rather
+than relying on the ``resources`` field ``activate_skill`` returns.
 """
 
 from pathlib import Path


### PR DESCRIPTION
**Jira:** [PUP-581](https://jira.walmart.com/browse/PUP-581)

## What

Splits the monolithic `code-puppy-agent` skill's `SKILL.md` (632 lines,
~24KB) into an index file plus six topic-specific reference files that
the model reads on demand via `read_file`. Also updates the skill's
content to document the new `namespace_skill_search` plugin (#713) and
two hook-system gotchas discovered while building it.

## Why

- `SKILL.md` was already over the project's own 600-line file cap
  before this PR touched it.
- It didn't cover `namespace_skill_search` at all (skill namespaces,
  the `browse_skill_namespace` tool, the `get_model_system_prompt`
  last-write-wins gotcha, the import-time-vs-`startup`-callback gotcha).
- Splitting means activating the skill now costs ~8KB (the index) in
  the common case instead of ~24KB (everything), with topic detail
  available on demand for whichever question is actually being asked.

## Files

- `SKILL.md` -- trimmed to: architecture diagram, a reference map table,
  condensed dev conventions, and the quick file-map table.
- `AGENTS_AND_TOOLS.md`, `PLUGINS_AND_CALLBACKS.md`, `MODELS_AND_MCP.md`,
  `SESSIONS_AND_HISTORY.md`, `SKILLS_SYSTEM.md`,
  `SYSTEM_PROMPT_CONFIG_AND_I18N.md` -- one topic each.
- `register_callbacks.py` docstring updated to explain the split and a
  real gotcha it documents: plugin-registered skills (`skill_md_path`)
  don't auto-surface sibling files through `activate_skill`'s
  `resources` field the way a real filesystem skill directory does, so
  the reference files are linked by plain repo path in `SKILL.md`'s
  prose instead.

## Known tradeoffs (raised and accepted before merging, not discovered after)

- Broad "explain the whole architecture" questions now cost multiple
  `read_file` round-trips instead of one `activate_skill` call.
- Relies on the model actually following the index's pointers to the
  right reference file -- nothing enforces that; a weaker model could
  answer shallowly from the index alone instead of fetching detail.
- Reference file paths are plain prose in `SKILL.md`, not validated by
  any test -- a future rename would silently break a pointer.
- No before/after eval showing this improves model answers. This is
  optional cleanup justified by analogy to `namespace_skill_search`'s
  reasoning (smaller context on demand beats one big flat block), not a
  proven fix for an observed problem -- nobody had reported the skill
  as too expensive to activate before this PR.
- Other known duplicate copies of this skill (internal fork, other
  worktrees) now have more files to keep in sync if anyone syncs them.

## Testing

- 225 existing plugin/skill tests pass, no regressions
  (`tests/plugins/test_agent_skills*.py`, `test_plugins_init*.py`,
  `test_plugin_meta.py`, `test_builtin_plugin_lock.py`).
- `ruff check` / `ruff format --check` clean on the plugin directory.
- Verified `parse_skill_metadata()` parses the new frontmatter (skill
  version bumped 1.1 -> 2.0) without error.
- No dedicated new tests added -- this is a content/structure change to
  a skill's documentation, not new executable behavior.

## Related

Builds on #713 (`namespace_skill_search` plugin) -- that PR documents
the feature from the user-facing "how do I use it" angle in
`docs/AGENT_SKILLS.md`; this PR documents it from the "how does Code
Puppy work internally" self-awareness angle covered by this skill.

