### PR TITLE
PUP-583: Gate codex-imagegen skill on Codex OAuth, add namespace tags

### DIFF
--- a/code_puppy/plugins/chatgpt_oauth/IMAGEGEN_SKILL.md
+++ b/code_puppy/plugins/chatgpt_oauth/IMAGEGEN_SKILL.md
@@ -3,6 +3,11 @@ name: codex-imagegen
 description: Generate raster images with gpt-image-2 through Codex OAuth. Activate when the user asks to create a photo, illustration, icon, sprite, texture, product image, banner, or other raster artwork.
 version: "1.0"
 author: code-puppy
+tags:
+  - image-generation
+  - codex
+  - gpt-image
+  - artwork
 ---
 
 # Codex Image Generation

--- a/code_puppy/plugins/chatgpt_oauth/register_callbacks.py
+++ b/code_puppy/plugins/chatgpt_oauth/register_callbacks.py
@@ -14,6 +14,7 @@ from code_puppy.callbacks import register_callback
 from code_puppy.i18n import t
 from code_puppy.messaging import emit_error, emit_info, emit_success, emit_warning
 from code_puppy.model_switching import set_model_and_reload_agent
+from code_puppy.plugins.agent_skills.discovery import refresh_skill_cache
 
 from .config import CHATGPT_OAUTH_CONFIG, get_token_storage_path
 from .oauth_flow import run_oauth_flow
@@ -89,6 +90,10 @@ def _handle_chatgpt_logout() -> None:
 
     if was_authenticated:
         _reload_active_agent()
+        # Mirror the tool-unbinding reload above: the codex-imagegen skill is
+        # gated on auth too, so drop it from the skill cache immediately
+        # instead of leaving it visible until the next restart.
+        refresh_skill_cache()
 
 
 def _is_codex_oauth_authenticated() -> bool:
@@ -125,6 +130,10 @@ def _handle_custom_command(command: str, name: str) -> Optional[bool]:
     if name in {"chatgpt-auth", "codex-auth"}:
         run_oauth_flow()
         set_model_and_reload_agent("codex-gpt-5.6-sol")
+        # Authentication may have just succeeded, so the codex-imagegen skill
+        # (gated the same way as the codex_imagegen tool) needs to be
+        # re-discovered rather than waiting for the next process restart.
+        refresh_skill_cache()
         return True
 
     if name in {"chatgpt-status", "codex-status"}:
