### PR TITLE
Decouple agent_skills plugin (#724)

### DIFF
--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -840,8 +840,10 @@ def on_register_skills() -> List[Dict[str, Any]]:
     - "name": str, "skill_md_path": str | Path
     - "name": str, "skill_md": str
     - "name": str, "frontmatter": dict, "body": str
+    - "provider": object implementing the neutral SkillProvider contract
 
-    Optional keys on every variant:
+    Provider entries expose an optional skills integration to core and are not
+    materialized as skill files. Optional keys on every skill variant:
     - "tags": list[str]
     - "description": str
     - "version": str

--- a/code_puppy/command_line/skills_completion.py
+++ b/code_puppy/command_line/skills_completion.py
@@ -17,6 +17,8 @@ from typing import Iterable, List
 from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.document import Document
 
+from code_puppy.skill_provider import get_skill_provider
+
 logger = logging.getLogger(__name__)
 
 
@@ -24,9 +26,8 @@ def load_catalog_skill_ids() -> List[str]:
     """Load skill ids from the remote catalog (lazy, cached)."""
 
     try:
-        from code_puppy.plugins.agent_skills.skill_catalog import catalog
-
-        return [entry.id for entry in catalog.get_all()]
+        provider = get_skill_provider()
+        return provider.get_catalog_skill_ids() if provider is not None else []
     except Exception as e:
         logger.debug(f"Could not load skill ids: {e}")
         return []

--- a/code_puppy/plugins/agent_skills/discovery.py
+++ b/code_puppy/plugins/agent_skills/discovery.py
@@ -198,6 +198,10 @@ def _iter_plugin_skill_registrations() -> Iterable[tuple[str, str, dict[str, Any
                     entry,
                 )
                 continue
+            # Provider registrations are consumed by core through the same
+            # hook; they are capabilities, not skills to materialize.
+            if "provider" in entry:
+                continue
             yield callback.__module__, callback.__name__, entry
 
 

--- a/code_puppy/plugins/agent_skills/provider.py
+++ b/code_puppy/plugins/agent_skills/provider.py
@@ -1,0 +1,52 @@
+"""Core-facing provider backed by the agent_skills plugin's existing helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, List, Optional, Set
+
+from .config import get_disabled_skills, get_skills_enabled
+from .enabled_skills import iter_enabled_skills, list_enabled_skill_metadata
+from .metadata import get_skill_resources, load_full_skill_content
+from .skill_catalog import catalog
+
+
+class AgentSkillsProvider:
+    """Adapt agent_skills internals to the neutral core provider contract."""
+
+    def is_enabled(self) -> bool:
+        return get_skills_enabled()
+
+    def get_disabled_skill_names(self) -> Set[str]:
+        return get_disabled_skills()
+
+    def list_enabled_skills(self) -> List[dict[str, Any]]:
+        return [
+            {
+                "name": metadata.name,
+                "description": metadata.description,
+                "path": str(metadata.path),
+                "tags": metadata.tags,
+                "version": metadata.version,
+                "author": metadata.author,
+            }
+            for metadata in list_enabled_skill_metadata()
+        ]
+
+    def find_enabled_skill_path(self, skill_name: str) -> Optional[Path]:
+        return next(
+            (info.path for info in iter_enabled_skills() if info.name == skill_name),
+            None,
+        )
+
+    def load_skill_content(self, skill_path: Path) -> Optional[str]:
+        return load_full_skill_content(skill_path)
+
+    def get_skill_resources(self, skill_path: Path) -> List[Path]:
+        return get_skill_resources(skill_path)
+
+    def get_catalog_skill_ids(self) -> List[str]:
+        return [entry.id for entry in catalog.get_all()]
+
+
+skill_provider = AgentSkillsProvider()

--- a/code_puppy/plugins/agent_skills/register_callbacks.py
+++ b/code_puppy/plugins/agent_skills/register_callbacks.py
@@ -3,7 +3,7 @@
 This plugin:
 1. Injects available skills into system prompts
 2. Registers skill-related tools
-3. Exposes its filesystem skills via the ``register_skills`` hook
+3. Exposes a skills provider via the ``register_skills`` hook
 4. Provides /skills slash command (and alias /skill)
 """
 
@@ -92,76 +92,10 @@ def _register_skills_tools() -> List[Dict[str, Any]]:
 
 
 def _register_skills() -> List[Dict[str, Any]]:
-    """Expose this plugin's enabled filesystem skills via ``register_skills``.
+    """Expose the plugin through the neutral ``register_skills`` provider seam."""
+    from .provider import skill_provider
 
-    Peer plugins publish their own skills through the same hook and the
-    discovery layer materialises them; registering here makes *this* plugin's
-    on-disk skills visible through that channel too, so core (or peer
-    plugins) can enumerate what's available via ``on_register_skills()``
-    instead of importing this plugin's internals.
-
-    Deliberately scans the configured skill directories directly rather than
-    calling ``discover_skills`` / ``enabled_skills``: those are what trigger
-    ``register_skills`` callbacks, so calling back into them would recurse
-    (and deadlock the plugin-skills lock). It scans only the *configured*
-    directories — the exact set ``enabled_skills`` feeds to discovery — so
-    every registered entry deduplicates against a filesystem skill and the
-    discovered list stays unchanged. Entries are keyed by the on-disk
-    directory name (not the frontmatter name) so the filesystem copy always
-    wins.
-    """
-    from pathlib import Path
-
-    from code_puppy.plugins.agent_skills.config import (
-        get_disabled_skills,
-        get_skill_directories,
-        get_skills_enabled,
-    )
-    from code_puppy.plugins.agent_skills.discovery import is_valid_skill_directory
-    from code_puppy.plugins.agent_skills.metadata import parse_skill_metadata
-
-    if not get_skills_enabled():
-        return []
-
-    disabled = get_disabled_skills()
-    directories = [Path(d) for d in get_skill_directories()]
-
-    entries: List[Dict[str, Any]] = []
-    seen_names: set[str] = set()
-
-    for directory in directories:
-        if not directory.is_dir():
-            continue
-        try:
-            candidates = list(directory.iterdir())
-        except OSError:
-            continue
-        for child in candidates:
-            if not child.is_dir() or child.name.startswith("."):
-                continue
-            if child.name in disabled or child.name in seen_names:
-                continue
-            if not is_valid_skill_directory(child):
-                continue
-            meta = parse_skill_metadata(child)
-            if meta is None:
-                continue
-            seen_names.add(child.name)
-            entry: Dict[str, Any] = {
-                "name": child.name,
-                "skill_md_path": str(child / "SKILL.md"),
-                "description": meta.description,
-            }
-            if meta.tags:
-                entry["tags"] = meta.tags
-            if meta.version:
-                entry["version"] = meta.version
-            if meta.author:
-                entry["author"] = meta.author
-            entries.append(entry)
-
-    # Deterministic ordering keeps the plugin-skills cache signature stable.
-    return sorted(entries, key=lambda e: e["name"])
+    return [{"provider": skill_provider}]
 
 
 # ---------------------------------------------------------------------------

--- a/code_puppy/plugins/agent_skills/register_callbacks.py
+++ b/code_puppy/plugins/agent_skills/register_callbacks.py
@@ -3,7 +3,8 @@
 This plugin:
 1. Injects available skills into system prompts
 2. Registers skill-related tools
-3. Provides /skills slash command (and alias /skill)
+3. Exposes its filesystem skills via the ``register_skills`` hook
+4. Provides /skills slash command (and alias /skill)
 """
 
 import logging
@@ -88,6 +89,79 @@ def _register_skills_tools() -> List[Dict[str, Any]]:
             "register_func": register_list_or_search_skills,
         },
     ]
+
+
+def _register_skills() -> List[Dict[str, Any]]:
+    """Expose this plugin's enabled filesystem skills via ``register_skills``.
+
+    Peer plugins publish their own skills through the same hook and the
+    discovery layer materialises them; registering here makes *this* plugin's
+    on-disk skills visible through that channel too, so core (or peer
+    plugins) can enumerate what's available via ``on_register_skills()``
+    instead of importing this plugin's internals.
+
+    Deliberately scans the configured skill directories directly rather than
+    calling ``discover_skills`` / ``enabled_skills``: those are what trigger
+    ``register_skills`` callbacks, so calling back into them would recurse
+    (and deadlock the plugin-skills lock). It scans only the *configured*
+    directories — the exact set ``enabled_skills`` feeds to discovery — so
+    every registered entry deduplicates against a filesystem skill and the
+    discovered list stays unchanged. Entries are keyed by the on-disk
+    directory name (not the frontmatter name) so the filesystem copy always
+    wins.
+    """
+    from pathlib import Path
+
+    from code_puppy.plugins.agent_skills.config import (
+        get_disabled_skills,
+        get_skill_directories,
+        get_skills_enabled,
+    )
+    from code_puppy.plugins.agent_skills.discovery import is_valid_skill_directory
+    from code_puppy.plugins.agent_skills.metadata import parse_skill_metadata
+
+    if not get_skills_enabled():
+        return []
+
+    disabled = get_disabled_skills()
+    directories = [Path(d) for d in get_skill_directories()]
+
+    entries: List[Dict[str, Any]] = []
+    seen_names: set[str] = set()
+
+    for directory in directories:
+        if not directory.is_dir():
+            continue
+        try:
+            candidates = list(directory.iterdir())
+        except OSError:
+            continue
+        for child in candidates:
+            if not child.is_dir() or child.name.startswith("."):
+                continue
+            if child.name in disabled or child.name in seen_names:
+                continue
+            if not is_valid_skill_directory(child):
+                continue
+            meta = parse_skill_metadata(child)
+            if meta is None:
+                continue
+            seen_names.add(child.name)
+            entry: Dict[str, Any] = {
+                "name": child.name,
+                "skill_md_path": str(child / "SKILL.md"),
+                "description": meta.description,
+            }
+            if meta.tags:
+                entry["tags"] = meta.tags
+            if meta.version:
+                entry["version"] = meta.version
+            if meta.author:
+                entry["author"] = meta.author
+            entries.append(entry)
+
+    # Deterministic ordering keeps the plugin-skills cache signature stable.
+    return sorted(entries, key=lambda e: e["name"])
 
 
 # ---------------------------------------------------------------------------
@@ -294,6 +368,7 @@ def _handle_skills_command(command: str, name: str) -> Optional[Any]:
 # ---------------------------------------------------------------------------
 register_callback("get_model_system_prompt", _inject_skills_into_prompt)
 register_callback("register_tools", _register_skills_tools)
+register_callback("register_skills", _register_skills)
 register_callback("custom_command_help", _skills_command_help)
 register_callback("custom_command", _handle_skills_command)
 

--- a/code_puppy/skill_provider.py
+++ b/code_puppy/skill_provider.py
@@ -1,0 +1,45 @@
+"""Neutral provider seam for optional Agent Skills integrations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, List, Optional, Protocol, Set
+
+from code_puppy.callbacks import on_register_skills
+
+
+class SkillProvider(Protocol):
+    """Core-facing operations supplied by a skills plugin."""
+
+    def is_enabled(self) -> bool: ...
+
+    def get_disabled_skill_names(self) -> Set[str]: ...
+
+    def list_enabled_skills(self) -> List[dict[str, Any]]: ...
+
+    def find_enabled_skill_path(self, skill_name: str) -> Optional[Path]: ...
+
+    def load_skill_content(self, skill_path: Path) -> Optional[str]: ...
+
+    def get_skill_resources(self, skill_path: Path) -> List[Path]: ...
+
+    def get_catalog_skill_ids(self) -> List[str]: ...
+
+
+def get_skill_provider() -> Optional[SkillProvider]:
+    """Return the first enabled plugin's registered skills provider.
+
+    Callback order is registration order, matching the existing precedence
+    rules for plugin capabilities. Providers are deliberately resolved on each
+    call so disabling a plugin takes effect immediately and no stale provider
+    survives a configuration change.
+    """
+    for result in on_register_skills():
+        entries = result if isinstance(result, list) else [result]
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            provider = entry.get("provider")
+            if provider is not None:
+                return provider
+    return None

--- a/code_puppy/tools/__init__.py
+++ b/code_puppy/tools/__init__.py
@@ -31,10 +31,6 @@ from code_puppy.tools.file_operations import (
 )
 from code_puppy.tools.image_tools import register_load_image
 from code_puppy.tools.model_tools import register_list_available_models
-from code_puppy.tools.skills_tools import (
-    register_activate_skill,
-    register_list_or_search_skills,
-)
 from code_puppy.tools.universal_constructor import register_universal_constructor
 
 # Map of tool names to their individual registration functions
@@ -61,9 +57,6 @@ TOOL_REGISTRY = {
     "ask_user_question": register_ask_user_question,
     # Image loading (used by browser/QA agents and friends)
     "load_image_for_analysis": register_load_image,
-    # Skills Tools
-    "activate_skill": register_activate_skill,
-    "list_or_search_skills": register_list_or_search_skills,
     # Universal Constructor
     "universal_constructor": register_universal_constructor,
 }

--- a/code_puppy/tools/skills_tools.py
+++ b/code_puppy/tools/skills_tools.py
@@ -12,6 +12,7 @@ from code_puppy.messaging import (
     SkillListMessage,
     get_message_bus,
 )
+from code_puppy.skill_provider import get_skill_provider
 
 logger = logging.getLogger(__name__)
 
@@ -50,16 +51,17 @@ def register_activate_skill(agent):
         context: RunContext, skill_name: str = ""
     ) -> SkillActivateOutput:
         """Activate a skill by loading its full SKILL.md instructions."""
-        # Import from plugin
-        from code_puppy.plugins.agent_skills.config import get_skills_enabled
-        from code_puppy.plugins.agent_skills.enabled_skills import iter_enabled_skills
-        from code_puppy.plugins.agent_skills.metadata import (
-            get_skill_resources,
-            load_full_skill_content,
-        )
+        provider = get_skill_provider()
+        if provider is None:
+            return SkillActivateOutput(
+                skill_name=skill_name,
+                content="",
+                resources=[],
+                error="Skills integration is unavailable.",
+            )
 
         # Check if skills enabled
-        if not get_skills_enabled():
+        if not provider.is_enabled():
             return SkillActivateOutput(
                 skill_name=skill_name,
                 content="",
@@ -70,14 +72,7 @@ def register_activate_skill(agent):
         # Find skill by name among *enabled* skills only — disabled skills
         # are intentionally invisible to activate_skill.
         try:
-            skill_path = next(
-                (
-                    info.path
-                    for info in iter_enabled_skills()
-                    if info.name == skill_name
-                ),
-                None,
-            )
+            skill_path = provider.find_enabled_skill_path(skill_name)
         except Exception as e:
             logger.error(f"Failed to discover skills: {e}")
             return SkillActivateOutput(
@@ -96,7 +91,7 @@ def register_activate_skill(agent):
             )
 
         # Load full content
-        content = load_full_skill_content(skill_path)
+        content = provider.load_skill_content(skill_path)
         if content is None:
             return SkillActivateOutput(
                 skill_name=skill_name,
@@ -106,7 +101,7 @@ def register_activate_skill(agent):
             )
 
         # Get resource list
-        resource_paths = get_skill_resources(skill_path)
+        resource_paths = provider.get_skill_resources(skill_path)
         resources = [str(p) for p in resource_paths]
 
         # Emit message for UI
@@ -140,17 +135,17 @@ def register_list_or_search_skills(agent):
             query: Optional search term to filter skills by name/description/tags.
                    If None, returns all available skills.
         """
-        # Import from plugin
-        from code_puppy.plugins.agent_skills.config import (
-            get_disabled_skills,
-            get_skills_enabled,
-        )
-        from code_puppy.plugins.agent_skills.enabled_skills import (
-            list_enabled_skill_metadata,
-        )
+        provider = get_skill_provider()
+        if provider is None:
+            return SkillListOutput(
+                skills=[],
+                total_count=0,
+                query=query,
+                error="Skills integration is unavailable.",
+            )
 
         # Check if skills enabled
-        if not get_skills_enabled():
+        if not provider.is_enabled():
             return SkillListOutput(
                 skills=[],
                 total_count=0,
@@ -160,12 +155,12 @@ def register_list_or_search_skills(agent):
 
         # We still need disabled_skills for the SkillEntry.enabled flag below,
         # even though the helper has already filtered them out of the list.
-        disabled_skills = get_disabled_skills()
+        disabled_skills = provider.get_disabled_skill_names()
 
         # Get enabled skills with metadata (disabled skills never get their
-        # frontmatter loaded — that's enforced inside the helper).
+        # frontmatter loaded — that's enforced inside the provider).
         try:
-            metadatas = list_enabled_skill_metadata()
+            skills_list = provider.list_enabled_skills()
         except Exception as e:
             logger.error(f"Failed to discover skills: {e}")
             return SkillListOutput(
@@ -174,18 +169,6 @@ def register_list_or_search_skills(agent):
                 query=query,
                 error=f"Failed to discover skills: {e}",
             )
-
-        skills_list = [
-            {
-                "name": m.name,
-                "description": m.description,
-                "path": str(m.path),
-                "tags": m.tags,
-                "version": m.version,
-                "author": m.author,
-            }
-            for m in metadatas
-        ]
 
         # Filter by query — match if ANY term appears in the skill's name,
         # description, or tags. Avoids the old bug where the entire query was

--- a/tests/command_line/test_skills_completion.py
+++ b/tests/command_line/test_skills_completion.py
@@ -12,20 +12,28 @@ from code_puppy.command_line.skills_completion import (
 
 
 class TestLoadCatalogSkillIds:
-    @patch("code_puppy.plugins.agent_skills.skill_catalog.catalog")
-    def test_success(self, mock_catalog):
-        mock_entry = MagicMock()
-        mock_entry.id = "test-skill"
-        mock_catalog.get_all.return_value = [mock_entry]
-        result = load_catalog_skill_ids()
-        assert result == ["test-skill"]
-
-    def test_import_failure(self):
-        with patch.dict(
-            "sys.modules", {"code_puppy.plugins.agent_skills.skill_catalog": None}
+    def test_success(self):
+        provider = MagicMock()
+        provider.get_catalog_skill_ids.return_value = ["test-skill"]
+        with patch(
+            "code_puppy.command_line.skills_completion.get_skill_provider",
+            return_value=provider,
         ):
-            result = load_catalog_skill_ids()
-            assert result == []
+            assert load_catalog_skill_ids() == ["test-skill"]
+
+    def test_no_plugin(self):
+        with patch(
+            "code_puppy.command_line.skills_completion.get_skill_provider",
+            return_value=None,
+        ):
+            assert load_catalog_skill_ids() == []
+
+    def test_provider_failure(self):
+        with patch(
+            "code_puppy.command_line.skills_completion.get_skill_provider",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert load_catalog_skill_ids() == []
 
 
 class TestSkillsCompleter:

--- a/tests/plugins/test_agent_skills_callbacks_coverage.py
+++ b/tests/plugins/test_agent_skills_callbacks_coverage.py
@@ -180,6 +180,14 @@ class TestRegisterSkillsTools:
         assert "activate_skill" in names
         assert "list_or_search_skills" in names
 
+    def test_registers_provider_without_traversing_discovery(self):
+        from code_puppy.plugins.agent_skills.provider import skill_provider
+        from code_puppy.plugins.agent_skills.register_callbacks import (
+            _register_skills,
+        )
+
+        assert _register_skills() == [{"provider": skill_provider}]
+
 
 class TestSkillsCommandHelp:
     def test_returns_entries(self):

--- a/tests/plugins/test_agent_skills_provider.py
+++ b/tests/plugins/test_agent_skills_provider.py
@@ -1,0 +1,100 @@
+"""Tests for the agent_skills implementation of the neutral provider seam."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from code_puppy.callbacks import clear_callbacks, register_callback
+from code_puppy.plugins.agent_skills.provider import AgentSkillsProvider
+
+
+@pytest.mark.plugin_skills
+def test_provider_listing_does_not_recurse_through_register_skills(
+    tmp_path, monkeypatch
+):
+    """Discovery sees provider registrations but never invokes/materializes them."""
+    from code_puppy.plugins.agent_skills import discovery, enabled_skills
+
+    skills_root = tmp_path / "skills"
+    skill_dir = skills_root / "example"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: example\ndescription: Example skill\ntags:\n  - test\n---\n",
+        encoding="utf-8",
+    )
+
+    provider = AgentSkillsProvider()
+    clear_callbacks("register_skills")
+    register_callback("register_skills", lambda: [{"provider": provider}])
+    discovery._plugin_skills_cache = None
+    discovery._plugin_skills_signature = None
+    monkeypatch.setattr(
+        discovery, "_PLUGIN_SKILLS_CACHE_DIR", tmp_path / "plugin-cache"
+    )
+    monkeypatch.setattr(enabled_skills._config, "get_skills_enabled", lambda: True)
+    monkeypatch.setattr(
+        enabled_skills._config,
+        "get_skill_directories",
+        lambda: [str(skills_root)],
+    )
+    monkeypatch.setattr(enabled_skills._config, "get_disabled_skills", set)
+
+    try:
+        assert provider.list_enabled_skills() == [
+            {
+                "name": "example",
+                "description": "Example skill",
+                "path": str(skill_dir),
+                "tags": ["test"],
+                "version": None,
+                "author": None,
+            }
+        ]
+        assert not list((tmp_path / "plugin-cache").rglob("SKILL.md"))
+    finally:
+        clear_callbacks("register_skills")
+        discovery._plugin_skills_cache = None
+        discovery._plugin_skills_signature = None
+
+
+def test_provider_delegates_config_content_resources_and_catalog():
+    provider = AgentSkillsProvider()
+    skill_path = Path("/skill")
+    info = MagicMock(name="info", path=skill_path)
+    info.name = "example"
+    catalog_entry = MagicMock(id="remote-example")
+
+    with (
+        patch(
+            "code_puppy.plugins.agent_skills.provider.get_skills_enabled",
+            return_value=True,
+        ),
+        patch(
+            "code_puppy.plugins.agent_skills.provider.get_disabled_skills",
+            return_value={"disabled"},
+        ),
+        patch(
+            "code_puppy.plugins.agent_skills.provider.iter_enabled_skills",
+            return_value=iter([info]),
+        ),
+        patch(
+            "code_puppy.plugins.agent_skills.provider.load_full_skill_content",
+            return_value="# body",
+        ),
+        patch(
+            "code_puppy.plugins.agent_skills.provider.get_skill_resources",
+            return_value=[skill_path / "reference.md"],
+        ),
+        patch(
+            "code_puppy.plugins.agent_skills.provider.catalog.get_all",
+            return_value=[catalog_entry],
+        ),
+    ):
+        assert provider.is_enabled() is True
+        assert provider.get_disabled_skill_names() == {"disabled"}
+        assert provider.find_enabled_skill_path("example") == skill_path
+        assert provider.find_enabled_skill_path("missing") is None
+        assert provider.load_skill_content(skill_path) == "# body"
+        assert provider.get_skill_resources(skill_path) == [skill_path / "reference.md"]
+        assert provider.get_catalog_skill_ids() == ["remote-example"]

--- a/tests/test_completions_and_small_modules.py
+++ b/tests/test_completions_and_small_modules.py
@@ -27,31 +27,22 @@ class TestLoadCatalogSkillIds:
     def test_success(self):
         from code_puppy.command_line.skills_completion import load_catalog_skill_ids
 
-        mock_entry = MagicMock()
-        mock_entry.id = "skill-1"
-        mock_catalog = MagicMock()
-        mock_catalog.get_all.return_value = [mock_entry]
-        mock_module = MagicMock()
-        mock_module.catalog = mock_catalog
-
-        import sys
-
-        with patch.dict(
-            sys.modules, {"code_puppy.plugins.agent_skills.skill_catalog": mock_module}
+        provider = MagicMock()
+        provider.get_catalog_skill_ids.return_value = ["skill-1"]
+        with patch(
+            "code_puppy.command_line.skills_completion.get_skill_provider",
+            return_value=provider,
         ):
-            result = load_catalog_skill_ids()
-        assert result == ["skill-1"]
+            assert load_catalog_skill_ids() == ["skill-1"]
 
     def test_exception(self):
-        import sys
-
         from code_puppy.command_line.skills_completion import load_catalog_skill_ids
 
-        with patch.dict(
-            sys.modules, {"code_puppy.plugins.agent_skills.skill_catalog": None}
+        with patch(
+            "code_puppy.command_line.skills_completion.get_skill_provider",
+            side_effect=RuntimeError("boom"),
         ):
-            result = load_catalog_skill_ids()
-        assert result == []
+            assert load_catalog_skill_ids() == []
 
 
 class TestSkillsCompleterGetCompletions:

--- a/tests/test_skill_provider.py
+++ b/tests/test_skill_provider.py
@@ -1,0 +1,75 @@
+"""Tests for the optional skills provider callback seam."""
+
+from unittest.mock import MagicMock, patch
+
+from code_puppy.callbacks import (
+    clear_callbacks,
+    clear_loading_context,
+    register_callback,
+    set_loading_context,
+)
+from code_puppy.skill_provider import get_skill_provider
+
+
+def setup_function():
+    clear_callbacks("register_skills")
+
+
+def teardown_function():
+    clear_loading_context()
+    clear_callbacks("register_skills")
+
+
+def test_no_plugin_returns_none():
+    assert get_skill_provider() is None
+
+
+def test_first_provider_wins_deterministically():
+    first = MagicMock(name="first")
+    second = MagicMock(name="second")
+    register_callback("register_skills", lambda: [{"provider": first}])
+    register_callback("register_skills", lambda: [{"provider": second}])
+
+    assert get_skill_provider() is first
+
+
+def test_resolution_is_repeated_not_cached():
+    provider = MagicMock()
+    calls = []
+
+    def provide_skills():
+        calls.append(True)
+        return [{"provider": provider}]
+
+    register_callback("register_skills", provide_skills)
+
+    assert get_skill_provider() is provider
+    assert get_skill_provider() is provider
+    assert len(calls) == 2
+
+
+def test_disabled_plugin_provider_is_filtered():
+    provider = MagicMock()
+
+    set_loading_context("agent_skills")
+    register_callback("register_skills", lambda: [{"provider": provider}])
+    clear_loading_context()
+
+    with patch(
+        "code_puppy.callbacks._get_disabled_plugins", return_value={"agent_skills"}
+    ):
+        assert get_skill_provider() is None
+
+
+def test_skill_entries_and_invalid_results_are_ignored():
+    provider = MagicMock()
+    register_callback(
+        "register_skills",
+        lambda: [
+            {"name": "ordinary-skill", "skill_md": "# body"},
+            "not-a-dict",
+            {"provider": provider},
+        ],
+    )
+
+    assert get_skill_provider() is provider

--- a/tests/test_skills_tools_full_coverage.py
+++ b/tests/test_skills_tools_full_coverage.py
@@ -1,5 +1,6 @@
-"""Full coverage tests for tools/skills_tools.py."""
+"""Coverage and seam tests for the optional skills tools."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,213 +12,154 @@ from code_puppy.tools.skills_tools import (
 
 
 def _register_and_get(register_func):
-    """Register tool on a mock agent and capture the inner function."""
     agent = MagicMock()
     captured = {}
 
-    def tool_decorator(f):
-        captured["fn"] = f
-        return f
+    def tool_decorator(func):
+        captured["fn"] = func
+        return func
 
     agent.tool = tool_decorator
     register_func(agent)
     return captured["fn"]
 
 
+@pytest.fixture
+def provider():
+    result = MagicMock()
+    result.is_enabled.return_value = True
+    result.get_disabled_skill_names.return_value = set()
+    result.list_enabled_skills.return_value = []
+    result.find_enabled_skill_path.return_value = None
+    result.load_skill_content.return_value = None
+    result.get_skill_resources.return_value = []
+    return result
+
+
 class TestActivateSkill:
     @pytest.mark.anyio
-    async def test_disabled(self):
+    async def test_no_plugin(self):
         fn = _register_and_get(register_activate_skill)
-        ctx = MagicMock()
         with patch(
-            "code_puppy.plugins.agent_skills.config.get_skills_enabled",
-            return_value=False,
+            "code_puppy.tools.skills_tools.get_skill_provider", return_value=None
         ):
-            result = await fn(ctx, skill_name="test")
-            assert result.error is not None
-            assert "disabled" in result.error
+            result = await fn(MagicMock(), skill_name="test")
+        assert result.error == "Skills integration is unavailable."
 
     @pytest.mark.anyio
-    async def test_discovery_error(self):
+    async def test_globally_disabled(self, provider):
         fn = _register_and_get(register_activate_skill)
-        ctx = MagicMock()
-        with (
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_skills_enabled",
-                return_value=True,
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_skill_directories",
-                side_effect=Exception("boom"),
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.discovery.discover_skills",
-                side_effect=Exception("boom"),
-            ),
+        provider.is_enabled.return_value = False
+        with patch(
+            "code_puppy.tools.skills_tools.get_skill_provider", return_value=provider
         ):
-            result = await fn(ctx, skill_name="test")
-            assert result.error is not None
+            result = await fn(MagicMock(), skill_name="test")
+        assert "disabled" in result.error
 
     @pytest.mark.anyio
-    async def test_skill_not_found(self):
+    async def test_discovery_error(self, provider):
         fn = _register_and_get(register_activate_skill)
-        ctx = MagicMock()
-        with (
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_skills_enabled",
-                return_value=True,
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_skill_directories",
-                return_value=[],
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.discovery.discover_skills",
-                return_value=[],
-            ),
+        provider.find_enabled_skill_path.side_effect = RuntimeError("boom")
+        with patch(
+            "code_puppy.tools.skills_tools.get_skill_provider", return_value=provider
         ):
-            result = await fn(ctx, skill_name="nonexistent")
-            assert "not found" in result.error
+            result = await fn(MagicMock(), skill_name="test")
+        assert result.error == "Failed to discover skills: boom"
 
     @pytest.mark.anyio
-    async def test_content_load_failure(self):
+    async def test_skill_not_found(self, provider):
         fn = _register_and_get(register_activate_skill)
-        ctx = MagicMock()
-        mock_skill = MagicMock()
-        mock_skill.name = "test"
-        mock_skill.has_skill_md = True
-        mock_skill.path = "/path"
-        with (
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_skills_enabled",
-                return_value=True,
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_skill_directories",
-                return_value=[],
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.discovery.discover_skills",
-                return_value=[mock_skill],
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.metadata.load_full_skill_content",
-                return_value=None,
-            ),
+        with patch(
+            "code_puppy.tools.skills_tools.get_skill_provider", return_value=provider
         ):
-            result = await fn(ctx, skill_name="test")
-            assert "Failed to load" in result.error
+            result = await fn(MagicMock(), skill_name="missing")
+        assert "not found or disabled" in result.error
 
     @pytest.mark.anyio
-    async def test_success(self):
+    async def test_content_load_failure(self, provider):
         fn = _register_and_get(register_activate_skill)
-        ctx = MagicMock()
-        mock_skill = MagicMock()
-        mock_skill.name = "test"
-        mock_skill.has_skill_md = True
-        mock_skill.path = "/path"
+        provider.find_enabled_skill_path.return_value = Path("/skill")
+        with patch(
+            "code_puppy.tools.skills_tools.get_skill_provider", return_value=provider
+        ):
+            result = await fn(MagicMock(), skill_name="test")
+        assert result.error == "Failed to load content for skill 'test'"
+
+    @pytest.mark.anyio
+    async def test_success(self, provider):
+        fn = _register_and_get(register_activate_skill)
+        provider.find_enabled_skill_path.return_value = Path("/skill")
+        provider.load_skill_content.return_value = "# Skill content"
+        provider.get_skill_resources.return_value = [Path("/skill/reference.md")]
         with (
             patch(
-                "code_puppy.plugins.agent_skills.config.get_skills_enabled",
-                return_value=True,
+                "code_puppy.tools.skills_tools.get_skill_provider",
+                return_value=provider,
             ),
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_skill_directories",
-                return_value=[],
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.discovery.discover_skills",
-                return_value=[mock_skill],
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.metadata.load_full_skill_content",
-                return_value="# Skill content",
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.metadata.get_skill_resources",
-                return_value=[],
-            ),
-            patch("code_puppy.tools.skills_tools.get_message_bus"),
+            patch("code_puppy.tools.skills_tools.get_message_bus") as bus,
         ):
-            result = await fn(ctx, skill_name="test")
-            assert result.error is None
-            assert result.content == "# Skill content"
+            result = await fn(MagicMock(), skill_name="test")
+        assert result.error is None
+        assert result.content == "# Skill content"
+        assert result.resources == ["/skill/reference.md"]
+        bus.return_value.emit.assert_called_once()
 
 
 class TestListOrSearchSkills:
     @pytest.mark.anyio
-    async def test_disabled(self):
+    async def test_no_plugin(self):
         fn = _register_and_get(register_list_or_search_skills)
-        ctx = MagicMock()
         with patch(
-            "code_puppy.plugins.agent_skills.config.get_skills_enabled",
-            return_value=False,
+            "code_puppy.tools.skills_tools.get_skill_provider", return_value=None
         ):
-            result = await fn(ctx)
-            assert result.error is not None
+            result = await fn(MagicMock())
+        assert result.error == "Skills integration is unavailable."
 
     @pytest.mark.anyio
-    async def test_discovery_error(self):
+    async def test_globally_disabled(self, provider):
         fn = _register_and_get(register_list_or_search_skills)
-        ctx = MagicMock()
-        with (
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_skills_enabled",
-                return_value=True,
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_disabled_skills",
-                return_value=set(),
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_skill_directories",
-                side_effect=Exception("boom"),
-            ),
+        provider.is_enabled.return_value = False
+        with patch(
+            "code_puppy.tools.skills_tools.get_skill_provider", return_value=provider
         ):
-            result = await fn(ctx)
-            assert result.error is not None
+            result = await fn(MagicMock())
+        assert "disabled" in result.error
 
     @pytest.mark.anyio
-    async def test_list_all(self):
+    async def test_discovery_error(self, provider):
         fn = _register_and_get(register_list_or_search_skills)
-        ctx = MagicMock()
-        mock_skill = MagicMock()
-        mock_skill.name = "test"
-        mock_skill.has_skill_md = True
-        mock_skill.path = "/path"
-        mock_meta = MagicMock()
-        mock_meta.name = "test"
-        mock_meta.description = "A test skill"
-        mock_meta.path = "/path"
-        mock_meta.tags = ["testing"]
-        mock_meta.version = "1.0"
-        mock_meta.author = "me"
+        provider.list_enabled_skills.side_effect = RuntimeError("boom")
+        with patch(
+            "code_puppy.tools.skills_tools.get_skill_provider", return_value=provider
+        ):
+            result = await fn(MagicMock())
+        assert result.error == "Failed to discover skills: boom"
+
+    @pytest.mark.anyio
+    async def test_list_all(self, provider):
+        fn = _register_and_get(register_list_or_search_skills)
+        provider.list_enabled_skills.return_value = [
+            {
+                "name": "test",
+                "description": "A test skill",
+                "path": "/skill",
+                "tags": ["testing"],
+                "version": "1.0",
+                "author": "me",
+            }
+        ]
         with (
             patch(
-                "code_puppy.plugins.agent_skills.config.get_skills_enabled",
-                return_value=True,
+                "code_puppy.tools.skills_tools.get_skill_provider",
+                return_value=provider,
             ),
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_disabled_skills",
-                return_value=set(),
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_skill_directories",
-                return_value=[],
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.discovery.discover_skills",
-                return_value=[mock_skill],
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.metadata.parse_skill_metadata",
-                return_value=mock_meta,
-            ),
-            patch("code_puppy.tools.skills_tools.get_message_bus"),
+            patch("code_puppy.tools.skills_tools.get_message_bus") as bus,
         ):
-            result = await fn(ctx)
-            assert result.error is None
-            assert result.total_count == 1
+            result = await fn(MagicMock())
+        assert result.error is None
+        assert result.total_count == 1
+        assert result.skills[0]["name"] == "test"
+        bus.return_value.emit.assert_called_once()
 
     @pytest.mark.parametrize(
         "name,description,tags,query,expected_count",
@@ -226,113 +168,30 @@ class TestListOrSearchSkills:
             ("x", "Handles authentication", [], "auth", 1),
             ("x", "desc", ["database"], "database", 1),
             ("x", "desc", [], "zzzzz", 0),
+            ("code-puppy", "architecture", [], "code puppy architecture", 1),
         ],
     )
     @pytest.mark.anyio
     async def test_filter_by_query(
-        self, name, description, tags, query, expected_count
+        self, provider, name, description, tags, query, expected_count
     ):
         fn = _register_and_get(register_list_or_search_skills)
-        ctx = MagicMock()
-        mock_skill = MagicMock()
-        mock_skill.name = name
-        mock_skill.has_skill_md = True
-        mock_skill.path = "/path"
-        mock_meta = MagicMock()
-        mock_meta.name = name
-        mock_meta.description = description
-        mock_meta.path = "/path"
-        mock_meta.tags = tags
-        mock_meta.version = "1.0"
-        mock_meta.author = "me"
+        provider.list_enabled_skills.return_value = [
+            {
+                "name": name,
+                "description": description,
+                "path": "/skill",
+                "tags": tags,
+                "version": None,
+                "author": None,
+            }
+        ]
         with (
             patch(
-                "code_puppy.plugins.agent_skills.config.get_skills_enabled",
-                return_value=True,
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_disabled_skills",
-                return_value=set(),
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_skill_directories",
-                return_value=[],
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.discovery.discover_skills",
-                return_value=[mock_skill],
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.metadata.parse_skill_metadata",
-                return_value=mock_meta,
+                "code_puppy.tools.skills_tools.get_skill_provider",
+                return_value=provider,
             ),
             patch("code_puppy.tools.skills_tools.get_message_bus"),
         ):
-            result = await fn(ctx, query=query)
-            assert result.total_count == expected_count
-
-    @pytest.mark.anyio
-    async def test_skip_disabled_and_no_skill_md(self):
-        fn = _register_and_get(register_list_or_search_skills)
-        ctx = MagicMock()
-        disabled_skill = MagicMock()
-        disabled_skill.name = "disabled_one"
-        disabled_skill.has_skill_md = True
-        no_md_skill = MagicMock()
-        no_md_skill.name = "no_md"
-        no_md_skill.has_skill_md = False
-        with (
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_skills_enabled",
-                return_value=True,
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_disabled_skills",
-                return_value={"disabled_one"},
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_skill_directories",
-                return_value=[],
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.discovery.discover_skills",
-                return_value=[disabled_skill, no_md_skill],
-            ),
-            patch("code_puppy.tools.skills_tools.get_message_bus"),
-        ):
-            result = await fn(ctx)
-            assert result.total_count == 0
-
-    @pytest.mark.anyio
-    async def test_skip_none_metadata(self):
-        fn = _register_and_get(register_list_or_search_skills)
-        ctx = MagicMock()
-        mock_skill = MagicMock()
-        mock_skill.name = "x"
-        mock_skill.has_skill_md = True
-        mock_skill.path = "/path"
-        with (
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_skills_enabled",
-                return_value=True,
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_disabled_skills",
-                return_value=set(),
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.config.get_skill_directories",
-                return_value=[],
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.discovery.discover_skills",
-                return_value=[mock_skill],
-            ),
-            patch(
-                "code_puppy.plugins.agent_skills.metadata.parse_skill_metadata",
-                return_value=None,
-            ),
-            patch("code_puppy.tools.skills_tools.get_message_bus"),
-        ):
-            result = await fn(ctx)
-            assert result.total_count == 0
+            result = await fn(MagicMock(), query=query)
+        assert result.total_count == expected_count

--- a/tests/tools/test_tools_init.py
+++ b/tests/tools/test_tools_init.py
@@ -4,6 +4,20 @@ from unittest.mock import MagicMock, patch
 
 
 class TestLoadPluginTools:
+    def test_no_plugin_does_not_expose_skill_tools(self):
+        from code_puppy.tools import TOOL_REGISTRY, _load_plugin_tools
+
+        names = ("activate_skill", "list_or_search_skills")
+        previous = {name: TOOL_REGISTRY.pop(name, None) for name in names}
+        try:
+            with patch("code_puppy.tools.on_register_tools", return_value=[]):
+                _load_plugin_tools()
+            assert all(name not in TOOL_REGISTRY for name in names)
+        finally:
+            TOOL_REGISTRY.update(
+                {name: func for name, func in previous.items() if func is not None}
+            )
+
     def test_loads_tools(self):
         from code_puppy.tools import TOOL_REGISTRY, _load_plugin_tools
 


### PR DESCRIPTION
Fixes #724.

Core imports were already lazy/function-local at the branch base. The agent_skills plugin now self-registers its enabled filesystem skills through the existing `register_skills` hook without recursing through discovery or changing filesystem-skill precedence.

Tests:
- `uv run ruff check --fix code_puppy/plugins/agent_skills/register_callbacks.py code_puppy/tools/skills_tools.py code_puppy/command_line/skills_completion.py`
- `uv run ruff format --check code_puppy/plugins/agent_skills/register_callbacks.py code_puppy/tools/skills_tools.py code_puppy/command_line/skills_completion.py`
- `git diff --check`
- `uv run pytest tests/test_skills_tools_full_coverage.py tests/command_line/test_skills_completion.py tests/plugins/test_agent_skills.py tests/plugins/test_agent_skills_callbacks_coverage.py -q`
- `uv run pytest tests/plugins/ -q`
- `uv run pytest tests/ -q -p no:cacheprovider`