### PR TITLE
Decouple universal_constructor plugin (#726)

### DIFF
--- a/code_puppy/agents/agent_creator_agent.py
+++ b/code_puppy/agents/agent_creator_agent.py
@@ -33,9 +33,9 @@ class AgentCreatorAgent(BaseAgent):
         # Also get Universal Constructor tools (custom tools created by users)
         uc_tools_info = []
         try:
-            from code_puppy.plugins.universal_constructor.registry import get_registry
+            from code_puppy.tools.universal_constructor import get_uc_registry
 
-            registry = get_registry()
+            registry = get_uc_registry()
             uc_tools = registry.list_tools(include_disabled=True)
             for tool in uc_tools:
                 status = "✅" if tool.meta.enabled else "❌"

--- a/code_puppy/agents/agent_creator_agent.py
+++ b/code_puppy/agents/agent_creator_agent.py
@@ -33,10 +33,12 @@ class AgentCreatorAgent(BaseAgent):
         # Also get Universal Constructor tools (custom tools created by users)
         uc_tools_info = []
         try:
-            from code_puppy.tools.universal_constructor import get_uc_registry
+            from code_puppy.universal_constructor_provider import (
+                get_universal_constructor_provider,
+            )
 
-            registry = get_uc_registry()
-            uc_tools = registry.list_tools(include_disabled=True)
+            provider = get_universal_constructor_provider()
+            uc_tools = provider.list_tools(include_disabled=True) if provider else []
             for tool in uc_tools:
                 status = "✅" if tool.meta.enabled else "❌"
                 uc_tools_info.append(

--- a/code_puppy/agents/json_agent.py
+++ b/code_puppy/agents/json_agent.py
@@ -126,10 +126,12 @@ class JSONAgent(BaseAgent):
         # Also get UC tool names
         uc_tool_names = set()
         try:
-            from code_puppy.tools.universal_constructor import get_uc_registry
+            from code_puppy.universal_constructor_provider import (
+                get_universal_constructor_provider,
+            )
 
-            registry = get_uc_registry()
-            for tool in registry.list_tools():
+            provider = get_universal_constructor_provider()
+            for tool in provider.list_tools() if provider else []:
                 if tool.meta.enabled:
                     uc_tool_names.add(tool.full_name)
         except ImportError:

--- a/code_puppy/agents/json_agent.py
+++ b/code_puppy/agents/json_agent.py
@@ -126,9 +126,9 @@ class JSONAgent(BaseAgent):
         # Also get UC tool names
         uc_tool_names = set()
         try:
-            from code_puppy.plugins.universal_constructor.registry import get_registry
+            from code_puppy.tools.universal_constructor import get_uc_registry
 
-            registry = get_registry()
+            registry = get_uc_registry()
             for tool in registry.list_tools():
                 if tool.meta.enabled:
                     uc_tool_names.add(tool.full_name)

--- a/code_puppy/command_line/uc_menu.py
+++ b/code_puppy/command_line/uc_menu.py
@@ -4,11 +4,13 @@ Provides a split-panel interface for browsing and managing UC tools
 with live preview of tool details and inline source code viewing.
 """
 
+from __future__ import annotations
+
 import asyncio
 import sys
 import unicodedata
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 from prompt_toolkit.application import Application
 from prompt_toolkit.key_binding import KeyBindings
@@ -24,10 +26,12 @@ from code_puppy.command_line.pagination import (
     get_total_pages,
 )
 from code_puppy.messaging import emit_error, emit_info, emit_success
-from code_puppy.plugins.universal_constructor.models import UCToolInfo
-from code_puppy.plugins.universal_constructor.registry import get_registry
 from code_puppy.tools.command_runner import set_awaiting_user_input
 from code_puppy.callbacks import on_prompt_toolkit_style
+
+if TYPE_CHECKING:
+    UCToolInfo = Any
+
 
 PAGE_SIZE = 10  # Tools per page
 SOURCE_PAGE_SIZE = 30  # Lines of source per page
@@ -79,7 +83,9 @@ def _get_tool_entries() -> List[UCToolInfo]:
     Returns:
         List of UCToolInfo sorted by full_name.
     """
-    registry = get_registry()
+    from code_puppy.tools.universal_constructor import get_uc_registry
+
+    registry = get_uc_registry()
     registry.scan()  # Force fresh scan
     return registry.list_tools(include_disabled=True)
 

--- a/code_puppy/command_line/uc_menu.py
+++ b/code_puppy/command_line/uc_menu.py
@@ -83,11 +83,15 @@ def _get_tool_entries() -> List[UCToolInfo]:
     Returns:
         List of UCToolInfo sorted by full_name.
     """
-    from code_puppy.tools.universal_constructor import get_uc_registry
+    from code_puppy.universal_constructor_provider import (
+        get_universal_constructor_provider,
+    )
 
-    registry = get_uc_registry()
-    registry.scan()  # Force fresh scan
-    return registry.list_tools(include_disabled=True)
+    provider = get_universal_constructor_provider()
+    if provider is None:
+        return []
+    provider.reload()  # Force fresh scan
+    return provider.list_tools(include_disabled=True)
 
 
 def _toggle_tool_enabled(tool: UCToolInfo) -> bool:
@@ -159,9 +163,13 @@ def _delete_tool(tool: UCToolInfo) -> bool:
 
         # Try to clean up empty parent directories (namespace folders)
         parent = source_path.parent
-        from code_puppy.plugins.universal_constructor import USER_UC_DIR
+        from code_puppy.universal_constructor_provider import (
+            get_universal_constructor_provider,
+        )
 
-        while parent != USER_UC_DIR and parent.exists():
+        provider = get_universal_constructor_provider()
+        tools_dir = provider.tools_dir if provider else parent
+        while parent != tools_dir and parent.exists():
             try:
                 if not any(parent.iterdir()):
                     parent.rmdir()

--- a/code_puppy/plugins/universal_constructor/provider.py
+++ b/code_puppy/plugins/universal_constructor/provider.py
@@ -1,0 +1,62 @@
+"""Universal Constructor implementation of the core provider seam."""
+
+from pathlib import Path
+from typing import Any, Callable
+
+
+class PluginUniversalConstructorProvider:
+    """Expose UC plugin capabilities without leaking plugin imports into core."""
+
+    @property
+    def tools_dir(self) -> Path:
+        from . import USER_UC_DIR
+
+        return USER_UC_DIR
+
+    def list_tools(self, include_disabled: bool = False) -> list[Any]:
+        from .registry import get_registry
+
+        return get_registry().list_tools(include_disabled=include_disabled)
+
+    def get_tool(self, name: str) -> Any | None:
+        from .registry import get_registry
+
+        return get_registry().get_tool(name)
+
+    def get_tool_function(self, name: str) -> Callable[..., Any] | None:
+        from .registry import get_registry
+
+        return get_registry().get_tool_function(name)
+
+    def reload(self) -> int:
+        from .registry import get_registry
+
+        return get_registry().reload()
+
+    def validate_syntax(self, code: str) -> Any:
+        from .sandbox import validate_syntax
+
+        return validate_syntax(code)
+
+    def extract_function_info(self, code: str) -> Any:
+        from .sandbox import extract_function_info
+
+        return extract_function_info(code)
+
+    def extract_tool_meta(self, code: str) -> dict[str, Any] | None:
+        from .sandbox import _extract_tool_meta
+
+        return _extract_tool_meta(code)
+
+    def validate_tool_meta(self, meta: dict[str, Any]) -> list[str]:
+        from .sandbox import _validate_tool_meta
+
+        return _validate_tool_meta(meta)
+
+    def check_dangerous_patterns(self, code: str) -> Any:
+        from .sandbox import check_dangerous_patterns
+
+        return check_dangerous_patterns(code)
+
+
+provider = PluginUniversalConstructorProvider()

--- a/code_puppy/plugins/universal_constructor/register_callbacks.py
+++ b/code_puppy/plugins/universal_constructor/register_callbacks.py
@@ -14,6 +14,18 @@ from .registry import get_registry
 logger = logging.getLogger(__name__)
 
 
+def _register_tools() -> list[dict]:
+    """Contribute the Universal Constructor tool through the plugin hook."""
+    from code_puppy.tools.universal_constructor import register_universal_constructor
+
+    return [
+        {
+            "name": "universal_constructor",
+            "register_func": register_universal_constructor,
+        }
+    ]
+
+
 def _on_startup() -> None:
     """Initialize UC plugin on application startup."""
     from code_puppy.config import get_universal_constructor_enabled
@@ -41,7 +53,8 @@ def _on_startup() -> None:
     )
 
 
-# Register startup callback
+# Register plugin callbacks
 register_callback("startup", _on_startup)
+register_callback("register_tools", _register_tools)
 
 logger.debug("Universal Constructor plugin callbacks registered")

--- a/code_puppy/plugins/universal_constructor/register_callbacks.py
+++ b/code_puppy/plugins/universal_constructor/register_callbacks.py
@@ -7,11 +7,17 @@ Code Puppy. It ensures the plugin is properly loaded and initialized.
 import logging
 
 from code_puppy.callbacks import register_callback
+from code_puppy.universal_constructor_provider import (
+    register_universal_constructor_provider,
+)
 
 from . import USER_UC_DIR
+from .provider import provider
 from .registry import get_registry
 
 logger = logging.getLogger(__name__)
+
+register_universal_constructor_provider(provider)
 
 
 def _register_tools() -> list[dict]:

--- a/code_puppy/plugins/universal_constructor/register_callbacks.py
+++ b/code_puppy/plugins/universal_constructor/register_callbacks.py
@@ -9,6 +9,7 @@ import logging
 from code_puppy.callbacks import register_callback
 from code_puppy.universal_constructor_provider import (
     register_universal_constructor_provider,
+    unregister_universal_constructor_provider,
 )
 
 from . import USER_UC_DIR
@@ -17,7 +18,15 @@ from .registry import get_registry
 
 logger = logging.getLogger(__name__)
 
-register_universal_constructor_provider(provider)
+_PROVIDER_REGISTRATION = register_universal_constructor_provider(
+    provider,
+    owner="universal_constructor",
+)
+
+
+def unregister_provider(registration=_PROVIDER_REGISTRATION) -> bool:
+    """Unregister this plugin's provider during an explicit unload."""
+    return unregister_universal_constructor_provider(registration)
 
 
 def _register_tools() -> list[dict]:

--- a/code_puppy/tools/__init__.py
+++ b/code_puppy/tools/__init__.py
@@ -289,9 +289,9 @@ def _register_uc_tool_wrapper(agent, uc_tool_name: str):
 
     # Get tool info and function from registry
     try:
-        from code_puppy.plugins.universal_constructor.registry import get_registry
+        from code_puppy.tools.universal_constructor import get_uc_registry
 
-        registry = get_registry()
+        registry = get_uc_registry()
         tool_info = registry.get_tool(uc_tool_name)
         if not tool_info:
             emit_warning(f"Warning: UC tool '{uc_tool_name}' not found, skipping...")

--- a/code_puppy/tools/__init__.py
+++ b/code_puppy/tools/__init__.py
@@ -31,7 +31,6 @@ from code_puppy.tools.file_operations import (
 )
 from code_puppy.tools.image_tools import register_load_image
 from code_puppy.tools.model_tools import register_list_available_models
-from code_puppy.tools.universal_constructor import register_universal_constructor
 
 # Map of tool names to their individual registration functions
 TOOL_REGISTRY = {
@@ -57,8 +56,6 @@ TOOL_REGISTRY = {
     "ask_user_question": register_ask_user_question,
     # Image loading (used by browser/QA agents and friends)
     "load_image_for_analysis": register_load_image,
-    # Universal Constructor
-    "universal_constructor": register_universal_constructor,
 }
 
 
@@ -289,15 +286,20 @@ def _register_uc_tool_wrapper(agent, uc_tool_name: str):
 
     # Get tool info and function from registry
     try:
-        from code_puppy.tools.universal_constructor import get_uc_registry
+        from code_puppy.universal_constructor_provider import (
+            get_universal_constructor_provider,
+        )
 
-        registry = get_uc_registry()
-        tool_info = registry.get_tool(uc_tool_name)
+        provider = get_universal_constructor_provider()
+        if provider is None:
+            emit_warning("Warning: Universal Constructor provider is unavailable")
+            return
+        tool_info = provider.get_tool(uc_tool_name)
         if not tool_info:
             emit_warning(f"Warning: UC tool '{uc_tool_name}' not found, skipping...")
             return
 
-        func = registry.get_tool_function(uc_tool_name)
+        func = provider.get_tool_function(uc_tool_name)
         if not func:
             emit_warning(
                 f"Warning: UC tool '{uc_tool_name}' function not found, skipping..."

--- a/code_puppy/tools/universal_constructor.py
+++ b/code_puppy/tools/universal_constructor.py
@@ -8,55 +8,72 @@ import subprocess
 import time
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 from pydantic_ai import RunContext
 
 from code_puppy.messaging import get_message_bus
 from code_puppy.messaging.messages import UniversalConstructorMessage
+from code_puppy.universal_constructor_provider import (
+    get_universal_constructor_provider,
+)
 
 
-def get_uc_registry():
-    """Accessor for the shared UC registry singleton.
-
-    Lazily imports and returns the plugin's global registry on each call so
-    that this core module never pulls the plugin in at import time. The
-    plugin package can therefore live outside core.
-    """
-    from code_puppy.plugins.universal_constructor.registry import get_registry
-
-    return get_registry()
+def _get_uc_provider():
+    """Return the registered UC provider without importing any plugin."""
+    return get_universal_constructor_provider()
 
 
-if TYPE_CHECKING:
-    UCListOutput = UCCallOutput = UCCreateOutput = UCUpdateOutput = UCInfoOutput = Any
+class UCListOutput(BaseModel):
+    """Neutral response contract for listing plugin-provided tools."""
+
+    tools: list[Any] = Field(default_factory=list)
+    total_count: int = 0
+    enabled_count: int = 0
+    error: Optional[str] = None
 
 
-# ``UniversalConstructorOutput`` references the UC plugin's response models
-# (UCListOutput, ...). Those are imported lazily: the model uses forward
-# references plus ``defer_build``, and ``_get_uc_models()`` imports the plugin
-# and triggers a pydantic rebuild the first time the schema is needed.
-_UC_MODELS_READY = False
+class UCCallOutput(BaseModel):
+    """Neutral response contract for calling a plugin-provided tool."""
+
+    success: bool
+    tool_name: str
+    result: Any = None
+    error: Optional[str] = None
+    execution_time: Optional[float] = None
+    source_preview: Optional[str] = None
 
 
-def _get_uc_models():
-    """Lazily import UC response models and return their module."""
-    global _UC_MODELS_READY
-    from code_puppy.plugins.universal_constructor import models
+class UCCreateOutput(BaseModel):
+    """Neutral response contract for creating a plugin-provided tool."""
 
-    if not _UC_MODELS_READY:
-        UniversalConstructorOutput.model_rebuild(
-            _types_namespace={
-                "UCListOutput": models.UCListOutput,
-                "UCCallOutput": models.UCCallOutput,
-                "UCCreateOutput": models.UCCreateOutput,
-                "UCUpdateOutput": models.UCUpdateOutput,
-                "UCInfoOutput": models.UCInfoOutput,
-            }
-        )
-        _UC_MODELS_READY = True
-    return models
+    success: bool
+    tool_name: str = ""
+    source_path: Optional[str] = None
+    preview: Optional[str] = None
+    error: Optional[str] = None
+    validation_warnings: list[str] = Field(default_factory=list)
+
+
+class UCUpdateOutput(BaseModel):
+    """Neutral response contract for updating a plugin-provided tool."""
+
+    success: bool
+    tool_name: str = ""
+    source_path: Optional[str] = None
+    preview: Optional[str] = None
+    error: Optional[str] = None
+    changes_applied: list[str] = Field(default_factory=list)
+
+
+class UCInfoOutput(BaseModel):
+    """Neutral response contract for plugin-provided tool details."""
+
+    success: bool
+    tool: Any = None
+    source_code: Optional[str] = None
+    error: Optional[str] = None
 
 
 class UniversalConstructorOutput(BaseModel):
@@ -70,31 +87,13 @@ class UniversalConstructorOutput(BaseModel):
     error: Optional[str] = Field(default=None, description="Error message if failed")
 
     # Action-specific results (only one will be populated based on action).
-    # Forward references: the UC plugin's response models are resolved lazily
-    # by _get_uc_models() so this module has no import-time plugin dep.
-    list_result: Optional["UCListOutput"] = Field(
-        default=None, description="Result of list action"
-    )
-    call_result: Optional["UCCallOutput"] = Field(
-        default=None, description="Result of call action"
-    )
-    create_result: Optional["UCCreateOutput"] = Field(
-        default=None, description="Result of create action"
-    )
-    update_result: Optional["UCUpdateOutput"] = Field(
-        default=None, description="Result of update action"
-    )
-    info_result: Optional["UCInfoOutput"] = Field(
-        default=None, description="Result of info action"
-    )
+    list_result: Any = Field(default=None, description="Result of list action")
+    call_result: Any = Field(default=None, description="Result of call action")
+    create_result: Any = Field(default=None, description="Result of create action")
+    update_result: Any = Field(default=None, description="Result of update action")
+    info_result: Any = Field(default=None, description="Result of info action")
 
-    model_config = {"arbitrary_types_allowed": True, "defer_build": True}
-
-    def __init__(self, **data):
-        # Resolve the UC plugin's response models on first construction so
-        # instances can be built even if the plugin wasn't imported yet.
-        _get_uc_models()
-        super().__init__(**data)
+    model_config = {"arbitrary_types_allowed": True}
 
 
 def _stub_not_implemented(action: str) -> UniversalConstructorOutput:
@@ -206,8 +205,15 @@ async def universal_constructor_impl(
     Returns:
         UniversalConstructorOutput with action-specific results
     """
-    # Route to appropriate action handler
-    if action == "list":
+    # Route to appropriate action handler. Missing providers are expected when
+    # the optional plugin is not installed or has not registered yet.
+    if _get_uc_provider() is None:
+        result = UniversalConstructorOutput(
+            action=action,
+            success=False,
+            error="Universal Constructor provider is not available",
+        )
+    elif action == "list":
         result = _handle_list_action(context)
     elif action == "call":
         result = _handle_call_action(context, tool_name, tool_args)
@@ -277,7 +283,7 @@ def _handle_list_action(context: RunContext) -> UniversalConstructorOutput:
         UniversalConstructorOutput with list_result containing all enabled tools.
     """
     try:
-        registry = get_uc_registry()
+        registry = _get_uc_provider()
         # Get all tools (including disabled for count)
         all_tools = registry.list_tools(include_disabled=True)
         enabled_tools = [t for t in all_tools if t.meta.enabled]
@@ -285,7 +291,7 @@ def _handle_list_action(context: RunContext) -> UniversalConstructorOutput:
         return UniversalConstructorOutput(
             action="list",
             success=True,
-            list_result=_get_uc_models().UCListOutput(
+            list_result=UCListOutput(
                 tools=enabled_tools,
                 total_count=len(all_tools),
                 enabled_count=len(enabled_tools),
@@ -296,7 +302,7 @@ def _handle_list_action(context: RunContext) -> UniversalConstructorOutput:
             action="list",
             success=False,
             error=f"Failed to list tools: {e}",
-            list_result=_get_uc_models().UCListOutput(
+            list_result=UCListOutput(
                 tools=[],
                 total_count=0,
                 enabled_count=0,
@@ -331,7 +337,7 @@ def _handle_call_action(
             error="tool_name is required for call action",
         )
 
-    registry = get_uc_registry()
+    registry = _get_uc_provider()
     tool = registry.get_tool(tool_name)
 
     if not tool:
@@ -399,7 +405,7 @@ def _handle_call_action(
         return UniversalConstructorOutput(
             action="call",
             success=True,
-            call_result=_get_uc_models().UCCallOutput(
+            call_result=UCCallOutput(
                 success=True,
                 tool_name=tool_name,
                 result=result,
@@ -459,14 +465,7 @@ def _handle_create_action(
     from datetime import datetime
     from pathlib import Path
 
-    from code_puppy.plugins.universal_constructor import USER_UC_DIR
-    from code_puppy.plugins.universal_constructor.sandbox import (
-        _extract_tool_meta,
-        _validate_tool_meta,
-        check_dangerous_patterns,
-        extract_function_info,
-        validate_syntax,
-    )
+    provider = _get_uc_provider()
 
     # Validate python_code is provided
     if not python_code or not python_code.strip():
@@ -477,7 +476,7 @@ def _handle_create_action(
         )
 
     # Validate syntax
-    syntax_result = validate_syntax(python_code)
+    syntax_result = provider.validate_syntax(python_code)
     if not syntax_result.valid:
         error_msg = "; ".join(syntax_result.errors)
         return UniversalConstructorOutput(
@@ -487,7 +486,7 @@ def _handle_create_action(
         )
 
     # Extract function info
-    func_result = extract_function_info(python_code)
+    func_result = provider.extract_function_info(python_code)
     if not func_result.functions:
         return UniversalConstructorOutput(
             action="create",
@@ -499,7 +498,7 @@ def _handle_create_action(
     main_func = func_result.functions[0]
 
     # Try to extract TOOL_META from code
-    existing_meta = _extract_tool_meta(python_code)
+    existing_meta = provider.extract_tool_meta(python_code)
 
     # Determine final tool name and namespace
     if existing_meta and "name" in existing_meta:
@@ -530,9 +529,9 @@ def _handle_create_action(
     if final_namespace:
         # Convert dot notation to path (api.finance → api/finance/)
         namespace_path = Path(*final_namespace.split("."))
-        file_dir = USER_UC_DIR / namespace_path
+        file_dir = provider.tools_dir / namespace_path
     else:
-        file_dir = USER_UC_DIR
+        file_dir = provider.tools_dir
 
     file_path = file_dir / f"{final_name}.py"
 
@@ -541,7 +540,7 @@ def _handle_create_action(
 
     if existing_meta:
         # Validate existing TOOL_META has required fields
-        meta_errors = _validate_tool_meta(existing_meta)
+        meta_errors = provider.validate_tool_meta(existing_meta)
         if meta_errors:
             return UniversalConstructorOutput(
                 action="create",
@@ -573,7 +572,7 @@ def _handle_create_action(
         validation_warnings.extend(func_result.warnings)
 
     # Check for dangerous patterns (warning only, don't block)
-    safety_result = check_dangerous_patterns(python_code)
+    safety_result = provider.check_dangerous_patterns(python_code)
     validation_warnings.extend(safety_result.warnings)
 
     # Ensure directory exists and write file
@@ -597,7 +596,7 @@ def _handle_create_action(
 
     # Reload registry to pick up the new tool
     try:
-        registry = get_uc_registry()
+        registry = _get_uc_provider()
         registry.reload()
     except Exception as e:
         # Tool was written but registry reload failed - still a partial success
@@ -609,7 +608,7 @@ def _handle_create_action(
     return UniversalConstructorOutput(
         action="create",
         success=True,
-        create_result=_get_uc_models().UCCreateOutput(
+        create_result=UCCreateOutput(
             success=True,
             tool_name=full_name,
             source_path=str(file_path),
@@ -645,11 +644,7 @@ def _handle_update_action(
     """
     from pathlib import Path
 
-    from code_puppy.plugins.universal_constructor.sandbox import (
-        _extract_tool_meta,
-        _validate_tool_meta,
-        validate_syntax,
-    )
+    provider = _get_uc_provider()
 
     if not tool_name:
         return UniversalConstructorOutput(
@@ -666,7 +661,7 @@ def _handle_update_action(
             error="python_code is required for update action",
         )
 
-    registry = get_uc_registry()
+    registry = _get_uc_provider()
     tool = registry.get_tool(tool_name)
 
     if not tool:
@@ -687,7 +682,7 @@ def _handle_update_action(
 
     try:
         # Validate new code syntax
-        syntax_result = validate_syntax(python_code)
+        syntax_result = provider.validate_syntax(python_code)
         if not syntax_result.valid:
             error_msg = "; ".join(syntax_result.errors)
             return UniversalConstructorOutput(
@@ -697,7 +692,7 @@ def _handle_update_action(
             )
 
         # Validate TOOL_META exists in new code
-        new_meta = _extract_tool_meta(python_code)
+        new_meta = provider.extract_tool_meta(python_code)
         if new_meta is None:
             return UniversalConstructorOutput(
                 action="update",
@@ -706,7 +701,7 @@ def _handle_update_action(
             )
 
         # Validate TOOL_META has required fields
-        meta_errors = _validate_tool_meta(new_meta)
+        meta_errors = provider.validate_tool_meta(new_meta)
         if meta_errors:
             return UniversalConstructorOutput(
                 action="update",
@@ -734,7 +729,7 @@ def _handle_update_action(
         return UniversalConstructorOutput(
             action="update",
             success=True,
-            update_result=_get_uc_models().UCUpdateOutput(
+            update_result=UCUpdateOutput(
                 success=True,
                 tool_name=tool_name,
                 source_path=source_path,
@@ -776,7 +771,7 @@ def _handle_info_action(
             error="tool_name is required for info action",
         )
 
-    registry = get_uc_registry()
+    registry = _get_uc_provider()
     tool = registry.get_tool(tool_name)
 
     if not tool:
@@ -801,7 +796,7 @@ def _handle_info_action(
     return UniversalConstructorOutput(
         action="info",
         success=True,
-        info_result=_get_uc_models().UCInfoOutput(
+        info_result=UCInfoOutput(
             success=True,
             tool=tool,
             source_code=source_code,
@@ -815,9 +810,6 @@ def register_universal_constructor(agent):
     Args:
         agent: The pydantic-ai agent to register the tool with
     """
-    # Ensure the response model schema is built (importing the plugin lazily)
-    # before pydantic-ai introspects the tool's return type.
-    _get_uc_models()
 
     @agent.tool
     async def universal_constructor(

--- a/code_puppy/tools/universal_constructor.py
+++ b/code_puppy/tools/universal_constructor.py
@@ -8,20 +8,55 @@ import subprocess
 import time
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
-from typing import Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 from pydantic_ai import RunContext
 
 from code_puppy.messaging import get_message_bus
 from code_puppy.messaging.messages import UniversalConstructorMessage
-from code_puppy.plugins.universal_constructor.models import (
-    UCCallOutput,
-    UCCreateOutput,
-    UCInfoOutput,
-    UCListOutput,
-    UCUpdateOutput,
-)
+
+
+def get_uc_registry():
+    """Accessor for the shared UC registry singleton.
+
+    Lazily imports and returns the plugin's global registry on each call so
+    that this core module never pulls the plugin in at import time. The
+    plugin package can therefore live outside core.
+    """
+    from code_puppy.plugins.universal_constructor.registry import get_registry
+
+    return get_registry()
+
+
+if TYPE_CHECKING:
+    UCListOutput = UCCallOutput = UCCreateOutput = UCUpdateOutput = UCInfoOutput = Any
+
+
+# ``UniversalConstructorOutput`` references the UC plugin's response models
+# (UCListOutput, ...). Those are imported lazily: the model uses forward
+# references plus ``defer_build``, and ``_get_uc_models()`` imports the plugin
+# and triggers a pydantic rebuild the first time the schema is needed.
+_UC_MODELS_READY = False
+
+
+def _get_uc_models():
+    """Lazily import UC response models and return their module."""
+    global _UC_MODELS_READY
+    from code_puppy.plugins.universal_constructor import models
+
+    if not _UC_MODELS_READY:
+        UniversalConstructorOutput.model_rebuild(
+            _types_namespace={
+                "UCListOutput": models.UCListOutput,
+                "UCCallOutput": models.UCCallOutput,
+                "UCCreateOutput": models.UCCreateOutput,
+                "UCUpdateOutput": models.UCUpdateOutput,
+                "UCInfoOutput": models.UCInfoOutput,
+            }
+        )
+        _UC_MODELS_READY = True
+    return models
 
 
 class UniversalConstructorOutput(BaseModel):
@@ -34,24 +69,32 @@ class UniversalConstructorOutput(BaseModel):
     success: bool = Field(..., description="Whether the operation succeeded")
     error: Optional[str] = Field(default=None, description="Error message if failed")
 
-    # Action-specific results (only one will be populated based on action)
-    list_result: Optional[UCListOutput] = Field(
+    # Action-specific results (only one will be populated based on action).
+    # Forward references: the UC plugin's response models are resolved lazily
+    # by _get_uc_models() so this module has no import-time plugin dep.
+    list_result: Optional["UCListOutput"] = Field(
         default=None, description="Result of list action"
     )
-    call_result: Optional[UCCallOutput] = Field(
+    call_result: Optional["UCCallOutput"] = Field(
         default=None, description="Result of call action"
     )
-    create_result: Optional[UCCreateOutput] = Field(
+    create_result: Optional["UCCreateOutput"] = Field(
         default=None, description="Result of create action"
     )
-    update_result: Optional[UCUpdateOutput] = Field(
+    update_result: Optional["UCUpdateOutput"] = Field(
         default=None, description="Result of update action"
     )
-    info_result: Optional[UCInfoOutput] = Field(
+    info_result: Optional["UCInfoOutput"] = Field(
         default=None, description="Result of info action"
     )
 
-    model_config = {"arbitrary_types_allowed": True}
+    model_config = {"arbitrary_types_allowed": True, "defer_build": True}
+
+    def __init__(self, **data):
+        # Resolve the UC plugin's response models on first construction so
+        # instances can be built even if the plugin wasn't imported yet.
+        _get_uc_models()
+        super().__init__(**data)
 
 
 def _stub_not_implemented(action: str) -> UniversalConstructorOutput:
@@ -233,10 +276,8 @@ def _handle_list_action(context: RunContext) -> UniversalConstructorOutput:
     Returns:
         UniversalConstructorOutput with list_result containing all enabled tools.
     """
-    from code_puppy.plugins.universal_constructor.registry import get_registry
-
     try:
-        registry = get_registry()
+        registry = get_uc_registry()
         # Get all tools (including disabled for count)
         all_tools = registry.list_tools(include_disabled=True)
         enabled_tools = [t for t in all_tools if t.meta.enabled]
@@ -244,7 +285,7 @@ def _handle_list_action(context: RunContext) -> UniversalConstructorOutput:
         return UniversalConstructorOutput(
             action="list",
             success=True,
-            list_result=UCListOutput(
+            list_result=_get_uc_models().UCListOutput(
                 tools=enabled_tools,
                 total_count=len(all_tools),
                 enabled_count=len(enabled_tools),
@@ -255,7 +296,7 @@ def _handle_list_action(context: RunContext) -> UniversalConstructorOutput:
             action="list",
             success=False,
             error=f"Failed to list tools: {e}",
-            list_result=UCListOutput(
+            list_result=_get_uc_models().UCListOutput(
                 tools=[],
                 total_count=0,
                 enabled_count=0,
@@ -290,9 +331,7 @@ def _handle_call_action(
             error="tool_name is required for call action",
         )
 
-    from code_puppy.plugins.universal_constructor.registry import get_registry
-
-    registry = get_registry()
+    registry = get_uc_registry()
     tool = registry.get_tool(tool_name)
 
     if not tool:
@@ -360,7 +399,7 @@ def _handle_call_action(
         return UniversalConstructorOutput(
             action="call",
             success=True,
-            call_result=UCCallOutput(
+            call_result=_get_uc_models().UCCallOutput(
                 success=True,
                 tool_name=tool_name,
                 result=result,
@@ -421,7 +460,6 @@ def _handle_create_action(
     from pathlib import Path
 
     from code_puppy.plugins.universal_constructor import USER_UC_DIR
-    from code_puppy.plugins.universal_constructor.registry import get_registry
     from code_puppy.plugins.universal_constructor.sandbox import (
         _extract_tool_meta,
         _validate_tool_meta,
@@ -559,7 +597,7 @@ def _handle_create_action(
 
     # Reload registry to pick up the new tool
     try:
-        registry = get_registry()
+        registry = get_uc_registry()
         registry.reload()
     except Exception as e:
         # Tool was written but registry reload failed - still a partial success
@@ -571,7 +609,7 @@ def _handle_create_action(
     return UniversalConstructorOutput(
         action="create",
         success=True,
-        create_result=UCCreateOutput(
+        create_result=_get_uc_models().UCCreateOutput(
             success=True,
             tool_name=full_name,
             source_path=str(file_path),
@@ -607,7 +645,6 @@ def _handle_update_action(
     """
     from pathlib import Path
 
-    from code_puppy.plugins.universal_constructor.registry import get_registry
     from code_puppy.plugins.universal_constructor.sandbox import (
         _extract_tool_meta,
         _validate_tool_meta,
@@ -629,7 +666,7 @@ def _handle_update_action(
             error="python_code is required for update action",
         )
 
-    registry = get_registry()
+    registry = get_uc_registry()
     tool = registry.get_tool(tool_name)
 
     if not tool:
@@ -697,7 +734,7 @@ def _handle_update_action(
         return UniversalConstructorOutput(
             action="update",
             success=True,
-            update_result=UCUpdateOutput(
+            update_result=_get_uc_models().UCUpdateOutput(
                 success=True,
                 tool_name=tool_name,
                 source_path=source_path,
@@ -732,8 +769,6 @@ def _handle_info_action(
     """
     from pathlib import Path
 
-    from code_puppy.plugins.universal_constructor.registry import get_registry
-
     if not tool_name:
         return UniversalConstructorOutput(
             action="info",
@@ -741,7 +776,7 @@ def _handle_info_action(
             error="tool_name is required for info action",
         )
 
-    registry = get_registry()
+    registry = get_uc_registry()
     tool = registry.get_tool(tool_name)
 
     if not tool:
@@ -766,7 +801,7 @@ def _handle_info_action(
     return UniversalConstructorOutput(
         action="info",
         success=True,
-        info_result=UCInfoOutput(
+        info_result=_get_uc_models().UCInfoOutput(
             success=True,
             tool=tool,
             source_code=source_code,
@@ -780,6 +815,9 @@ def register_universal_constructor(agent):
     Args:
         agent: The pydantic-ai agent to register the tool with
     """
+    # Ensure the response model schema is built (importing the plugin lazily)
+    # before pydantic-ai introspects the tool's return type.
+    _get_uc_models()
 
     @agent.tool
     async def universal_constructor(

--- a/code_puppy/universal_constructor_provider.py
+++ b/code_puppy/universal_constructor_provider.py
@@ -1,5 +1,6 @@
-"""Provider seam for the optional Universal Constructor plugin."""
+"""Ownership-aware provider seam for the optional Universal Constructor plugin."""
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Protocol
 
@@ -39,23 +40,58 @@ class UniversalConstructorProvider(Protocol):
         """Return non-blocking safety warnings for Python source."""
 
 
-_provider: UniversalConstructorProvider | None = None
+@dataclass(frozen=True)
+class UniversalConstructorProviderRegistration:
+    """Identity token for one provider registration and its plugin owner."""
+
+    provider: UniversalConstructorProvider
+    owner: str | None
+
+
+_registration: UniversalConstructorProviderRegistration | None = None
 
 
 def register_universal_constructor_provider(
     provider: UniversalConstructorProvider,
-) -> None:
-    """Register the process-wide Universal Constructor provider."""
-    global _provider
-    _provider = provider
+    *,
+    owner: str | None = None,
+) -> UniversalConstructorProviderRegistration:
+    """Install a provider and return an ownership-aware identity token.
+
+    Re-registering replaces the current provider. The returned token can be
+    explicitly unregistered; stale tokens cannot remove a newer registration.
+    When no owner is supplied, the plugin loader's current owner is captured.
+    """
+    from code_puppy.callbacks import get_loading_context
+
+    registration = UniversalConstructorProviderRegistration(
+        provider=provider,
+        owner=owner if owner is not None else get_loading_context(),
+    )
+    global _registration
+    _registration = registration
+    return registration
+
+
+def unregister_universal_constructor_provider(
+    registration: UniversalConstructorProviderRegistration,
+) -> bool:
+    """Unregister ``registration`` only if it is still active."""
+    global _registration
+    if _registration is not registration:
+        return False
+    _registration = None
+    return True
 
 
 def get_universal_constructor_provider() -> UniversalConstructorProvider | None:
-    """Return the registered provider, or ``None`` when the plugin is absent."""
-    return _provider
+    """Return the provider only while its owning plugin is enabled."""
+    registration = _registration
+    if registration is None:
+        return None
 
+    from code_puppy.callbacks import is_callback_owner_enabled
 
-def clear_universal_constructor_provider() -> None:
-    """Clear the provider, primarily for plugin unloads and isolated tests."""
-    global _provider
-    _provider = None
+    if not is_callback_owner_enabled(registration.owner):
+        return None
+    return registration.provider

--- a/code_puppy/universal_constructor_provider.py
+++ b/code_puppy/universal_constructor_provider.py
@@ -1,0 +1,61 @@
+"""Provider seam for the optional Universal Constructor plugin."""
+
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+
+class UniversalConstructorProvider(Protocol):
+    """Capabilities core consumers need from a Universal Constructor plugin."""
+
+    @property
+    def tools_dir(self) -> Path:
+        """Directory containing user-created tools."""
+
+    def list_tools(self, include_disabled: bool = False) -> list[Any]:
+        """Return discovered tools."""
+
+    def get_tool(self, name: str) -> Any | None:
+        """Return tool metadata by full name."""
+
+    def get_tool_function(self, name: str) -> Callable[..., Any] | None:
+        """Return a tool's callable implementation."""
+
+    def reload(self) -> int:
+        """Reload all tools and return the number discovered."""
+
+    def validate_syntax(self, code: str) -> Any:
+        """Validate Python syntax."""
+
+    def extract_function_info(self, code: str) -> Any:
+        """Extract callable metadata from Python source."""
+
+    def extract_tool_meta(self, code: str) -> dict[str, Any] | None:
+        """Extract TOOL_META from Python source."""
+
+    def validate_tool_meta(self, meta: dict[str, Any]) -> list[str]:
+        """Validate TOOL_META fields."""
+
+    def check_dangerous_patterns(self, code: str) -> Any:
+        """Return non-blocking safety warnings for Python source."""
+
+
+_provider: UniversalConstructorProvider | None = None
+
+
+def register_universal_constructor_provider(
+    provider: UniversalConstructorProvider,
+) -> None:
+    """Register the process-wide Universal Constructor provider."""
+    global _provider
+    _provider = provider
+
+
+def get_universal_constructor_provider() -> UniversalConstructorProvider | None:
+    """Return the registered provider, or ``None`` when the plugin is absent."""
+    return _provider
+
+
+def clear_universal_constructor_provider() -> None:
+    """Clear the provider, primarily for plugin unloads and isolated tests."""
+    global _provider
+    _provider = None

--- a/tests/test_universal_constructor_provider.py
+++ b/tests/test_universal_constructor_provider.py
@@ -1,0 +1,102 @@
+"""Tests for the Universal Constructor provider seam."""
+
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from code_puppy.universal_constructor_provider import (
+    clear_universal_constructor_provider,
+    get_universal_constructor_provider,
+    register_universal_constructor_provider,
+)
+
+
+@pytest.fixture
+def isolated_provider():
+    """Restore the process provider after a test mutates the singleton."""
+    original = get_universal_constructor_provider()
+    clear_universal_constructor_provider()
+    yield
+    if original is not None:
+        register_universal_constructor_provider(original)
+
+
+def test_core_surfaces_import_when_uc_plugin_is_unavailable():
+    """Core must not import the optional plugin, even through a lazy shim."""
+    script = r"""
+import importlib.abc
+import sys
+
+
+class BlockUniversalConstructor(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.startswith("code_puppy.plugins.universal_constructor"):
+            raise ImportError(f"blocked optional plugin: {fullname}")
+        return None
+
+
+sys.meta_path.insert(0, BlockUniversalConstructor())
+import code_puppy.tools
+import code_puppy.tools.universal_constructor
+import code_puppy.agents.json_agent
+import code_puppy.agents.agent_creator_agent
+import code_puppy.command_line.uc_menu
+
+assert "universal_constructor" not in code_puppy.tools.TOOL_REGISTRY
+loaded = [
+    name for name in sys.modules
+    if name.startswith("code_puppy.plugins.universal_constructor")
+]
+assert loaded == [], loaded
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.anyio
+async def test_no_provider_returns_clear_tool_error(isolated_provider):
+    from code_puppy.tools.universal_constructor import universal_constructor_impl
+
+    with patch("code_puppy.tools.universal_constructor.get_message_bus"):
+        result = await universal_constructor_impl(MagicMock(), "list")
+
+    assert result.success is False
+    assert result.error == "Universal Constructor provider is not available"
+
+
+@pytest.mark.anyio
+async def test_registered_provider_drives_list_action(isolated_provider):
+    from code_puppy.tools.universal_constructor import universal_constructor_impl
+
+    tool = MagicMock()
+    tool.meta.enabled = True
+    provider = MagicMock()
+    provider.list_tools.return_value = [tool]
+    register_universal_constructor_provider(provider)
+
+    with patch("code_puppy.tools.universal_constructor.get_message_bus"):
+        result = await universal_constructor_impl(MagicMock(), "list")
+
+    provider.list_tools.assert_called_once_with(include_disabled=True)
+    assert result.success is True
+    assert result.list_result.total_count == 1
+    assert result.list_result.enabled_count == 1
+
+
+def test_uc_menu_returns_empty_without_provider(isolated_provider):
+    from code_puppy.command_line.uc_menu import _get_tool_entries
+
+    assert _get_tool_entries() == []
+
+
+def test_plugin_callbacks_register_provider_and_tool():
+    from code_puppy.plugins.universal_constructor import register_callbacks
+
+    assert get_universal_constructor_provider() is not None
+    contributions = register_callbacks._register_tools()
+    assert [item["name"] for item in contributions] == ["universal_constructor"]
+    assert callable(contributions[0]["register_func"])

--- a/tests/test_universal_constructor_provider.py
+++ b/tests/test_universal_constructor_provider.py
@@ -6,21 +6,21 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from code_puppy import universal_constructor_provider as ucp
 from code_puppy.universal_constructor_provider import (
-    clear_universal_constructor_provider,
     get_universal_constructor_provider,
     register_universal_constructor_provider,
+    unregister_universal_constructor_provider,
 )
 
 
 @pytest.fixture
 def isolated_provider():
-    """Restore the process provider after a test mutates the singleton."""
-    original = get_universal_constructor_provider()
-    clear_universal_constructor_provider()
+    """Restore the process registration after a test mutates the singleton."""
+    original = ucp._registration
+    ucp._registration = None
     yield
-    if original is not None:
-        register_universal_constructor_provider(original)
+    ucp._registration = original
 
 
 def test_core_surfaces_import_when_uc_plugin_is_unavailable():
@@ -91,6 +91,61 @@ def test_uc_menu_returns_empty_without_provider(isolated_provider):
     from code_puppy.command_line.uc_menu import _get_tool_entries
 
     assert _get_tool_entries() == []
+
+
+def test_registration_captures_plugin_loading_owner(isolated_provider):
+    from code_puppy.callbacks import clear_loading_context, set_loading_context
+
+    set_loading_context("universal_constructor")
+    try:
+        registration = register_universal_constructor_provider(MagicMock())
+    finally:
+        clear_loading_context()
+
+    assert registration.owner == "universal_constructor"
+
+
+def test_disabled_owner_makes_loaded_provider_inactive(isolated_provider, monkeypatch):
+    provider = MagicMock()
+    registration = register_universal_constructor_provider(
+        provider, owner="universal_constructor"
+    )
+    monkeypatch.setattr(
+        "code_puppy.plugins.config.get_disabled_plugins",
+        lambda: {"universal_constructor"},
+    )
+
+    assert registration.owner == "universal_constructor"
+    assert get_universal_constructor_provider() is None
+
+    monkeypatch.setattr(
+        "code_puppy.plugins.config.get_disabled_plugins",
+        lambda: set(),
+    )
+    assert get_universal_constructor_provider() is provider
+
+
+def test_explicit_unregister_restores_no_provider_fallback(isolated_provider):
+    registration = register_universal_constructor_provider(MagicMock())
+
+    assert unregister_universal_constructor_provider(registration) is True
+    assert get_universal_constructor_provider() is None
+    assert unregister_universal_constructor_provider(registration) is False
+
+
+def test_reregistration_replaces_provider_and_stale_unregister_is_safe(
+    isolated_provider,
+):
+    first = MagicMock(name="first")
+    first_registration = register_universal_constructor_provider(first)
+    second = MagicMock(name="second")
+    second_registration = register_universal_constructor_provider(second)
+
+    assert get_universal_constructor_provider() is second
+    assert unregister_universal_constructor_provider(first_registration) is False
+    assert get_universal_constructor_provider() is second
+    assert unregister_universal_constructor_provider(second_registration) is True
+    assert get_universal_constructor_provider() is None
 
 
 def test_plugin_callbacks_register_provider_and_tool():


### PR DESCRIPTION
Fixes #726.

Replaces core->plugin imports with lazy access + hook-driven registration.