### PR TITLE
Preserve default skill directories in enabled skill discovery

### DIFF
--- a/code_puppy/plugins/agent_skills/enabled_skills.py
+++ b/code_puppy/plugins/agent_skills/enabled_skills.py
@@ -42,9 +42,6 @@ def iter_enabled_skill_metadata(
     if not _config.get_skills_enabled():
         return
 
-    if directories is None:
-        directories = [Path(d) for d in _config.get_skill_directories()]
-
     disabled = _config.get_disabled_skills()
 
     for info in _discovery.discover_skills(directories):
@@ -74,9 +71,6 @@ def iter_enabled_skills(
     """
     if not _config.get_skills_enabled():
         return
-
-    if directories is None:
-        directories = [Path(d) for d in _config.get_skill_directories()]
 
     disabled = _config.get_disabled_skills()
 

--- a/tests/plugins/test_agent_skills_callbacks_coverage.py
+++ b/tests/plugins/test_agent_skills_callbacks_coverage.py
@@ -4,12 +4,24 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # Patch targets for lazy imports inside _get_skills_prompt_section
 _CFG = "code_puppy.plugins.agent_skills.config"
 _DISC = "code_puppy.plugins.agent_skills.discovery"
 _META = "code_puppy.plugins.agent_skills.metadata"
 _PB = "code_puppy.plugins.agent_skills.prompt_builder"
 _ENABLED = "code_puppy.plugins.agent_skills.enabled_skills"
+
+
+def _write_skill(root, name, description="A test skill."):
+    """Create a minimal valid skill directory with SKILL.md under root."""
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\nBody.\n"
+    )
+    return skill_dir
 
 
 class TestGetSkillsPromptSection:
@@ -139,6 +151,129 @@ class TestEnabledSkillsHelper:
         ):
             assert list_enabled_skill_metadata() == []
         mock_parse.assert_not_called()
+
+
+class TestEnabledSkillsDirectoryPassthrough:
+    # Regression coverage for the additive-directory bug: discover_skills()
+    # only performs its configured-plus-default directory merge when it
+    # receives directories=None. The enabled-skills iterators must forward
+    # an omitted `directories` argument as None unchanged -- pre-resolving
+    # it into an explicit configured-only list silently hides every skill
+    # living in a default directory (~/.code_puppy/skills, ./skills, etc).
+    #
+    # These tests exercise the real discover_skills (not a mock) against
+    # real temp directories, so a regression here is caught independently
+    # of the mocked-discover_skills tests above.
+
+    @pytest.fixture(autouse=True)
+    def _isolate_plugin_skills(self):
+        # Plugin-registered skills are process-global; keep this hermetic.
+        with patch(f"{_DISC}._collect_plugin_skills", return_value=[]):
+            yield
+
+    def test_omitted_directories_still_finds_default_dir_skill(self, tmp_path):
+        # The headline bug: a configured custom directory must not push
+        # out skills that live in a default directory.
+        from code_puppy.plugins.agent_skills.enabled_skills import (
+            list_enabled_skill_metadata,
+        )
+
+        configured_dir = tmp_path / "configured"
+        configured_dir.mkdir()
+        default_dir = tmp_path / "default"
+        default_dir.mkdir()
+        _write_skill(default_dir, "default-dir-skill")
+
+        with (
+            patch(f"{_CFG}.get_skills_enabled", return_value=True),
+            patch(f"{_CFG}.get_disabled_skills", return_value=set()),
+            # Buggy code path resolves via config.get_skill_directories()
+            # before ever reaching discover_skills.
+            patch(
+                f"{_CFG}.get_skill_directories",
+                return_value=[str(configured_dir)],
+            ),
+            # Fixed code path forwards None into discover_skills, which
+            # resolves configured + default dirs via these two.
+            patch(
+                f"{_DISC}.get_skill_directories",
+                return_value=[str(configured_dir)],
+            ),
+            patch(
+                f"{_DISC}.get_default_skill_directories",
+                return_value=[default_dir],
+            ),
+        ):
+            names = {meta.name for meta in list_enabled_skill_metadata()}
+
+        assert "default-dir-skill" in names, (
+            "Skill in a default directory disappeared when a custom "
+            "skill_directories value was configured -- the additive merge "
+            "regressed."
+        )
+
+    def test_explicit_directories_still_restrict_scope(self, tmp_path):
+        # Callers that intentionally pass an explicit list keep the old,
+        # non-additive behaviour.
+        from code_puppy.plugins.agent_skills.enabled_skills import (
+            list_enabled_skill_metadata,
+        )
+
+        explicit_dir = tmp_path / "explicit"
+        explicit_dir.mkdir()
+        _write_skill(explicit_dir, "explicit-skill")
+
+        default_dir = tmp_path / "default"
+        default_dir.mkdir()
+        _write_skill(default_dir, "default-skill-should-not-appear")
+
+        with (
+            patch(f"{_CFG}.get_skills_enabled", return_value=True),
+            patch(f"{_CFG}.get_disabled_skills", return_value=set()),
+            patch(
+                f"{_DISC}.get_default_skill_directories",
+                return_value=[default_dir],
+            ),
+        ):
+            names = {
+                meta.name
+                for meta in list_enabled_skill_metadata(directories=[explicit_dir])
+            }
+
+        assert names == {"explicit-skill"}
+
+    def test_disabled_skills_excluded_from_merged_directories(self, tmp_path):
+        # Disabling still works once directories are merged.
+        from code_puppy.plugins.agent_skills.enabled_skills import (
+            list_enabled_skill_metadata,
+        )
+
+        configured_dir = tmp_path / "configured"
+        configured_dir.mkdir()
+        default_dir = tmp_path / "default"
+        default_dir.mkdir()
+        _write_skill(default_dir, "keep-me")
+        _write_skill(default_dir, "disable-me")
+
+        with (
+            patch(f"{_CFG}.get_skills_enabled", return_value=True),
+            patch(f"{_CFG}.get_disabled_skills", return_value={"disable-me"}),
+            patch(
+                f"{_CFG}.get_skill_directories",
+                return_value=[str(configured_dir)],
+            ),
+            patch(
+                f"{_DISC}.get_skill_directories",
+                return_value=[str(configured_dir)],
+            ),
+            patch(
+                f"{_DISC}.get_default_skill_directories",
+                return_value=[default_dir],
+            ),
+        ):
+            names = {meta.name for meta in list_enabled_skill_metadata()}
+
+        assert names == {"keep-me"}
 
 
 class TestInjectSkillsIntoPrompt:

--- a/tests/plugins/test_agent_skills_provider.py
+++ b/tests/plugins/test_agent_skills_provider.py
@@ -39,6 +39,13 @@ def test_provider_listing_does_not_recurse_through_register_skills(
         lambda: [str(skills_root)],
     )
     monkeypatch.setattr(enabled_skills._config, "get_disabled_skills", set)
+    # discover_skills() resolves directories via its own bound names
+    # (imported at module load time from config), not via the config
+    # module attribute patched above -- pin those too so this test stays
+    # hermetic from whatever real default-directory skills exist on the
+    # machine running the suite.
+    monkeypatch.setattr(discovery, "get_skill_directories", lambda: [str(skills_root)])
+    monkeypatch.setattr(discovery, "get_default_skill_directories", lambda: [])
 
     try:
         assert provider.list_enabled_skills() == [


### PR DESCRIPTION
## Problem

When `skill_directories` is configured, `iter_enabled_skill_metadata()` and `iter_enabled_skills()` only scanned the configured directories. This silently hides valid skills living in default locations (`~/.code_puppy/skills`, `./skills`, `~/.claude/skills`, project `.code_puppy/skills`, etc.) from skill search and activation -- even though those skills exist on disk and are not disabled. Users see a misleading "skill not found" from `activate_skill`/`list_or_search_skills` instead of a clear configuration error.

## Root cause

`enabled_skills.py` converted an omitted `directories` argument into an explicit list resolved from `config.get_skill_directories()` **before** calling `discover_skills()`:

```python
if directories is None:
    directories = [Path(d) for d in _config.get_skill_directories()]
```

`discover_skills()` only performs its configured-plus-default directory merge when it receives `directories=None`. Passing it an explicit list (even one built from the same config value) makes it treat that list as the *complete* set of directories to scan, skipping the additive merge with defaults entirely.

## Fix

Pass the optional `directories` argument straight through to `discover_skills()` unchanged in both `iter_enabled_skill_metadata()` and `iter_enabled_skills()`. Explicit directory lists (from callers who intentionally scope discovery) still behave as explicit lists; an omitted argument now reaches `discover_skills()` as `None`, letting it perform its normal additive merge.

Net diff in `enabled_skills.py`: 6 lines removed, 0 added.

## Tests

- Added `TestEnabledSkillsDirectoryPassthrough` in `tests/plugins/test_agent_skills_callbacks_coverage.py` with 3 cases against the **real** `discover_skills()` and real temp directories (not mocked):
  - omitted `directories` still finds a skill living only in a (mocked) default directory
  - explicit `directories=[...]` still restricts scope as before
  - disabled skills stay excluded once directories are merged
- Confirmed these tests fail against the pre-fix code and pass after the fix.
- Corrected `tests/plugins/test_agent_skills_provider.py::test_provider_listing_does_not_recurse_through_register_skills`, whose monkeypatch targeted `enabled_skills._config.get_skill_directories` -- a name `discovery.py` imports and binds at module load time, so the patch never reached the real call site. That test passed only because the bug being fixed here made `enabled_skills.py` resolve directories via the patched `config` function directly; removing that pre-resolution exposed the stale patch target and started leaking real default-directory skills from the machine running the suite into the assertion. Retargeted the patch at `discovery.get_skill_directories` / `discovery.get_default_skill_directories`, the functions `discover_skills()` actually calls when `directories is None`.
- Full suite: 7103 passed, 23 skipped, 1 xpassed, 0 failed.
- `ruff check` / `ruff format` clean.