### PR TITLE
fix: support Ollama custom endpoint config

### DIFF
--- a/code_puppy/plugins/ollama/register_callbacks.py
+++ b/code_puppy/plugins/ollama/register_callbacks.py
@@ -73,7 +73,7 @@ def create_ollama_model(
     """
     try:
         if "custom_endpoint" in model_config:
-            url, headers, verify, api_key = get_custom_config(model_config)
+            url, headers, verify, api_key, _timeout = get_custom_config(model_config)
         else:
             # Derive base URL: OLLAMA_HOST env var → default
             ollama_host = os.environ.get("OLLAMA_HOST", "").rstrip("/")

--- a/tests/plugins/test_ollama_model.py
+++ b/tests/plugins/test_ollama_model.py
@@ -1,0 +1,80 @@
+"""Tests for the Ollama model plugin."""
+
+import asyncio
+from unittest.mock import patch
+
+import httpx
+
+from code_puppy.plugins.ollama.register_callbacks import create_ollama_model
+
+
+def _client(**kwargs):
+    return httpx.AsyncClient(**kwargs)
+
+
+@patch(
+    "code_puppy.plugins.ollama.register_callbacks.create_async_client",
+    side_effect=_client,
+)
+def test_custom_endpoint_accepts_timeout_from_get_custom_config(mock_client):
+    """A custom Ollama endpoint should instantiate with the current config shape."""
+    model_config = {
+        "type": "ollama",
+        "name": "qwen3:4b",
+        "custom_endpoint": {
+            "url": "https://ollama.example.com/v1",
+            "api_key": "ollama",
+        },
+    }
+
+    model = create_ollama_model("ollama-qwen3", model_config, {})
+
+    assert model is not None
+    assert model.model_name == "qwen3:4b"
+    assert str(model._provider.base_url).rstrip("/") == "https://ollama.example.com/v1"
+    mock_client.assert_called_once_with(headers={}, verify=None)
+    asyncio.run(model._provider._client.close())
+
+
+@patch(
+    "code_puppy.plugins.ollama.register_callbacks.create_async_client",
+    side_effect=_client,
+)
+def test_custom_endpoint_passes_headers_and_tls_config(mock_client):
+    """Custom endpoint headers and certificate settings remain supported."""
+    model_config = {
+        "type": "ollama",
+        "name": "qwen3:4b",
+        "custom_endpoint": {
+            "url": "https://ollama.example.com/v1",
+            "headers": {"X-Test": "value"},
+            "ca_certs_path": False,
+            "api_key": "ollama",
+        },
+    }
+
+    model = create_ollama_model("ollama-qwen3", model_config, {})
+
+    assert model is not None
+    mock_client.assert_called_once_with(
+        headers={"X-Test": "value"}, verify=False
+    )
+    asyncio.run(model._provider._client.close())
+
+
+@patch(
+    "code_puppy.plugins.ollama.register_callbacks.create_async_client",
+    side_effect=_client,
+)
+def test_local_endpoint_uses_ollama_defaults(mock_client, monkeypatch):
+    """Local Ollama configurations should not require a custom endpoint."""
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+
+    model = create_ollama_model(
+        "ollama-qwen3", {"type": "ollama", "name": "qwen3:4b"}, {}
+    )
+
+    assert model is not None
+    assert str(model._provider.base_url).rstrip("/") == "http://localhost:11434/v1"
+    mock_client.assert_called_once_with(headers={}, verify=None)
+    asyncio.run(model._provider._client.close())


### PR DESCRIPTION
## Summary
- Update the Ollama plugin for the current five-value `get_custom_config()` return shape.
- Add regression coverage for custom endpoints, headers/TLS settings, and local Ollama defaults.

## Bug
Ollama models configured with `custom_endpoint` failed during instantiation with `too many values to unpack (expected 4)` after `get_custom_config()` began returning the endpoint timeout as a fifth value.

## Test plan
- `uv run ruff check code_puppy/plugins/ollama/register_callbacks.py tests/plugins/test_ollama_model.py`
- `uv run pytest tests/plugins/test_ollama_model.py tests/test_model_factory.py -q`

No personal data, credentials, private endpoints, or local configuration were included. The repository does not contain a CONTRIBUTING.md or CODE_OF_CONDUCT.md file, so the change follows the existing code style, test layout, and conventional commit format.