### PR TITLE
Decouple ask-user-question theme integration

### DIFF
--- a/code_puppy/tools/ask_user_question/theme.py
+++ b/code_puppy/tools/ask_user_question/theme.py
@@ -126,12 +126,15 @@ _DEFAULT_RICH = RichColors()
 
 def get_rich_colors() -> RichColors:
     """Return Rich styles backed by the shared prompt-toolkit palette."""
-    from code_puppy.plugins.theme.prompt_toolkit_theme import get_style_rules
+    from code_puppy.callbacks import on_prompt_toolkit_style
 
-    muted_rule = get_style_rules().get("tui.muted", "").removeprefix("fg:")
-    if not muted_rule:
+    style = on_prompt_toolkit_style()
+    if style is None:
         return _DEFAULT_RICH
-    muted = muted_rule.split(maxsplit=1)[0]
+
+    muted = style.get_attrs_for_style_str("class:tui.muted").color
+    if not muted or muted == "default":
+        return _DEFAULT_RICH
 
     muted_style = f"{muted} italic"
     return _DEFAULT_RICH._replace(

--- a/tests/tools/test_ask_user_question/test_theme.py
+++ b/tests/tools/test_ask_user_question/test_theme.py
@@ -1,0 +1,30 @@
+"""Tests for ask-user-question theme callback integration."""
+
+from prompt_toolkit.styles import Style
+
+from code_puppy.tools.ask_user_question.theme import RichColors, get_rich_colors
+
+
+def test_rich_colors_use_muted_role_from_prompt_toolkit_callback(monkeypatch):
+    resolved_style = Style.from_dict({"tui.muted": "fg:#93a1a1"})
+    monkeypatch.setattr(
+        "code_puppy.callbacks.on_prompt_toolkit_style",
+        lambda: resolved_style,
+    )
+
+    colors = get_rich_colors()
+
+    assert colors.progress == "93a1a1 italic"
+    assert colors.question_hint == "93a1a1 italic"
+    assert colors.description == "93a1a1 italic"
+    assert colors.input_hint == "93a1a1 italic"
+    assert colors.help_close == "93a1a1 italic"
+
+
+def test_rich_colors_preserve_defaults_without_plugin_style(monkeypatch):
+    monkeypatch.setattr(
+        "code_puppy.callbacks.on_prompt_toolkit_style",
+        lambda: None,
+    )
+
+    assert get_rich_colors() == RichColors()


### PR DESCRIPTION
## Summary
- resolve ask-user-question Rich colors through the public `prompt_toolkit_style` callback chain
- remove the direct dependency on the theme plugin style-rule implementation
- preserve default colors when no plugin-provided style is available
- add focused callback integration tests

## Tests
- `uv run ruff check code_puppy/tools/ask_user_question/theme.py tests/tools/test_ask_user_question/test_theme.py`
- `uv run pytest -q tests/tools/test_ask_user_question/test_theme.py tests/tools/test_ask_user_question tests/test_ask_user_question_full_coverage.py tests/plugins/test_prompt_toolkit_theme.py tests/plugins/test_theme_plugin.py` (226 passed)
- `uv run pytest -q tests/plugins` (1812 passed)
- `git diff --check`

Fixes #734