### PR TITLE
Decouple DBOS state from set menu catalog

### DIFF
--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -66,6 +66,7 @@ PhaseType = Literal[
     "notification",
     "awaiting_user_input",
     "git_branch_provider",
+    "feature_capability",
 ]
 CallbackFunc = Callable[..., Any]
 
@@ -146,6 +147,7 @@ _callbacks: Dict[PhaseType, List[CallbackFunc]] = {
     "notification": [],
     "awaiting_user_input": [],
     "git_branch_provider": [],
+    "feature_capability": [],
 }
 
 logger = logging.getLogger(__name__)
@@ -291,6 +293,14 @@ def count_callbacks(phase: Optional[PhaseType] = None) -> int:
     if phase is None:
         return sum(len(callbacks) for callbacks in _callbacks.values())
     return len(_callbacks.get(phase, []))
+
+
+def get_feature_capability(name: str) -> bool:
+    """Return the last plugin-provided state for *name*, or safely default false."""
+    results = _trigger_callbacks_sync("feature_capability", name)
+    return next(
+        (result for result in reversed(results) if isinstance(result, bool)), False
+    )
 
 
 def _trigger_callbacks_sync(

--- a/code_puppy/command_line/set_menu_catalog.py
+++ b/code_puppy/command_line/set_menu_catalog.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from typing import Tuple
 
 from code_puppy.command_line.set_menu_schema import Setting, SettingsCategory
+from code_puppy.callbacks import get_feature_capability
 from code_puppy.command_line.set_menu_shims import (
     get_disable_mcp_servers_effective,
     get_goal_max_iterations_effective,
@@ -68,7 +69,6 @@ from code_puppy.config import (
     get_yolo_mode,
 )
 from code_puppy.keymap import get_cancel_agent_key
-from code_puppy.plugins.dbos_durable_exec.config import is_enabled as get_dbos_enabled
 
 
 # ---------------------------------------------------------------------------
@@ -313,7 +313,7 @@ _FEATURES = SettingsCategory(
             display_name="DBOS Durable Execution",
             description="Enable DBOS durable execution plugin.",
             type_hint="bool",
-            effective_getter=get_dbos_enabled,
+            effective_getter=lambda: get_feature_capability("dbos_durable_exec"),
             requires_restart=True,
         ),
         Setting(

--- a/code_puppy/plugins/dbos_durable_exec/config.py
+++ b/code_puppy/plugins/dbos_durable_exec/config.py
@@ -21,6 +21,11 @@ def is_enabled() -> bool:
     return str(cfg_val).strip().lower() in ("true", "1", "yes", "on")
 
 
+def feature_capability(name: str) -> bool | None:
+    """Expose plugin state through the generic feature-capability callback."""
+    return is_enabled() if name == "dbos_durable_exec" else None
+
+
 def set_enabled(enabled: bool) -> None:
     """Persist the 'enable_dbos' switch to puppy.cfg."""
     set_config_value("enable_dbos", "true" if enabled else "false")

--- a/code_puppy/plugins/dbos_durable_exec/register_callbacks.py
+++ b/code_puppy/plugins/dbos_durable_exec/register_callbacks.py
@@ -8,12 +8,15 @@ from code_puppy.callbacks import register_callback
 
 from .cancel import cancel_workflow
 from .commands import dbos_command_help, handle_dbos_command
-from .config import is_enabled
+from .config import feature_capability, is_enabled
 from .lifecycle import on_shutdown, on_startup
 from .runtime import dbos_run_context, skip_fallback_render
 from .wrapper import wrap_with_dbos_agent
 
 logger = logging.getLogger(__name__)
+
+
+register_callback("feature_capability", feature_capability)
 
 
 # Slash command is always available so users can /dbos on even when the

--- a/tests/command_line/test_set_menu.py
+++ b/tests/command_line/test_set_menu.py
@@ -47,6 +47,16 @@ def find_setting(key: str) -> Setting:
     raise AssertionError(f"Setting '{key}' not found in SETTINGS_CATEGORIES")
 
 
+def test_dbos_effective_value_uses_plugin_capability():
+    setting = find_setting("enable_dbos")
+    with patch(
+        "code_puppy.command_line.set_menu_catalog.get_feature_capability",
+        return_value=False,
+    ) as capability:
+        assert setting.effective_getter() is False
+    capability.assert_called_once_with("dbos_durable_exec")
+
+
 # ---------------------------------------------------------------------------
 # apply_setting validation
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_dbos_durable_exec.py
+++ b/tests/plugins/test_dbos_durable_exec.py
@@ -19,6 +19,7 @@ from code_puppy.callbacks import (
     clear_callbacks,
     count_callbacks,
     get_callbacks,
+    get_feature_capability,
 )
 from code_puppy.plugins.dbos_durable_exec import cancel as cancel_mod
 from code_puppy.plugins.dbos_durable_exec import commands as commands_mod
@@ -350,7 +351,7 @@ class TestHandleDbosCommand:
 
 
 # Phases owned by this plugin (slash-cmd hooks always, lifecycle behind dbos).
-_SLASH_PHASES = ("custom_command", "custom_command_help")
+_ALWAYS_PHASES = ("custom_command", "custom_command_help", "feature_capability")
 _DBOS_PHASES = (
     "startup",
     "shutdown",
@@ -364,7 +365,7 @@ _DBOS_PHASES = (
 @pytest.fixture
 def clean_callbacks():
     """Snapshot + restore the global callback registry around each test."""
-    saved = {p: get_callbacks(p) for p in _SLASH_PHASES + _DBOS_PHASES}
+    saved = {p: get_callbacks(p) for p in _ALWAYS_PHASES + _DBOS_PHASES}
     for p in saved:
         clear_callbacks(p)
     yield
@@ -387,9 +388,11 @@ class TestRegisterCallbacksWiring:
     def test_disabled_registers_only_slash_commands(self, monkeypatch, clean_callbacks):
         monkeypatch.setattr(config_mod, "is_enabled", lambda: False)
         _reload_register_callbacks()
-        # Slash command hooks always register.
-        for p in _SLASH_PHASES:
-            assert count_callbacks(p) == 1, f"expected slash cmd registered for {p}"
+        # Slash command and capability hooks always register.
+        for p in _ALWAYS_PHASES:
+            assert count_callbacks(p) == 1, f"expected callback registered for {p}"
+        assert get_feature_capability("dbos_durable_exec") is False
+        assert get_feature_capability("unknown") is False
         # DBOS-specific hooks should NOT.
         for p in _DBOS_PHASES:
             assert count_callbacks(p) == 0, f"unexpected callback on phase {p}"
@@ -400,8 +403,9 @@ class TestRegisterCallbacksWiring:
         monkeypatch.setattr(config_mod, "is_enabled", lambda: True)
         monkeypatch.setitem(sys.modules, "dbos", None)
         _reload_register_callbacks()
-        for p in _SLASH_PHASES:
+        for p in _ALWAYS_PHASES:
             assert count_callbacks(p) == 1
+        assert get_feature_capability("dbos_durable_exec") is True
         for p in _DBOS_PHASES:
             assert count_callbacks(p) == 0
 
@@ -412,8 +416,9 @@ class TestRegisterCallbacksWiring:
         fake_mod = types.ModuleType("dbos")
         monkeypatch.setitem(sys.modules, "dbos", fake_mod)
         _reload_register_callbacks()
-        for p in _SLASH_PHASES + _DBOS_PHASES:
+        for p in _ALWAYS_PHASES + _DBOS_PHASES:
             assert count_callbacks(p) >= 1, f"missing callback on phase {p}"
+        assert get_feature_capability("dbos_durable_exec") is True
 
     def test_idempotent_reload_does_not_double_register(
         self, monkeypatch, clean_callbacks
@@ -422,7 +427,7 @@ class TestRegisterCallbacksWiring:
         fake_mod = types.ModuleType("dbos")
         monkeypatch.setitem(sys.modules, "dbos", fake_mod)
         _reload_register_callbacks()
-        counts = {p: count_callbacks(p) for p in _SLASH_PHASES + _DBOS_PHASES}
+        counts = {p: count_callbacks(p) for p in _ALWAYS_PHASES + _DBOS_PHASES}
         _reload_register_callbacks()
-        counts_after = {p: count_callbacks(p) for p in _SLASH_PHASES + _DBOS_PHASES}
+        counts_after = {p: count_callbacks(p) for p in _ALWAYS_PHASES + _DBOS_PHASES}
         assert counts == counts_after, "register_callback should dedupe on reload"


### PR DESCRIPTION
## Summary
- remove the set-menu catalog's top-level import of DBOS plugin config
- expose DBOS enabled state through a generic plugin capability callback with a safe false fallback
- preserve configured enabled state even when the optional `dbos` package is unavailable

## Tests
- `uv run ruff format --check code_puppy/callbacks.py code_puppy/command_line/set_menu_catalog.py code_puppy/plugins/dbos_durable_exec/config.py code_puppy/plugins/dbos_durable_exec/register_callbacks.py tests/command_line/test_set_menu.py tests/plugins/test_dbos_durable_exec.py`
- `uv run ruff check code_puppy/callbacks.py code_puppy/command_line/set_menu_catalog.py code_puppy/plugins/dbos_durable_exec/config.py code_puppy/plugins/dbos_durable_exec/register_callbacks.py tests/command_line/test_set_menu.py tests/plugins/test_dbos_durable_exec.py`
- `uv run pytest -q tests/command_line/test_set_menu.py tests/plugins/test_dbos_durable_exec.py tests/plugins/test_dbos_startup_lock.py --no-cov` (89 passed)
- `uv run pytest -q tests/plugins --no-cov` (1812 passed)

Fixes #732