### PR TITLE
fix: drain queue-mode steers at the idle prompt (Discord/queue messages stuck 'pending')

### DIFF
--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -843,8 +843,24 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
             emit_info(f"{user_prompt}\n")
 
         try:
-            if persistent_prompt:
+            # Idle + queued prompts (a Discord / queue-mode steer, /queue, or
+            # a cancelled run's leftovers): consume the oldest as THIS turn
+            # instead of blocking on input. Checked for BOTH prompt modes so a
+            # message arriving while the REPL sits idle actually runs. Runs
+            # added mid-run drain inside _runtime's between-turns loop and
+            # never reach here.
+            from code_puppy.messaging.pause_controller import (
+                get_pause_controller as _get_pc,
+            )
+
+            queued_task = _get_pc().pop_next_steer_queued()
+            if queued_task is not None:
+                task = queued_task
+                emit_info(_prompt_echo_text(task))
+                emit_info(t("cli.queue.running"))
+            elif persistent_prompt:
                 from code_puppy.messaging.run_ui import (
+                    IDLE_WAKE,
                     set_idle_prompt_prefix,
                     wait_for_idle_submission,
                 )
@@ -852,30 +868,19 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
                 # Model/agent may have changed since last turn.
                 prompt_prefix, prompt_prefix_sgrs = _persistent_prompt_parts()
                 set_idle_prompt_prefix(prompt_prefix, prompt_prefix_sgrs)
-                # Idle + queued prompts (added via /queue, or a cancelled
-                # run's leftovers): consume the oldest as this turn instead
-                # of waiting for input. Runs added mid-run normally drain
-                # inside _runtime's between-turns loop and never get here.
-                from code_puppy.messaging.pause_controller import (
-                    get_pause_controller as _get_pc,
-                )
-
-                queued_task = _get_pc().pop_next_steer_queued()
-                if queued_task is not None:
-                    task = queued_task
-                    emit_info(_prompt_echo_text(task))
-                    emit_info(t("cli.queue.running"))
-                else:
-                    # Raises EOFError on Ctrl+D-with-empty-buffer, which the
-                    # existing quit branch below handles.
-                    task = await wait_for_idle_submission()
-                    # Echo into the transcript: the editor clears its row
-                    # on submit, so scrollback needs the record of what was
-                    # asked. JUST the user's text (bold, '> ' marker) --
-                    # repeating the whole prompt chrome doubled every
-                    # line's noise. Text() (not markup) so bracket-y input
-                    # renders as-is.
-                    emit_info(_prompt_echo_text(task))
+                # Raises EOFError on Ctrl+D-with-empty-buffer, which the
+                # existing quit branch below handles.
+                task = await wait_for_idle_submission()
+                # A queue-mode steer landed while we were parked: loop back so
+                # the pop_next_steer_queued() above runs it as a fresh turn.
+                if task is IDLE_WAKE:
+                    continue
+                # Echo into the transcript: the editor clears its row on
+                # submit, so scrollback needs the record of what was asked.
+                # JUST the user's text (bold, '> ' marker) -- repeating the
+                # whole prompt chrome doubled every line's noise. Text() (not
+                # markup) so bracket-y input renders as-is.
+                emit_info(_prompt_echo_text(task))
             else:
                 # Use prompt_toolkit for enhanced input with path completion
                 try:

--- a/code_puppy/messaging/run_ui.py
+++ b/code_puppy/messaging/run_ui.py
@@ -76,6 +76,17 @@ def _get_loop() -> Optional[asyncio.AbstractEventLoop]:
 _listener_handle = None  # KeyListenerHandle owned by the persistent UI
 _EOF = object()  # idle-queue sentinel: Ctrl+D on an empty buffer
 
+#: idle-queue sentinel: a queue-mode steer (e.g. a Discord message from the
+#: cp_discord plugin) arrived while the REPL was parked at the idle prompt.
+#: Pushed by the pause-queue listener so the blocked ``wait_for_idle_submission``
+#: returns AT ONCE and the REPL loops back to drain ``pop_next_steer_queued``
+#: -- without it the message would sit unseen until the user typed something
+#: at the terminal.
+_WAKE = object()
+
+#: Public alias the REPL loop compares against (``task is IDLE_WAKE``).
+IDLE_WAKE = _WAKE
+
 #: How long the consumer waits for the agent to actually park at its
 #: pause boundary before running commands anyway (best-effort).
 _PARK_TIMEOUT_S = 2.0
