### PR TITLE
Decouple Ollama setup completion provider

### DIFF
--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -47,6 +47,7 @@ PhaseType = Literal[
     "register_mcp_catalog_servers",
     "register_browser_types",
     "register_model_providers",
+    "register_completion_provider",
     "message_history_processor_start",
     "message_history_processor_end",
     "on_message",
@@ -110,6 +111,7 @@ _callbacks: Dict[PhaseType, List[CallbackFunc]] = {
     "register_mcp_catalog_servers": [],
     "register_browser_types": [],
     "register_model_providers": [],
+    "register_completion_provider": [],
     "message_history_processor_start": [],
     "message_history_processor_end": [],
     "on_message": [],
@@ -242,6 +244,19 @@ def get_callbacks(
         return all_cbs
 
     return [cb for cb in all_cbs if _callback_owners.get(cb) not in disabled]
+
+
+def get_completion_providers() -> List[Any]:
+    """Build completers contributed by enabled plugins.
+
+    Provider failures are isolated by the normal callback machinery, and
+    ``None`` lets an optional provider decline registration at runtime.
+    """
+    return [
+        completer
+        for completer in _trigger_callbacks_sync("register_completion_provider")
+        if completer is not None
+    ]
 
 
 def count_callbacks(phase: Optional[PhaseType] = None) -> int:

--- a/code_puppy/command_line/prompt_toolkit_completion.py
+++ b/code_puppy/command_line/prompt_toolkit_completion.py
@@ -708,7 +708,7 @@ async def get_input_with_combined_completion(
     # Use SafeFileHistory to handle encoding errors gracefully on Windows
     history = SafeFileHistory(history_file) if history_file else None
     # Build the base completer list, then bolt on any plugin completers.
-    from code_puppy.plugins.ollama_setup.completer import OllamaSetupCompleter
+    from code_puppy.callbacks import get_completion_providers
 
     completer = merge_completers(
         [
@@ -728,7 +728,7 @@ async def get_input_with_combined_completion(
             ModelNameCompleter(trigger="/fork", prefix="@"),
             MCPCompleter(trigger="/mcp"),
             SkillsCompleter(trigger="/skills"),
-            OllamaSetupCompleter(),
+            *get_completion_providers(),
             SlashCompleter(),
         ]
     )

--- a/code_puppy/messaging/editor_completion.py
+++ b/code_puppy/messaging/editor_completion.py
@@ -41,6 +41,7 @@ def build_completer():
     """
     from prompt_toolkit.completion import merge_completers
 
+    from code_puppy.callbacks import get_completion_providers
     from code_puppy.command_line.file_path_completion import FilePathCompleter
     from code_puppy.command_line.load_context_completion import LoadContextCompleter
     from code_puppy.command_line.mcp_completion import MCPCompleter
@@ -56,7 +57,6 @@ def build_completer():
         SlashCompleter,
     )
     from code_puppy.command_line.skills_completion import SkillsCompleter
-    from code_puppy.plugins.ollama_setup.completer import OllamaSetupCompleter
 
     return merge_completers(
         [
@@ -76,7 +76,7 @@ def build_completer():
             ModelNameCompleter(trigger="/fork", prefix="@"),
             MCPCompleter(trigger="/mcp"),
             SkillsCompleter(trigger="/skills"),
-            OllamaSetupCompleter(),
+            *get_completion_providers(),
             SlashCompleter(),
         ]
     )

--- a/code_puppy/plugins/ollama_setup/register_callbacks.py
+++ b/code_puppy/plugins/ollama_setup/register_callbacks.py
@@ -408,5 +408,13 @@ def _custom_help():
 
 # ── Register ────────────────────────────────────────────────────────────────
 
+
+def _completion_provider():
+    from code_puppy.plugins.ollama_setup.completer import OllamaSetupCompleter
+
+    return OllamaSetupCompleter()
+
+
+register_callback("register_completion_provider", _completion_provider)
 register_callback("custom_command", _handle_ollama_setup)
 register_callback("custom_command_help", _custom_help)

--- a/tests/plugins/test_completion_provider.py
+++ b/tests/plugins/test_completion_provider.py
@@ -1,0 +1,50 @@
+"""Completion-provider seam and Ollama plugin registration tests."""
+
+from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.document import Document
+
+from code_puppy import callbacks
+from code_puppy.messaging.editor_completion import build_completer
+
+
+class PluginCompleter(Completer):
+    def get_completions(self, document, complete_event):
+        if document.text_before_cursor == "/plugin":
+            yield Completion("-command", start_position=0)
+
+
+def _completion_texts(completer, text):
+    return {
+        item.text
+        for item in completer.get_completions(
+            Document(text, cursor_position=len(text)), None
+        )
+    }
+
+
+def test_build_completer_works_without_plugin_providers(monkeypatch):
+    monkeypatch.setitem(callbacks._callbacks, "register_completion_provider", [])
+
+    completer = build_completer()
+
+    assert "-command" not in _completion_texts(completer, "/plugin")
+
+
+def test_build_completer_includes_registered_provider(monkeypatch):
+    monkeypatch.setitem(callbacks._callbacks, "register_completion_provider", [])
+    callbacks.register_callback("register_completion_provider", PluginCompleter)
+
+    completer = build_completer()
+
+    assert "-command" in _completion_texts(completer, "/plugin")
+
+
+def test_ollama_plugin_registers_completion_provider(monkeypatch):
+    monkeypatch.setitem(callbacks._callbacks, "register_completion_provider", [])
+    from code_puppy.plugins.ollama_setup.register_callbacks import _completion_provider
+
+    callbacks.register_callback("register_completion_provider", _completion_provider)
+
+    assert "glm-5:cloud" in _completion_texts(
+        callbacks.get_completion_providers()[0], "/ollama-setup g"
+    )


### PR DESCRIPTION
## Summary
- add a small generic callback seam for plugin completion providers
- have `ollama_setup` self-register its completer
- preserve classic prompt and persistent editor completion without direct Ollama imports
- cover provider registration and absent-plugin fallback

## Tests
- `uv run ruff check code_puppy/callbacks.py code_puppy/command_line/prompt_toolkit_completion.py code_puppy/messaging/editor_completion.py code_puppy/plugins/ollama_setup/register_callbacks.py tests/plugins/test_completion_provider.py`
- `uv run pytest -q --no-cov tests/plugins/test_completion_provider.py tests/messaging/test_editor_completion.py tests/test_prompt_toolkit_completion.py` (71 passed, 1 xpassed)
- `uv run pytest -q --no-cov tests/plugins` (1815 passed)
- `git diff --check`

Fixes #733