### PR TITLE
Decouple file_permission_handler plugin (#729)

### DIFF
--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -159,6 +159,11 @@ def clear_loading_context() -> None:
     _current_loading_plugin = None
 
 
+def get_loading_context() -> Optional[str]:
+    """Return the plugin currently being loaded, if any."""
+    return _current_loading_plugin
+
+
 def get_callback_owner(func: CallbackFunc) -> Optional[str]:
     """Return the plugin name that registered *func*, or ``None``."""
     return _callback_owners.get(func)
@@ -225,6 +230,11 @@ def clear_callbacks(phase: Optional[PhaseType] = None) -> None:
             logger.debug(f"Cleared async callbacks for phase '{phase}'")
 
 
+def is_callback_owner_enabled(owner: Optional[str]) -> bool:
+    """Return whether callbacks and providers owned by *owner* are enabled."""
+    return owner is None or owner not in _get_disabled_plugins()
+
+
 def get_callbacks(
     phase: PhaseType, *, include_disabled: bool = False
 ) -> List[CallbackFunc]:
@@ -237,11 +247,11 @@ def get_callbacks(
     if include_disabled:
         return all_cbs
 
-    disabled = _get_disabled_plugins()
-    if not disabled:
-        return all_cbs
-
-    return [cb for cb in all_cbs if _callback_owners.get(cb) not in disabled]
+    return [
+        callback
+        for callback in all_cbs
+        if is_callback_owner_enabled(_callback_owners.get(callback))
+    ]
 
 
 def count_callbacks(phase: Optional[PhaseType] = None) -> int:

--- a/code_puppy/plugins/file_permission_handler/register_callbacks.py
+++ b/code_puppy/plugins/file_permission_handler/register_callbacks.py
@@ -564,7 +564,7 @@ async def handle_file_permission_async(
 # `file_permission` hook for the approval decision and reaches the shared
 # state (diff-already-shown flag, last user feedback) through this small
 # provider API instead of importing this plugin module.
-register_file_permission_state_provider(
+_STATE_PROVIDER_REGISTRATION = register_file_permission_state_provider(
     set_diff_already_shown=set_diff_already_shown,
     was_diff_already_shown=was_diff_already_shown,
     clear_diff_shown_flag=clear_diff_shown_flag,

--- a/code_puppy/plugins/file_permission_handler/register_callbacks.py
+++ b/code_puppy/plugins/file_permission_handler/register_callbacks.py
@@ -13,6 +13,9 @@ from rich.text import Text as RichText
 
 from code_puppy.callbacks import register_callback
 from code_puppy.config import get_diff_context_lines, get_yolo_mode
+from code_puppy.tools.file_permission_state import (
+    register_file_permission_state_provider,
+)
 from code_puppy.tools.common import (
     _find_best_window,
     get_user_approval,
@@ -556,6 +559,18 @@ async def handle_file_permission_async(
     _set_user_feedback(user_feedback)
     return confirmed
 
+
+# Expose the thread-local UX-state accessors to core. Core consumes the
+# `file_permission` hook for the approval decision and reaches the shared
+# state (diff-already-shown flag, last user feedback) through this small
+# provider API instead of importing this plugin module.
+register_file_permission_state_provider(
+    set_diff_already_shown=set_diff_already_shown,
+    was_diff_already_shown=was_diff_already_shown,
+    clear_diff_shown_flag=clear_diff_shown_flag,
+    get_last_user_feedback=get_last_user_feedback,
+    clear_user_feedback=clear_user_feedback,
+)
 
 # Register the async callback for file permission handling. The async
 # dispatcher (`on_file_permission_async`) awaits it directly; the sync

--- a/code_puppy/tools/common.py
+++ b/code_puppy/tools/common.py
@@ -21,6 +21,7 @@ from rich.panel import Panel
 from rich.prompt import Prompt
 from rich.text import Text
 from code_puppy.callbacks import on_prompt_toolkit_style
+from code_puppy.tools.file_permission_state import set_diff_already_shown
 
 # =============================================================================
 # Approval queueing locks
@@ -1276,15 +1277,9 @@ def _get_user_approval_impl(
 
         panel_content.append(preview_text)
 
-        # Mark that we showed a diff preview
-        try:
-            from code_puppy.plugins.file_permission_handler.register_callbacks import (
-                set_diff_already_shown,
-            )
-
-            set_diff_already_shown(True)
-        except ImportError:
-            pass
+        # Mark that we showed a diff preview (no-op when no permission
+        # provider is registered, i.e. the file-permission plugin is absent).
+        set_diff_already_shown(True)
 
     # Create panel
     panel = Panel(
@@ -1475,15 +1470,9 @@ async def _get_user_approval_async_impl(
 
         panel_content.append(preview_text)
 
-        # Mark that we showed a diff preview
-        try:
-            from code_puppy.plugins.file_permission_handler.register_callbacks import (
-                set_diff_already_shown,
-            )
-
-            set_diff_already_shown(True)
-        except ImportError:
-            pass
+        # Mark that we showed a diff preview (no-op when no permission
+        # provider is registered, i.e. the file-permission plugin is absent).
+        set_diff_already_shown(True)
 
     # Create panel
     panel = Panel(

--- a/code_puppy/tools/file_modifications.py
+++ b/code_puppy/tools/file_modifications.py
@@ -30,13 +30,19 @@ from code_puppy.messaging import (  # Structured messaging types
     emit_warning,
     get_message_bus,
 )
+from code_puppy.tools import fs_access
 from code_puppy.tools.common import (
     _find_best_window,
     generate_group_id,
     resolve_path,
     write_project_file,
 )
-from code_puppy.tools import fs_access
+from code_puppy.tools.file_permission_state import (
+    clear_diff_shown_flag,
+    clear_user_feedback,
+    get_last_user_feedback,
+    was_diff_already_shown,
+)
 
 
 def _permission_denied(permission_results: List[Any]) -> bool:
@@ -57,18 +63,11 @@ def _create_rejection_response(file_path: str) -> Dict[str, Any]:
     Returns:
         Dict containing rejection details and any user feedback
     """
-    # Check for user feedback from permission handler
-    try:
-        from code_puppy.plugins.file_permission_handler.register_callbacks import (
-            clear_user_feedback,
-            get_last_user_feedback,
-        )
-
-        user_feedback = get_last_user_feedback()
-        # Clear feedback after reading it
-        clear_user_feedback()
-    except ImportError:
-        user_feedback = None
+    # Check for user feedback from the permission provider. Falls back to
+    # None when no provider (i.e. the file-permission plugin) is registered.
+    user_feedback = get_last_user_feedback()
+    # Clear feedback after reading it
+    clear_user_feedback()
 
     rejection_message = (
         "USER REJECTED: The user explicitly rejected these file changes."
@@ -186,19 +185,12 @@ def _emit_diff_message(
         old_content: Original file content (optional)
         new_content: New file content (optional)
     """
-    # Check if diff was already shown during permission prompt
-    try:
-        from code_puppy.plugins.file_permission_handler.register_callbacks import (
-            clear_diff_shown_flag,
-            was_diff_already_shown,
-        )
-
-        if was_diff_already_shown():
-            # Diff already displayed in permission panel, skip redundant display
-            clear_diff_shown_flag()
-            return
-    except ImportError:
-        pass  # Permission handler not available, emit anyway
+    # Check if diff was already shown during permission prompt. Defaults to
+    # False (emit anyway) when no permission provider is registered.
+    if was_diff_already_shown():
+        # Diff already displayed in permission panel, skip redundant display
+        clear_diff_shown_flag()
+        return
 
     if not diff_text or not diff_text.strip():
         return

--- a/code_puppy/tools/file_permission_state.py
+++ b/code_puppy/tools/file_permission_state.py
@@ -13,13 +13,17 @@ through this small registration API:
   user typed while rejecting, surfaced in the rejection response.
 
 A provider (e.g. the file-permission plugin) installs thread-local
-accessors with :func:`register_file_permission_state_provider`. Until one
-is registered, core behaves exactly as it did before the plugin could be
-imported: no diff was shown and no feedback is available.
+accessors with :func:`register_file_permission_state_provider`. Its plugin
+owner is captured from the callback loading context, so disabling that owner
+also disables this provider. Registrations can be explicitly unregistered
+for unloads, and stale unload tokens cannot remove a replacement after reload.
+Until an enabled provider is registered, core behaves exactly as it did before
+the plugin could be imported: no diff was shown and no feedback is available.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Callable, Optional
 
 _DiffShownSetter = Callable[[bool], None]
@@ -27,11 +31,20 @@ _DiffShownGetter = Callable[[], bool]
 _NoArg = Callable[[], None]
 _FeedbackGetter = Callable[[], Optional[str]]
 
-_diff_shown_setter: Optional[_DiffShownSetter] = None
-_diff_shown_getter: Optional[_DiffShownGetter] = None
-_diff_shown_clearer: Optional[_NoArg] = None
-_feedback_getter: Optional[_FeedbackGetter] = None
-_feedback_clearer: Optional[_NoArg] = None
+
+@dataclass(frozen=True)
+class FilePermissionStateProvider:
+    """Accessors registered by one plugin, plus its callback owner."""
+
+    set_diff_already_shown: _DiffShownSetter
+    was_diff_already_shown: _DiffShownGetter
+    clear_diff_shown_flag: _NoArg
+    get_last_user_feedback: _FeedbackGetter
+    clear_user_feedback: _NoArg
+    owner: Optional[str]
+
+
+_provider: Optional[FilePermissionStateProvider] = None
 
 
 def register_file_permission_state_provider(
@@ -41,54 +54,84 @@ def register_file_permission_state_provider(
     clear_diff_shown_flag: _NoArg,
     get_last_user_feedback: _FeedbackGetter,
     clear_user_feedback: _NoArg,
-) -> None:
-    """Install the accessors behind the file-permission UX state.
+    owner: Optional[str] = None,
+) -> FilePermissionStateProvider:
+    """Install and return an ownership-aware provider registration token.
 
-    Called by a file-permission provider (e.g. the built-in
-    ``file_permission_handler`` plugin) at load time. All five accessors
-    are required: they form the single cohesion unit -- thread-local state
-    shared between the approval prompt and core's diff/rejection plumbing.
+    The plugin loader's current owner is captured automatically. Calls only
+    reach the provider while that owner is enabled under the same filtering
+    used by the callback registry. Passing ``owner`` explicitly is useful for
+    embedders and tests that register outside plugin loading.
 
-    Until a provider is registered every accessor falls back to a default
-    that mirrors the pre-decoupling behavior of an absent plugin: no diff
-    was shown and no user feedback is available.
+    Re-registering replaces the current provider. The returned identity token
+    can later be passed to :func:`unregister_file_permission_state_provider`;
+    stale tokens cannot unregister a newer provider after reload.
     """
-    global _diff_shown_setter, _diff_shown_getter, _diff_shown_clearer
-    global _feedback_getter, _feedback_clearer
-    _diff_shown_setter = set_diff_already_shown
-    _diff_shown_getter = was_diff_already_shown
-    _diff_shown_clearer = clear_diff_shown_flag
-    _feedback_getter = get_last_user_feedback
-    _feedback_clearer = clear_user_feedback
+    from code_puppy.callbacks import get_loading_context
+
+    provider = FilePermissionStateProvider(
+        set_diff_already_shown=set_diff_already_shown,
+        was_diff_already_shown=was_diff_already_shown,
+        clear_diff_shown_flag=clear_diff_shown_flag,
+        get_last_user_feedback=get_last_user_feedback,
+        clear_user_feedback=clear_user_feedback,
+        owner=owner if owner is not None else get_loading_context(),
+    )
+    global _provider
+    _provider = provider
+    return provider
+
+
+def unregister_file_permission_state_provider(
+    provider: FilePermissionStateProvider,
+) -> bool:
+    """Unregister *provider* if it is still the active registration."""
+    global _provider
+    if _provider is not provider:
+        return False
+    _provider = None
+    return True
+
+
+def _get_active_provider() -> Optional[FilePermissionStateProvider]:
+    """Return the provider only while its owning plugin is enabled."""
+    provider = _provider
+    if provider is None:
+        return None
+
+    from code_puppy.callbacks import is_callback_owner_enabled
+
+    return provider if is_callback_owner_enabled(provider.owner) else None
 
 
 def set_diff_already_shown(shown: bool = True) -> None:
     """Record that a diff preview was rendered in the approval prompt."""
-    if _diff_shown_setter is not None:
-        _diff_shown_setter(shown)
+    provider = _get_active_provider()
+    if provider is not None:
+        provider.set_diff_already_shown(shown)
 
 
 def was_diff_already_shown() -> bool:
     """Return True when a diff preview was already shown for this op."""
-    if _diff_shown_getter is not None:
-        return _diff_shown_getter()
-    return False
+    provider = _get_active_provider()
+    return provider.was_diff_already_shown() if provider is not None else False
 
 
 def clear_diff_shown_flag() -> None:
     """Clear the diff-already-shown flag once it has been consumed."""
-    if _diff_shown_clearer is not None:
-        _diff_shown_clearer()
+    provider = _get_active_provider()
+    if provider is not None:
+        provider.clear_diff_shown_flag()
 
 
 def get_last_user_feedback() -> Optional[str]:
     """Return the user feedback captured by the last permission prompt."""
-    if _feedback_getter is not None:
-        return _feedback_getter()
-    return None
+    provider = _get_active_provider()
+    return provider.get_last_user_feedback() if provider is not None else None
 
 
 def clear_user_feedback() -> None:
     """Clear the captured user feedback once it has been consumed."""
-    if _feedback_clearer is not None:
-        _feedback_clearer()
+    provider = _get_active_provider()
+    if provider is not None:
+        provider.clear_user_feedback()

--- a/code_puppy/tools/file_permission_state.py
+++ b/code_puppy/tools/file_permission_state.py
@@ -1,0 +1,94 @@
+"""Core-side contract for the file-permission UX state.
+
+The interactive file-permission flow is owned by a plugin (the built-in
+``file_permission_handler``), which registers its ``file_permission``
+decision callback through :mod:`code_puppy.callbacks`. Core never imports
+the plugin: instead it reaches the shared *UX state* the flow relies on
+through this small registration API:
+
+* ``set_diff_already_shown`` / ``was_diff_already_shown`` /
+  ``clear_diff_shown_flag`` - the "a diff preview was already rendered in
+  the approval panel" flag so core can skip a redundant inline diff.
+* ``get_last_user_feedback`` / ``clear_user_feedback`` - the feedback the
+  user typed while rejecting, surfaced in the rejection response.
+
+A provider (e.g. the file-permission plugin) installs thread-local
+accessors with :func:`register_file_permission_state_provider`. Until one
+is registered, core behaves exactly as it did before the plugin could be
+imported: no diff was shown and no feedback is available.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+_DiffShownSetter = Callable[[bool], None]
+_DiffShownGetter = Callable[[], bool]
+_NoArg = Callable[[], None]
+_FeedbackGetter = Callable[[], Optional[str]]
+
+_diff_shown_setter: Optional[_DiffShownSetter] = None
+_diff_shown_getter: Optional[_DiffShownGetter] = None
+_diff_shown_clearer: Optional[_NoArg] = None
+_feedback_getter: Optional[_FeedbackGetter] = None
+_feedback_clearer: Optional[_NoArg] = None
+
+
+def register_file_permission_state_provider(
+    *,
+    set_diff_already_shown: _DiffShownSetter,
+    was_diff_already_shown: _DiffShownGetter,
+    clear_diff_shown_flag: _NoArg,
+    get_last_user_feedback: _FeedbackGetter,
+    clear_user_feedback: _NoArg,
+) -> None:
+    """Install the accessors behind the file-permission UX state.
+
+    Called by a file-permission provider (e.g. the built-in
+    ``file_permission_handler`` plugin) at load time. All five accessors
+    are required: they form the single cohesion unit -- thread-local state
+    shared between the approval prompt and core's diff/rejection plumbing.
+
+    Until a provider is registered every accessor falls back to a default
+    that mirrors the pre-decoupling behavior of an absent plugin: no diff
+    was shown and no user feedback is available.
+    """
+    global _diff_shown_setter, _diff_shown_getter, _diff_shown_clearer
+    global _feedback_getter, _feedback_clearer
+    _diff_shown_setter = set_diff_already_shown
+    _diff_shown_getter = was_diff_already_shown
+    _diff_shown_clearer = clear_diff_shown_flag
+    _feedback_getter = get_last_user_feedback
+    _feedback_clearer = clear_user_feedback
+
+
+def set_diff_already_shown(shown: bool = True) -> None:
+    """Record that a diff preview was rendered in the approval prompt."""
+    if _diff_shown_setter is not None:
+        _diff_shown_setter(shown)
+
+
+def was_diff_already_shown() -> bool:
+    """Return True when a diff preview was already shown for this op."""
+    if _diff_shown_getter is not None:
+        return _diff_shown_getter()
+    return False
+
+
+def clear_diff_shown_flag() -> None:
+    """Clear the diff-already-shown flag once it has been consumed."""
+    if _diff_shown_clearer is not None:
+        _diff_shown_clearer()
+
+
+def get_last_user_feedback() -> Optional[str]:
+    """Return the user feedback captured by the last permission prompt."""
+    if _feedback_getter is not None:
+        return _feedback_getter()
+    return None
+
+
+def clear_user_feedback() -> None:
+    """Clear the captured user feedback once it has been consumed."""
+    if _feedback_clearer is not None:
+        _feedback_clearer()

--- a/tests/tools/test_file_permission_state.py
+++ b/tests/tools/test_file_permission_state.py
@@ -1,12 +1,8 @@
-"""Tests for the core-side file-permission UX state provider API.
-
-The approval *decision* flows through the ``file_permission`` hook; this
-module's state (diff-already-shown flag, last user feedback) is reached
-through ``code_puppy.tools.file_permission_state`` so core never imports
-the file-permission plugin.
-"""
+"""Tests for the core-side file-permission UX state provider API."""
 
 from __future__ import annotations
+
+from typing import Any
 
 import pytest
 
@@ -15,33 +11,18 @@ from code_puppy.tools import file_permission_state as fps
 
 @pytest.fixture(autouse=True)
 def _isolate_provider():
-    """Start each test with no provider and restore the previous one after.
-
-    Other test files may already have registered the real plugin provider in
-    the same process (plugin modules cache in ``sys.modules``), so fallback
-    tests must actively clear it to stay deterministic -- while teardown
-    restores whatever was registered before, so nothing leaks out.
-    """
-    saved = {
-        "_diff_shown_setter": fps._diff_shown_setter,
-        "_diff_shown_getter": fps._diff_shown_getter,
-        "_diff_shown_clearer": fps._diff_shown_clearer,
-        "_feedback_getter": fps._feedback_getter,
-        "_feedback_clearer": fps._feedback_clearer,
-    }
-    fps._diff_shown_setter = None
-    fps._diff_shown_getter = None
-    fps._diff_shown_clearer = None
-    fps._feedback_getter = None
-    fps._feedback_clearer = None
+    """Start each test provider-free and restore the previous registration."""
+    saved = fps._provider
+    fps._provider = None
     yield
-    for name, value in saved.items():
-        setattr(fps, name, value)
+    fps._provider = saved
 
 
-def _install_provider() -> dict:
-    """Install dummy accessors backed by a shared dict; returns that dict."""
-    state: dict = {"diff_shown": False, "feedback": None}
+def _install_provider(
+    *, owner: str | None = None
+) -> tuple[dict[str, Any], fps.FilePermissionStateProvider]:
+    """Install dummy accessors backed by shared state."""
+    state: dict[str, Any] = {"diff_shown": False, "feedback": None}
 
     def set_diff_shown(shown: bool = True) -> None:
         state["diff_shown"] = shown
@@ -52,30 +33,29 @@ def _install_provider() -> dict:
     def clear_diff_shown() -> None:
         state["diff_shown"] = False
 
-    def get_feedback():
+    def get_feedback() -> str | None:
         return state["feedback"]
 
     def clear_feedback() -> None:
         state["feedback"] = None
 
-    fps.register_file_permission_state_provider(
+    token = fps.register_file_permission_state_provider(
         set_diff_already_shown=set_diff_shown,
         was_diff_already_shown=was_diff_shown,
         clear_diff_shown_flag=clear_diff_shown,
         get_last_user_feedback=get_feedback,
         clear_user_feedback=clear_feedback,
+        owner=owner,
     )
-    return state
+    return state, token
 
 
 class TestFallbackDefaults:
-    def test_no_provider_returns_false_for_diff_shown(self):
+    def test_no_provider_returns_defaults(self):
         assert fps.was_diff_already_shown() is False
-
-    def test_no_provider_returns_none_for_feedback(self):
         assert fps.get_last_user_feedback() is None
 
-    def test_no_provider_set_clear_are_noops(self):
+    def test_no_provider_mutations_are_noops(self):
         fps.set_diff_already_shown(True)
         fps.clear_diff_shown_flag()
         fps.clear_user_feedback()
@@ -85,31 +65,67 @@ class TestFallbackDefaults:
 
 class TestProviderDelegation:
     def test_diff_shown_flag_round_trips(self):
-        state = _install_provider()
-        fps.set_diff_already_shown(True)
+        state, _ = _install_provider()
+        fps.set_diff_already_shown()
         assert fps.was_diff_already_shown() is True
         assert state["diff_shown"] is True
         fps.clear_diff_shown_flag()
-        assert state["diff_shown"] is False
         assert fps.was_diff_already_shown() is False
 
     def test_feedback_round_trips(self):
-        state = _install_provider()
+        state, _ = _install_provider()
         state["feedback"] = "fix the message"
         assert fps.get_last_user_feedback() == "fix the message"
         fps.clear_user_feedback()
         assert fps.get_last_user_feedback() is None
 
-    def test_reregister_replaces_provider(self):
-        first = _install_provider()
-        first["feedback"] = "from first"
-        second = _install_provider()
-        # The second registration fully replaces the accessors.
-        assert fps.get_last_user_feedback() is None
-        second["feedback"] = "from second"
-        assert fps.get_last_user_feedback() == "from second"
+    def test_registration_captures_plugin_loading_owner(self):
+        from code_puppy.callbacks import clear_loading_context, set_loading_context
 
-    def test_default_flag_arg_sets_true(self):
-        _install_provider()
-        fps.set_diff_already_shown()
-        assert fps.was_diff_already_shown() is True
+        set_loading_context("permission-plugin")
+        try:
+            _, token = _install_provider()
+        finally:
+            clear_loading_context()
+        assert token.owner == "permission-plugin"
+
+
+class TestProviderLifecycle:
+    def test_disabled_owner_uses_fallback_without_calling_provider(self, monkeypatch):
+        state, token = _install_provider(owner="permission-plugin")
+        state["diff_shown"] = True
+        state["feedback"] = "stale feedback"
+        monkeypatch.setattr(
+            "code_puppy.plugins.config.get_disabled_plugins",
+            lambda: {"permission-plugin"},
+        )
+
+        assert token.owner == "permission-plugin"
+        assert fps.was_diff_already_shown() is False
+        assert fps.get_last_user_feedback() is None
+        fps.set_diff_already_shown(False)
+        fps.clear_diff_shown_flag()
+        fps.clear_user_feedback()
+        assert state == {"diff_shown": True, "feedback": "stale feedback"}
+
+    def test_unregister_restores_no_provider_fallback(self):
+        state, token = _install_provider()
+        state["diff_shown"] = True
+        state["feedback"] = "feedback"
+
+        assert fps.unregister_file_permission_state_provider(token) is True
+        assert fps.was_diff_already_shown() is False
+        assert fps.get_last_user_feedback() is None
+        assert fps.unregister_file_permission_state_provider(token) is False
+
+    def test_reload_replaces_provider_and_stale_unregister_is_safe(self):
+        first_state, first_token = _install_provider()
+        first_state["feedback"] = "old"
+        second_state, second_token = _install_provider()
+        second_state["feedback"] = "new"
+
+        assert fps.get_last_user_feedback() == "new"
+        assert fps.unregister_file_permission_state_provider(first_token) is False
+        assert fps.get_last_user_feedback() == "new"
+        assert fps.unregister_file_permission_state_provider(second_token) is True
+        assert fps.get_last_user_feedback() is None

--- a/tests/tools/test_file_permission_state.py
+++ b/tests/tools/test_file_permission_state.py
@@ -1,0 +1,115 @@
+"""Tests for the core-side file-permission UX state provider API.
+
+The approval *decision* flows through the ``file_permission`` hook; this
+module's state (diff-already-shown flag, last user feedback) is reached
+through ``code_puppy.tools.file_permission_state`` so core never imports
+the file-permission plugin.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from code_puppy.tools import file_permission_state as fps
+
+
+@pytest.fixture(autouse=True)
+def _isolate_provider():
+    """Start each test with no provider and restore the previous one after.
+
+    Other test files may already have registered the real plugin provider in
+    the same process (plugin modules cache in ``sys.modules``), so fallback
+    tests must actively clear it to stay deterministic -- while teardown
+    restores whatever was registered before, so nothing leaks out.
+    """
+    saved = {
+        "_diff_shown_setter": fps._diff_shown_setter,
+        "_diff_shown_getter": fps._diff_shown_getter,
+        "_diff_shown_clearer": fps._diff_shown_clearer,
+        "_feedback_getter": fps._feedback_getter,
+        "_feedback_clearer": fps._feedback_clearer,
+    }
+    fps._diff_shown_setter = None
+    fps._diff_shown_getter = None
+    fps._diff_shown_clearer = None
+    fps._feedback_getter = None
+    fps._feedback_clearer = None
+    yield
+    for name, value in saved.items():
+        setattr(fps, name, value)
+
+
+def _install_provider() -> dict:
+    """Install dummy accessors backed by a shared dict; returns that dict."""
+    state: dict = {"diff_shown": False, "feedback": None}
+
+    def set_diff_shown(shown: bool = True) -> None:
+        state["diff_shown"] = shown
+
+    def was_diff_shown() -> bool:
+        return state["diff_shown"]
+
+    def clear_diff_shown() -> None:
+        state["diff_shown"] = False
+
+    def get_feedback():
+        return state["feedback"]
+
+    def clear_feedback() -> None:
+        state["feedback"] = None
+
+    fps.register_file_permission_state_provider(
+        set_diff_already_shown=set_diff_shown,
+        was_diff_already_shown=was_diff_shown,
+        clear_diff_shown_flag=clear_diff_shown,
+        get_last_user_feedback=get_feedback,
+        clear_user_feedback=clear_feedback,
+    )
+    return state
+
+
+class TestFallbackDefaults:
+    def test_no_provider_returns_false_for_diff_shown(self):
+        assert fps.was_diff_already_shown() is False
+
+    def test_no_provider_returns_none_for_feedback(self):
+        assert fps.get_last_user_feedback() is None
+
+    def test_no_provider_set_clear_are_noops(self):
+        fps.set_diff_already_shown(True)
+        fps.clear_diff_shown_flag()
+        fps.clear_user_feedback()
+        assert fps.was_diff_already_shown() is False
+        assert fps.get_last_user_feedback() is None
+
+
+class TestProviderDelegation:
+    def test_diff_shown_flag_round_trips(self):
+        state = _install_provider()
+        fps.set_diff_already_shown(True)
+        assert fps.was_diff_already_shown() is True
+        assert state["diff_shown"] is True
+        fps.clear_diff_shown_flag()
+        assert state["diff_shown"] is False
+        assert fps.was_diff_already_shown() is False
+
+    def test_feedback_round_trips(self):
+        state = _install_provider()
+        state["feedback"] = "fix the message"
+        assert fps.get_last_user_feedback() == "fix the message"
+        fps.clear_user_feedback()
+        assert fps.get_last_user_feedback() is None
+
+    def test_reregister_replaces_provider(self):
+        first = _install_provider()
+        first["feedback"] = "from first"
+        second = _install_provider()
+        # The second registration fully replaces the accessors.
+        assert fps.get_last_user_feedback() is None
+        second["feedback"] = "from second"
+        assert fps.get_last_user_feedback() == "from second"
+
+    def test_default_flag_arg_sets_true(self):
+        _install_provider()
+        fps.set_diff_already_shown()
+        assert fps.was_diff_already_shown() is True


### PR DESCRIPTION
Fixes #729.

Core consumes the existing `file_permission` hook for approval decisions and a registered file-permission state provider for feedback/diff UX state instead of importing the plugin.