@@ -228,6 +237,13 @@ def _create_chatgpt_oauth_model(
 
 
 def _register_imagegen_skill() -> list[dict[str, str]]:
+    # Gated the same way as _advertise_imagegen_tool below: the skill's own
+    # instructions tell the model to call codex_imagegen(...), which doesn't
+    # exist as an available tool for an unauthenticated user. Hiding the
+    # skill itself avoids the confusing case where a model activates it,
+    # tries the tool call, and only then discovers auth is missing.
+    if not _is_codex_oauth_authenticated():
+        return []
     return [
         {
             "name": "codex-imagegen",

--- a/code_puppy/plugins/chatgpt_oauth/test_plugin.py
+++ b/code_puppy/plugins/chatgpt_oauth/test_plugin.py
@@ -216,14 +216,14 @@ def test_codex_imagegen_command():
 def test_imagegen_skill_and_tool_registration():
     from code_puppy.plugins.chatgpt_oauth import register_callbacks
 
-    skills = register_callbacks._register_imagegen_skill()
-    assert skills[0]["name"] == "codex-imagegen"
-    assert Path(skills[0]["skill_md_path"]).is_file()
     with patch.object(
         register_callbacks,
         "load_stored_tokens",
         return_value={"access_token": "token", "account_id": "account"},
     ):
+        skills = register_callbacks._register_imagegen_skill()
+        assert skills[0]["name"] == "codex-imagegen"
+        assert Path(skills[0]["skill_md_path"]).is_file()
         assert register_callbacks._advertise_imagegen_tool("code-puppy") == [
             "codex_imagegen"
         ]
@@ -231,6 +231,13 @@ def test_imagegen_skill_and_tool_registration():
     assert tools == [
         {"name": "codex_imagegen", "register_func": image_tool.register_codex_imagegen}
     ]
+
+
+def test_imagegen_skill_is_not_registered_when_logged_out():
+    from code_puppy.plugins.chatgpt_oauth import register_callbacks
+
+    with patch.object(register_callbacks, "load_stored_tokens", return_value=None):
+        assert register_callbacks._register_imagegen_skill() == []
 
 
 def test_imagegen_tool_is_not_advertised_when_logged_out():
@@ -258,11 +265,52 @@ def test_logout_reloads_agent_to_unbind_imagegen(tmp_path):
         patch.object(register_callbacks, "emit_info"),
         patch.object(register_callbacks, "emit_success"),
         patch.object(register_callbacks, "_reload_active_agent") as reload_agent,
+        patch.object(register_callbacks, "refresh_skill_cache") as refresh_skills,
     ):
         register_callbacks._handle_chatgpt_logout()
 
     assert not token_path.exists()
     reload_agent.assert_called_once_with()
+    refresh_skills.assert_called_once_with()
+
+
+def test_logout_does_not_refresh_skills_when_already_logged_out(tmp_path):
+    from code_puppy.plugins.chatgpt_oauth import register_callbacks
+
+    token_path = tmp_path / "tokens.json"
+    with (
+        patch.object(register_callbacks, "load_stored_tokens", return_value=None),
+        patch.object(
+            register_callbacks, "get_token_storage_path", return_value=token_path
+        ),
+        patch.object(register_callbacks, "remove_chatgpt_models", return_value=0),
+        patch.object(register_callbacks, "emit_info"),
+        patch.object(register_callbacks, "emit_success"),
+        patch.object(register_callbacks, "_reload_active_agent") as reload_agent,
+        patch.object(register_callbacks, "refresh_skill_cache") as refresh_skills,
+    ):
+        register_callbacks._handle_chatgpt_logout()
+
+    reload_agent.assert_not_called()
+    refresh_skills.assert_not_called()
+
+
+def test_auth_command_refreshes_skill_cache():
+    from code_puppy.plugins.chatgpt_oauth import register_callbacks
+
+    with (
+        patch.object(register_callbacks, "run_oauth_flow") as oauth_flow,
+        patch.object(register_callbacks, "set_model_and_reload_agent") as set_model,
+        patch.object(register_callbacks, "refresh_skill_cache") as refresh_skills,
+    ):
+        assert (
+            register_callbacks._handle_custom_command("/codex-auth", "codex-auth")
+            is True
+        )
+
+    oauth_flow.assert_called_once_with()
+    set_model.assert_called_once_with("codex-gpt-5.6-sol")
+    refresh_skills.assert_called_once_with()
 
 
 def test_codex_imagegen_agent_tool(tmp_path):


### PR DESCRIPTION
**Jira:** [PUP-583](https://jira.walmart.com/browse/PUP-583)

## What

Two related fixes to the built-in `codex-imagegen` skill (`chatgpt_oauth` plugin):

1. **Proactively hide the skill when Codex OAuth isn't authenticated**, instead of only gating the tool it depends on.
2. **Add namespace tags** to its frontmatter, which it previously had none of.

## Why

`codex_imagegen` (the tool) was already gated on auth via `_advertise_imagegen_tool`:

```python
def _advertise_imagegen_tool(agent_name: str | None = None) -> list[str]:
    del agent_name
    if not _is_codex_oauth_authenticated():
        return []
    return ["codex_imagegen"]
```

But `codex-imagegen` (the **skill**) was registered unconditionally via `_register_imagegen_skill`, with no equivalent check. An unauthenticated user could still see the skill in `/skills list` and the namespace directory, `activate_skill` it, and get instructions telling the model to call `codex_imagegen(...)` -- a tool that isn't actually wired into any agent for them. The skill's own content already anticipates this ("If authentication is missing, tell the user to run `/codex-auth`"), but that's a reactive fallback that only works if the model correctly diagnoses the failed tool call, not a proactive fix.

Separately: the skill had no `tags:` field at all. Under `namespace_skill_search` (#713), an untagged skill falls into the generic `General` namespace alongside every other untagged skill -- exactly the crowded/unhelpful bucket the authoring guide (also from #713/#714) tells skill authors to avoid landing in.

## How it works

1. **`_register_imagegen_skill()` now checks `_is_codex_oauth_authenticated()`** before returning the skill registration, mirroring `_advertise_imagegen_tool` exactly. Logged out -> skill doesn't register at all.
2. **`refresh_skill_cache()` is called from both the login and logout paths** so this takes effect immediately instead of requiring a process restart:
   - After `/codex-auth` / `/chatgpt-auth` succeeds (alongside the existing `set_model_and_reload_agent` call).
   - After `/codex-logout` / `/chatgpt-logout`, alongside the existing `_reload_active_agent()` call that already does the equivalent job for tool unbinding.
3. **Added tags** to `IMAGEGEN_SKILL.md`: `image-generation` (first tag -> namespace), `codex`, `gpt-image`, `artwork`.

## Testing

- Updated `test_imagegen_skill_and_tool_registration` to authenticate before asserting the skill registers (previously asserted unconditionally).
- Added `test_imagegen_skill_is_not_registered_when_logged_out` (mirrors the existing tool-side test of the same name pattern).
- Added `test_logout_reloads_agent_to_unbind_imagegen` assertion that `refresh_skill_cache()` is now also called, plus a new `test_logout_does_not_refresh_skills_when_already_logged_out` to confirm no-op behavior when there was nothing to unbind.
- Added `test_auth_command_refreshes_skill_cache` for the login path.
- 33/33 tests pass in `code_puppy/plugins/chatgpt_oauth/test_plugin.py`.
- Broader regression sweep: 235 tests pass across `test_plugin_meta.py`, `test_builtin_plugin_lock.py`, `test_agent_skills*.py`, and `test_namespace_skill_search_plugin.py` -- no interaction effects with the namespace/skills work in #713/#714.
- `ruff check` / `ruff format --check` clean.

## Related

Builds on the tag-order guidance from #713's `docs/AGENT_SKILLS.md` update and #714's `code-puppy-agent` skill work -- this is Code Puppy's own built-in skill following the advice both of those PRs give to everyone else.

