### PR TITLE
Decouple claude_code_oauth plugin (#727)

### DIFF
--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -332,6 +332,10 @@ def _trigger_callbacks_sync(
                     logger.warning(
                         f"Async callback {callback.__name__} called from async context in sync trigger"
                     )
+                    # The sync dispatcher cannot await while its event loop is
+                    # already running. Explicitly close the coroutine so this
+                    # safe fallback never leaks an unawaited-coroutine warning.
+                    result.close()
                     results.append(None)
                     continue
                 except RuntimeError:
@@ -1210,6 +1214,11 @@ def on_check_claude_oauth_token_expiry() -> List[Any]:
     return _trigger_callbacks_sync("check_claude_oauth_token_expiry")
 
 
+async def on_check_claude_oauth_token_expiry_async() -> List[Any]:
+    """Async variant for consumers already running inside an event loop."""
+    return await _trigger_callbacks("check_claude_oauth_token_expiry")
+
+
 def on_refresh_claude_oauth_token() -> List[Any]:
     """Ask the claude_code_oauth plugin to force a refresh-token exchange.
 
@@ -1218,6 +1227,11 @@ def on_refresh_claude_oauth_token() -> List[Any]:
         registered callbacks; empty when the plugin is not loaded.
     """
     return _trigger_callbacks_sync("refresh_claude_oauth_token")
+
+
+async def on_refresh_claude_oauth_token_async() -> List[Any]:
+    """Async variant for consumers already running inside an event loop."""
+    return await _trigger_callbacks("refresh_claude_oauth_token")
 
 
 def on_load_claude_oauth_models() -> List[Any]:

--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -49,6 +49,10 @@ PhaseType = Literal[
     "register_browser_types",
     "register_model_providers",
     "register_completion_provider",
+    "check_claude_oauth_token_expiry",
+    "refresh_claude_oauth_token",
+    "load_claude_oauth_models",
+    "claude_oauth_authenticate",
     "message_history_processor_start",
     "message_history_processor_end",
     "on_message",
@@ -129,6 +133,10 @@ _callbacks: Dict[PhaseType, List[CallbackFunc]] = {
     "register_browser_types": [],
     "register_model_providers": [],
     "register_completion_provider": [],
+    "check_claude_oauth_token_expiry": [],
+    "refresh_claude_oauth_token": [],
+    "load_claude_oauth_models": [],
+    "claude_oauth_authenticate": [],
     "message_history_processor_start": [],
     "message_history_processor_end": [],
     "on_message": [],
@@ -1187,6 +1195,49 @@ def on_register_model_providers() -> List[Any]:
         List of dicts from all registered callbacks.
     """
     return _trigger_callbacks_sync("register_model_providers")
+
+
+def on_check_claude_oauth_token_expiry() -> List[Any]:
+    """Ask the claude_code_oauth plugin whether the stored token is expiring.
+
+    The plugin self-registers this capability; core consumes it so it never
+    imports the plugin directly. An empty result (plugin not loaded) means
+    ``False`` to callers.
+
+    Returns:
+        List of bool results from registered callbacks.
+    """
+    return _trigger_callbacks_sync("check_claude_oauth_token_expiry")
+
+
+def on_refresh_claude_oauth_token() -> List[Any]:
+    """Ask the claude_code_oauth plugin to force a refresh-token exchange.
+
+    Returns:
+        List containing the refreshed access token (or ``None``) from
+        registered callbacks; empty when the plugin is not loaded.
+    """
+    return _trigger_callbacks_sync("refresh_claude_oauth_token")
+
+
+def on_load_claude_oauth_models() -> List[Any]:
+    """Load the claude_code_oauth plugin's own Claude model configurations.
+
+    Returns:
+        List of model-config dicts from registered callbacks; empty when the
+        plugin is not loaded (core then falls back to plain JSON loading).
+    """
+    return _trigger_callbacks_sync("load_claude_oauth_models")
+
+
+def on_claude_oauth_authenticate() -> List[Any]:
+    """Run the claude_code_oauth plugin's interactive authentication flow.
+
+    Returns:
+        List of results from registered callbacks; empty when the plugin is
+        not loaded (core skips authentication).
+    """
+    return _trigger_callbacks_sync("claude_oauth_authenticate")
 
 
 def on_message_history_processor_start(

--- a/code_puppy/claude_cache_client.py
+++ b/code_puppy/claude_cache_client.py
@@ -246,7 +246,7 @@ class ClaudeCacheAsyncClient(httpx.AsyncClient):
             from code_puppy.callbacks import on_check_claude_oauth_token_expiry
 
             results = on_check_claude_oauth_token_expiry()
-            return bool(results and results[0])
+            return any(result is True for result in results)
         except Exception as exc:
             logger.debug("Error checking stored token expiry: %s", exc)
             return False
@@ -703,7 +703,10 @@ class ClaudeCacheAsyncClient(httpx.AsyncClient):
                 return None
 
             logger.info("Attempting to refresh Claude Code OAuth token...")
-            refreshed_token = results[0]
+            refreshed_token = next(
+                (result for result in results if isinstance(result, str) and result),
+                None,
+            )
             if refreshed_token:
                 self._update_auth_headers(self.headers, refreshed_token)
                 self._notify_token_recovered(refreshed_token)

--- a/code_puppy/claude_cache_client.py
+++ b/code_puppy/claude_cache_client.py
@@ -199,39 +199,49 @@ class ClaudeCacheAsyncClient(httpx.AsyncClient):
             return auth_header[7:]  # Strip "Bearer " prefix
         return None
 
-    def _should_refresh_token(self, request: httpx.Request) -> bool:
-        """Check if the token should be refreshed (within the max-age window).
-
-        Uses two strategies:
-        1. Decode JWT to check token age (if possible)
-        2. Fall back to stored expires_at from token file
-
-        Returns True if token expires within TOKEN_MAX_AGE_SECONDS.
-        """
+    def _jwt_refresh_decision(self, request: httpx.Request) -> bool | None:
+        """Return a JWT-based refresh decision, or ``None`` for stored fallback."""
         token = self._extract_bearer_token(request)
         if not token:
             return False
 
-        # Strategy 1: Try to decode JWT age
         age = self._get_jwt_age_seconds(token)
-        if age is not None:
-            should_refresh = age >= TOKEN_MAX_AGE_SECONDS
-            if should_refresh:
-                logger.info(
-                    "JWT token is %.1f seconds old (>= %d), will refresh proactively",
-                    age,
-                    TOKEN_MAX_AGE_SECONDS,
-                )
-            return should_refresh
+        if age is None:
+            return None
 
-        # Strategy 2: Fall back to stored expires_at from token file
-        should_refresh = self._check_stored_token_expiry()
+        should_refresh = age >= TOKEN_MAX_AGE_SECONDS
+        if should_refresh:
+            logger.info(
+                "JWT token is %.1f seconds old (>= %d), will refresh proactively",
+                age,
+                TOKEN_MAX_AGE_SECONDS,
+            )
+        return should_refresh
+
+    @staticmethod
+    def _log_stored_token_refresh(should_refresh: bool) -> bool:
         if should_refresh:
             logger.info(
                 "Stored token expires within %d seconds, will refresh proactively",
                 TOKEN_MAX_AGE_SECONDS,
             )
         return should_refresh
+
+    def _should_refresh_token(self, request: httpx.Request) -> bool:
+        """Synchronously check JWT age, then the stored-token callback."""
+        decision = self._jwt_refresh_decision(request)
+        if decision is not None:
+            return decision
+        return self._log_stored_token_refresh(self._check_stored_token_expiry())
+
+    async def _should_refresh_token_async(self, request: httpx.Request) -> bool:
+        """Check token expiry while awaiting async providers in ``send()``."""
+        decision = self._jwt_refresh_decision(request)
+        if decision is not None:
+            return decision
+        return self._log_stored_token_refresh(
+            await self._check_stored_token_expiry_async()
+        )
 
     @staticmethod
     def _check_stored_token_expiry() -> bool:
@@ -246,6 +256,20 @@ class ClaudeCacheAsyncClient(httpx.AsyncClient):
             from code_puppy.callbacks import on_check_claude_oauth_token_expiry
 
             results = on_check_claude_oauth_token_expiry()
+            return any(result is True for result in results)
+        except Exception as exc:
+            logger.debug("Error checking stored token expiry: %s", exc)
+            return False
+
+    @staticmethod
+    async def _check_stored_token_expiry_async() -> bool:
+        """Await stored-token expiry providers from an active event loop."""
+        try:
+            from code_puppy.callbacks import (
+                on_check_claude_oauth_token_expiry_async,
+            )
+
+            results = await on_check_claude_oauth_token_expiry_async()
             return any(result is True for result in results)
         except Exception as exc:
             logger.debug("Error checking stored token expiry: %s", exc)
@@ -354,8 +378,8 @@ class ClaudeCacheAsyncClient(httpx.AsyncClient):
         # Proactive token refresh: check JWT age before every request
         if not request.extensions.get("claude_oauth_proactive_refresh_attempted"):
             try:
-                if self._should_refresh_token(request):
-                    refreshed_token = self._refresh_claude_oauth_token()
+                if await self._should_refresh_token_async(request):
+                    refreshed_token = await self._refresh_claude_oauth_token_async()
                     if refreshed_token:
                         logger.info("Proactively refreshed token before request")
                         # Rebuild request with new token
@@ -620,10 +644,14 @@ class ClaudeCacheAsyncClient(httpx.AsyncClient):
         headers: MutableMapping[str, str], access_token: str
     ) -> None:
         bearer_value = f"Bearer {access_token}"
-        if "Authorization" in headers or "authorization" in headers:
+        if "Authorization" in headers:
             headers["Authorization"] = bearer_value
-        elif "x-api-key" in headers or "X-API-Key" in headers:
+        elif "authorization" in headers:
+            headers["authorization"] = bearer_value
+        elif "x-api-key" in headers:
             headers["x-api-key"] = access_token
+        elif "X-API-Key" in headers:
+            headers["X-API-Key"] = access_token
         else:
             headers["Authorization"] = bearer_value
 
@@ -693,27 +721,40 @@ class ClaudeCacheAsyncClient(httpx.AsyncClient):
         self._notify_token_recovered(reauthenticated_token)
         return reauthenticated_token
 
+    def _apply_token_refresh_results(self, results: list[Any]) -> str | None:
+        if not results:
+            # Plugin not loaded — nothing to refresh.
+            return None
+
+        logger.info("Attempting to refresh Claude Code OAuth token...")
+        refreshed_token = next(
+            (result for result in results if isinstance(result, str) and result),
+            None,
+        )
+        if refreshed_token:
+            self._update_auth_headers(self.headers, refreshed_token)
+            self._notify_token_recovered(refreshed_token)
+            logger.info("Successfully refreshed Claude Code OAuth token")
+        else:
+            logger.warning("Token refresh returned None")
+        return refreshed_token
+
     def _refresh_claude_oauth_token(self) -> str | None:
         try:
             from code_puppy.callbacks import on_refresh_claude_oauth_token
 
-            results = on_refresh_claude_oauth_token()
-            if not results:
-                # Plugin not loaded — nothing to refresh.
-                return None
+            return self._apply_token_refresh_results(on_refresh_claude_oauth_token())
+        except Exception as exc:
+            logger.error("Exception during token refresh: %s", exc)
+            return None
 
-            logger.info("Attempting to refresh Claude Code OAuth token...")
-            refreshed_token = next(
-                (result for result in results if isinstance(result, str) and result),
-                None,
-            )
-            if refreshed_token:
-                self._update_auth_headers(self.headers, refreshed_token)
-                self._notify_token_recovered(refreshed_token)
-                logger.info("Successfully refreshed Claude Code OAuth token")
-            else:
-                logger.warning("Token refresh returned None")
-            return refreshed_token
+    async def _refresh_claude_oauth_token_async(self) -> str | None:
+        """Await token-refresh providers from an active event loop."""
+        try:
+            from code_puppy.callbacks import on_refresh_claude_oauth_token_async
+
+            results = await on_refresh_claude_oauth_token_async()
+            return self._apply_token_refresh_results(results)
         except Exception as exc:
             logger.error("Exception during token refresh: %s", exc)
             return None

--- a/code_puppy/claude_cache_client.py
+++ b/code_puppy/claude_cache_client.py
@@ -238,20 +238,15 @@ class ClaudeCacheAsyncClient(httpx.AsyncClient):
         """Check if the stored token expires within TOKEN_MAX_AGE_SECONDS.
 
         This is a fallback for when JWT decoding fails or isn't available.
-        Uses the expires_at timestamp from the stored token file.
+        Uses the expires_at timestamp from the stored token file.  The
+        claude_code_oauth plugin self-registers this capability; when it
+        isn't loaded (or the check fails) we conservatively report ``False``.
         """
         try:
-            from code_puppy.plugins.claude_code_oauth.utils import (
-                is_token_expired,
-                load_stored_tokens,
-            )
+            from code_puppy.callbacks import on_check_claude_oauth_token_expiry
 
-            tokens = load_stored_tokens()
-            if not tokens:
-                return False
-
-            # is_token_expired already uses the configured refresh buffer window
-            return is_token_expired(tokens)
+            results = on_check_claude_oauth_token_expiry()
+            return bool(results and results[0])
         except Exception as exc:
             logger.debug("Error checking stored token expiry: %s", exc)
             return False
@@ -700,10 +695,15 @@ class ClaudeCacheAsyncClient(httpx.AsyncClient):
 
     def _refresh_claude_oauth_token(self) -> str | None:
         try:
-            from code_puppy.plugins.claude_code_oauth.utils import refresh_access_token
+            from code_puppy.callbacks import on_refresh_claude_oauth_token
+
+            results = on_refresh_claude_oauth_token()
+            if not results:
+                # Plugin not loaded — nothing to refresh.
+                return None
 
             logger.info("Attempting to refresh Claude Code OAuth token...")
-            refreshed_token = refresh_access_token(force=True)
+            refreshed_token = results[0]
             if refreshed_token:
                 self._update_auth_headers(self.headers, refreshed_token)
                 self._notify_token_recovered(refreshed_token)

--- a/code_puppy/command_line/core_commands.py
+++ b/code_puppy/command_line/core_commands.py
@@ -215,7 +215,8 @@ def handle_tutorial_command(command: str) -> bool:
         emit_info(t("cmd.tutorial.claude_oauth"))
         from code_puppy.callbacks import on_claude_oauth_authenticate
 
-        if on_claude_oauth_authenticate():
+        auth_results = on_claude_oauth_authenticate()
+        if any(result is True for result in auth_results):
             set_model_and_reload_agent("claude-code-claude-opus-4-7")
     elif result == "completed":
         emit_info(t("cmd.tutorial.complete"))

--- a/code_puppy/command_line/core_commands.py
+++ b/code_puppy/command_line/core_commands.py
@@ -213,12 +213,10 @@ def handle_tutorial_command(command: str) -> bool:
         on_custom_command("/chatgpt-auth", "chatgpt-auth")
     elif result == "claude":
         emit_info(t("cmd.tutorial.claude_oauth"))
-        from code_puppy.plugins.claude_code_oauth.register_callbacks import (
-            _perform_authentication,
-        )
+        from code_puppy.callbacks import on_claude_oauth_authenticate
 
-        _perform_authentication()
-        set_model_and_reload_agent("claude-code-claude-opus-4-7")
+        if on_claude_oauth_authenticate():
+            set_model_and_reload_agent("claude-code-claude-opus-4-7")
     elif result == "completed":
         emit_info(t("cmd.tutorial.complete"))
     elif result == "skipped":

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -584,11 +584,13 @@ class ModelFactory:
                 # the 'load_claude_oauth_models' hook; fall back to standard JSON
                 # loading when it isn't loaded.
                 if use_filtered:
-                    load_hooks = callbacks.get_callbacks("load_claude_oauth_models")
-                    if load_hooks:
-                        extra_config = load_hooks[0]()
-                    else:
-                        # Plugin not available, fall back to standard JSON loading
+                    load_results = callbacks.on_load_claude_oauth_models()
+                    extra_config = next(
+                        (result for result in load_results if isinstance(result, dict)),
+                        None,
+                    )
+                    if extra_config is None:
+                        # Plugin unavailable or failed; fall back to plain JSON.
                         logging.getLogger(__name__).debug(
                             f"claude_code_oauth plugin not available, loading {label} as plain JSON"
                         )

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -579,15 +579,15 @@ class ModelFactory:
             if not source_path.exists():
                 continue
             try:
-                # Use filtered loading for Claude Code OAuth models to show only latest versions
+                # Use filtered loading for Claude Code OAuth models to show only
+                # latest versions. The plugin self-registers this capability via
+                # the 'load_claude_oauth_models' hook; fall back to standard JSON
+                # loading when it isn't loaded.
                 if use_filtered:
-                    try:
-                        from code_puppy.plugins.claude_code_oauth.utils import (
-                            load_claude_models_filtered,
-                        )
-
-                        extra_config = load_claude_models_filtered()
-                    except ImportError:
+                    load_hooks = callbacks.get_callbacks("load_claude_oauth_models")
+                    if load_hooks:
+                        extra_config = load_hooks[0]()
+                    else:
                         # Plugin not available, fall back to standard JSON loading
                         logging.getLogger(__name__).debug(
                             f"claude_code_oauth plugin not available, loading {label} as plain JSON"

--- a/code_puppy/plugins/claude_code_oauth/register_callbacks.py
+++ b/code_puppy/plugins/claude_code_oauth/register_callbacks.py
@@ -41,9 +41,11 @@ from .utils import (
     exchange_code_for_tokens,
     fetch_claude_code_models,
     get_valid_access_token,
+    is_token_expired,
     load_claude_models_filtered,
     load_stored_tokens,
     prepare_oauth_context,
+    refresh_access_token,
     remove_claude_code_models,
     save_tokens,
 )
@@ -671,8 +673,50 @@ async def _on_agent_run_end(
             logger.debug("Error stopping token refresh heartbeat: %s", exc)
 
 
+def _hook_check_token_expiry() -> bool:
+    """Hook: is the stored Claude Code OAuth token inside its refresh window?
+
+    Consumed by core's ``ClaudeCacheAsyncClient._check_stored_token_expiry``
+    (replacing a direct core->plugin import).
+    """
+    tokens = load_stored_tokens()
+    if not tokens:
+        return False
+    return is_token_expired(tokens)
+
+
+def _hook_refresh_token() -> Optional[str]:
+    """Hook: force a refresh-token exchange, returning the new access token.
+
+    Consumed by core's ``ClaudeCacheAsyncClient._refresh_claude_oauth_token``.
+    """
+    return refresh_access_token(force=True)
+
+
+def _hook_load_models() -> Dict[str, Any]:
+    """Hook: return this plugin's Claude models filtered to latest versions.
+
+    Consumed by core's ``ModelFactory.load_config`` (replacing a direct
+    ``load_claude_models_filtered`` import from ``.utils``).
+    """
+    return load_claude_models_filtered()
+
+
+def _hook_authenticate() -> None:
+    """Hook: run the full interactive Claude Code OAuth flow.
+
+    Consumed by core's ``handle_tutorial_command`` (replacing a direct import
+    of ``_perform_authentication``).
+    """
+    _perform_authentication()
+
+
 register_callback("custom_command_help", _custom_help)
 register_callback("custom_command", _handle_custom_command)
+register_callback("check_claude_oauth_token_expiry", _hook_check_token_expiry)
+register_callback("refresh_claude_oauth_token", _hook_refresh_token)
+register_callback("load_claude_oauth_models", _hook_load_models)
+register_callback("claude_oauth_authenticate", _hook_authenticate)
 register_callback("register_model_type", _register_model_types)
 register_callback("prepare_model_prompt", prepare_claude_code_prompt)
 register_callback("agent_run_start", _on_agent_run_start)

--- a/code_puppy/plugins/claude_code_oauth/register_callbacks.py
+++ b/code_puppy/plugins/claude_code_oauth/register_callbacks.py
@@ -318,40 +318,41 @@ def _custom_help() -> List[Tuple[str, str]]:
     ]
 
 
-def _perform_authentication() -> None:
+def _perform_authentication() -> bool:
     context = prepare_oauth_context()
     code = _await_callback(context)
     if not code:
-        return
+        return False
 
     emit_info(t("oauth.auth.exchanging"))
     tokens = exchange_code_for_tokens(code, context)
     if not tokens:
         emit_error(t("oauth.auth.exchange_failed"))
-        return
+        return False
 
     if not save_tokens(tokens):
         emit_error(t("oauth.auth.save_failed"))
-        return
+        return False
 
     emit_success(t("oauth.claude.auth.success"))
 
     access_token = tokens.get("access_token")
     if not access_token:
         emit_warning(t("oauth.auth.no_access_token"))
-        return
+        return False
 
     emit_info(t("oauth.claude.auth.fetching_models"))
     models = fetch_claude_code_models(access_token)
     if not models:
         emit_warning(t("oauth.claude.auth.no_models"))
-        return
+        return True
 
     emit_info(
         t("oauth.auth.discovered_models", count=len(models), models=", ".join(models))
     )
     if add_models_to_extra_config(models):
         emit_success(t("oauth.claude.auth.models_added"))
+    return True
 
 
 def _reauthenticate_after_expired_oauth(model_name: str) -> Optional[str]:
@@ -702,13 +703,13 @@ def _hook_load_models() -> Dict[str, Any]:
     return load_claude_models_filtered()
 
 
-def _hook_authenticate() -> None:
+def _hook_authenticate() -> bool:
     """Hook: run the full interactive Claude Code OAuth flow.
 
     Consumed by core's ``handle_tutorial_command`` (replacing a direct import
     of ``_perform_authentication``).
     """
-    _perform_authentication()
+    return _perform_authentication()
 
 
 register_callback("custom_command_help", _custom_help)

--- a/tests/plugins/test_claude_oauth_callback_seams.py
+++ b/tests/plugins/test_claude_oauth_callback_seams.py
@@ -1,0 +1,295 @@
+"""Regression tests for the decoupled Claude Code OAuth callback seams."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+
+from code_puppy import callbacks
+from code_puppy.claude_cache_client import ClaudeCacheAsyncClient
+from code_puppy.model_factory import ModelFactory
+
+PLUGIN_NAME = "claude_code_oauth"
+
+
+@pytest.fixture
+def isolate_callback_phases() -> Iterator[Callable[[str], None]]:
+    """Clear requested phases and restore callbacks plus ownership afterward."""
+    saved: dict[str, list[tuple[Callable, str | None]]] = {}
+
+    def isolate(phase: str) -> None:
+        if phase in saved:
+            return
+        saved[phase] = [
+            (callback, callbacks.get_callback_owner(callback))
+            for callback in callbacks.get_callbacks(phase, include_disabled=True)
+        ]
+        callbacks.clear_callbacks(phase)
+
+    yield isolate
+
+    callbacks.clear_loading_context()
+    for phase, registered in saved.items():
+        callbacks.clear_callbacks(phase)
+        for callback, owner in registered:
+            if owner:
+                callbacks.set_loading_context(owner)
+            callbacks.register_callback(phase, callback)
+            callbacks.clear_loading_context()
+
+
+@pytest.fixture
+def install_provider(isolate_callback_phases, monkeypatch):
+    """Install one owned provider and optionally disable its plugin owner."""
+
+    def install(phase: str, provider: Callable, *, disabled: bool = False) -> None:
+        isolate_callback_phases(phase)
+        callbacks.set_loading_context(PLUGIN_NAME)
+        try:
+            callbacks.register_callback(phase, provider)
+        finally:
+            callbacks.clear_loading_context()
+        monkeypatch.setattr(
+            callbacks,
+            "_get_disabled_plugins",
+            lambda: {PLUGIN_NAME} if disabled else set(),
+        )
+
+    return install
+
+
+def _raising_provider() -> None:
+    raise RuntimeError("provider exploded")
+
+
+@pytest.mark.parametrize("result", [False, True])
+def test_auth_hook_returns_real_success_boolean(result, monkeypatch):
+    from code_puppy.plugins.claude_code_oauth import register_callbacks
+
+    authenticate = MagicMock(return_value=result)
+    monkeypatch.setattr(register_callbacks, "_perform_authentication", authenticate)
+
+    assert register_callbacks._hook_authenticate() is result
+    authenticate.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    ("phase", "dispatcher", "expected"),
+    [
+        (
+            "check_claude_oauth_token_expiry",
+            callbacks.on_check_claude_oauth_token_expiry,
+            True,
+        ),
+        (
+            "refresh_claude_oauth_token",
+            callbacks.on_refresh_claude_oauth_token,
+            "access-token",
+        ),
+        (
+            "load_claude_oauth_models",
+            callbacks.on_load_claude_oauth_models,
+            {"claude": {"type": "claude_code"}},
+        ),
+        (
+            "claude_oauth_authenticate",
+            callbacks.on_claude_oauth_authenticate,
+            True,
+        ),
+    ],
+)
+@pytest.mark.parametrize("is_async", [False, True], ids=["sync", "async"])
+def test_dispatchers_support_sync_and_async_providers(
+    phase, dispatcher, expected, is_async, install_provider
+):
+    if is_async:
+
+        async def provider():
+            return expected
+
+    else:
+
+        def provider():
+            return expected
+
+    install_provider(phase, provider)
+
+    assert dispatcher() == [expected]
+
+
+@pytest.mark.parametrize(
+    "phase",
+    [
+        "check_claude_oauth_token_expiry",
+        "refresh_claude_oauth_token",
+        "load_claude_oauth_models",
+        "claude_oauth_authenticate",
+    ],
+)
+def test_callback_registration_is_idempotent(phase, isolate_callback_phases):
+    isolate_callback_phases(phase)
+
+    def provider():
+        return None
+
+    callbacks.register_callback(phase, provider)
+    callbacks.register_callback(phase, provider)
+
+    assert callbacks.get_callbacks(phase, include_disabled=True) == [provider]
+
+
+@pytest.mark.parametrize(
+    ("case", "expected"),
+    [
+        ("absent", False),
+        ("exception", False),
+        ("disabled", False),
+        ("valid", True),
+    ],
+)
+def test_token_expiry_seam(case, expected, install_provider, isolate_callback_phases):
+    phase = "check_claude_oauth_token_expiry"
+    isolate_callback_phases(phase)
+    if case == "exception":
+        install_provider(phase, _raising_provider)
+    elif case == "disabled":
+        install_provider(phase, lambda: True, disabled=True)
+    elif case == "valid":
+        install_provider(phase, lambda: True)
+
+    assert ClaudeCacheAsyncClient._check_stored_token_expiry() is expected
+
+
+@pytest.mark.parametrize(
+    ("case", "expected"),
+    [
+        ("absent", None),
+        ("exception", None),
+        ("disabled", None),
+        ("valid", "new-token"),
+    ],
+)
+def test_token_refresh_seam(case, expected, install_provider, isolate_callback_phases):
+    phase = "refresh_claude_oauth_token"
+    isolate_callback_phases(phase)
+    if case == "exception":
+        install_provider(phase, _raising_provider)
+    elif case == "disabled":
+        install_provider(phase, lambda: "new-token", disabled=True)
+    elif case == "valid":
+        install_provider(phase, lambda: "new-token")
+
+    client = ClaudeCacheAsyncClient(headers={"Authorization": "Bearer old-token"})
+    try:
+        assert client._refresh_claude_oauth_token() == expected
+        if expected:
+            assert client.headers["Authorization"] == f"Bearer {expected}"
+    finally:
+        asyncio.run(client.aclose())
+
+
+@contextmanager
+def _claude_models_config(monkeypatch, tmp_path):
+    import code_puppy.config as config
+    import code_puppy.model_factory as model_factory
+
+    claude_file = tmp_path / "claude_models.json"
+    fallback = {"fallback-model": {"type": "claude_code", "name": "fallback"}}
+    claude_file.write_text(json.dumps(fallback), encoding="utf-8")
+    missing = tmp_path / "missing.json"
+
+    monkeypatch.setattr(model_factory, "EXTRA_MODELS_FILE", str(missing))
+    monkeypatch.setattr(config, "CHATGPT_MODELS_FILE", str(missing))
+    monkeypatch.setattr(config, "CLAUDE_MODELS_FILE", str(claude_file))
+    monkeypatch.setattr(config, "GEMINI_MODELS_FILE", str(missing))
+    monkeypatch.setattr(config, "COPILOT_MODELS_FILE", str(missing))
+    yield fallback
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_model"),
+    [
+        ("absent", "fallback-model"),
+        ("exception", "fallback-model"),
+        ("disabled", "fallback-model"),
+        ("valid", "provider-model"),
+    ],
+)
+def test_filtered_model_loading_seam(
+    case,
+    expected_model,
+    install_provider,
+    isolate_callback_phases,
+    monkeypatch,
+    tmp_path,
+):
+    for phase in (
+        "load_model_config",
+        "load_models_config",
+        "load_model_descriptions",
+        "load_claude_oauth_models",
+    ):
+        isolate_callback_phases(phase)
+
+    phase = "load_claude_oauth_models"
+    provider_models = {"provider-model": {"type": "claude_code", "name": "provider"}}
+    if case == "exception":
+        install_provider(phase, _raising_provider)
+    elif case == "disabled":
+        install_provider(phase, lambda: provider_models, disabled=True)
+    elif case == "valid":
+        install_provider(phase, lambda: provider_models)
+
+    with _claude_models_config(monkeypatch, tmp_path):
+        loaded = ModelFactory.load_config()
+
+    assert expected_model in loaded
+    assert ("fallback-model" in loaded) is (case != "valid")
+
+
+@pytest.mark.parametrize(
+    ("case", "should_switch"),
+    [
+        ("absent", False),
+        ("exception", False),
+        ("disabled", False),
+        ("valid", True),
+    ],
+)
+def test_tutorial_authentication_seam(
+    case,
+    should_switch,
+    install_provider,
+    isolate_callback_phases,
+    monkeypatch,
+):
+    import concurrent.futures
+
+    from code_puppy.command_line import onboarding_wizard
+    from code_puppy.command_line.core_commands import handle_tutorial_command
+    from code_puppy import model_switching
+
+    phase = "claude_oauth_authenticate"
+    isolate_callback_phases(phase)
+    if case == "exception":
+        install_provider(phase, _raising_provider)
+    elif case == "disabled":
+        install_provider(phase, lambda: True, disabled=True)
+    elif case == "valid":
+        install_provider(phase, lambda: True)
+
+    executor = MagicMock()
+    executor.return_value.__enter__.return_value.submit.return_value.result.return_value = "claude"
+    switch_model = MagicMock()
+    monkeypatch.setattr(concurrent.futures, "ThreadPoolExecutor", executor)
+    monkeypatch.setattr(onboarding_wizard, "reset_onboarding", MagicMock())
+    monkeypatch.setattr(onboarding_wizard, "require_model_setup_if_needed", MagicMock())
+    monkeypatch.setattr(model_switching, "set_model_and_reload_agent", switch_model)
+
+    assert handle_tutorial_command("/tutorial") is True
+    assert switch_model.called is should_switch

