### PR TITLE
Decouple customizable command dispatch

### DIFF
--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -66,6 +66,20 @@ PhaseType = Literal[
 ]
 CallbackFunc = Callable[..., Any]
 
+
+class CustomCommandResult:
+    """Custom command content that should be processed as user input."""
+
+    def __init__(self, content: str):
+        self.content = content
+
+    def __str__(self) -> str:
+        return self.content
+
+    def __repr__(self) -> str:
+        return f"CustomCommandResult({len(self.content)} chars)"
+
+
 _callbacks: Dict[PhaseType, List[CallbackFunc]] = {
     "startup": [],
     "shutdown": [],

--- a/code_puppy/command_line/command_handler.py
+++ b/code_puppy/command_line/command_handler.py
@@ -8,23 +8,6 @@ import code_puppy.command_line.uc_menu  # noqa: F401
 _PLUGINS_LOADED = False
 
 
-def _is_namespaced_custom_command(first_token: str) -> bool:
-    """True if ``first_token`` (e.g. ``/flux/status``) is a loaded custom command.
-
-    Namespaced custom commands legitimately contain multiple slashes, which
-    would otherwise trip the file-path disambiguation heuristic in
-    :func:`handle_command`. Fails closed (returns False) if the plugin isn't
-    available so genuine paths still fall through to normal input.
-    """
-    try:
-        from code_puppy.plugins.customizable_commands.register_callbacks import (
-            is_custom_command,
-        )
-    except ImportError:
-        return False
-    return is_custom_command(first_token.lstrip("/"))
-
-
 def get_commands_help():
     """Generate aligned commands help using Rich Text for safe markup.
 
@@ -179,6 +162,27 @@ def _ensure_plugins_loaded() -> None:
 # All command handlers moved to builtin_commands.py
 # The import above triggers their registration
 
+
+def _dispatch_custom_command(command: str, name: str):
+    """Dispatch through the plugin callback boundary.
+
+    Returns ``(handled, result)`` so namespaced commands can be distinguished
+    from file paths without knowing which plugin provides them.
+    """
+    from code_puppy import callbacks
+    from code_puppy.messaging import emit_info
+
+    for result in callbacks.on_custom_command(command=command, name=name):
+        if result is True:
+            return True, True
+        if isinstance(result, callbacks.CustomCommandResult):
+            return True, result.content
+        if isinstance(result, str):
+            emit_info(result)
+            return True, True
+    return False, None
+
+
 # ============================================================================
 # MAIN COMMAND DISPATCHER
 # ============================================================================
@@ -214,7 +218,15 @@ def handle_command(command: str):
     if command.startswith("/"):
         first_token = command.split()[0] if command.split() else command
         slash_count = first_token.count("/")
-        if slash_count > 1 and not _is_namespaced_custom_command(first_token):
+        if slash_count > 1:
+            name = first_token.lstrip("/")
+            try:
+                handled, result = _dispatch_custom_command(command, name)
+            except Exception as e:
+                emit_warning(f"Custom command hook error: {e}")
+                handled, result = False, None
+            if handled:
+                return result
             # This looks like a file path, not a command - let it be processed as normal input
             return False
 
@@ -271,33 +283,9 @@ def handle_command(command: str):
         # Extract command name without leading slash and arguments intact
         name = command[1:].split()[0] if len(command) > 1 else ""
         try:
-            from code_puppy import callbacks
-
-            # Import the special result class for markdown commands
-            try:
-                from code_puppy.plugins.customizable_commands.register_callbacks import (
-                    MarkdownCommandResult,
-                )
-            except ImportError:
-                MarkdownCommandResult = None
-
-            results = callbacks.on_custom_command(command=command, name=name)
-            # Iterate through callback results; treat str as handled (no model run)
-            for res in results:
-                if res is True:
-                    return True
-                if MarkdownCommandResult and isinstance(res, MarkdownCommandResult):
-                    # Special case: markdown command that should be processed as input
-                    # Replace the command with the markdown content and let it be processed
-                    # This is handled by the caller, so return the content as string
-                    return res.content
-                if isinstance(res, str):
-                    # Display returned text to the user and treat as handled
-                    try:
-                        emit_info(res)
-                    except Exception:
-                        pass
-                    return True
+            handled, result = _dispatch_custom_command(command, name)
+            if handled:
+                return result
         except Exception as e:
             # Log via emit_error but do not block default handling
             emit_warning(f"Custom command hook error: {e}")

--- a/code_puppy/plugins/customizable_commands/register_callbacks.py
+++ b/code_puppy/plugins/customizable_commands/register_callbacks.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from code_puppy.callbacks import register_callback
+from code_puppy.callbacks import CustomCommandResult, register_callback
 from code_puppy.config import CONFIG_DIR
 from code_puppy.messaging import emit_error, emit_info, emit_shell_line, emit_warning
 
@@ -70,17 +70,8 @@ def _is_trusted_exec_dir(dir_path: Path) -> bool:
     return False
 
 
-class MarkdownCommandResult:
-    """Special marker for markdown command results that should be processed as input."""
-
-    def __init__(self, content: str):
-        self.content = content
-
-    def __str__(self) -> str:
-        return self.content
-
-    def __repr__(self) -> str:
-        return f"MarkdownCommandResult({len(self.content)} chars)"
+# Backwards-compatible name for consumers that imported the plugin's marker.
+MarkdownCommandResult = CustomCommandResult
 
 
 # Namespace directories beginning with these prefixes are skipped entirely

--- a/tests/command_line/test_command_handler_coverage.py
+++ b/tests/command_line/test_command_handler_coverage.py
@@ -182,6 +182,31 @@ class TestHandleCommand:
             # Result is either True or the markdown content string
             assert result is not None and result is not False
 
+    @patch("code_puppy.command_line.command_handler._ensure_plugins_loaded")
+    @patch("code_puppy.callbacks.on_custom_command")
+    def test_namespaced_custom_command_dispatches_via_callback(
+        self, mock_custom, mock_plugins
+    ):
+        from code_puppy.callbacks import CustomCommandResult
+        from code_puppy.command_line.command_handler import handle_command
+
+        mock_custom.return_value = [CustomCommandResult("namespaced prompt")]
+
+        assert handle_command("/flux/status todo") == "namespaced prompt"
+        mock_custom.assert_called_once_with(
+            command="/flux/status todo", name="flux/status"
+        )
+
+    @patch("code_puppy.command_line.command_handler._ensure_plugins_loaded")
+    @patch("code_puppy.callbacks.on_custom_command", return_value=[None])
+    def test_namespaced_path_falls_through_callback(self, mock_custom, mock_plugins):
+        from code_puppy.command_line.command_handler import handle_command
+
+        assert handle_command("/Users/mike/project.py") is False
+        mock_custom.assert_called_once_with(
+            command="/Users/mike/project.py", name="Users/mike/project.py"
+        )
+
     def test_non_command(self):
         from code_puppy.command_line.command_handler import handle_command
 


### PR DESCRIPTION
## Summary
- route custom command execution through the registered `custom_command` callback
- preserve namespaced custom commands while allowing file paths to fall through
- move the custom command input result contract into core callbacks while retaining the plugin alias
- remove all customizable_commands plugin imports from the core command handler

Fixes #730

## Tests
- `uv run ruff check code_puppy/command_line/command_handler.py code_puppy/callbacks.py code_puppy/plugins/customizable_commands/register_callbacks.py tests/command_line/test_command_handler_coverage.py`
- `git diff --check`
- `uv run pytest -q tests/test_command_handler.py tests/command_line/test_command_handler_coverage.py tests/command_line/test_remaining_coverage.py tests/plugins/test_flux_bootstrap.py tests/plugins/test_remaining_coverage.py` (242 passed)
- `uv run pytest -q tests/plugins` (1812 passed, 1 warning)