### PR TITLE
Decouple quick resume from statusline

### DIFF
--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -63,6 +63,7 @@ PhaseType = Literal[
     "post_autosave",
     "notification",
     "awaiting_user_input",
+    "git_branch_provider",
 ]
 CallbackFunc = Callable[..., Any]
 
@@ -126,6 +127,7 @@ _callbacks: Dict[PhaseType, List[CallbackFunc]] = {
     "post_autosave": [],
     "notification": [],
     "awaiting_user_input": [],
+    "git_branch_provider": [],
 }
 
 logger = logging.getLogger(__name__)
@@ -350,6 +352,14 @@ async def on_version_check(*args, **kwargs) -> List[Any]:
 
 def on_load_model_config(*args, **kwargs) -> List[Any]:
     return _trigger_callbacks_sync("load_model_config", *args, **kwargs)
+
+
+def get_git_branch(cwd: str) -> Optional[str]:
+    """Return a branch from the first plugin provider that can detect one."""
+    for branch in _trigger_callbacks_sync("git_branch_provider", cwd):
+        if branch:
+            return str(branch)
+    return None
 
 
 def on_load_models_config() -> List[Any]:

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -2556,9 +2556,9 @@ def get_quick_resume_location(
     branch: Optional[str] = None
     if git_root:
         try:
-            from code_puppy.plugins.statusline.payload import detect_git_branch
+            from code_puppy.callbacks import get_git_branch
 
-            branch = detect_git_branch(cwd)
+            branch = get_git_branch(cwd)
         except Exception:
             branch = None
     return os.path.realpath(cwd), branch

--- a/code_puppy/plugins/statusline/register_callbacks.py
+++ b/code_puppy/plugins/statusline/register_callbacks.py
@@ -7,6 +7,7 @@ from typing import Any, List, Optional, Tuple
 
 from code_puppy.callbacks import register_callback
 
+from .payload import detect_git_branch
 from .prompt_patch import install_prompt_patch
 from .statusline_command import handle_statusline_command, statusline_command_help
 
@@ -32,6 +33,7 @@ def _handle_custom_command(command: str, name: str) -> Optional[Any]:
         return None
 
 
+register_callback("git_branch_provider", detect_git_branch)
 register_callback("startup", _on_startup)
 register_callback("custom_command_help", _custom_command_help)
 register_callback("custom_command", _handle_custom_command)

--- a/tests/test_quick_resume.py
+++ b/tests/test_quick_resume.py
@@ -11,6 +11,7 @@ import pytest
 
 from code_puppy.cli_runner import apply_quick_resume
 from code_puppy.command_line.session_commands import _parse_quick_resume_target
+from code_puppy.config import get_quick_resume_location
 
 
 @pytest.mark.parametrize(
@@ -41,6 +42,43 @@ def _args(**kwargs):
     for key, value in kwargs.items():
         setattr(ns, key, value)
     return ns
+
+
+def test_git_branch_provider_returns_first_detected_branch(monkeypatch):
+    from code_puppy import callbacks
+
+    monkeypatch.setattr(
+        callbacks,
+        "_trigger_callbacks_sync",
+        lambda phase, cwd: [None, "feature/provider", "ignored"],
+    )
+
+    assert callbacks.get_git_branch("/repo") == "feature/provider"
+
+
+def test_git_branch_provider_safely_defaults_to_none(monkeypatch):
+    from code_puppy import callbacks
+
+    monkeypatch.setattr(callbacks, "_trigger_callbacks_sync", lambda phase, cwd: [])
+
+    assert callbacks.get_git_branch("/repo") is None
+
+
+def test_get_quick_resume_location_uses_registered_branch_provider(monkeypatch):
+    """Git scopes retain branch-specific quick-resume keys via the plugin seam."""
+    monkeypatch.setattr("code_puppy.config._detect_git_toplevel", lambda path: "/repo")
+    branch = "feature/statusline-decoupling"
+    monkeypatch.setattr("code_puppy.callbacks.get_git_branch", lambda cwd: branch)
+
+    assert get_quick_resume_location("/repo") == ("/repo", branch)
+
+
+def test_get_quick_resume_location_without_branch_provider(monkeypatch):
+    """Quick-resume safely falls back to an unbranched Git scope."""
+    monkeypatch.setattr("code_puppy.config._detect_git_toplevel", lambda path: "/repo")
+    monkeypatch.setattr("code_puppy.callbacks.get_git_branch", lambda cwd: None)
+
+    assert get_quick_resume_location("/repo") == ("/repo", None)
 
 
 def test_apply_quick_resume_noop_when_unset():


### PR DESCRIPTION
## Summary
- add a narrow git-branch provider hook to the existing callback registry
- have the statusline plugin self-register its existing branch detector
- make quick-resume consume the provider with a safe no-plugin fallback
- preserve branch-scoped quick-resume behavior when statusline is loaded

## Tests
- `uv run ruff check code_puppy/callbacks.py code_puppy/config.py code_puppy/plugins/statusline/register_callbacks.py tests/test_quick_resume.py`
- `git diff --check`
- `uv run pytest -q tests/test_quick_resume.py tests/plugins/test_statusline_plugin.py tests/test_config_full_coverage.py` (247 passed)
- `uv run pytest -q tests/plugins` (1812 passed, 1 pre-existing RuntimeWarning)

Fixes #731