### PR TITLE
Decouple chatgpt_oauth plugin (#728)

### DIFF
--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -23,6 +23,7 @@ PhaseType = Literal[
     "agent_reload",
     "custom_command",
     "custom_command_help",
+    "usage_status",
     "file_permission",
     "pre_tool_call",
     "post_tool_call",
@@ -86,6 +87,7 @@ _callbacks: Dict[PhaseType, List[CallbackFunc]] = {
     "agent_reload": [],
     "custom_command": [],
     "custom_command_help": [],
+    "usage_status": [],
     "file_permission": [],
     "pre_tool_call": [],
     "post_tool_call": [],
@@ -458,6 +460,21 @@ def on_custom_command(command: str, name: str) -> List[Any]:
         - None to indicate not handled
     """
     return _trigger_callbacks_sync("custom_command", command, name)
+
+
+def get_usage_status() -> str:
+    """Return cached provider quota status supplied by plugins.
+
+    Plugins (e.g. ``chatgpt_oauth``) register a ``usage_status`` callback that
+    returns a short cached-quota string and never performs I/O. The first
+    non-empty result wins; ``""`` is returned when no handler is registered or
+    none produced output. Sync and error-isolated, so it is safe on rendering
+    hot paths and can never raise.
+    """
+    for result in _trigger_callbacks_sync("usage_status"):
+        if result:
+            return str(result)
+    return ""
 
 
 def on_file_permission(

--- a/code_puppy/command_line/core_commands.py
+++ b/code_puppy/command_line/core_commands.py
@@ -205,10 +205,12 @@ def handle_tutorial_command(command: str) -> bool:
 
     if result == "chatgpt":
         emit_info(t("cmd.tutorial.chatgpt_oauth"))
-        from code_puppy.plugins.chatgpt_oauth.oauth_flow import run_oauth_flow
+        # Decoupled: the chatgpt_oauth plugin owns this flow. Dispatch through
+        # its self-registered /chatgpt-auth custom command rather than
+        # importing the plugin module directly.
+        from code_puppy.callbacks import on_custom_command
 
-        run_oauth_flow()
-        set_model_and_reload_agent("codex-gpt-5.6-sol")
+        on_custom_command("/chatgpt-auth", "chatgpt-auth")
     elif result == "claude":
         emit_info(t("cmd.tutorial.claude_oauth"))
         from code_puppy.plugins.claude_code_oauth.register_callbacks import (

--- a/code_puppy/messaging/spinner/__init__.py
+++ b/code_puppy/messaging/spinner/__init__.py
@@ -62,8 +62,8 @@ def _compact_count(n: int) -> str:
 def _codex_usage_suffix() -> str:
     """Return cached Codex limits only while a Codex OAuth model is active."""
     try:
+        from code_puppy.callbacks import get_usage_status
         from code_puppy.config import get_global_model_name
-        from code_puppy.plugins.chatgpt_oauth.usage import get_usage_status
 
         if not (get_global_model_name() or "").startswith("codex-"):
             return ""

--- a/code_puppy/plugins/chatgpt_oauth/register_callbacks.py
+++ b/code_puppy/plugins/chatgpt_oauth/register_callbacks.py
@@ -17,7 +17,7 @@ from code_puppy.model_switching import set_model_and_reload_agent
 
 from .config import CHATGPT_OAUTH_CONFIG, get_token_storage_path
 from .oauth_flow import run_oauth_flow
-from .usage import refresh_usage_in_background
+from .usage import get_usage_status, refresh_usage_in_background
 from .utils import (
     get_valid_access_token,
     load_chatgpt_models,
@@ -269,6 +269,7 @@ def _refresh_usage_on_agent_run(
 
 register_callback("custom_command_help", _custom_help)
 register_callback("custom_command", _handle_custom_command)
+register_callback("usage_status", get_usage_status)
 register_callback("register_model_type", _register_model_types)
 register_callback("register_skills", _register_imagegen_skill)
 register_callback("register_tools", _register_imagegen_tools)

--- a/tests/messaging/spinner/test_spinner_shim.py
+++ b/tests/messaging/spinner/test_spinner_shim.py
@@ -111,27 +111,39 @@ def test_format_context_info_zero_or_negative_capacity():
     assert format_context_info(100, -5, 0.0) == ""
 
 
+def _codex_usage_status() -> str:
+    """Fake plugin usage_status hook result."""
+    return "5h 66% remaining · week 90% remaining"
+
+
 def test_format_context_info_appends_usage_for_codex_model(monkeypatch):
+    from code_puppy.callbacks import register_callback, unregister_callback
+
     monkeypatch.setattr(
         "code_puppy.config.get_global_model_name", lambda: "codex-gpt-5.4"
     )
-    monkeypatch.setattr(
-        "code_puppy.plugins.chatgpt_oauth.usage.get_usage_status",
-        lambda: "5h 66% remaining · week 90% remaining",
-    )
-
-    assert format_context_info(5000, 10000, 0.5) == (
-        "5k/10k tokens (50%) · Codex 5h 66% remaining · week 90% remaining"
-    )
+    register_callback("usage_status", _codex_usage_status)
+    try:
+        assert format_context_info(5000, 10000, 0.5) == (
+            "5k/10k tokens (50%) · Codex 5h 66% remaining · week 90% remaining"
+        )
+    finally:
+        unregister_callback("usage_status", _codex_usage_status)
 
 
 def test_format_context_info_hides_codex_usage_for_other_models(monkeypatch):
+    from code_puppy.callbacks import register_callback, unregister_callback
+
     monkeypatch.setattr(
         "code_puppy.config.get_global_model_name", lambda: "openai-gpt-5"
     )
-    monkeypatch.setattr(
-        "code_puppy.plugins.chatgpt_oauth.usage.get_usage_status",
-        lambda: "5h 66% remaining",
-    )
+    register_callback("usage_status", _codex_usage_status)
+    try:
+        assert format_context_info(5000, 10000, 0.5) == "5k/10k tokens (50%)"
+    finally:
+        unregister_callback("usage_status", _codex_usage_status)
 
+
+def test_format_context_info_no_handler_returns_plain_context():
+    # No plugin handler registered -> suffix falls back to "".
     assert format_context_info(5000, 10000, 0.5) == "5k/10k tokens (50%)"


### PR DESCRIPTION
Closes #728. Lazy oauth_flow imports + new usage_status callback hook.