### PR TITLE
fix(agents): validate agent JSON configuration before saving

### DIFF
--- a/code_puppy/agents/agent_creator_agent.py
+++ b/code_puppy/agents/agent_creator_agent.py
@@ -4,6 +4,7 @@ import json
 import os
 from typing import Dict, List, Optional
 
+from code_puppy.callbacks import register_callback
 from code_puppy.config import get_user_agents_directory
 from code_puppy.model_factory import ModelFactory
 from code_puppy.tools import get_available_tool_names
@@ -645,3 +646,47 @@ Your goal is to take users from idea to working agent in one smooth conversation
     def get_user_prompt(self) -> Optional[str]:
         """Get the initial user prompt."""
         return "Hi! I'm the Agent Creator 🏗️ Let's build an awesome agent together!"
+
+
+def _validate_agent_creation(tool_name: str, tool_args: dict, context=None) -> Optional[dict]:
+    """Intercept create_file to validate agent JSON configs before saving."""
+    if tool_name != "create_file":
+        return None
+
+    file_path = tool_args.get("file_path", "")
+    content = tool_args.get("content", "")
+
+    if not isinstance(file_path, str) or not file_path.endswith(".json"):
+        return None
+
+    agents_dir = get_user_agents_directory()
+    # Check if the path points into the agents directory
+    if agents_dir not in file_path:
+        return None
+
+    try:
+        agent_config = json.loads(content)
+        # Use an instance of AgentCreatorAgent to run validation
+        agent = AgentCreatorAgent()
+        errors = agent.validate_agent_json(agent_config)
+
+        if errors:
+            error_msg = "Validation errors:\n" + "\n".join(f"- {error}" for error in errors)
+            return {
+                "blocked": True,
+                "error_message": f"Invalid JSON agent config: {error_msg}"
+            }
+    except json.JSONDecodeError as e:
+        return {
+            "blocked": True,
+            "error_message": f"Syntax error: Invalid JSON payload. {str(e)}"
+        }
+    except Exception as e:
+        return {
+            "blocked": True,
+            "error_message": f"Validation failed: {str(e)}"
+        }
+    
+    return None
+
+register_callback("pre_tool_call", _validate_agent_creation)

--- a/tests/agents/test_agent_creator_agent.py
+++ b/tests/agents/test_agent_creator_agent.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from code_puppy.agents.agent_creator_agent import AgentCreatorAgent
+from code_puppy.agents.agent_creator_agent import AgentCreatorAgent, _validate_agent_creation
 
 
 class TestAgentCreatorAgent:
@@ -228,3 +228,51 @@ class TestAgentCreatorAgent:
         agent = AgentCreatorAgent()
         expected = "Hi! I'm the Agent Creator 🏗️ Let's build an awesome agent together!"
         assert agent.get_user_prompt() == expected
+
+    def test_validate_agent_creation_not_create_file(self):
+        """Test that it ignores tools other than create_file."""
+        result = _validate_agent_creation("read_file", {})
+        assert result is None
+
+    def test_validate_agent_creation_not_json_file(self):
+        """Test that it ignores non-JSON files."""
+        result = _validate_agent_creation("create_file", {"file_path": "test.txt", "content": "{}"})
+        assert result is None
+
+    def test_validate_agent_creation_not_agents_dir(self, monkeypatch):
+        """Test that it ignores files outside the agents directory."""
+        monkeypatch.setattr("code_puppy.agents.agent_creator_agent.get_user_agents_directory", lambda: "/mock/agents/dir")
+        result = _validate_agent_creation("create_file", {"file_path": "/some/other/dir/test.json", "content": "{}"})
+        assert result is None
+
+    def test_validate_agent_creation_invalid_json(self, monkeypatch):
+        """Test that invalid JSON blocks the tool call."""
+        monkeypatch.setattr("code_puppy.agents.agent_creator_agent.get_user_agents_directory", lambda: "/mock/agents/dir")
+        result = _validate_agent_creation("create_file", {"file_path": "/mock/agents/dir/test.json", "content": "{invalid json"})
+        assert result is not None
+        assert result.get("blocked") is True
+        assert "Syntax error: Invalid JSON payload" in result.get("error_message", "")
+
+    def test_validate_agent_creation_validation_error(self, monkeypatch):
+        """Test that valid JSON with schema errors blocks the tool call."""
+        monkeypatch.setattr("code_puppy.agents.agent_creator_agent.get_user_agents_directory", lambda: "/mock/agents/dir")
+        # Valid JSON but missing required fields
+        result = _validate_agent_creation("create_file", {"file_path": "/mock/agents/dir/test.json", "content": '{"name": "test"}'})
+        assert result is not None
+        assert result.get("blocked") is True
+        assert "Validation errors:" in result.get("error_message", "")
+        assert "Missing required field: 'description'" in result.get("error_message", "")
+
+    def test_validate_agent_creation_valid(self, monkeypatch):
+        """Test that perfectly valid agent config does not block the tool call."""
+        monkeypatch.setattr("code_puppy.agents.agent_creator_agent.get_user_agents_directory", lambda: "/mock/agents/dir")
+        monkeypatch.setattr("code_puppy.agents.agent_creator_agent.get_available_tool_names", lambda: ["tool1"])
+        
+        valid_json = '''{
+            "name": "test-agent",
+            "description": "desc",
+            "system_prompt": "prompt",
+            "tools": []
+        }'''
+        result = _validate_agent_creation("create_file", {"file_path": "/mock/agents/dir/test.json", "content": valid_json})
+        assert result is None


### PR DESCRIPTION


***

## Description
Closes mpfaffenberger/code_puppy#47
**Fixes:** https://github.com/mpfaffenberger/code_puppy/issues/47

The `agent-creator` LLM occasionally hallucinates invalid JSON (e.g., trailing commas, missing brackets) when calling the `create_file` tool to save new agent configurations. Because the generic `create_file` tool blindly writes the raw string payload to disk, this resulted in syntax errors when attempting to load the corrupted agents later.

This PR wires up the existing, unused validation logic (`validate_agent_json`) by utilizing the plugin architecture's `pre_tool_call` hook. 

### What's Changed:
* **Intercept File Creation:** Added a `_validate_agent_creation` hook inside `agent_creator_agent.py` that listens for `create_file` tool calls.
* **Pre-Write Validation:** If the target is a `.json` file within the user's agents directory, the payload is parsed and evaluated against the schema.
* **LLM Auto-Correction:** Invalid JSON (either via `JSONDecodeError` or missing required fields) safely aborts the file write and returns a descriptive `error_message` with `"blocked": True`. This allows the LLM to realize its mistake and retry with valid syntax.

### Testing
Added 5 new unit tests to `test_agent_creator_agent.py` to ensure:
- Standard non-JSON and non-agent tool calls pass through unharmed.
- Invalid JSON strings are properly caught and blocked.
- Valid JSON strings missing required schema fields (like `description`) are blocked with clear feedback.
- Perfectly valid agent configs pass through the interceptor successfully.