--- a/tests/plugins/test_claude_oauth_callback_seams.py
+++ b/tests/plugins/test_claude_oauth_callback_seams.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import json
+import warnings
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 
 from code_puppy import callbacks
@@ -293,3 +296,80 @@ def test_tutorial_authentication_seam(
 
     assert handle_tutorial_command("/tutorial") is True
     assert switch_model.called is should_switch
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("expiry_raises", "expected_token"),
+    [(False, "new-token"), (True, "old-token")],
+    ids=["async-provider-result", "async-provider-exception-fallback"],
+)
+async def test_real_send_awaits_async_oauth_providers_without_runtime_warning(
+    expiry_raises,
+    expected_token,
+    install_provider,
+    isolate_callback_phases,
+    monkeypatch,
+):
+    expiry_phase = "check_claude_oauth_token_expiry"
+    refresh_phase = "refresh_claude_oauth_token"
+    isolate_callback_phases(expiry_phase)
+    isolate_callback_phases(refresh_phase)
+
+    async def expiry_provider():
+        if expiry_raises:
+            raise RuntimeError("expiry provider exploded")
+        return True
+
+    async def refresh_provider():
+        return "new-token"
+
+    install_provider(expiry_phase, expiry_provider)
+    install_provider(refresh_phase, refresh_provider)
+
+    captured = {}
+
+    async def fake_send(self, request, *args, **kwargs):
+        captured["authorization"] = request.headers.get("Authorization")
+        return httpx.Response(200, request=request, json={})
+
+    monkeypatch.setattr(httpx.AsyncClient, "send", fake_send)
+    client = ClaudeCacheAsyncClient(headers={"Authorization": "Bearer old-token"})
+    request = httpx.Request(
+        "GET",
+        "https://api.anthropic.com/health",
+        headers={"Authorization": "Bearer old-token"},
+    )
+
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            response = await client.send(request)
+            gc.collect()
+            await asyncio.sleep(0)
+    finally:
+        await client.aclose()
+
+    assert response.status_code == 200
+    assert captured["authorization"] == f"Bearer {expected_token}"
+    assert not [warning for warning in caught if warning.category is RuntimeWarning]
+
+
+@pytest.mark.asyncio
+async def test_sync_dispatcher_closes_async_provider_inside_running_loop(
+    install_provider,
+):
+    phase = "refresh_claude_oauth_token"
+
+    async def provider():
+        return "unused-token"
+
+    install_provider(phase, provider)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert callbacks.on_refresh_claude_oauth_token() == [None]
+        gc.collect()
+        await asyncio.sleep(0)
+
+    assert not [warning for warning in caught if warning.category is RuntimeWarning]

--- a/tests/test_claude_cache_client.py
+++ b/tests/test_claude_cache_client.py
@@ -191,7 +191,7 @@ class TestProactiveTokenRefresh:
         ) as mock_send:
             with patch.object(
                 ClaudeCacheAsyncClient,
-                "_refresh_claude_oauth_token",
+                "_refresh_claude_oauth_token_async",
                 return_value="new_fresh_token",
             ) as mock_refresh:
                 client = ClaudeCacheAsyncClient(
@@ -235,7 +235,7 @@ class TestProactiveTokenRefresh:
         ):
             with patch.object(
                 ClaudeCacheAsyncClient,
-                "_refresh_claude_oauth_token",
+                "_refresh_claude_oauth_token_async",
             ) as mock_refresh:
                 client = ClaudeCacheAsyncClient(
                     headers={"Authorization": f"Bearer {fresh_token}"}


### PR DESCRIPTION
Fixes #727.

Removes core-to-plugin imports by routing token expiry checks, token refresh, filtered model loading, and tutorial authentication through callback hooks registered by the claude_code_oauth plugin.