@@ -270,6 +281,12 @@ def start_persistent_ui(
     editor.set_submit_router(_persistent_router)
     editor.set_eof_handler(_handle_eof)
     _spawn_persistent_listener()
+    try:
+        from code_puppy.messaging.pause_controller import get_pause_controller
+
+        get_pause_controller().add_steer_queue_listener(_on_steer_queue_change)
+    except Exception:
+        logger.debug("could not register idle steer wake listener", exc_info=True)
     return True
 
 
@@ -283,6 +300,12 @@ def stop_persistent_ui() -> None:
         _idle_queue = None
         handle = _listener_handle
         _listener_handle = None
+    try:
+        from code_puppy.messaging.pause_controller import get_pause_controller
+
+        get_pause_controller().remove_steer_queue_listener(_on_steer_queue_change)
+    except Exception:
+        logger.debug("could not remove idle steer wake listener", exc_info=True)
     if was_persistent:
         editor = get_run_editor()
         if editor is not None:
@@ -334,6 +357,10 @@ async def wait_for_idle_submission() -> str:
     item = await q.get()
     if item is _EOF:
         raise EOFError
+    if item is _WAKE:
+        # A queue-mode steer arrived while we were parked. Hand the sentinel
+        # back so the REPL loop re-checks pop_next_steer_queued() and runs it.
+        return _WAKE
     return item
 
 
@@ -415,6 +442,36 @@ def _handle_eof() -> None:
     if is_run_active():
         return
     _push_idle(_EOF)
+
+
+def wake_idle_for_queued_steer() -> None:
+    """Wake a REPL parked at the idle prompt so it drains a queued steer.
+
+    Called from the pause-queue listener, which may fire on the Discord
+    socket thread. Only meaningful when persistent + idle; ``_push_idle``
+    already no-ops safely when the loop/queue are gone, so this is a plain
+    delegation with nothing to guard here.
+    """
+    _push_idle(_WAKE)
+
+
+def _on_steer_queue_change(_count: int) -> None:
+    """Pause-queue listener: nudge the idle prompt when a queued steer lands.
+
+    Now-mode steers are drained by the running turn's history processor, so
+    we wake ONLY when a queue-mode steer is actually pending AND no run is in
+    flight -- i.e. a message that arrived while the REPL sits blocked on
+    input. Every other mutation (now-mode adds, drains to zero) is ignored.
+    """
+    try:
+        if is_run_active():
+            return
+        from code_puppy.messaging.pause_controller import get_pause_controller
+
+        if get_pause_controller().has_pending_steer_queued():
+            wake_idle_for_queued_steer()
+    except Exception:
+        logger.debug("idle steer wake failed", exc_info=True)
 
 
 def _push_idle(item) -> None:
@@ -691,6 +748,7 @@ def _suspended_key_listener():
 
 
 __all__ = [
+    "IDLE_WAKE",
     "MID_RUN_DENYLIST",
     "clear_idle_buffer",
     "get_run_editor",
@@ -705,4 +763,5 @@ __all__ = [
     "stop_run_ui",
     "suspended_run_ui",
     "wait_for_idle_submission",
+    "wake_idle_for_queued_steer",
 ]

--- a/tests/messaging/test_run_ui_idle_wake.py
+++ b/tests/messaging/test_run_ui_idle_wake.py
@@ -1,0 +1,113 @@
+"""Tests for the idle-prompt wake-on-queued-steer path.
+
+Regression: a queue-mode steer (for example a message routed in by the
+``cp_discord`` plugin) that arrived while the REPL was parked at the idle
+prompt used to sit unseen until the user typed something at the terminal --
+nothing woke the blocked ``wait_for_idle_submission``. The pause-queue
+listener now nudges the idle prompt so the message runs as a fresh turn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from code_puppy.messaging import run_ui
+from code_puppy.messaging.pause_controller import (
+    get_pause_controller,
+    reset_pause_controller,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    reset_pause_controller()
+    yield
+    reset_pause_controller()
+
+
+# =============================================================================
+# _on_steer_queue_change: when to wake the idle prompt
+# =============================================================================
+
+
+def test_queued_steer_wakes_idle_prompt(monkeypatch):
+    """A pending queue-mode steer at idle wakes the parked prompt."""
+    woke: list[int] = []
+    monkeypatch.setattr(run_ui, "is_run_active", lambda: False)
+    monkeypatch.setattr(run_ui, "wake_idle_for_queued_steer", lambda: woke.append(1))
+
+    get_pause_controller().request_steer("discord msg", mode="queue")
+    run_ui._on_steer_queue_change(1)
+
+    assert woke == [1]
+
+
+def test_now_steer_does_not_wake_idle_prompt(monkeypatch):
+    """now-mode steers are drained by the run's history processor, not the
+    idle loop -- so with only a now-mode steer pending we must NOT wake.
+    """
+    woke: list[int] = []
+    monkeypatch.setattr(run_ui, "is_run_active", lambda: False)
+    monkeypatch.setattr(run_ui, "wake_idle_for_queued_steer", lambda: woke.append(1))
+
+    get_pause_controller().request_steer("now msg", mode="now")
+    run_ui._on_steer_queue_change(1)
+
+    assert woke == []
+
+
+def test_no_wake_while_run_active(monkeypatch):
+    """A run in flight drains queued steers via _runtime's between-turns
+    loop; the idle wake must stay out of its way.
+    """
+    woke: list[int] = []
+    monkeypatch.setattr(run_ui, "is_run_active", lambda: True)
+    monkeypatch.setattr(run_ui, "wake_idle_for_queued_steer", lambda: woke.append(1))
+
+    get_pause_controller().request_steer("mid-run queued", mode="queue")
+    run_ui._on_steer_queue_change(1)
+
+    assert woke == []
+
+
+def test_listener_swallows_errors(monkeypatch):
+    """The listener runs on the steer-producer thread and must never raise."""
+
+    def _boom() -> bool:
+        raise RuntimeError("state boom")
+
+    monkeypatch.setattr(run_ui, "is_run_active", _boom)
+
+    # Must not propagate.
+    run_ui._on_steer_queue_change(1)
+
+
+# =============================================================================
+# wait_for_idle_submission: the wake sentinel round-trips
+# =============================================================================
+
+
+async def test_wait_for_idle_submission_returns_wake_sentinel(monkeypatch):
+    """When the wake sentinel is pushed, the blocked wait returns IDLE_WAKE
+    so the REPL loop can re-check ``pop_next_steer_queued``.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    monkeypatch.setattr(run_ui, "_idle_queue", q)
+    await q.put(run_ui._WAKE)
+
+    result = await run_ui.wait_for_idle_submission()
+
+    assert result is run_ui.IDLE_WAKE
+
+
+async def test_wait_for_idle_submission_still_returns_plain_text(monkeypatch):
+    """A normal submission is unaffected by the new sentinel handling."""
+    q: asyncio.Queue = asyncio.Queue()
+    monkeypatch.setattr(run_ui, "_idle_queue", q)
+    await q.put("hello puppy")
+
+    result = await run_ui.wait_for_idle_submission()
+
+    assert result == "hello puppy"


### PR DESCRIPTION
## Problem

A **queue-mode steer** that arrives while the REPL is parked at the **idle prompt** is not processed until the user types something at the terminal.

This is most visible with the `cp_discord` plugin: send a message from Discord while the session sits idle, and it shows as "pending" but never runs until you press a key in the terminal. It also affects `/queue` entries and steers left over from a cancelled run.

## Root cause

`PauseController.pop_next_steer_queued()` is documented as *"Owned by the idle REPL loop: consume queued prompts one at a time as fresh turns when no run is in flight."* — but the idle loop only consulted it **once**, at the top of the persistent-prompt branch, and then blocked on `wait_for_idle_submission()`. A steer arriving *while blocked* had nothing to wake it. The classic `prompt_toolkit` branch never consulted it at all.

`cp_discord`'s inbound router is doing the right thing: when `run_depth == 0` (idle) it correctly picks `MODE_QUEUE`. The gap was entirely on the core side — the idle loop never drained the queue until the next keystroke.

## Fix

- **`messaging/run_ui.py`**
  - Add a `_WAKE` idle-queue sentinel (public alias `IDLE_WAKE`) and `wake_idle_for_queued_steer()`, which reuses the existing thread-safe `_push_idle` → `loop.call_soon_threadsafe` hand-off (no new threading machinery).
  - Register a pause-queue listener `_on_steer_queue_change` in `start_persistent_ui` (removed in `stop_persistent_ui`) that nudges the idle prompt **only** when a queue-mode steer is actually pending **and** no run is in flight. now-mode steers (drained by the run's history processor) and drains-to-zero are ignored.
  - `wait_for_idle_submission()` returns `IDLE_WAKE` when it dequeues the sentinel so the REPL can re-check the queue.
- **`cli_runner.py`**
  - Hoist the `pop_next_steer_queued()` drain **above** the persistent/classic split so **both** prompt modes drain queued steers, and treat `IDLE_WAKE` as "loop back and drain".

The instant-wake works in the persistent-prompt mode (the default). Classic `prompt_toolkit` mode now at least drains queued steers at the top of each loop iteration (previously it never did).

## Tests

Adds `tests/messaging/test_run_ui_idle_wake.py`:

- queued steer at idle → wakes
- now-mode-only steer → does **not** wake
- run in flight → does **not** wake (the between-turns loop owns it)
- listener swallows errors (it runs on the steer-producer thread)
- `wait_for_idle_submission()` returns `IDLE_WAKE` for the sentinel and plain text otherwise

All 6 new tests pass, along with the existing `test_run_ui*`, `test_pause_controller*`, and `test_steer_queue` suites. `ruff check` and `ruff format --check` are clean on the changed files.

_(Three unrelated pre-existing failures — `test_tty_without_flags_selects_new_path` and two `QueueMenuApp` tests — reproduce on a pristine checkout in a headless environment because prompt_toolkit needs a real Windows console; they are not touched by this change.)_
