### PR TITLE
feat(hooks): let a PostToolUse hook withhold a tool's output

### DIFF
--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -99,6 +99,7 @@ from code_puppy.config import (
 )
 from code_puppy.keymap import sigint_fallback_cancels
 from code_puppy.messaging import emit_error, emit_info, emit_warning
+from code_puppy.session_context import get_session_id, set_session_id
 from code_puppy.tools.command_runner import is_awaiting_user_input
 
 # ---- Streaming retry helpers ------------------------------------------------
@@ -642,6 +643,10 @@ async def run_with_mcp(
     global _active_run_depth
     is_nested_run = _active_run_depth > 0
     _active_run_depth += 1
+    # Restored on the way out so a nested run hands its parent's id back, and
+    # the outermost run leaves no stale id behind for code that runs between
+    # turns. The impl publishes this run's own id once it mints one.
+    previous_session_id = get_session_id()
     try:
         return await _run_with_mcp_impl(
             agent,
@@ -654,6 +659,7 @@ async def run_with_mcp(
         )
     finally:
         _active_run_depth -= 1
+        set_session_id(previous_session_id)
 
 
 async def _run_with_mcp_impl(
@@ -682,6 +688,11 @@ async def _run_with_mcp_impl(
 
     prompt = _sanitize_prompt(prompt)
     group_id = str(uuid.uuid4())
+
+    # Publish the run id before the agent task is created below, so the task
+    # inherits it and callbacks with no run-scoped argument — notably
+    # pre_tool_call / post_tool_call — can correlate their events with this run.
+    set_session_id(group_id)
 
     # Fire user_prompt_submit hooks BEFORE prompt is sent. Plugins (e.g. the
     # claude_code_hooks bridge) may return a string to replace the prompt —

--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -83,6 +83,7 @@ from code_puppy.agents._run_signals import (
 )
 from code_puppy.agents.event_stream_handler import event_stream_handler
 from code_puppy.callbacks import (
+    PromptBlocked,
     on_agent_exception,
     on_agent_run_cancel,
     on_agent_run_context,
@@ -701,7 +702,21 @@ async def _run_with_mcp_impl(
     try:
         submit_results = await on_user_prompt_submit(prompt, group_id)
         for r in submit_results:
-            if isinstance(r, str) and r:
+            if isinstance(r, PromptBlocked):
+                if not is_nested_run:
+                    # Cancel the turn outright: return before the agent is
+                    # built, so the prompt never reaches the model and no LLM
+                    # call is made. Mirrors the None a cancelled run returns —
+                    # callers already handle that. on_agent_run_start has not
+                    # fired yet, so there is no run-end to pair with either.
+                    emit_warning(f"🚫 Prompt blocked by hook: {r.reason}")
+                    return None
+                # A nested run's caller dereferences the result (e.g. an
+                # internal assessment call passing output_type), so None would
+                # break it. Substitute instead — the prompt text is still
+                # withheld from the model.
+                prompt = r.replacement
+            elif isinstance(r, str) and r:
                 prompt = r
     except Exception:
         # Hook failures must never block the run.

--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -674,6 +674,12 @@ async def on_post_tool_call(
     This allows plugins to inspect tool results, log execution times,
     or perform post-processing.
 
+    A callback may return ``{"blocked": True, "reason": ...}`` to withhold the
+    tool's OUTPUT: the model and the message history receive a notice naming the
+    reason instead of the real result. The tool has already run by this point, so
+    this controls what the output reaches — not whether the side effect happened.
+    Use ``pre_tool_call`` to stop the call itself.
+
     Args:
         tool_name: Name of the tool that was called
         tool_args: Arguments that were passed to the tool
@@ -682,7 +688,7 @@ async def on_post_tool_call(
         context: Optional context data for the tool call
 
     Returns:
-        List of results from registered callbacks.
+        List of results from registered callbacks (dict | None).
     """
     return await _trigger_callbacks(
         "post_tool_call", tool_name, tool_args, result, duration_ms, context

--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import traceback
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Literal, Optional, Set
 
 PhaseType = Literal[
@@ -1451,6 +1452,29 @@ async def on_interactive_turn_cancel(
     )
 
 
+@dataclass(frozen=True)
+class PromptBlocked:
+    """Returned by a ``user_prompt_submit`` callback to stop a prompt entirely.
+
+    A top-level run handed one of these is **cancelled**: the prompt is never
+    sent to the model, no LLM call is made, and ``run_with_mcp`` returns
+    ``None`` — the same shape it already returns for a cancelled run.
+
+    Nested runs cannot be cancelled that way. A plugin making its own internal
+    ``run_with_mcp`` call (the shell-safety assessment, anything passing
+    ``output_type``) dereferences the result, so returning ``None`` there would
+    break the caller. Those fall back to ``replacement``, which is substituted
+    for the prompt instead.
+
+    Attributes:
+        reason: Why the prompt was blocked. Shown to the user.
+        replacement: Prompt text used instead when the run cannot be cancelled.
+    """
+
+    reason: str
+    replacement: str
+
+
 async def on_user_prompt_submit(
     prompt: str, session_id: str | None = None
 ) -> List[Any]:
@@ -1462,12 +1486,15 @@ async def on_user_prompt_submit(
     returns a non-None, non-empty string wins; all others are merged in order
     via concatenation. Returning None means "don't touch the prompt".
 
+    A callback may instead return a :class:`PromptBlocked` to stop the prompt
+    outright; see that class for how top-level and nested runs differ.
+
     Args:
         prompt: The raw user prompt about to be sent.
         session_id: Optional run/session identifier.
 
     Returns:
-        List of results from registered callbacks (str | None).
+        List of results from registered callbacks (str | PromptBlocked | None).
     """
     return await _trigger_callbacks("user_prompt_submit", prompt, session_id)
 

--- a/code_puppy/hook_engine/executor.py
+++ b/code_puppy/hook_engine/executor.py
@@ -72,6 +72,14 @@ def _build_stdin_payload(event_data: EventData) -> bytes:
         payload["tool_result"] = _make_serializable(event_data.context["result"])
     if "duration_ms" in event_data.context:
         payload["tool_duration_ms"] = event_data.context["duration_ms"]
+    # Stop / SubagentStop: the agent's final text. Claude Code hands end-of-turn
+    # hooks a transcript_path to read; code puppy has no transcript file, so the
+    # response itself is the equivalent. Without it a Stop hook fires with
+    # nothing to inspect and cannot do end-of-turn review at all.
+    if event_data.context.get("response_text") is not None:
+        payload["response_text"] = _make_serializable(
+            event_data.context["response_text"]
+        )
 
     return json.dumps(payload, ensure_ascii=False).encode("utf-8")
 

--- a/code_puppy/plugins/claude_code_hooks/register_callbacks.py
+++ b/code_puppy/plugins/claude_code_hooks/register_callbacks.py
@@ -22,9 +22,9 @@ where Claude Code's spec says it should become "additional context"
 """
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
-from code_puppy.callbacks import register_callback
+from code_puppy.callbacks import PromptBlocked, register_callback
 from code_puppy.hook_engine import EventData, HookEngine
 from code_puppy.session_context import get_session_id
 
@@ -278,15 +278,16 @@ register_callback("session_end", on_session_end_hook)
 
 async def on_user_prompt_submit_hook(
     prompt: str, session_id: Optional[str] = None
-) -> Optional[str]:
+) -> Optional[Union[str, PromptBlocked]]:
     """Fire UserPromptSubmit hooks and inject their stdout (+ any pending
     SessionStart stdout) into the user prompt.
 
     A blocking hook (exit code 1, or a ``deny`` / ``block`` stdout control
-    payload) replaces the prompt outright with a block notice, so the original
-    text never reaches the model.
+    payload) returns a :class:`PromptBlocked`, which cancels the turn on a
+    top-level run and substitutes a block notice on a nested one. Either way
+    the prompt text never reaches the model.
 
-    Returns the replacement prompt, the augmented prompt, or ``None`` if there's
+    Returns ``PromptBlocked``, the augmented prompt, or ``None`` if there's
     nothing to add. See issue #298.
     """
     hook_chunks: List[str] = []
@@ -302,11 +303,17 @@ async def on_user_prompt_submit_hook(
         try:
             result = await _hook_engine.process_event("UserPromptSubmit", event_data)
             if result.blocked:
-                logger.debug(f"Prompt blocked by hook: {result.blocking_reason}")
+                reason = (
+                    result.blocking_reason or ""
+                ).strip() or "No reason was provided by the hook."
+                logger.debug(f"Prompt blocked by hook: {reason}")
                 # _pending_session_context is deliberately left intact: this
                 # prompt never runs, so its SessionStart context still belongs
                 # to the next prompt that does.
-                return _blocked_prompt_replacement(result.blocking_reason)
+                return PromptBlocked(
+                    reason=reason,
+                    replacement=_blocked_prompt_replacement(reason),
+                )
             hook_chunks = _collect_context_stdout(result)
         except Exception as e:
             logger.error(f"Error in UserPromptSubmit hook: {e}", exc_info=True)

--- a/code_puppy/plugins/claude_code_hooks/register_callbacks.py
+++ b/code_puppy/plugins/claude_code_hooks/register_callbacks.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, Optional
 
 from code_puppy.callbacks import register_callback
 from code_puppy.hook_engine import EventData, HookEngine
+from code_puppy.session_context import get_session_id
 
 from .config import load_hooks_config
 
@@ -78,6 +79,46 @@ def _initialize_engine() -> Optional[HookEngine]:
 _hook_engine = _initialize_engine()
 
 
+def _event_context(
+    extra: Optional[Dict[str, Any]] = None,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build an ``EventData.context`` that carries the current run's session id.
+
+    ``_build_stdin_payload`` reads ``session_id`` from here. Without it every
+    event falls back to the placeholder ``"codepuppy-session"``, so a hook
+    script cannot tell one run from another.
+
+    An explicit *session_id* wins (the callback was handed one); otherwise we
+    fall back to the run-scoped ContextVar. The key is omitted entirely when
+    neither is available, so the payload builder's own default still applies.
+    """
+    ctx: Dict[str, Any] = dict(extra or {})
+    resolved = session_id or ctx.get("session_id") or get_session_id()
+    if resolved:
+        ctx["session_id"] = resolved
+    else:
+        ctx.pop("session_id", None)
+    return ctx
+
+
+def _blocked_prompt_replacement(reason: Optional[str]) -> str:
+    """The prompt substituted for one a ``UserPromptSubmit`` hook blocked.
+
+    The user's original text is deliberately dropped — that is the entire point
+    of a block — so it never reaches the model. ``run_with_mcp`` sends whatever
+    string this returns in place of the prompt.
+    """
+    detail = (reason or "").strip() or "No reason was provided by the hook."
+    return (
+        "[BLOCKED BY HOOK] The user's prompt was withheld by a UserPromptSubmit "
+        "policy hook and is not available to you.\n\n"
+        f"Reason: {detail}\n\n"
+        "Do not guess at, reconstruct, or act on the withheld prompt. Tell the "
+        "user their prompt was blocked, relay the reason above, and stop."
+    )
+
+
 def _collect_context_stdout(result: Any) -> List[str]:
     """Pull stdout from non-blocking, exit-0 hook results.
 
@@ -115,7 +156,7 @@ async def on_pre_tool_call_hook(
         event_type="PreToolUse",
         tool_name=tool_name,
         tool_args=tool_args,
-        context={"context": context} if context else {},
+        context=_event_context({"context": context} if context else None),
     )
 
     try:
@@ -158,7 +199,9 @@ async def on_post_tool_call_hook(
         event_type="PostToolUse",
         tool_name=tool_name,
         tool_args=tool_args,
-        context={"result": result, "duration_ms": duration_ms, "context": context},
+        context=_event_context(
+            {"result": result, "duration_ms": duration_ms, "context": context}
+        ),
     )
 
     try:
@@ -190,6 +233,7 @@ async def on_startup_hook() -> None:
         event_type="SessionStart",
         tool_name="session",
         tool_args={},
+        context=_event_context(),
     )
 
     try:
@@ -214,6 +258,7 @@ async def on_session_end_hook() -> None:
         event_type="SessionEnd",
         tool_name="session",
         tool_args={},
+        context=_event_context(),
     )
 
     try:
@@ -237,9 +282,35 @@ async def on_user_prompt_submit_hook(
     """Fire UserPromptSubmit hooks and inject their stdout (+ any pending
     SessionStart stdout) into the user prompt.
 
-    Returns the (possibly augmented) prompt, or ``None`` if there's nothing
-    to add. See issue #298.
+    A blocking hook (exit code 1, or a ``deny`` / ``block`` stdout control
+    payload) replaces the prompt outright with a block notice, so the original
+    text never reaches the model.
+
+    Returns the replacement prompt, the augmented prompt, or ``None`` if there's
+    nothing to add. See issue #298.
     """
+    hook_chunks: List[str] = []
+
+    if _hook_engine:
+        event_data = EventData(
+            event_type="UserPromptSubmit",
+            tool_name="user_prompt",
+            tool_args={"prompt": prompt},
+            context=_event_context(session_id=session_id),
+        )
+
+        try:
+            result = await _hook_engine.process_event("UserPromptSubmit", event_data)
+            if result.blocked:
+                logger.debug(f"Prompt blocked by hook: {result.blocking_reason}")
+                # _pending_session_context is deliberately left intact: this
+                # prompt never runs, so its SessionStart context still belongs
+                # to the next prompt that does.
+                return _blocked_prompt_replacement(result.blocking_reason)
+            hook_chunks = _collect_context_stdout(result)
+        except Exception as e:
+            logger.error(f"Error in UserPromptSubmit hook: {e}", exc_info=True)
+
     chunks: List[str] = []
 
     # Drain any pending SessionStart context first.
@@ -247,19 +318,7 @@ async def on_user_prompt_submit_hook(
         chunks.extend(_pending_session_context)
         _pending_session_context.clear()
 
-    if _hook_engine:
-        event_data = EventData(
-            event_type="UserPromptSubmit",
-            tool_name="user_prompt",
-            tool_args={"prompt": prompt},
-            context={"session_id": session_id} if session_id else {},
-        )
-
-        try:
-            result = await _hook_engine.process_event("UserPromptSubmit", event_data)
-            chunks.extend(_collect_context_stdout(result))
-        except Exception as e:
-            logger.error(f"Error in UserPromptSubmit hook: {e}", exc_info=True)
+    chunks.extend(hook_chunks)
 
     if not chunks:
         return None
@@ -295,6 +354,7 @@ async def on_pre_compact_hook(
             "message_count": message_count,
             "token_count": token_count,
         },
+        context=_event_context(),
     )
 
     try:
@@ -322,7 +382,7 @@ async def on_notification_hook(
         event_type="Notification",
         tool_name="notification",
         tool_args={"message": message, "level": level},
-        context={"context": context} if context else {},
+        context=_event_context({"context": context} if context else None),
     )
 
     try:
@@ -360,15 +420,17 @@ async def on_agent_run_end_hook(
         event_type=event_type,
         tool_name=agent_name or "agent",
         tool_args={},
-        context={
-            "agent_name": agent_name,
-            "model_name": model_name,
-            "session_id": session_id,
-            "success": success,
-            "error": str(error) if error else None,
-            "response_text": response_text,
-            "metadata": metadata,
-        },
+        context=_event_context(
+            {
+                "agent_name": agent_name,
+                "model_name": model_name,
+                "success": success,
+                "error": str(error) if error else None,
+                "response_text": response_text,
+                "metadata": metadata,
+            },
+            session_id=session_id,
+        ),
     )
 
     try:

--- a/code_puppy/plugins/claude_code_hooks/register_callbacks.py
+++ b/code_puppy/plugins/claude_code_hooks/register_callbacks.py
@@ -30,12 +30,38 @@ from code_puppy.session_context import get_session_id
 
 from .config import load_hooks_config
 
-_SUBAGENT_NAMES = frozenset(
+
+def _is_subagent_run(agent_name: Optional[str]) -> bool:
+    """Whether the run that just ended was a sub-agent's.
+
+    Decided by the sub-agent depth ContextVar, which is what actually tracks
+    nesting. The name is only a fallback for a caller that ends a run outside
+    the ``subagent_context`` manager.
+
+    This deliberately does NOT guess from the agent's name alone: the DEFAULT
+    agent is called ``code-puppy``, so a name-matching list containing it
+    classified every top-level turn as a sub-agent and ``Stop`` never fired at
+    all. A sub-agent can also be named anything, so the name was never a sound
+    signal in either direction.
+    """
+    try:
+        from code_puppy.tools.subagent_context import is_subagent
+
+        if is_subagent():
+            return True
+    except Exception:
+        pass
+
+    lowered = (agent_name or "").lower()
+    return any(name in lowered for name in _FALLBACK_SUBAGENT_NAMES)
+
+
+# Names checked only when the depth ContextVar is unavailable. ``code-puppy``
+# and ``code_puppy`` are absent on purpose — that is the default agent.
+_FALLBACK_SUBAGENT_NAMES = frozenset(
     {
         "pack_leader",
         "bloodhound",
-        "code-puppy",
-        "code_puppy",
         "retriever",
         "shepherd",
         "terrier",
@@ -102,6 +128,26 @@ def _event_context(
     return ctx
 
 
+def _block_reason(result: Any) -> str:
+    """The human-facing reason a hook blocked, preferring the hook's own stderr.
+
+    ``ProcessEventResult.blocking_reason`` is a diagnostic string of the form
+    ``Hook '<full command line>' failed: <stderr>``. That is useful in a log and
+    poor in front of a user — it leaks the hook's path and says "failed" for a
+    hook that deliberately blocked. The individual result carries the stderr on
+    its own, so use that and fall back to the diagnostic form.
+    """
+    for r in getattr(result, "results", []) or []:
+        if not getattr(r, "blocked", False):
+            continue
+        for candidate in (getattr(r, "stderr", ""), getattr(r, "error", "")):
+            text = (candidate or "").strip()
+            if text:
+                return text
+    reason = (getattr(result, "blocking_reason", "") or "").strip()
+    return reason or "No reason was provided by the hook."
+
+
 def _blocked_prompt_replacement(reason: Optional[str]) -> str:
     """The prompt substituted for one a ``UserPromptSubmit`` hook blocked.
 
@@ -163,13 +209,12 @@ async def on_pre_tool_call_hook(
         result = await _hook_engine.process_event("PreToolUse", event_data)
 
         if result.blocked:
-            logger.debug(
-                f"Tool '{tool_name}' blocked by hook: {result.blocking_reason}"
-            )
+            reason = _block_reason(result)
+            logger.debug(f"Tool '{tool_name}' blocked by hook: {reason}")
             return {
                 "blocked": True,
-                "reason": result.blocking_reason,
-                "error_message": result.blocking_reason,
+                "reason": reason,
+                "error_message": reason,
             }
 
         # Exit code 0 hooks: propagate their stdout to the model context.
@@ -303,9 +348,7 @@ async def on_user_prompt_submit_hook(
         try:
             result = await _hook_engine.process_event("UserPromptSubmit", event_data)
             if result.blocked:
-                reason = (
-                    result.blocking_reason or ""
-                ).strip() or "No reason was provided by the hook."
+                reason = _block_reason(result)
                 logger.debug(f"Prompt blocked by hook: {reason}")
                 # _pending_session_context is deliberately left intact: this
                 # prompt never runs, so its SessionStart context still belongs
@@ -419,9 +462,7 @@ async def on_agent_run_end_hook(
     if not _hook_engine:
         return
 
-    agent_lower = (agent_name or "").lower()
-    is_subagent = any(name in agent_lower for name in _SUBAGENT_NAMES)
-    event_type = "SubagentStop" if is_subagent else "Stop"
+    event_type = "SubagentStop" if _is_subagent_run(agent_name) else "Stop"
 
     event_data = EventData(
         event_type=event_type,

--- a/code_puppy/plugins/claude_code_hooks/register_callbacks.py
+++ b/code_puppy/plugins/claude_code_hooks/register_callbacks.py
@@ -235,10 +235,15 @@ async def on_post_tool_call_hook(
     result: Any,
     duration_ms: float,
     context: Any = None,
-) -> None:
-    """Post-tool callback — executes hooks after tool completes."""
+) -> Optional[Dict[str, Any]]:
+    """Post-tool callback — executes hooks after a tool completes.
+
+    A blocking hook here withholds the tool's OUTPUT from the model; the tool
+    itself has already run. Returns the block verdict for ``_run_post_tool_call``
+    to act on, or ``None`` to pass the result through untouched.
+    """
     if not _hook_engine:
-        return
+        return None
 
     event_data = EventData(
         event_type="PostToolUse",
@@ -250,9 +255,15 @@ async def on_post_tool_call_hook(
     )
 
     try:
-        await _hook_engine.process_event("PostToolUse", event_data)
+        outcome = await _hook_engine.process_event("PostToolUse", event_data)
+        if outcome.blocked:
+            reason = _block_reason(outcome)
+            logger.debug(f"Output of '{tool_name}' withheld by hook: {reason}")
+            return {"blocked": True, "reason": reason, "error_message": reason}
+        return None
     except Exception as e:
         logger.error(f"Error in post-tool hook: {e}", exc_info=True)
+        return None
 
 
 register_callback("pre_tool_call", on_pre_tool_call_hook)

--- a/code_puppy/pydantic_patches.py
+++ b/code_puppy/pydantic_patches.py
@@ -205,6 +205,57 @@ def _writeback_tool_args(call: Any, tool_args: dict, mode: str | None) -> None:
         pass  # never block tool execution on writeback failure
 
 
+async def _run_post_tool_call(
+    tool_name: str,
+    tool_args: dict,
+    result: Any,
+    duration_ms: float,
+) -> Any:
+    """Fire ``post_tool_call`` and honour a withhold verdict.
+
+    Returns what pydantic-ai should receive: the original result, or a
+    replacement notice when a hook returned ``{"blocked": True}``.
+
+    Scope matters here. The tool has ALREADY executed and its side effects have
+    happened — a verdict at this point cannot undo them. It governs only what
+    reaches the model and the message history, which is what makes it useful for
+    keeping secrets in a tool's output out of the transcript and out of the
+    provider's logs. Use ``pre_tool_call`` to stop the call itself.
+
+    Never raises: a failing hook leaves the result untouched.
+    """
+    try:
+        from code_puppy import callbacks
+
+        callback_results = await callbacks.on_post_tool_call(
+            tool_name, tool_args, result, duration_ms
+        )
+    except Exception:
+        return result
+
+    for callback_result in callback_results or []:
+        if not isinstance(callback_result, dict):
+            continue
+        if not callback_result.get("blocked"):
+            continue
+        reason = (
+            callback_result.get("reason") or callback_result.get("error_message") or ""
+        ).strip() or "Withheld by hook policy"
+        try:
+            from code_puppy.messaging import emit_warning
+
+            emit_warning(f"🚫 Hook withheld this tool's output: {reason}")
+        except Exception:
+            pass
+        return (
+            "ERROR: The tool ran, but a PostToolUse hook withheld its output."
+            f"\n\nReason: {reason}\n\nThe output is not available to you. Do not "
+            "retry the call or try another route to read the same data — report "
+            "the block to the user instead."
+        )
+    return result
+
+
 def patch_tool_call_callbacks() -> None:
     """Patch pydantic-ai tool handling to support callbacks and Claude Code tool names.
 
@@ -402,6 +453,7 @@ def patch_tool_call_callbacks() -> None:
             start = time.perf_counter()
             error: Exception | None = None
             result = None
+            post_tool_call_fired = False
             try:
                 result = await _original_call_tool(
                     self,
@@ -424,21 +476,36 @@ def patch_tool_call_callbacks() -> None:
                         result = prefix + result
                     else:
                         result = prefix + str(result)
+                # PostToolUse runs here — BEFORE the result is handed back — so a
+                # hook can withhold it. Firing it from the `finally` below meant
+                # the return value was already decided and the hook's verdict was
+                # discarded, leaving PostToolUse purely observational.
+                post_tool_call_fired = True
+                result = await _run_post_tool_call(
+                    tool_name,
+                    tool_args,
+                    result,
+                    (time.perf_counter() - start) * 1000,
+                )
                 return result
             except Exception as exc:
                 error = exc
                 raise
             finally:
-                duration_ms = (time.perf_counter() - start) * 1000
-                final_result = result if error is None else {"error": str(error)}
-                try:
-                    from code_puppy import callbacks
+                # Error path only: there is no result to withhold, so this stays
+                # observational. Guarded so a tool that succeeded never notifies
+                # twice.
+                if not post_tool_call_fired:
+                    duration_ms = (time.perf_counter() - start) * 1000
+                    final_result = result if error is None else {"error": str(error)}
+                    try:
+                        from code_puppy import callbacks
 
-                    await callbacks.on_post_tool_call(
-                        tool_name, tool_args, final_result, duration_ms
-                    )
-                except Exception:
-                    pass  # never block tool execution
+                        await callbacks.on_post_tool_call(
+                            tool_name, tool_args, final_result, duration_ms
+                        )
+                    except Exception:
+                        pass  # never block tool execution
 
         ToolManager.get_tool_def = _patched_get_tool_def
         ToolManager.handle_call = _patched_handle_call

--- a/code_puppy/session_context.py
+++ b/code_puppy/session_context.py
@@ -1,0 +1,35 @@
+"""The current run's session id, readable from anywhere inside that run.
+
+``run_with_mcp`` mints a fresh ``group_id`` (a UUID) for every agent run and
+hands it to the ``user_prompt_submit``, ``agent_run_start`` and
+``agent_run_end`` callbacks. It does *not* reach ``pre_tool_call`` /
+``post_tool_call``: pydantic-ai invokes those deep inside the run, and the
+callback contract has no run-scoped argument to carry it.
+
+So anything that wants to correlate tool calls with the run they belong to —
+hook scripts, telemetry, audit logs — had no way to recover the id. This module
+publishes it instead, so any code executing inside the run can read it.
+
+Why a ContextVar rather than a module global: nested runs are real (a sub-agent
+calling ``run_with_mcp`` while its parent run is still in flight), and the agent
+run itself executes in its own ``asyncio.Task``. ContextVars are copied into a
+task at ``create_task`` time and writes inside a task stay local to it, so every
+run observes its own id and a nested run can never clobber its parent's.
+"""
+
+from contextvars import ContextVar
+from typing import Optional
+
+_session_id: ContextVar[Optional[str]] = ContextVar(
+    "code_puppy_session_id", default=None
+)
+
+
+def set_session_id(session_id: Optional[str]) -> None:
+    """Publish *session_id* as the current context's run id."""
+    _session_id.set(session_id)
+
+
+def get_session_id() -> Optional[str]:
+    """Return the current run's session id, or ``None`` outside of a run."""
+    return _session_id.get()

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -77,7 +77,7 @@ Every hook script receives a JSON object on **stdin**:
 
 ```json
 {
-  "session_id": "codepuppy-session",
+  "session_id": "0f9c1e7a-3d42-4b8e-9a11-6c5d8e2f7b30",
   "hook_event_name": "PreToolUse",
   "tool_name": "agent_run_shell_command",
   "tool_input": {
@@ -89,6 +89,10 @@ Every hook script receives a JSON object on **stdin**:
 ```
 
 For `PostToolUse`, the payload also includes `tool_result` and `tool_duration_ms`.
+
+`session_id` is the id of the agent run the event belongs to, so events from one
+run can be correlated. Sub-agent runs get their own id. Events fired outside any
+run — `SessionStart` at boot, for instance — fall back to `"codepuppy-session"`.
 
 ### Environment Variables
 
@@ -124,11 +128,37 @@ For `PostToolUse`, the payload also includes `tool_result` and `tool_duration_ms
 
 | Event | Fires | Can Block? |
 |-------|-------|-----------|
-| `PreToolUse` | Before any tool call | Yes (exit 1) |
+| `PreToolUse` | Before any tool call | Yes (exit 1) — tool never runs |
 | `PostToolUse` | After any tool call | No (observation only) |
+| `UserPromptSubmit` | Before a prompt is sent to the model | Yes (exit 1) — see below |
 | `SessionStart` | When a session begins | No |
-| `Stop` | When agent finishes a task | Yes |
-| `SubagentStop` | When a sub-agent finishes | Yes |
+| `SessionEnd` | When a session ends | No |
+| `PreCompact` | Before history compaction | No |
+| `Notification` | On a user-attention event | No |
+| `Stop` | When agent finishes a task | No (observation only) |
+| `SubagentStop` | When a sub-agent finishes | No (observation only) |
+
+### Blocking a prompt
+
+When a `UserPromptSubmit` hook blocks, the user's prompt is **replaced** with a
+block notice carrying your reason — the original text never reaches the model.
+The agent then reports the block to the user instead of acting on the prompt.
+
+```bash
+#!/bin/bash
+# Block prompts that mention production credentials
+input=$(cat)
+prompt=$(echo "$input" | jq -r '.tool_input.prompt // empty')
+
+if echo "$prompt" | grep -qiE 'prod.*(password|secret|api[_ -]?key)'; then
+  echo "Prompts referencing production credentials are not permitted." >&2
+  exit 1
+fi
+exit 0
+```
+
+Note that the turn still runs — on the replacement text, not the original.
+There is currently no way for a hook to cancel a turn outright.
 
 ---
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -140,9 +140,9 @@ run — `SessionStart` at boot, for instance — fall back to `"codepuppy-sessio
 
 ### Blocking a prompt
 
-When a `UserPromptSubmit` hook blocks, the user's prompt is **replaced** with a
-block notice carrying your reason — the original text never reaches the model.
-The agent then reports the block to the user instead of acting on the prompt.
+When a `UserPromptSubmit` hook blocks, the turn is **cancelled**: the prompt is
+never sent to the model, no LLM call is made, and your reason is shown to the
+user.
 
 ```bash
 #!/bin/bash
@@ -157,8 +157,10 @@ fi
 exit 0
 ```
 
-Note that the turn still runs — on the replacement text, not the original.
-There is currently no way for a hook to cancel a turn outright.
+One exception: a plugin making its own internal agent call (a nested run — the
+shell-safety assessment, or anything passing `output_type`) cannot be cancelled,
+because its caller needs a result back. A block there substitutes a notice for
+the prompt instead. The prompt text is withheld from the model either way.
 
 ---
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -129,7 +129,7 @@ run — `SessionStart` at boot, for instance — fall back to `"codepuppy-sessio
 | Event | Fires | Can Block? |
 |-------|-------|-----------|
 | `PreToolUse` | Before any tool call | Yes (exit 1) — tool never runs |
-| `PostToolUse` | After any tool call | No (observation only) |
+| `PostToolUse` | After any tool call | Yes (exit 1) — withholds the output; see below |
 | `UserPromptSubmit` | Before a prompt is sent to the model | Yes (exit 1) — see below |
 | `SessionStart` | When a session begins | No |
 | `SessionEnd` | When a session ends | No |
@@ -161,6 +161,27 @@ One exception: a plugin making its own internal agent call (a nested run — the
 shell-safety assessment, or anything passing `output_type`) cannot be cancelled,
 because its caller needs a result back. A block there substitutes a notice for
 the prompt instead. The prompt text is withheld from the model either way.
+
+### Blocking a tool's output
+
+A `PostToolUse` hook runs after the tool has executed, so it cannot undo the
+call — but blocking there **withholds the output**. The model and the message
+history get a notice naming your reason instead of the real result, which keeps
+secrets in tool output out of the transcript and out of your provider's logs.
+
+```bash
+#!/bin/bash
+# Withhold any tool output containing what looks like an AWS key
+input=$(cat)
+if echo "$input" | jq -r '.tool_result // empty' | grep -qE 'AKIA[0-9A-Z]{16}'; then
+  echo "Tool output contained an AWS access key and was withheld." >&2
+  exit 1
+fi
+exit 0
+```
+
+To stop the call from happening at all, use `PreToolUse` — by `PostToolUse` the
+side effect has already occurred.
 
 ---
 

--- a/tests/plugins/test_claude_code_hooks_prompt_block.py
+++ b/tests/plugins/test_claude_code_hooks_prompt_block.py
@@ -213,6 +213,156 @@ class TestRuntimeHonorsPromptBlocked:
 
 
 # ---------------------------------------------------------------------------
+# Stop vs SubagentStop, and the end-of-turn payload
+# ---------------------------------------------------------------------------
+
+
+class TestStopClassification:
+    @pytest.mark.asyncio
+    async def test_default_agent_ending_a_turn_fires_stop(self):
+        """``code-puppy`` is the DEFAULT agent — a top-level turn is a Stop."""
+        from code_puppy.plugins.claude_code_hooks import register_callbacks
+
+        engine = _engine(_allowed())
+        original = register_callbacks._hook_engine
+        register_callbacks._hook_engine = engine
+        try:
+            await register_callbacks.on_agent_run_end_hook(
+                agent_name="code-puppy",
+                model_name="some-model",
+                response_text="all done",
+            )
+        finally:
+            register_callbacks._hook_engine = original
+
+        assert engine.process_event.await_args.args[0] == "Stop"
+
+    @pytest.mark.asyncio
+    async def test_run_inside_subagent_context_fires_subagent_stop(self):
+        from code_puppy.plugins.claude_code_hooks import register_callbacks
+        from code_puppy.tools.subagent_context import subagent_context
+
+        engine = _engine(_allowed())
+        original = register_callbacks._hook_engine
+        register_callbacks._hook_engine = engine
+        try:
+            with subagent_context("retriever"):
+                await register_callbacks.on_agent_run_end_hook(
+                    agent_name="code-puppy",
+                    model_name="some-model",
+                    response_text="all done",
+                )
+        finally:
+            register_callbacks._hook_engine = original
+
+        assert engine.process_event.await_args.args[0] == "SubagentStop"
+
+    @pytest.mark.asyncio
+    async def test_known_subagent_name_still_fires_subagent_stop(self):
+        """Fallback for a run ended outside the context manager."""
+        from code_puppy.plugins.claude_code_hooks import register_callbacks
+
+        engine = _engine(_allowed())
+        original = register_callbacks._hook_engine
+        register_callbacks._hook_engine = engine
+        try:
+            await register_callbacks.on_agent_run_end_hook(
+                agent_name="bloodhound",
+                model_name="some-model",
+                response_text="all done",
+            )
+        finally:
+            register_callbacks._hook_engine = original
+
+        assert engine.process_event.await_args.args[0] == "SubagentStop"
+
+
+class TestEndOfTurnPayload:
+    def test_stop_payload_carries_the_agents_final_response(self):
+        """Without this a Stop hook has nothing to review."""
+        import json
+
+        from code_puppy.hook_engine.executor import _build_stdin_payload
+        from code_puppy.hook_engine.models import EventData
+
+        event = EventData(
+            event_type="Stop",
+            tool_name="code-puppy",
+            tool_args={},
+            context={"session_id": "run-1", "response_text": "the final answer"},
+        )
+        payload = json.loads(_build_stdin_payload(event).decode())
+
+        assert payload["response_text"] == "the final answer"
+        assert payload["hook_event_name"] == "Stop"
+        assert payload["session_id"] == "run-1"
+
+    def test_absent_response_text_adds_no_key(self):
+        import json
+
+        from code_puppy.hook_engine.executor import _build_stdin_payload
+        from code_puppy.hook_engine.models import EventData
+
+        event = EventData(event_type="PreToolUse", tool_name="Bash", tool_args={})
+        payload = json.loads(_build_stdin_payload(event).decode())
+
+        assert "response_text" not in payload
+
+
+class TestBlockReasonIsHumanFacing:
+    """The reason shown to a user must not be the internal diagnostic string."""
+
+    @pytest.mark.asyncio
+    async def test_hook_stderr_is_preferred_over_the_diagnostic_string(self):
+        from code_puppy.callbacks import PromptBlocked
+        from code_puppy.hook_engine.models import ExecutionResult, ProcessEventResult
+        from code_puppy.plugins.claude_code_hooks import register_callbacks
+
+        execution = ExecutionResult(
+            blocked=True,
+            hook_command="python3 /very/long/path/to/guard.py",
+            stderr="Onyx AI Guard: blocked by policy.",
+            exit_code=1,
+        )
+        result = ProcessEventResult(
+            blocked=True,
+            executed_hooks=1,
+            results=[execution],
+            blocking_reason=(
+                "Hook 'python3 /very/long/path/to/guard.py' failed: "
+                "Onyx AI Guard: blocked by policy."
+            ),
+        )
+
+        original = register_callbacks._hook_engine
+        register_callbacks._hook_engine = _engine(result)
+        try:
+            blocked = await register_callbacks.on_user_prompt_submit_hook("hi")
+        finally:
+            register_callbacks._hook_engine = original
+
+        assert isinstance(blocked, PromptBlocked)
+        assert blocked.reason == "Onyx AI Guard: blocked by policy."
+        assert "/very/long/path" not in blocked.reason
+        assert "failed" not in blocked.reason
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_blocking_reason_when_no_stderr(self):
+        from code_puppy.callbacks import PromptBlocked
+        from code_puppy.plugins.claude_code_hooks import register_callbacks
+
+        original = register_callbacks._hook_engine
+        register_callbacks._hook_engine = _engine(_blocked("terse reason"))
+        try:
+            blocked = await register_callbacks.on_user_prompt_submit_hook("hi")
+        finally:
+            register_callbacks._hook_engine = original
+
+        assert isinstance(blocked, PromptBlocked)
+        assert blocked.reason == "terse reason"
+
+
+# ---------------------------------------------------------------------------
 # Session id propagation
 # ---------------------------------------------------------------------------
 

--- a/tests/plugins/test_claude_code_hooks_prompt_block.py
+++ b/tests/plugins/test_claude_code_hooks_prompt_block.py
@@ -213,6 +213,88 @@ class TestRuntimeHonorsPromptBlocked:
 
 
 # ---------------------------------------------------------------------------
+# PostToolUse can withhold a tool's output
+# ---------------------------------------------------------------------------
+
+
+class TestPostToolUseWithholding:
+    @pytest.mark.asyncio
+    async def test_bridge_returns_a_block_verdict(self):
+        from code_puppy.plugins.claude_code_hooks import register_callbacks
+
+        original = register_callbacks._hook_engine
+        register_callbacks._hook_engine = _engine(_blocked("secret in output"))
+        try:
+            verdict = await register_callbacks.on_post_tool_call_hook(
+                "Bash", {"command": "cat s.txt"}, "AKIAIOSFODNN7EXAMPLE", 5.0
+            )
+        finally:
+            register_callbacks._hook_engine = original
+
+        assert verdict == {
+            "blocked": True,
+            "reason": "secret in output",
+            "error_message": "secret in output",
+        }
+
+    @pytest.mark.asyncio
+    async def test_bridge_passes_output_through_when_allowed(self):
+        from code_puppy.plugins.claude_code_hooks import register_callbacks
+
+        original = register_callbacks._hook_engine
+        register_callbacks._hook_engine = _engine(_allowed())
+        try:
+            verdict = await register_callbacks.on_post_tool_call_hook(
+                "Bash", {"command": "echo hi"}, "hi", 5.0
+            )
+        finally:
+            register_callbacks._hook_engine = original
+
+        assert verdict is None
+
+    @pytest.mark.asyncio
+    async def test_runtime_replaces_the_result_on_a_block(self, monkeypatch):
+        """The secret must not survive into what pydantic-ai receives."""
+        from code_puppy import callbacks as cb_module
+        from code_puppy.pydantic_patches import _run_post_tool_call as run
+
+        async def _fire(tool_name, tool_args, result, duration_ms):
+            return [{"blocked": True, "reason": "secret in output"}]
+
+        monkeypatch.setattr(cb_module, "on_post_tool_call", _fire)
+
+        out = await run("Bash", {"command": "cat s.txt"}, "AKIAIOSFODNN7EXAMPLE", 1.0)
+
+        assert "AKIAIOSFODNN7EXAMPLE" not in out
+        assert "withheld" in out
+        assert "secret in output" in out
+
+    @pytest.mark.asyncio
+    async def test_runtime_passes_the_result_through_when_allowed(self, monkeypatch):
+        from code_puppy import callbacks as cb_module
+        from code_puppy.pydantic_patches import _run_post_tool_call as run
+
+        async def _fire(tool_name, tool_args, result, duration_ms):
+            return [None]
+
+        monkeypatch.setattr(cb_module, "on_post_tool_call", _fire)
+
+        assert await run("Bash", {}, "untouched output", 1.0) == "untouched output"
+
+    @pytest.mark.asyncio
+    async def test_a_failing_hook_leaves_the_result_alone(self, monkeypatch):
+        from code_puppy import callbacks as cb_module
+        from code_puppy.pydantic_patches import _run_post_tool_call as run
+
+        async def _boom(tool_name, tool_args, result, duration_ms):
+            raise RuntimeError("hook exploded")
+
+        monkeypatch.setattr(cb_module, "on_post_tool_call", _boom)
+
+        assert await run("Bash", {}, "untouched output", 1.0) == "untouched output"
+
+
+# ---------------------------------------------------------------------------
 # Stop vs SubagentStop, and the end-of-turn payload
 # ---------------------------------------------------------------------------
 

--- a/tests/plugins/test_claude_code_hooks_prompt_block.py
+++ b/tests/plugins/test_claude_code_hooks_prompt_block.py
@@ -39,6 +39,7 @@ def _allowed() -> ProcessEventResult:
 class TestUserPromptSubmitBlocking:
     @pytest.mark.asyncio
     async def test_blocked_prompt_is_withheld_from_the_model(self):
+        from code_puppy.callbacks import PromptBlocked
         from code_puppy.plugins.claude_code_hooks import register_callbacks
 
         secret = "deploy with password hunter2"
@@ -49,15 +50,17 @@ class TestUserPromptSubmitBlocking:
         finally:
             register_callbacks._hook_engine = original
 
-        assert result is not None
-        # The whole point: the original text must not survive into the prompt.
-        assert secret not in result
-        assert "hunter2" not in result
-        assert "BLOCKED BY HOOK" in result
-        assert "no credentials in prompts" in result
+        assert isinstance(result, PromptBlocked)
+        assert result.reason == "no credentials in prompts"
+        # The whole point: the original text must not survive anywhere.
+        assert secret not in result.replacement
+        assert "hunter2" not in result.replacement
+        assert "BLOCKED BY HOOK" in result.replacement
+        assert "no credentials in prompts" in result.replacement
 
     @pytest.mark.asyncio
     async def test_block_without_reason_still_blocks(self):
+        from code_puppy.callbacks import PromptBlocked
         from code_puppy.plugins.claude_code_hooks import register_callbacks
 
         original = register_callbacks._hook_engine
@@ -67,9 +70,10 @@ class TestUserPromptSubmitBlocking:
         finally:
             register_callbacks._hook_engine = original
 
-        assert result is not None
-        assert "do a thing" not in result
-        assert "BLOCKED BY HOOK" in result
+        assert isinstance(result, PromptBlocked)
+        assert result.reason == "No reason was provided by the hook."
+        assert "do a thing" not in result.replacement
+        assert "BLOCKED BY HOOK" in result.replacement
 
     @pytest.mark.asyncio
     async def test_allowed_prompt_is_passed_through_untouched(self):
@@ -110,6 +114,102 @@ class TestUserPromptSubmitBlocking:
         finally:
             register_callbacks._hook_engine = original
             register_callbacks._pending_session_context.clear()
+
+
+# ---------------------------------------------------------------------------
+# run_with_mcp honors a block
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeHonorsPromptBlocked:
+    @pytest.mark.asyncio
+    async def test_top_level_run_is_cancelled_outright(self, monkeypatch):
+        """No agent is built, no LLM call is made, and the run returns None."""
+        from code_puppy.agents import _runtime
+        from code_puppy.callbacks import PromptBlocked
+
+        blocked = PromptBlocked(reason="secrets policy", replacement="[BLOCKED] ...")
+
+        async def _submit(prompt, session_id=None):
+            return [blocked]
+
+        warnings = []
+
+        def _must_not_run(agent, prompt):
+            raise AssertionError(
+                "run continued past the block — the prompt would have been sent"
+            )
+
+        monkeypatch.setattr(_runtime, "on_user_prompt_submit", _submit)
+        monkeypatch.setattr(_runtime, "emit_warning", lambda msg: warnings.append(msg))
+        # Anything downstream of the block firing is a failure. This is the
+        # last thing touched before the prompt payload is built.
+        monkeypatch.setattr(_runtime, "_should_prepend_system_prompt", _must_not_run)
+
+        result = await _runtime.run_with_mcp(MagicMock(), "leak the prod password")
+
+        assert result is None
+        assert any("secrets policy" in w for w in warnings)
+
+    @pytest.mark.asyncio
+    async def test_nested_run_falls_back_to_substitution(self, monkeypatch):
+        """A nested caller dereferences the result, so None would break it."""
+        from code_puppy.agents import _runtime
+        from code_puppy.callbacks import PromptBlocked
+
+        blocked = PromptBlocked(
+            reason="secrets policy", replacement="[BLOCKED] withheld"
+        )
+
+        async def _submit(prompt, session_id=None):
+            return [blocked]
+
+        seen_prompts = []
+
+        class _Stop(Exception):
+            pass
+
+        def _capture(agent, prompt):
+            seen_prompts.append(prompt)
+            raise _Stop()
+
+        monkeypatch.setattr(_runtime, "on_user_prompt_submit", _submit)
+        monkeypatch.setattr(_runtime, "_should_prepend_system_prompt", _capture)
+
+        # Simulate being inside an outer run.
+        monkeypatch.setattr(_runtime, "_active_run_depth", 1)
+
+        with pytest.raises(_Stop):
+            await _runtime.run_with_mcp(MagicMock(), "leak the prod password")
+
+        # Got past the block (not cancelled) but on the replacement text.
+        assert seen_prompts == ["[BLOCKED] withheld"]
+        assert "leak the prod password" not in seen_prompts[0]
+
+    @pytest.mark.asyncio
+    async def test_plain_string_result_still_replaces_the_prompt(self, monkeypatch):
+        """The pre-existing additional-context contract is unchanged."""
+        from code_puppy.agents import _runtime
+
+        async def _submit(prompt, session_id=None):
+            return ["[hook context]\nbe careful\n\noriginal prompt"]
+
+        seen_prompts = []
+
+        class _Stop(Exception):
+            pass
+
+        def _capture(agent, prompt):
+            seen_prompts.append(prompt)
+            raise _Stop()
+
+        monkeypatch.setattr(_runtime, "on_user_prompt_submit", _submit)
+        monkeypatch.setattr(_runtime, "_should_prepend_system_prompt", _capture)
+
+        with pytest.raises(_Stop):
+            await _runtime.run_with_mcp(MagicMock(), "original prompt")
+
+        assert seen_prompts == ["[hook context]\nbe careful\n\noriginal prompt"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_claude_code_hooks_prompt_block.py
+++ b/tests/plugins/test_claude_code_hooks_prompt_block.py
@@ -1,0 +1,258 @@
+"""UserPromptSubmit blocking + session-id propagation for the hooks bridge.
+
+Covers two behaviours the bridge previously dropped on the floor:
+
+1. A blocking ``UserPromptSubmit`` hook must keep the user's prompt away from
+   the model.
+2. Every event must carry the id of the run it belongs to, not the
+   ``"codepuppy-session"`` placeholder.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from code_puppy.hook_engine.models import ProcessEventResult
+
+
+def _engine(result: ProcessEventResult) -> MagicMock:
+    engine = MagicMock()
+    engine.process_event = AsyncMock(return_value=result)
+    return engine
+
+
+def _blocked(reason: str | None = "policy violation") -> ProcessEventResult:
+    return ProcessEventResult(
+        blocked=True, executed_hooks=1, results=[], blocking_reason=reason
+    )
+
+
+def _allowed() -> ProcessEventResult:
+    return ProcessEventResult(blocked=False, executed_hooks=1, results=[])
+
+
+# ---------------------------------------------------------------------------
+# UserPromptSubmit blocking
+# ---------------------------------------------------------------------------
+
+
+class TestUserPromptSubmitBlocking:
+    @pytest.mark.asyncio
+    async def test_blocked_prompt_is_withheld_from_the_model(self):
+        from code_puppy.plugins.claude_code_hooks import register_callbacks
+
+        secret = "deploy with password hunter2"
+        original = register_callbacks._hook_engine
+        register_callbacks._hook_engine = _engine(_blocked("no credentials in prompts"))
+        try:
+            result = await register_callbacks.on_user_prompt_submit_hook(secret)
+        finally:
+            register_callbacks._hook_engine = original
+
+        assert result is not None
+        # The whole point: the original text must not survive into the prompt.
+        assert secret not in result
+        assert "hunter2" not in result
+        assert "BLOCKED BY HOOK" in result
+        assert "no credentials in prompts" in result
+
+    @pytest.mark.asyncio
+    async def test_block_without_reason_still_blocks(self):
+        from code_puppy.plugins.claude_code_hooks import register_callbacks
+
+        original = register_callbacks._hook_engine
+        register_callbacks._hook_engine = _engine(_blocked(None))
+        try:
+            result = await register_callbacks.on_user_prompt_submit_hook("do a thing")
+        finally:
+            register_callbacks._hook_engine = original
+
+        assert result is not None
+        assert "do a thing" not in result
+        assert "BLOCKED BY HOOK" in result
+
+    @pytest.mark.asyncio
+    async def test_allowed_prompt_is_passed_through_untouched(self):
+        from code_puppy.plugins.claude_code_hooks import register_callbacks
+
+        original = register_callbacks._hook_engine
+        register_callbacks._hook_engine = _engine(_allowed())
+        try:
+            result = await register_callbacks.on_user_prompt_submit_hook("list files")
+        finally:
+            register_callbacks._hook_engine = original
+
+        # Nothing to add => None, and run_with_mcp keeps the original prompt.
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_block_preserves_pending_session_context_for_next_prompt(self):
+        """A blocked prompt never runs, so its SessionStart context must survive."""
+        from code_puppy.plugins.claude_code_hooks import register_callbacks
+
+        original = register_callbacks._hook_engine
+        register_callbacks._hook_engine = _engine(_blocked())
+        register_callbacks._pending_session_context.clear()
+        register_callbacks._pending_session_context.append("project constitution")
+        try:
+            await register_callbacks.on_user_prompt_submit_hook("blocked prompt")
+            assert register_callbacks._pending_session_context == [
+                "project constitution"
+            ]
+
+            # The next, allowed prompt picks it up.
+            register_callbacks._hook_engine = _engine(_allowed())
+            result = await register_callbacks.on_user_prompt_submit_hook("ok prompt")
+            assert result is not None
+            assert "project constitution" in result
+            assert "ok prompt" in result
+            assert register_callbacks._pending_session_context == []
+        finally:
+            register_callbacks._hook_engine = original
+            register_callbacks._pending_session_context.clear()
+
+
+# ---------------------------------------------------------------------------
+# Session id propagation
+# ---------------------------------------------------------------------------
+
+
+class TestSessionIdPropagation:
+    @pytest.mark.asyncio
+    async def test_pre_tool_use_carries_the_current_run_id(self):
+        from code_puppy.plugins.claude_code_hooks import register_callbacks
+        from code_puppy.session_context import set_session_id
+
+        engine = _engine(_allowed())
+        original = register_callbacks._hook_engine
+        register_callbacks._hook_engine = engine
+        set_session_id("run-abc")
+        try:
+            await register_callbacks.on_pre_tool_call_hook("Bash", {"command": "ls"})
+        finally:
+            register_callbacks._hook_engine = original
+            set_session_id(None)
+
+        event_data = engine.process_event.await_args.args[1]
+        assert event_data.context["session_id"] == "run-abc"
+
+    @pytest.mark.asyncio
+    async def test_post_tool_use_carries_the_current_run_id(self):
+        from code_puppy.plugins.claude_code_hooks import register_callbacks
+        from code_puppy.session_context import set_session_id
+
+        engine = _engine(_allowed())
+        original = register_callbacks._hook_engine
+        register_callbacks._hook_engine = engine
+        set_session_id("run-xyz")
+        try:
+            await register_callbacks.on_post_tool_call_hook(
+                "Bash", {"command": "ls"}, "output", 12.5
+            )
+        finally:
+            register_callbacks._hook_engine = original
+            set_session_id(None)
+
+        event_data = engine.process_event.await_args.args[1]
+        assert event_data.context["session_id"] == "run-xyz"
+        # Existing context keys must survive alongside it.
+        assert event_data.context["result"] == "output"
+        assert event_data.context["duration_ms"] == 12.5
+
+    @pytest.mark.asyncio
+    async def test_explicit_session_id_wins_over_the_context_var(self):
+        from code_puppy.plugins.claude_code_hooks import register_callbacks
+        from code_puppy.session_context import set_session_id
+
+        engine = _engine(_allowed())
+        original = register_callbacks._hook_engine
+        register_callbacks._hook_engine = engine
+        set_session_id("from-contextvar")
+        try:
+            await register_callbacks.on_user_prompt_submit_hook(
+                "hello", session_id="from-argument"
+            )
+        finally:
+            register_callbacks._hook_engine = original
+            set_session_id(None)
+
+        event_data = engine.process_event.await_args.args[1]
+        assert event_data.context["session_id"] == "from-argument"
+
+    @pytest.mark.asyncio
+    async def test_outside_a_run_the_placeholder_default_still_applies(self):
+        """No id available => omit the key so the payload builder's default wins."""
+        from code_puppy.hook_engine.executor import _build_stdin_payload
+        from code_puppy.plugins.claude_code_hooks import register_callbacks
+        from code_puppy.session_context import set_session_id
+
+        engine = _engine(_allowed())
+        original = register_callbacks._hook_engine
+        register_callbacks._hook_engine = engine
+        set_session_id(None)
+        try:
+            await register_callbacks.on_pre_tool_call_hook("Bash", {"command": "ls"})
+        finally:
+            register_callbacks._hook_engine = original
+
+        event_data = engine.process_event.await_args.args[1]
+        assert "session_id" not in event_data.context
+
+        import json
+
+        payload = json.loads(_build_stdin_payload(event_data).decode())
+        assert payload["session_id"] == "codepuppy-session"
+
+
+class TestSessionContextVar:
+    def test_defaults_to_none(self):
+        from code_puppy.session_context import get_session_id, set_session_id
+
+        set_session_id(None)
+        assert get_session_id() is None
+
+    def test_set_and_get_round_trip(self):
+        from code_puppy.session_context import get_session_id, set_session_id
+
+        set_session_id("abc123")
+        try:
+            assert get_session_id() == "abc123"
+        finally:
+            set_session_id(None)
+
+    @pytest.mark.asyncio
+    async def test_value_is_inherited_by_a_child_task(self):
+        """create_task copies the context — this is what carries the id into the run."""
+        import asyncio
+
+        from code_puppy.session_context import get_session_id, set_session_id
+
+        seen = []
+
+        async def child():
+            seen.append(get_session_id())
+
+        set_session_id("parent-run")
+        try:
+            await asyncio.create_task(child())
+        finally:
+            set_session_id(None)
+
+        assert seen == ["parent-run"]
+
+    @pytest.mark.asyncio
+    async def test_a_child_task_cannot_clobber_its_parent(self):
+        """Nested-run isolation: a task's write stays local to that task."""
+        import asyncio
+
+        from code_puppy.session_context import get_session_id, set_session_id
+
+        async def child():
+            set_session_id("nested-run")
+
+        set_session_id("outer-run")
+        try:
+            await asyncio.create_task(child())
+            assert get_session_id() == "outer-run"
+        finally:
+            set_session_id(None)


### PR DESCRIPTION
`PostToolUse` currently cannot affect anything. `on_post_tool_call` fires from the `finally` of the `_call_tool` wrapper — after `return result` has already decided the value — and its return is discarded. A hook can see a secret in a tool's output and has no way to keep it out of the model.

This makes a `{"blocked": True, "reason": ...}` verdict from a `post_tool_call` callback substitute a notice for the result.

## What this does and does not do

The tool has **already run** by the time `PostToolUse` fires, and this does not change that. Side effects have happened — the file was read, the command executed. What the verdict controls is where the output *goes*: it stays out of the model's context, out of the message history, and out of your provider's logs. `PreToolUse` remains the way to stop a call from happening at all.

That distinction is stated in the docs rather than left for someone to discover.

## Implementation

The callback moves from the `finally` onto the success path, before the result is handed back. The mechanism is the one already used a few lines above to prepend `PreToolUse` stdout to a tool result, so this isn't new plumbing — just the same rewrite point, with a verdict attached.

The `finally` still fires on the exception path, where there is no result to withhold and the notification stays observational. A flag prevents a successful call from notifying twice.

**Additive for existing consumers.** All eight `post_tool_call` registrants — run stats, subagent panel, ACP bridge, timestamp heartbeat, frontend emitter, quick-resume, herdr, and the hooks bridge — are observational and return nothing, so none of them change behaviour. `_run_post_tool_call` never raises: a hook that throws leaves the result untouched.

## Honest framing

Unlike the other hook work I've sent, this is **not** a Claude Code parity fix. Claude Code's `PostToolUse` cannot withhold a result either — exit 2 there feeds stderr back to the model *alongside* the result. This is a capability request, so it's a separate PR rather than bundled with the compat fixes, and easy to decline on its own merits.

## Stacking

This sits on top of the three-commit hooks-blocking branch (`fix/user-prompt-submit-block-and-session-id`), because it reuses the `_block_reason` helper introduced there. Until that lands, this PR's diff shows those commits too; the commit unique to this PR is the last one. Both branches are rebased onto current `main`.

## Testing

Six new tests: the bridge verdict, the runtime substitution, pass-through when allowed, and a hook that throws.

Full suite on current `main` + this branch: **7124 passed, 8 skipped**. `ruff check` clean; `ruff format --check` flags only two files this branch doesn't touch (`agent_creator_agent.py` and its test, already unformatted on `main`).

Verified end-to-end against a live agent and a real model, on 0.0.702:

- `cat` a file containing a marker → hook blocks → the agent replies *"I can't see what's in that file"*, where before this change it echoed the secret straight back.
- The `Stop` payload confirms the secret is absent from the agent's final response, so it never entered the transcript either.
- `PostToolUse` still receives the real `tool_result`, which is what makes it scannable in the first place — only what flows onward is replaced.

The withheld output is still printed in the operator's own terminal by code puppy's shell display, which runs before the hook. That is expected: this protects the model context, not the local screen.