### PR TITLE
PUP-585: fix(subagent): fall back instead of hard-failing when a pinned model is unavailable

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -307,15 +307,52 @@ def reload_mcp_servers(agent_name: Optional[str] = None) -> List[Any]:
     return manager.get_servers_for_agent(agent_name=agent_name)
 
 
+# (agent_name, requested_model_name) combos we've already warned about this
+# conversation. Deliberately NOT cleared when a model finally loads again --
+# only reset_model_fallback_warnings() (wired to /clear) resets it, so a
+# still-broken pin doesn't re-nag on every agent rebuild within one
+# conversation, but a fresh conversation gets the reminder again. We
+# deliberately do NOT auto-clear the pin itself -- see
+# config.clear_agent_pinned_model; that stays a human decision.
+_warned_model_fallbacks: Set[Tuple[Optional[str], str]] = set()
+
+
+def reset_model_fallback_warnings() -> None:
+    """Forget which (agent, model) fallback warnings have already fired.
+
+    Called when the user starts a fresh conversation (/clear) so a
+    persistently broken pin gets re-flagged instead of going silent forever.
+    """
+    _warned_model_fallbacks.clear()
+
+
+def _model_fallback_fix_hint(agent_name: Optional[str]) -> str:
+    """Build the how-to-fix tail appended to model fallback warnings."""
+    if agent_name:
+        return (
+            f"Fix it with `/pin {agent_name} <model>` once a working model is "
+            f"available, or `/unpin {agent_name}` to just track the global "
+            "default from now on. Run `/model` to see configured models."
+        )
+    return "Set a valid model with `/model`, or check your models configuration."
+
+
 def load_model_with_fallback(
     requested_model_name: str,
     models_config: Dict[str, Any],
     message_group: str,
+    agent_name: Optional[str] = None,
 ) -> Tuple[Any, str]:
     """Load the requested model, or fall back to a sensible alternative.
 
     Falls back in order: the globally configured model, then any other
     configured model. Raises ``ValueError`` only if nothing loads.
+
+    ``agent_name``, when given, scopes the model-unavailable warning to fire
+    once per (agent, requested model) combo per conversation (see
+    ``reset_model_fallback_warnings``) and tailors the fix instructions to
+    that agent's ``/pin``/``/unpin`` commands. The agent's pinned model is
+    never auto-cleared -- that stays a deliberate, human-initiated action.
     """
     try:
         model = ModelFactory.get_model(requested_model_name, models_config)
@@ -330,30 +367,38 @@ def load_model_with_fallback(
         available_str = (
             ", ".join(sorted(available)) if available else "no configured models"
         )
+        warn_key = (agent_name, requested_model_name)
+        already_warned = warn_key in _warned_model_fallbacks
+        _warned_model_fallbacks.add(warn_key)
+        fix_hint = _model_fallback_fix_hint(agent_name)
+
         # Distinguish between "key missing", "type unsupported", and "creation failed"
         exc_msg = str(exc)
-        if "not found in configuration" in exc_msg:
+        if already_warned:
+            pass
+        elif "not found in configuration" in exc_msg:
             emit_warning(
-                f"Model '{requested_model_name}' not found. Available models: {available_str}",
+                f"Model '{requested_model_name}' not found. Available models: "
+                f"{available_str}. {fix_hint}",
                 message_group=message_group,
             )
         elif "Unsupported model type" in exc_msg:
             model_type = models_config.get(requested_model_name, {}).get("type", "?")
             emit_warning(
                 f"Model type '{model_type}' is not supported (model '{requested_model_name}'). "
-                f"Available models: {available_str}",
+                f"Available models: {available_str}. {fix_hint}",
                 message_group=message_group,
             )
         elif "could not be instantiated" in exc_msg:
             emit_warning(
                 f"Model '{requested_model_name}' could not be instantiated. "
-                f"Available models: {available_str}",
+                f"Available models: {available_str}. {fix_hint}",
                 message_group=message_group,
             )
         else:
             emit_warning(
                 f"Model '{requested_model_name}' failed: {exc_msg}. "
-                f"Available models: {available_str}",
+                f"Available models: {available_str}. {fix_hint}",
                 message_group=message_group,
             )
 
@@ -526,7 +571,10 @@ def build_pydantic_agent(
 
     models_config = ModelFactory.load_config()
     model, resolved_model_name = load_model_with_fallback(
-        agent.get_model_name(), models_config, message_group
+        agent.get_model_name(),
+        models_config,
+        message_group,
+        agent_name=getattr(agent, "name", None),
     )
     instructions = _assemble_instructions(agent, resolved_model_name)
     mcp_servers = load_mcp_servers(agent_name=getattr(agent, "name", None))
@@ -618,6 +666,7 @@ def build_tool_probe_for_agent(agent: Any) -> Optional[Any]:
             agent.get_model_name() or "",
             models_config,
             message_group=str(uuid.uuid4()),
+            agent_name=getattr(agent, "name", None),
         )
     except Exception:
         return None

--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -307,23 +307,49 @@ def reload_mcp_servers(agent_name: Optional[str] = None) -> List[Any]:
     return manager.get_servers_for_agent(agent_name=agent_name)
 
 
-# (agent_name, requested_model_name) combos we've already warned about this
-# conversation. Deliberately NOT cleared when a model finally loads again --
-# only reset_model_fallback_warnings() (wired to /clear) resets it, so a
-# still-broken pin doesn't re-nag on every agent rebuild within one
-# conversation, but a fresh conversation gets the reminder again. We
-# deliberately do NOT auto-clear the pin itself -- see
-# config.clear_agent_pinned_model; that stays a human decision.
-_warned_model_fallbacks: Set[Tuple[Optional[str], str]] = set()
+# (conversation_scope, agent_name, requested_model_name) combos we've
+# already warned about this conversation. ``conversation_scope`` lets
+# independent conversations sharing one process (concurrent ACP sessions,
+# notably) keep separate warning state, so one session's warning can't
+# silently suppress -- or a reset silently un-suppress -- another's; see
+# ``subagent_invocation.py`` (passes the parent conversation's session id)
+# and ``build_pydantic_agent``/``build_tool_probe_for_agent`` (leave it
+# ``None``, matching the pre-existing single-main-agent-per-process model).
+# Deliberately NOT cleared when a model finally loads again -- only
+# reset_model_fallback_warnings() resets it, so a still-broken pin doesn't
+# re-nag on every agent rebuild within one conversation, but a fresh
+# conversation gets the reminder again. We deliberately do NOT auto-clear
+# the pin itself -- see config.clear_agent_pinned_model; that stays a human
+# decision.
+_warned_model_fallbacks: Set[Tuple[Optional[str], Optional[str], str]] = set()
+
+# Sentinel distinguishing "reset() called with no args" (nuke everything --
+# the CLI's /clear, a genuinely fresh process-wide start) from
+# "reset(scope=X)" (clear only that conversation's bucket -- e.g. ACP session
+# creation clearing just the shared main-agent-build bucket without touching
+# other live sessions' own scoped sub-agent warnings). ``None`` is itself a
+# valid, meaningful scope (the unscoped/main-agent bucket), so it can't
+# double as "unset".
+_UNSET = object()
 
 
-def reset_model_fallback_warnings() -> None:
-    """Forget which (agent, model) fallback warnings have already fired.
+def reset_model_fallback_warnings(scope: Any = _UNSET) -> None:
+    """Forget which fallback warnings have already fired.
 
-    Called when the user starts a fresh conversation (/clear) so a
-    persistently broken pin gets re-flagged instead of going silent forever.
+    Called with no arguments on a genuinely fresh conversation (the CLI's
+    ``/clear``) to clear every scope's warning state.
+
+    Called with an explicit ``scope`` (e.g. an ACP session boundary) to
+    clear only that conversation's bucket -- notably ``scope=None`` clears
+    just the shared main-agent-build bucket without wiping the per-session
+    warning state other live conversations already earned via
+    ``load_model_with_fallback(..., conversation_scope=<their own id>)``.
     """
-    _warned_model_fallbacks.clear()
+    if scope is _UNSET:
+        _warned_model_fallbacks.clear()
+        return
+    stale = {key for key in _warned_model_fallbacks if key[0] == scope}
+    _warned_model_fallbacks.difference_update(stale)
 
 
 def _model_fallback_fix_hint(agent_name: Optional[str]) -> str:
@@ -342,6 +368,7 @@ def load_model_with_fallback(
     models_config: Dict[str, Any],
     message_group: str,
     agent_name: Optional[str] = None,
+    conversation_scope: Optional[str] = None,
 ) -> Tuple[Any, str]:
     """Load the requested model, or fall back to a sensible alternative.
 
@@ -349,10 +376,17 @@ def load_model_with_fallback(
     configured model. Raises ``ValueError`` only if nothing loads.
 
     ``agent_name``, when given, scopes the model-unavailable warning to fire
-    once per (agent, requested model) combo per conversation (see
-    ``reset_model_fallback_warnings``) and tailors the fix instructions to
-    that agent's ``/pin``/``/unpin`` commands. The agent's pinned model is
+    once per (conversation, agent, requested model) combo per conversation
+    (see ``reset_model_fallback_warnings``) and tailors the fix instructions
+    to that agent's ``/pin``/``/unpin`` commands. The agent's pinned model is
     never auto-cleared -- that stays a deliberate, human-initiated action.
+
+    ``conversation_scope`` identifies the conversation this call belongs to
+    (e.g. an ACP session id) so independent conversations sharing one
+    process don't share warning-dedup state -- one session's warning must
+    not silently suppress the identical warning for a completely different
+    session. Leave ``None`` for the single main-agent-per-process case
+    (default; unaffected by this parameter).
     """
     try:
         model = ModelFactory.get_model(requested_model_name, models_config)
@@ -367,7 +401,7 @@ def load_model_with_fallback(
         available_str = (
             ", ".join(sorted(available)) if available else "no configured models"
         )
-        warn_key = (agent_name, requested_model_name)
+        warn_key = (conversation_scope, agent_name, requested_model_name)
         already_warned = warn_key in _warned_model_fallbacks
         _warned_model_fallbacks.add(warn_key)
         fix_hint = _model_fallback_fix_hint(agent_name)

--- a/code_puppy/agents/agent_creator_agent.py
+++ b/code_puppy/agents/agent_creator_agent.py
@@ -648,7 +648,9 @@ Your goal is to take users from idea to working agent in one smooth conversation
         return "Hi! I'm the Agent Creator 🏗️ Let's build an awesome agent together!"
 
 
-def _validate_agent_creation(tool_name: str, tool_args: dict, context=None) -> Optional[dict]:
+def _validate_agent_creation(
+    tool_name: str, tool_args: dict, context=None
+) -> Optional[dict]:
     """Intercept create_file to validate agent JSON configs before saving."""
     if tool_name != "create_file":
         return None
@@ -671,22 +673,22 @@ def _validate_agent_creation(tool_name: str, tool_args: dict, context=None) -> O
         errors = agent.validate_agent_json(agent_config)
 
         if errors:
-            error_msg = "Validation errors:\n" + "\n".join(f"- {error}" for error in errors)
+            error_msg = "Validation errors:\n" + "\n".join(
+                f"- {error}" for error in errors
+            )
             return {
                 "blocked": True,
-                "error_message": f"Invalid JSON agent config: {error_msg}"
+                "error_message": f"Invalid JSON agent config: {error_msg}",
             }
     except json.JSONDecodeError as e:
         return {
             "blocked": True,
-            "error_message": f"Syntax error: Invalid JSON payload. {str(e)}"
+            "error_message": f"Syntax error: Invalid JSON payload. {str(e)}",
         }
     except Exception as e:
-        return {
-            "blocked": True,
-            "error_message": f"Validation failed: {str(e)}"
-        }
-    
+        return {"blocked": True, "error_message": f"Validation failed: {str(e)}"}
+
     return None
+
 
 register_callback("pre_tool_call", _validate_agent_creation)

--- a/code_puppy/command_line/session_commands.py
+++ b/code_puppy/command_line/session_commands.py
@@ -109,6 +109,7 @@ def handle_session_command(command: str) -> bool:
 )
 def handle_clear_command(command: str) -> bool:
     """Clear conversation history and rotate autosave session."""
+    from code_puppy.agents._builder import reset_model_fallback_warnings
     from code_puppy.agents.agent_manager import get_current_agent
     from code_puppy.command_line.clipboard import get_clipboard_manager
     from code_puppy.config import finalize_autosave_session
@@ -117,6 +118,9 @@ def handle_clear_command(command: str) -> bool:
     agent = get_current_agent()
     new_session_id = finalize_autosave_session()
     agent.clear_message_history()
+    # New conversation: a stale pinned-model warning deserves to resurface
+    # rather than staying silenced from the previous conversation forever.
+    reset_model_fallback_warnings()
     emit_warning(t("cmd.clear.cleared"))
     emit_system_message(t("cmd.clear.agent_notice"))
     emit_info(t("cmd.clear.session_rotated", id=new_session_id))

--- a/code_puppy/plugins/acp/agent.py
+++ b/code_puppy/plugins/acp/agent.py
@@ -382,7 +382,21 @@ class CodePuppyAgent(Agent):
         When ``rehydrate`` is set, any persisted history for ``session_id`` is
         replayed into the agent so the model continues the real conversation.
         Client-injected ``mcp_servers`` are attached best-effort.
+
+        Also resets ``load_model_with_fallback``'s once-per-conversation
+        pinned-model-unavailable dedup (see ``_builder.reset_model_fallback_warnings``).
+        That dedup is process-lifetime global state whose only other reset hook
+        is the CLI's ``/clear`` -- without this, a long-running ACP server
+        hosting multiple concurrent client sessions would silently suppress a
+        dead-pin warning for every session after the first one that ever hit
+        it, even sessions from a different client/workspace that never saw the
+        first warning. Resetting on every new/loaded/forked session trades a
+        possible extra warning for a new session against that cross-session
+        silence, which is the safer direction to be wrong in.
         """
+        from code_puppy.agents._builder import reset_model_fallback_warnings
+
+        reset_model_fallback_warnings()
         agent = self._new_agent()
         if rehydrate:
             history = persistence.load_history(session_id)

--- a/code_puppy/plugins/acp/agent.py
+++ b/code_puppy/plugins/acp/agent.py
@@ -383,20 +383,25 @@ class CodePuppyAgent(Agent):
         replayed into the agent so the model continues the real conversation.
         Client-injected ``mcp_servers`` are attached best-effort.
 
-        Also resets ``load_model_with_fallback``'s once-per-conversation
+        Also resets the SHARED/unscoped bucket of
+        ``load_model_with_fallback``'s once-per-conversation
         pinned-model-unavailable dedup (see ``_builder.reset_model_fallback_warnings``).
-        That dedup is process-lifetime global state whose only other reset hook
-        is the CLI's ``/clear`` -- without this, a long-running ACP server
-        hosting multiple concurrent client sessions would silently suppress a
-        dead-pin warning for every session after the first one that ever hit
-        it, even sessions from a different client/workspace that never saw the
-        first warning. Resetting on every new/loaded/forked session trades a
-        possible extra warning for a new session against that cross-session
-        silence, which is the safer direction to be wrong in.
+        Sub-agent invocations scope their own warning state to the parent
+        conversation's session id (see ``subagent_invocation.py``), so they
+        already can't leak across sessions and don't need this reset at all.
+        The *main* agent build path (``build_pydantic_agent``, used to build
+        each session's own top-level agent) still shares one unscoped bucket
+        across every session in this process, matching the pre-existing
+        single-main-agent-per-process model -- so without this reset, session
+        A hitting a dead pin during its own build could silently suppress the
+        identical warning for session B's build too. Resetting only the
+        ``scope=None`` bucket on every new/loaded/forked session avoids that
+        without touching any other session's already-scoped sub-agent
+        warnings.
         """
         from code_puppy.agents._builder import reset_model_fallback_warnings
 
-        reset_model_fallback_warnings()
+        reset_model_fallback_warnings(scope=None)
         agent = self._new_agent()
         if rehydrate:
             history = persistence.load_history(session_id)

--- a/code_puppy/plugins/acp/agent.py
+++ b/code_puppy/plugins/acp/agent.py
@@ -340,11 +340,23 @@ class CodePuppyAgent(Agent):
         otherwise the session would resurrect in the next ``list_sessions``,
         which is exactly the "disappeared session that won't stay gone" bug in
         reverse.
+
+        Also purges this session's own bucket of
+        ``load_model_with_fallback``'s once-per-conversation dead-model-warning
+        dedup (keyed by the session's ``conversation_root_id`` -- see
+        ``subagent_invocation.py`` / ``subagent_context.py``). Sub-agent
+        warnings are scoped per session precisely so they never leak into any
+        OTHER session; without this, a long-running server churning through
+        many short-lived sessions would accumulate one dangling bucket per
+        closed session forever.
         """
+        from code_puppy.agents._builder import reset_model_fallback_warnings
+
         session = self._sessions.pop(session_id, None)
         if session is not None:
             session.cancel()
         persistence.delete(session_id)
+        reset_model_fallback_warnings(scope=session_id)
         return CloseSessionResponse()
 
     # ---- Prompt turn ------------------------------------------------------

--- a/code_puppy/plugins/acp/agent.py
+++ b/code_puppy/plugins/acp/agent.py
@@ -343,18 +343,25 @@ class CodePuppyAgent(Agent):
 
         Also purges this session's own bucket of
         ``load_model_with_fallback``'s once-per-conversation dead-model-warning
-        dedup (keyed by the session's ``conversation_root_id`` -- see
+        dedup (keyed by the session's conversation root id -- see
         ``subagent_invocation.py`` / ``subagent_context.py``). Sub-agent
         warnings are scoped per session precisely so they never leak into any
         OTHER session; without this, a long-running server churning through
         many short-lived sessions would accumulate one dangling bucket per
         closed session forever.
+
+        Waits for any in-flight run to actually finish unwinding
+        (``cancel_and_wait``, not the bare ``cancel``) before purging --
+        otherwise a run still mid-flight inside ``_invoke_agent_impl`` could
+        write a fresh warning into this session's bucket a moment *after*
+        the purge, leaking that one entry forever (nothing will call
+        ``close_session`` for this id a second time).
         """
         from code_puppy.agents._builder import reset_model_fallback_warnings
 
         session = self._sessions.pop(session_id, None)
         if session is not None:
-            session.cancel()
+            await session.cancel_and_wait()
         persistence.delete(session_id)
         reset_model_fallback_warnings(scope=session_id)
         return CloseSessionResponse()
@@ -398,12 +405,14 @@ class CodePuppyAgent(Agent):
         Also resets the SHARED/unscoped bucket of
         ``load_model_with_fallback``'s once-per-conversation
         pinned-model-unavailable dedup (see ``_builder.reset_model_fallback_warnings``).
-        Sub-agent invocations scope their own warning state to the parent
-        conversation's session id (see ``subagent_invocation.py``), so they
-        already can't leak across sessions and don't need this reset at all.
-        The *main* agent build path (``build_pydantic_agent``, used to build
-        each session's own top-level agent) still shares one unscoped bucket
-        across every session in this process, matching the pre-existing
+        Sub-agent invocations scope their own warning state to the
+        conversation's ROOT id (a ContextVar -- see
+        ``subagent_context.get_conversation_root_id``/``session.py``'s prompt
+        handler), so they already can't leak across sessions and don't need
+        this reset at all. The *main* agent build path
+        (``build_pydantic_agent``, used to build each session's own
+        top-level agent) still shares one unscoped bucket across every
+        session in this process, matching the pre-existing
         single-main-agent-per-process model -- so without this reset, session
         A hitting a dead pin during its own build could silently suppress the
         identical warning for session B's build too. Resetting only the

--- a/code_puppy/plugins/acp/session.py
+++ b/code_puppy/plugins/acp/session.py
@@ -207,6 +207,11 @@ class ACPSession:
         Besides cancelling the asyncio task, force-kill any local shell
         processes the run spawned so they don't orphan. (Shells delegated to
         the client run client-side and are unaffected.)
+
+        Only *requests* cancellation -- delivery happens at the task's next
+        await point, whenever that is, not immediately. Callers that need
+        the run to have actually finished unwinding (its ``finally`` block
+        included) before they act should use :meth:`cancel_and_wait` instead.
         """
         task = self._task
         if task is not None and not task.done():
@@ -219,6 +224,36 @@ class ACPSession:
             kill_all_running_shell_processes()
         except Exception:  # noqa: BLE001
             logger.debug("ACP: shell kill on cancel failed", exc_info=True)
+
+    async def cancel_and_wait(self, timeout: float = 2.0) -> None:
+        """Cancel the in-flight run and wait for it to actually unwind.
+
+        ``cancel()`` alone only *requests* cancellation; asyncio only
+        delivers it at the task's next await point, with no guarantee of
+        when that is. A caller that needs the run's own cleanup to have
+        genuinely finished first -- notably ``close_session`` purging this
+        session's warn-dedup bucket, which would otherwise race a
+        still-in-flight ``_invoke_agent_impl`` synchronously writing into
+        that same bucket a moment later -- must await this instead of the
+        bare ``cancel()``.
+
+        Bounded by ``timeout`` so a run stuck ignoring cancellation (blocked
+        in genuinely non-cancellable I/O, say) can't hang session close
+        forever; on timeout we give up waiting and return anyway -- the task
+        is still cancelled, just not confirmed finished.
+        """
+        task = self._task
+        self.cancel()
+        if task is None:
+            return
+        try:
+            await asyncio.wait_for(task, timeout=timeout)
+        except (asyncio.CancelledError, asyncio.TimeoutError):
+            pass
+        except Exception:  # noqa: BLE001
+            # prompt()'s own except block already logs/handles run failures;
+            # a close shouldn't raise because the run it interrupted failed.
+            logger.debug("ACP: cancel_and_wait observed run failure", exc_info=True)
 
     async def _send_error_notice(self, error: Optional[BaseException]) -> None:
         """Tell the client a turn failed, so it isn't a silent empty response.

--- a/code_puppy/plugins/acp/session.py
+++ b/code_puppy/plugins/acp/session.py
@@ -106,8 +106,18 @@ class ACPSession:
             reset_working_directory,
             set_working_directory,
         )
+        from code_puppy.tools.subagent_context import (
+            reset_conversation_root_id,
+            set_conversation_root_id,
+        )
 
         cwd_token = set_working_directory(self.cwd) if self.cwd else None
+        # ContextVar, not set_session_context (see subagent_context.py) --
+        # this is what load_model_with_fallback's conversation_scope reads,
+        # and it needs real per-task isolation across concurrent ACP
+        # sessions / parallel tool calls, which set_session_context's shared
+        # mutable attribute cannot provide.
+        root_id_token = set_conversation_root_id(self.session_id)
 
         set_session_context(self.session_id)
         state.begin_run(self.session_id)
@@ -146,6 +156,7 @@ class ACPSession:
             self._task = None
             state.end_run()
             set_session_context(None)
+            reset_conversation_root_id(root_id_token)
             if cwd_token is not None:
                 reset_working_directory(cwd_token)
 

--- a/code_puppy/tools/subagent_context.py
+++ b/code_puppy/tools/subagent_context.py
@@ -48,8 +48,8 @@ print(is_subagent())  # False
 """
 
 from contextlib import contextmanager
-from contextvars import ContextVar
-from typing import Generator
+from contextvars import ContextVar, Token
+from typing import Generator, Optional
 
 __all__ = [
     "subagent_context",
@@ -58,6 +58,9 @@ __all__ = [
     "get_subagent_chain",
     "get_subagent_depth",
     "get_subagent_model_name",
+    "set_conversation_root_id",
+    "reset_conversation_root_id",
+    "get_conversation_root_id",
 ]
 
 # Track sub-agent depth (0 = main agent, 1+ = sub-agent)
@@ -74,6 +77,30 @@ _subagent_model_name: ContextVar[str | None] = ContextVar(
 # tuple is empty in the main-agent context and `(deepest_name,)` for a
 # single-level sub-agent. For ``code-puppy -> A -> B`` it is ``("A", "B")``.
 _subagent_chain: ContextVar[tuple[str, ...]] = ContextVar("subagent_chain", default=())
+
+# Identifies the single top-level conversation this call tree belongs to
+# (an ACP session id, or ``None`` for the CLI's one-conversation-at-a-time
+# process). Deliberately a plain ``ContextVar`` -- NOT the message-bus's
+# ``set_session_context``/``get_session_context``, which is a shared mutable
+# attribute on a process-wide singleton with no per-task isolation (see
+# ``code_puppy/messaging/bus.py``) and is unsafe to read for anything
+# correctness-sensitive under concurrent asyncio tasks (parallel tool calls,
+# concurrent ACP sessions). A ``ContextVar`` is copied into every child task
+# pydantic-ai spawns (``asyncio.create_task``/anyio ``to_thread``), so:
+#   * concurrent sibling tool calls / concurrent ACP sessions each see their
+#     own independent copy -- no cross-talk, no clobbering;
+#   * nested sub-agent invocations (A invokes B) all inherit the SAME root
+#     value set once at the true conversation root, rather than each level
+#     minting its own fresh transient id -- so "once per conversation"
+#     dedup keys (see ``_builder.load_model_with_fallback``'s
+#     ``conversation_scope``) stay stable across an entire nested call tree.
+# Set once per top-level conversation (ACP's session prompt handler); never
+# touched by ``subagent_context`` itself, so sub-agent nesting doesn't shift
+# it. ``None`` for the CLI, matching its single-conversation-per-process
+# model (unaffected by this scope).
+_conversation_root_id: ContextVar[Optional[str]] = ContextVar(
+    "conversation_root_id", default=None
+)
 
 
 @contextmanager
@@ -202,7 +229,36 @@ def get_subagent_chain() -> tuple[str, ...]:
         ...     get_subagent_chain()
         ('retriever',)
         ...     with subagent_context("terrier"):
-        ...         get_subagent_chain()
+            ...         get_subagent_chain()
         ('retriever', 'terrier')
     """
     return _subagent_chain.get()
+
+
+def set_conversation_root_id(value: Optional[str]) -> Token:
+    """Mark the current asyncio task as belonging to conversation ``value``.
+
+    Call once at the true root of a conversation (e.g. an ACP session's
+    prompt handler) -- NOT inside ``subagent_context``, so nested sub-agent
+    invocations inherit the same root rather than each minting their own.
+
+    Returns a token; pass it to :func:`reset_conversation_root_id` to restore
+    the previous value (typically in a ``finally`` block).
+    """
+    return _conversation_root_id.set(value)
+
+
+def reset_conversation_root_id(token: Token) -> None:
+    """Restore the conversation root id to its value before ``set``."""
+    _conversation_root_id.reset(token)
+
+
+def get_conversation_root_id() -> Optional[str]:
+    """Return the current task's conversation root id, or ``None``.
+
+    ``None`` both for the CLI (which never sets this -- single conversation
+    per process, matching its existing ``/clear``-driven reset model) and
+    for any code path that runs outside a ``set_conversation_root_id``
+    scope.
+    """
+    return _conversation_root_id.get()

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -362,7 +362,21 @@ async def _invoke_agent_impl(
                 effective_model_name = requested_model_name
             else:
                 model, effective_model_name = load_model_with_fallback(
-                    requested_model_name, models_config, group_id, agent_name=agent_name
+                    requested_model_name,
+                    models_config,
+                    group_id,
+                    agent_name=agent_name,
+                    # Scope the warn-once-per-conversation dedup to the
+                    # PARENT conversation (captured above, before it was
+                    # overwritten with this sub-agent's own transient
+                    # session_id) -- not this call's own session_id, which
+                    # would make every invocation its own "conversation" and
+                    # defeat the dedup entirely. This also means independent
+                    # conversations sharing one process (concurrent ACP
+                    # sessions, notably) never share warning-dedup state in
+                    # the first place, so nothing needs to reset it between
+                    # them.
+                    conversation_scope=previous_session_id,
                 )
 
             # Create a temporary agent instance to avoid interfering with current agent state

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -321,17 +321,49 @@ async def _invoke_agent_impl(
             if not requested_model_name:
                 raise ValueError("No model configured for sub-agent invocation")
 
-            # A pinned/overridden model that has since vanished from config
+            # A pinned/ambient model that has since vanished from config
             # (removed model entry, unsupported type, missing credentials, ...)
             # must degrade the same way the main agent does: warn and fall back
             # to the global default (then any other configured model) instead
             # of hard-failing the whole sub-agent invocation. See
             # ``load_model_with_fallback`` for the exact fallback order.
+            #
+            # An EXPLICIT override (``invoke_agent_with_model``'s ``model_name``
+            # argument) is a different contract: the caller said "run this one
+            # call on exactly this model", on purpose. Silently substituting a
+            # different model there -- possibly weaker/pricier, with no forced
+            # signal beyond a once-per-conversation warning -- would violate
+            # that contract for automated callers. So a bad explicit override
+            # stays a hard, per-call failure; only the ambient/pinned path
+            # (plain ``invoke_agent``, no override) gets the graceful fallback.
             from code_puppy.agents._builder import load_model_with_fallback
 
-            model, effective_model_name = load_model_with_fallback(
-                requested_model_name, models_config, group_id, agent_name=agent_name
-            )
+            if model_name:
+                try:
+                    model = ModelFactory.get_model(requested_model_name, models_config)
+                    if model is None:
+                        raise ValueError(
+                            f"Model '{requested_model_name}' is configured but "
+                            "could not be initialized. Check credentials, "
+                            "provider availability, and usage limits for that "
+                            "model."
+                        )
+                except ValueError as exc:
+                    available = list(models_config.keys())
+                    available_str = (
+                        ", ".join(sorted(available))
+                        if available
+                        else "no configured models"
+                    )
+                    raise ValueError(
+                        f"Explicit model override '{requested_model_name}' is "
+                        f"unavailable: {exc} Available models: {available_str}."
+                    ) from exc
+                effective_model_name = requested_model_name
+            else:
+                model, effective_model_name = load_model_with_fallback(
+                    requested_model_name, models_config, group_id, agent_name=agent_name
+                )
 
             # Create a temporary agent instance to avoid interfering with current agent state
             instructions = agent_config.get_full_system_prompt()

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -315,25 +315,23 @@ async def _invoke_agent_impl(
 
             # Resolve the effective model through the agent so precedence lives
             # in one place: runtime override -> pinned model -> global default.
-            effective_model_name = agent_config.get_model_name()
+            requested_model_name = agent_config.get_model_name()
             models_config = ModelFactory.load_config()
 
-            if not effective_model_name:
+            if not requested_model_name:
                 raise ValueError("No model configured for sub-agent invocation")
 
-            # Only proceed if we have a valid model configuration
-            if effective_model_name not in models_config:
-                raise ValueError(
-                    f"Model '{effective_model_name}' not found in configuration"
-                )
+            # A pinned/overridden model that has since vanished from config
+            # (removed model entry, unsupported type, missing credentials, ...)
+            # must degrade the same way the main agent does: warn and fall back
+            # to the global default (then any other configured model) instead
+            # of hard-failing the whole sub-agent invocation. See
+            # ``load_model_with_fallback`` for the exact fallback order.
+            from code_puppy.agents._builder import load_model_with_fallback
 
-            model = ModelFactory.get_model(effective_model_name, models_config)
-            if model is None:
-                raise ValueError(
-                    f"Model '{effective_model_name}' is configured but could not be "
-                    "initialized. Check credentials, provider availability, and usage "
-                    "limits for that model."
-                )
+            model, effective_model_name = load_model_with_fallback(
+                requested_model_name, models_config, group_id, agent_name=agent_name
+            )
 
             # Create a temporary agent instance to avoid interfering with current agent state
             instructions = agent_config.get_full_system_prompt()

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -45,6 +45,7 @@ from code_puppy.tools.agent_tools import (
 )
 from code_puppy.tools.common import generate_group_id
 from code_puppy.tools.subagent_context import (
+    get_conversation_root_id,
     get_subagent_chain,
     get_subagent_depth,
     get_subagent_model_name,
@@ -367,16 +368,25 @@ async def _invoke_agent_impl(
                     group_id,
                     agent_name=agent_name,
                     # Scope the warn-once-per-conversation dedup to the
-                    # PARENT conversation (captured above, before it was
-                    # overwritten with this sub-agent's own transient
-                    # session_id) -- not this call's own session_id, which
-                    # would make every invocation its own "conversation" and
-                    # defeat the dedup entirely. This also means independent
-                    # conversations sharing one process (concurrent ACP
-                    # sessions, notably) never share warning-dedup state in
-                    # the first place, so nothing needs to reset it between
-                    # them.
-                    conversation_scope=previous_session_id,
+                    # conversation's ROOT identity (a ContextVar set once at
+                    # the true top-level conversation boundary -- an ACP
+                    # session's prompt handler, or left None for the CLI's
+                    # one-conversation-per-process model) -- NOT this call's
+                    # own transient session_id, and NOT the message-bus's
+                    # get_session_context() (a shared mutable attribute with
+                    # no per-task isolation; see subagent_context.py's
+                    # docstring for why that's unsafe here). Using the root
+                    # id means:
+                    #   * concurrent conversations sharing one process (
+                    #     concurrent ACP sessions, parallel sibling tool
+                    #     calls) never share warning-dedup state, so nothing
+                    #     needs to reset it between them;
+                    #   * NESTED sub-agent invocations (A invokes B invokes
+                    #     C) all inherit the SAME root value instead of each
+                    #     level minting its own fresh id, so "once per
+                    #     conversation" holds through an entire call tree,
+                    #     not just one hop.
+                    conversation_scope=get_conversation_root_id(),
                 )
 
             # Create a temporary agent instance to avoid interfering with current agent state

--- a/tests/agents/test_agent_creator_agent.py
+++ b/tests/agents/test_agent_creator_agent.py
@@ -2,7 +2,10 @@
 
 from unittest.mock import patch
 
-from code_puppy.agents.agent_creator_agent import AgentCreatorAgent, _validate_agent_creation
+from code_puppy.agents.agent_creator_agent import (
+    AgentCreatorAgent,
+    _validate_agent_creation,
+)
 
 
 class TestAgentCreatorAgent:
@@ -236,43 +239,73 @@ class TestAgentCreatorAgent:
 
     def test_validate_agent_creation_not_json_file(self):
         """Test that it ignores non-JSON files."""
-        result = _validate_agent_creation("create_file", {"file_path": "test.txt", "content": "{}"})
+        result = _validate_agent_creation(
+            "create_file", {"file_path": "test.txt", "content": "{}"}
+        )
         assert result is None
 
     def test_validate_agent_creation_not_agents_dir(self, monkeypatch):
         """Test that it ignores files outside the agents directory."""
-        monkeypatch.setattr("code_puppy.agents.agent_creator_agent.get_user_agents_directory", lambda: "/mock/agents/dir")
-        result = _validate_agent_creation("create_file", {"file_path": "/some/other/dir/test.json", "content": "{}"})
+        monkeypatch.setattr(
+            "code_puppy.agents.agent_creator_agent.get_user_agents_directory",
+            lambda: "/mock/agents/dir",
+        )
+        result = _validate_agent_creation(
+            "create_file", {"file_path": "/some/other/dir/test.json", "content": "{}"}
+        )
         assert result is None
 
     def test_validate_agent_creation_invalid_json(self, monkeypatch):
         """Test that invalid JSON blocks the tool call."""
-        monkeypatch.setattr("code_puppy.agents.agent_creator_agent.get_user_agents_directory", lambda: "/mock/agents/dir")
-        result = _validate_agent_creation("create_file", {"file_path": "/mock/agents/dir/test.json", "content": "{invalid json"})
+        monkeypatch.setattr(
+            "code_puppy.agents.agent_creator_agent.get_user_agents_directory",
+            lambda: "/mock/agents/dir",
+        )
+        result = _validate_agent_creation(
+            "create_file",
+            {"file_path": "/mock/agents/dir/test.json", "content": "{invalid json"},
+        )
         assert result is not None
         assert result.get("blocked") is True
         assert "Syntax error: Invalid JSON payload" in result.get("error_message", "")
 
     def test_validate_agent_creation_validation_error(self, monkeypatch):
         """Test that valid JSON with schema errors blocks the tool call."""
-        monkeypatch.setattr("code_puppy.agents.agent_creator_agent.get_user_agents_directory", lambda: "/mock/agents/dir")
+        monkeypatch.setattr(
+            "code_puppy.agents.agent_creator_agent.get_user_agents_directory",
+            lambda: "/mock/agents/dir",
+        )
         # Valid JSON but missing required fields
-        result = _validate_agent_creation("create_file", {"file_path": "/mock/agents/dir/test.json", "content": '{"name": "test"}'})
+        result = _validate_agent_creation(
+            "create_file",
+            {"file_path": "/mock/agents/dir/test.json", "content": '{"name": "test"}'},
+        )
         assert result is not None
         assert result.get("blocked") is True
         assert "Validation errors:" in result.get("error_message", "")
-        assert "Missing required field: 'description'" in result.get("error_message", "")
+        assert "Missing required field: 'description'" in result.get(
+            "error_message", ""
+        )
 
     def test_validate_agent_creation_valid(self, monkeypatch):
         """Test that perfectly valid agent config does not block the tool call."""
-        monkeypatch.setattr("code_puppy.agents.agent_creator_agent.get_user_agents_directory", lambda: "/mock/agents/dir")
-        monkeypatch.setattr("code_puppy.agents.agent_creator_agent.get_available_tool_names", lambda: ["tool1"])
-        
-        valid_json = '''{
+        monkeypatch.setattr(
+            "code_puppy.agents.agent_creator_agent.get_user_agents_directory",
+            lambda: "/mock/agents/dir",
+        )
+        monkeypatch.setattr(
+            "code_puppy.agents.agent_creator_agent.get_available_tool_names",
+            lambda: ["tool1"],
+        )
+
+        valid_json = """{
             "name": "test-agent",
             "description": "desc",
             "system_prompt": "prompt",
             "tools": []
-        }'''
-        result = _validate_agent_creation("create_file", {"file_path": "/mock/agents/dir/test.json", "content": valid_json})
+        }"""
+        result = _validate_agent_creation(
+            "create_file",
+            {"file_path": "/mock/agents/dir/test.json", "content": valid_json},
+        )
         assert result is None

--- a/tests/command_line/test_session_commands.py
+++ b/tests/command_line/test_session_commands.py
@@ -533,3 +533,32 @@ class TestHandleClearCommand:
 
         names = {c.name for c in get_unique_commands()}
         assert "clear" in names
+
+    def test_clear_resets_model_fallback_warnings(self):
+        """A fresh conversation should re-arm any silenced pinned-model
+        fallback warning rather than leaving it suppressed forever."""
+        agent = MagicMock()
+        clipboard = MagicMock()
+        clipboard.get_pending_count.return_value = 0
+        with (
+            patch(
+                "code_puppy.agents.agent_manager.get_current_agent",
+                return_value=agent,
+            ),
+            patch(
+                "code_puppy.command_line.clipboard.get_clipboard_manager",
+                return_value=clipboard,
+            ),
+            patch(
+                "code_puppy.config.finalize_autosave_session",
+                return_value="sid",
+            ),
+            patch("code_puppy.messaging.emit_warning"),
+            patch("code_puppy.messaging.emit_system_message"),
+            patch("code_puppy.messaging.emit_info"),
+            patch(
+                "code_puppy.agents._builder.reset_model_fallback_warnings"
+            ) as mock_reset,
+        ):
+            assert self._run() is True
+            mock_reset.assert_called_once_with()

--- a/tests/plugins/test_ollama_model.py
+++ b/tests/plugins/test_ollama_model.py
@@ -56,9 +56,7 @@ def test_custom_endpoint_passes_headers_and_tls_config(mock_client):
     model = create_ollama_model("ollama-qwen3", model_config, {})
 
     assert model is not None
-    mock_client.assert_called_once_with(
-        headers={"X-Test": "value"}, verify=False
-    )
+    mock_client.assert_called_once_with(headers={"X-Test": "value"}, verify=False)
     asyncio.run(model._provider._client.close())
 
 

--- a/tests/test_acp_plugin.py
+++ b/tests/test_acp_plugin.py
@@ -244,6 +244,33 @@ async def test_new_session_resets_model_fallback_warnings(wired_agent, monkeypat
 
 
 @pytest.mark.asyncio
+async def test_close_session_purges_its_own_fallback_warning_bucket(
+    wired_agent, monkeypatch
+):
+    """Sub-agent invocation scopes its dead-model-warning dedup by this
+    session's own conversation-root id (see subagent_context.py /
+    subagent_invocation.py) precisely so it never leaks into any OTHER
+    session -- but that also means nothing else will ever clean it up. A
+    long-running server churning through many short-lived sessions must not
+    accumulate one dangling bucket per closed session forever, so
+    close_session must purge exactly this session's own scope.
+    """
+    agent, _ = wired_agent
+    calls = []
+    monkeypatch.setattr(
+        "code_puppy.agents._builder.reset_model_fallback_warnings",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    session = await agent.new_session(cwd="/tmp")
+    calls.clear()  # drop the new_session's own scope=None reset call
+
+    await agent.close_session(session.session_id)
+
+    assert calls == [{"scope": session.session_id}]
+
+
+@pytest.mark.asyncio
 async def test_prompt_absorbs_history_for_memory_and_persistence(monkeypatch):
     """A completed turn must fold result.all_messages() back into the agent.
 

--- a/tests/test_acp_plugin.py
+++ b/tests/test_acp_plugin.py
@@ -223,23 +223,24 @@ async def test_new_session_and_prompt_streams(wired_agent):
 
 @pytest.mark.asyncio
 async def test_new_session_resets_model_fallback_warnings(wired_agent, monkeypatch):
-    """``_warned_model_fallbacks`` (code_puppy/agents/_builder.py) is a
-    process-lifetime global whose only other reset hook is the CLI's
-    ``/clear``. A long-running ACP server hosting multiple concurrent client
-    sessions must not let session A's dead-pin warning silently suppress the
-    identical warning forever for session B, which never saw it -- so every
-    new/loaded/forked session must reset the dedup set.
+    """``_warned_model_fallbacks``'s shared/unscoped bucket (code_puppy/
+    agents/_builder.py) backs the main-agent-build warning, which -- unlike
+    sub-agent invocation's own per-session-scoped warnings -- has no
+    per-session identity of its own. Every new/loaded/forked session must
+    reset that shared bucket (scope=None only) so session A's dead-pin
+    warning during its own agent build can't silently suppress the identical
+    warning for session B's build.
     """
     agent, _ = wired_agent
     calls = []
     monkeypatch.setattr(
         "code_puppy.agents._builder.reset_model_fallback_warnings",
-        lambda: calls.append(1),
+        lambda **kwargs: calls.append(kwargs),
     )
 
     await agent.new_session(cwd="/tmp")
 
-    assert calls == [1]
+    assert calls == [{"scope": None}]
 
 
 @pytest.mark.asyncio

--- a/tests/test_acp_plugin.py
+++ b/tests/test_acp_plugin.py
@@ -222,6 +222,27 @@ async def test_new_session_and_prompt_streams(wired_agent):
 
 
 @pytest.mark.asyncio
+async def test_new_session_resets_model_fallback_warnings(wired_agent, monkeypatch):
+    """``_warned_model_fallbacks`` (code_puppy/agents/_builder.py) is a
+    process-lifetime global whose only other reset hook is the CLI's
+    ``/clear``. A long-running ACP server hosting multiple concurrent client
+    sessions must not let session A's dead-pin warning silently suppress the
+    identical warning forever for session B, which never saw it -- so every
+    new/loaded/forked session must reset the dedup set.
+    """
+    agent, _ = wired_agent
+    calls = []
+    monkeypatch.setattr(
+        "code_puppy.agents._builder.reset_model_fallback_warnings",
+        lambda: calls.append(1),
+    )
+
+    await agent.new_session(cwd="/tmp")
+
+    assert calls == [1]
+
+
+@pytest.mark.asyncio
 async def test_prompt_absorbs_history_for_memory_and_persistence(monkeypatch):
     """A completed turn must fold result.all_messages() back into the agent.
 

--- a/tests/test_acp_plugin.py
+++ b/tests/test_acp_plugin.py
@@ -467,6 +467,65 @@ async def test_cancel_stops_run(monkeypatch):
         state.set_connection(None, None)
 
 
+@pytest.mark.asyncio
+async def test_close_session_waits_for_in_flight_run_before_purging(monkeypatch):
+    """Round-4 adversarial review finding: closing a session while a prompt
+    is still running against it raced ``reset_model_fallback_warnings``
+    against that prompt's own (synchronous) write into the same bucket --
+    ``cancel()`` alone only *requests* cancellation, it doesn't wait for the
+    run to actually unwind, so the purge could complete before the write
+    ever happens, leaking that one warning-bucket entry forever (nothing
+    else will ever purge it once the session is closed).
+
+    ``close_session`` must use ``cancel_and_wait`` -- confirmed here by
+    hanging a slow run just past the point where it (would) write into the
+    dedup bucket, and asserting ``close_session`` only returns once that run
+    has actually finished, not merely been asked to stop.
+    """
+    monkeypatch.setattr(
+        "code_puppy.agents.agent_manager.get_current_agent_name", lambda: "code-puppy"
+    )
+    run_finished = asyncio.Event()
+
+    class SlowAgent:
+        _message_history: list = []
+
+        async def run_with_mcp(self, prompt, **_):
+            try:
+                await asyncio.sleep(30)
+                return SimpleNamespace(output="never")
+            finally:
+                # Stands in for the point deep inside _invoke_agent_impl
+                # where load_model_with_fallback synchronously writes into
+                # _warned_model_fallbacks -- if close_session's purge can
+                # race ahead of this, the entry leaks.
+                run_finished.set()
+
+    monkeypatch.setattr(
+        "code_puppy.agents.agent_manager.load_agent", lambda name: SlowAgent()
+    )
+    conn = FakeConnection()
+    agent = CodePuppyAgent()
+    agent.on_connect(conn)
+    try:
+        new = await agent.new_session(cwd="/tmp")
+        prompt_task = asyncio.ensure_future(
+            agent.prompt([SimpleNamespace(type="text", text="go")], new.session_id)
+        )
+        await asyncio.sleep(0.05)  # let the run actually start
+
+        await agent.close_session(new.session_id)
+
+        # close_session must not have returned until the run's own cleanup
+        # (here standing in for the warn-dedup write) had already happened.
+        assert run_finished.is_set()
+        prompt_task.cancel()
+    finally:
+        permissions.uninstall()
+        io_delegation.uninstall()
+        state.set_connection(None, None)
+
+
 # --------------------------------------------------------------------------- #
 # Event bridge — tool-call correlation
 # --------------------------------------------------------------------------- #

--- a/tests/test_pinned_model_fallback.py
+++ b/tests/test_pinned_model_fallback.py
@@ -1,0 +1,259 @@
+"""Regression coverage: a sub-agent's pinned/configured model can vanish from
+``models.json`` after being pinned (deleted entry, unsupported type, missing
+creds, ...). Sub-agent invocation must degrade the same way the main agent
+does -- warn and fall back to the global default model -- instead of
+hard-failing the whole invocation.
+
+Also locks in the "warn once per (agent, model) combo per conversation, with
+fix instructions, never auto-clear the pin" behavior in
+``load_model_with_fallback`` (code_puppy/agents/_builder.py), reached both
+from the main agent build path and sub-agent invocation
+(code_puppy/tools/subagent_invocation.py).
+"""
+
+from contextlib import ExitStack, contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from code_puppy.agents._builder import reset_model_fallback_warnings
+from code_puppy.tools.subagent_invocation import register_invoke_agent
+
+
+@pytest.fixture(autouse=True)
+def _clean_fallback_warning_state():
+    """``_warned_model_fallbacks`` is process-lifetime module state in
+    ``_builder.py`` -- reset it around every test so ordering across this
+    file (and the rest of the suite) can't leak a "already warned" flag.
+    """
+    reset_model_fallback_warnings()
+    yield
+    reset_model_fallback_warnings()
+
+
+def _capture_invoke_default():
+    """Capture the registered invoke_agent (no model override) callable."""
+    mock_agent = MagicMock()
+    captured = {}
+
+    def capture_tool(func):
+        captured["func"] = func
+        return func
+
+    mock_agent.tool = capture_tool
+    register_invoke_agent(mock_agent)
+    return captured["func"]
+
+
+def _build_agent_config(pinned_model_name):
+    config = MagicMock()
+
+    @contextmanager
+    def temporary_override(_model_name):
+        yield
+
+    config.temporary_model_name_override.side_effect = temporary_override
+    config.get_model_name.return_value = pinned_model_name
+    config.get_full_system_prompt.return_value = "Test instructions"
+    config.get_available_tools.return_value = ["list_files"]
+    config.get_message_history.return_value = []
+    return config
+
+
+def _passthrough_retry(*_args, **_kwargs):
+    def _decorator(func):
+        return func
+
+    return _decorator
+
+
+async def _invoke_with_dead_pin(agent_name="test-agent", pinned_model="dead-model"):
+    """Drive ``invoke_agent`` for ``agent_name`` pinned to a model that isn't
+    in ``models_config``, and return ``(output, mock_warning)``.
+
+    ``mock_warning`` is the patched ``emit_warning`` in ``_builder.py`` --
+    that's where ``load_model_with_fallback`` actually emits the fallback
+    warning, not ``subagent_invocation.py``.
+    """
+    invoke = _capture_invoke_default()
+    mock_context = MagicMock()
+    agent_config = _build_agent_config(pinned_model)
+
+    result = MagicMock()
+    result.output = "subagent response"
+    result.all_messages.return_value = ["updated-history"]
+    result.usage = MagicMock(return_value=None)
+
+    mock_temp_agent = MagicMock()
+    mock_temp_agent.run = AsyncMock(return_value=result)
+
+    def fake_get_model(model_name, config):
+        if model_name not in config:
+            raise ValueError(f"Model '{model_name}' not found in configuration.")
+        return MagicMock()
+
+    with ExitStack() as stack:
+        p = stack.enter_context
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation.generate_group_id",
+                return_value="test-group",
+            )
+        )
+        p(patch("code_puppy.tools.subagent_invocation.get_message_bus"))
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation.get_session_context",
+                return_value="parent",
+            )
+        )
+        p(patch("code_puppy.tools.subagent_invocation.set_session_context"))
+        p(patch("code_puppy.tools.subagent_invocation.emit_info"))
+        p(patch("code_puppy.tools.subagent_invocation.emit_error"))
+        p(patch("code_puppy.tools.subagent_invocation.emit_success"))
+        p(patch("code_puppy.tools.subagent_invocation.emit_warning"))
+        # load_model_with_fallback (where the actual fallback + warning
+        # happens) imports emit_warning directly into its own module
+        # namespace, so that's the one to assert against.
+        mock_warning = p(patch("code_puppy.agents._builder.emit_warning"))
+        p(patch("code_puppy.tools.subagent_invocation._save_session_history"))
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation._load_session_history",
+                return_value=[],
+            )
+        )
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation._generate_session_hash_suffix",
+                return_value="abc123",
+            )
+        )
+        p(
+            patch(
+                "code_puppy.agents.agent_manager.load_agent",
+                return_value=agent_config,
+            )
+        )
+        p(
+            patch(
+                "code_puppy.model_factory.ModelFactory.load_config",
+                return_value={"global-default-model": {}},
+            )
+        )
+        p(
+            patch(
+                "code_puppy.model_factory.ModelFactory.get_model",
+                side_effect=fake_get_model,
+            )
+        )
+        p(patch("code_puppy.model_factory.make_model_settings"))
+        p(
+            patch(
+                "code_puppy.agents._builder.get_global_model_name",
+                return_value="global-default-model",
+            )
+        )
+        p(patch("code_puppy.agents._builder.load_puppy_rules", return_value=None))
+        p(patch("code_puppy.callbacks.on_load_prompt", return_value=[]))
+        mock_prepare = p(patch("code_puppy.model_utils.prepare_prompt_for_model"))
+        mock_prepare.return_value = MagicMock(
+            instructions="prepared instructions", user_prompt="prepared prompt"
+        )
+        p(
+            patch(
+                "code_puppy.agents._builder.autostart_bound_servers_async",
+                new=AsyncMock(),
+            )
+        )
+        p(patch("code_puppy.config.get_value", return_value="true"))
+        p(patch("code_puppy.config.get_output_level", return_value="medium"))
+        p(
+            patch(
+                "code_puppy.agents._compaction.make_history_processor",
+                return_value=lambda messages: messages,
+            )
+        )
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation.Agent",
+                return_value=mock_temp_agent,
+            )
+        )
+        p(patch("code_puppy.tools.register_tools_for_agent"))
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation.on_wrap_pydantic_agent",
+                side_effect=lambda _cfg, agent, **_kwargs: agent,
+            )
+        )
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation.on_agent_run_context",
+                return_value=[],
+            )
+        )
+        p(
+            patch(
+                "code_puppy.agents.retry_profiles.make_streaming_retry",
+                new=_passthrough_retry,
+            )
+        )
+
+        out = await invoke(mock_context, agent_name=agent_name, prompt="Hello")
+
+    return out, mock_warning
+
+
+class TestPinnedModelFallback:
+    @pytest.mark.asyncio
+    async def test_falls_back_to_global_default_model(self):
+        out, mock_warning = await _invoke_with_dead_pin()
+
+        # No hard failure: the run completed using the fallback model.
+        assert out.error is None
+        assert out.response == "subagent response"
+        assert out.model_name == "global-default-model"
+        # A warning was emitted about the dead pin, not a swallowed silence.
+        assert any(
+            "dead-model" in str(call.args[0]) for call in mock_warning.call_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_warning_includes_fix_instructions(self):
+        _out, mock_warning = await _invoke_with_dead_pin(agent_name="qa-expert")
+
+        warning_text = mock_warning.call_args_list[0].args[0]
+        assert "/pin qa-expert" in warning_text
+        assert "/unpin qa-expert" in warning_text
+
+    @pytest.mark.asyncio
+    async def test_only_warns_once_per_agent_model_combo(self):
+        """Repeated invocations with the same dead pin, in the same
+        conversation, must only warn the first time -- not spam every call.
+        """
+        _out1, mock_warning = await _invoke_with_dead_pin(agent_name="qa-expert")
+        assert mock_warning.call_count == 1
+
+        # Same agent, same dead pin, no /clear in between -> silent this time.
+        _out2, mock_warning_again = await _invoke_with_dead_pin(agent_name="qa-expert")
+        assert mock_warning_again.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_different_agent_gets_its_own_warning(self):
+        """The dedup key is (agent, model) -- a different agent pinned to the
+        same dead model still deserves its own warning.
+        """
+        await _invoke_with_dead_pin(agent_name="qa-expert")
+        _out, mock_warning = await _invoke_with_dead_pin(agent_name="reviewer")
+        assert mock_warning.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_reset_reopens_warning_for_a_new_conversation(self):
+        """``/clear`` calls ``reset_model_fallback_warnings()``; simulate
+        that boundary and confirm the warning resurfaces.
+        """
+        await _invoke_with_dead_pin(agent_name="qa-expert")
+        reset_model_fallback_warnings()
+        _out, mock_warning = await _invoke_with_dead_pin(agent_name="qa-expert")
+        assert mock_warning.call_count == 1

--- a/tests/test_pinned_model_fallback.py
+++ b/tests/test_pinned_model_fallback.py
@@ -16,7 +16,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from code_puppy.agents._builder import reset_model_fallback_warnings
+from code_puppy.agents._builder import (
+    load_model_with_fallback,
+    reset_model_fallback_warnings,
+)
 from code_puppy.tools.subagent_invocation import (
     register_invoke_agent,
     register_invoke_agent_with_model,
@@ -84,13 +87,21 @@ def _passthrough_retry(*_args, **_kwargs):
     return _decorator
 
 
-async def _invoke_with_dead_pin(agent_name="test-agent", pinned_model="dead-model"):
+async def _invoke_with_dead_pin(
+    agent_name="test-agent", pinned_model="dead-model", conversation_scope="parent"
+):
     """Drive ``invoke_agent`` for ``agent_name`` pinned to a model that isn't
     in ``models_config``, and return ``(output, mock_warning)``.
 
     ``mock_warning`` is the patched ``emit_warning`` in ``_builder.py`` --
     that's where ``load_model_with_fallback`` actually emits the fallback
     warning, not ``subagent_invocation.py``.
+
+    ``conversation_scope`` stands in for the parent conversation's session id
+    (``get_session_context()``, captured by ``_invoke_agent_impl`` BEFORE it
+    overwrites the context with this call's own transient sub-agent session
+    id) -- vary it across calls to simulate two independent conversations
+    (e.g. two concurrent ACP sessions) sharing one process.
     """
     invoke = _capture_invoke_default()
     mock_context = MagicMock()
@@ -121,7 +132,7 @@ async def _invoke_with_dead_pin(agent_name="test-agent", pinned_model="dead-mode
         p(
             patch(
                 "code_puppy.tools.subagent_invocation.get_session_context",
-                return_value="parent",
+                return_value=conversation_scope,
             )
         )
         p(patch("code_puppy.tools.subagent_invocation.set_session_context"))
@@ -275,6 +286,46 @@ class TestPinnedModelFallback:
         _out, mock_warning = await _invoke_with_dead_pin(agent_name="qa-expert")
         assert mock_warning.call_count == 1
 
+    @pytest.mark.asyncio
+    async def test_independent_conversations_do_not_share_warning_state(self):
+        """Two independent conversations (e.g. two concurrent ACP sessions)
+        sharing one process must each get their own warning for the exact
+        same (agent, dead-model) combo -- one conversation's warning must
+        NOT silently suppress the identical warning for a totally unrelated
+        conversation that never saw it.
+        """
+        _out_a, warning_a = await _invoke_with_dead_pin(
+            agent_name="qa-expert", conversation_scope="acp-session-a"
+        )
+        assert warning_a.call_count == 1
+
+        _out_b, warning_b = await _invoke_with_dead_pin(
+            agent_name="qa-expert", conversation_scope="acp-session-b"
+        )
+        assert warning_b.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_unscoped_reset_does_not_wipe_other_conversations(self):
+        """``reset_model_fallback_warnings(scope=None)`` (what ACP's
+        ``_make_session`` calls on every new/loaded/forked session) must only
+        clear the shared/unscoped bucket -- it must NOT wipe a different,
+        already-scoped conversation's warning state. Otherwise creating an
+        unrelated ACP session would re-open a warning for a conversation
+        that's still live and already saw it once.
+        """
+        await _invoke_with_dead_pin(
+            agent_name="qa-expert", conversation_scope="acp-session-a"
+        )
+
+        reset_model_fallback_warnings(scope=None)
+
+        # Session A's own warning state must have survived the scope=None
+        # reset triggered by session B's creation.
+        _out, mock_warning_again = await _invoke_with_dead_pin(
+            agent_name="qa-expert", conversation_scope="acp-session-a"
+        )
+        assert mock_warning_again.call_count == 0
+
 
 async def _invoke_with_dead_explicit_override(dead_model="dead-model"):
     """Drive ``invoke_agent_with_model`` with an EXPLICIT ``model_name``
@@ -399,3 +450,82 @@ class TestExplicitModelOverrideHardFails:
             agent_name="test-agent", pinned_model="another-dead-model"
         )
         assert mock_warning.call_count == 1
+
+
+class TestLoadModelWithFallbackScopingUnit:
+    """Fast, direct unit tests on ``load_model_with_fallback`` itself (no
+    sub-agent-invocation mock stack) pinning down the exact
+    ``conversation_scope`` dedup-key and ``reset_model_fallback_warnings``
+    semantics the integration-style tests above exercise indirectly.
+    """
+
+    @staticmethod
+    def _fake_get_model(model_name, config):
+        if model_name not in config:
+            raise ValueError(f"Model '{model_name}' not found in configuration.")
+        return MagicMock()
+
+    def _call(self, *, agent_name="qa-expert", conversation_scope=None):
+        models_config = {"global-default-model": {}}
+        with (
+            patch(
+                "code_puppy.agents._builder.ModelFactory.get_model",
+                side_effect=self._fake_get_model,
+            ),
+            patch(
+                "code_puppy.agents._builder.get_global_model_name",
+                return_value="global-default-model",
+            ),
+            patch("code_puppy.agents._builder.emit_info"),
+            patch("code_puppy.agents._builder.emit_error"),
+            patch("code_puppy.agents._builder.emit_warning") as mock_warning,
+        ):
+            load_model_with_fallback(
+                "dead-model",
+                models_config,
+                "group-id",
+                agent_name=agent_name,
+                conversation_scope=conversation_scope,
+            )
+        return mock_warning
+
+    def test_same_scope_warns_once(self):
+        assert self._call(conversation_scope="session-a").call_count == 1
+        assert self._call(conversation_scope="session-a").call_count == 0
+
+    def test_different_scope_warns_independently(self):
+        assert self._call(conversation_scope="session-a").call_count == 1
+        assert self._call(conversation_scope="session-b").call_count == 1
+
+    def test_none_scope_is_its_own_bucket(self):
+        """``conversation_scope=None`` (the main-agent-build default) is a
+        distinct bucket from any named scope, not "no dedup at all".
+        """
+        assert self._call(conversation_scope=None).call_count == 1
+        assert self._call(conversation_scope=None).call_count == 0
+        assert self._call(conversation_scope="session-a").call_count == 1
+
+    def test_full_reset_clears_every_scope(self):
+        self._call(conversation_scope="session-a")
+        self._call(conversation_scope=None)
+
+        reset_model_fallback_warnings()
+
+        assert self._call(conversation_scope="session-a").call_count == 1
+        assert self._call(conversation_scope=None).call_count == 1
+
+    def test_scoped_reset_only_clears_that_scope(self):
+        """This is the exact property ACP's ``_make_session`` relies on:
+        ``reset_model_fallback_warnings(scope=None)`` must clear ONLY the
+        unscoped bucket, leaving a different named scope's already-earned
+        warning state untouched.
+        """
+        self._call(conversation_scope="session-a")
+        self._call(conversation_scope=None)
+
+        reset_model_fallback_warnings(scope=None)
+
+        # The unscoped bucket was cleared -> warns again.
+        assert self._call(conversation_scope=None).call_count == 1
+        # session-a's bucket was untouched -> stays silent.
+        assert self._call(conversation_scope="session-a").call_count == 0

--- a/tests/test_pinned_model_fallback.py
+++ b/tests/test_pinned_model_fallback.py
@@ -17,7 +17,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from code_puppy.agents._builder import reset_model_fallback_warnings
-from code_puppy.tools.subagent_invocation import register_invoke_agent
+from code_puppy.tools.subagent_invocation import (
+    register_invoke_agent,
+    register_invoke_agent_with_model,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -42,6 +45,20 @@ def _capture_invoke_default():
 
     mock_agent.tool = capture_tool
     register_invoke_agent(mock_agent)
+    return captured["func"]
+
+
+def _capture_invoke_with_model():
+    """Capture the registered invoke_agent_with_model (explicit override) callable."""
+    mock_agent = MagicMock()
+    captured = {}
+
+    def capture_tool(func):
+        captured["func"] = func
+        return func
+
+    mock_agent.tool = capture_tool
+    register_invoke_agent_with_model(mock_agent)
     return captured["func"]
 
 
@@ -256,4 +273,129 @@ class TestPinnedModelFallback:
         await _invoke_with_dead_pin(agent_name="qa-expert")
         reset_model_fallback_warnings()
         _out, mock_warning = await _invoke_with_dead_pin(agent_name="qa-expert")
+        assert mock_warning.call_count == 1
+
+
+async def _invoke_with_dead_explicit_override(dead_model="dead-model"):
+    """Drive ``invoke_agent_with_model`` with an EXPLICIT ``model_name``
+    override that isn't in ``models_config``, and return the output.
+
+    Unlike the ambient/pinned path (``_invoke_with_dead_pin``), a bad explicit
+    override must hard-fail -- silently substituting a different model than
+    the one the caller explicitly asked for would violate that tool's
+    contract for automated callers.
+    """
+    invoke = _capture_invoke_with_model()
+    mock_context = MagicMock()
+    agent_config = _build_agent_config(dead_model)
+
+    def fake_get_model(model_name, config):
+        if model_name not in config:
+            raise ValueError(f"Model '{model_name}' not found in configuration.")
+        return MagicMock()
+
+    with ExitStack() as stack:
+        p = stack.enter_context
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation.generate_group_id",
+                return_value="test-group",
+            )
+        )
+        p(patch("code_puppy.tools.subagent_invocation.get_message_bus"))
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation.get_session_context",
+                return_value="parent",
+            )
+        )
+        p(patch("code_puppy.tools.subagent_invocation.set_session_context"))
+        p(patch("code_puppy.tools.subagent_invocation.emit_info"))
+        p(patch("code_puppy.tools.subagent_invocation.emit_error"))
+        p(patch("code_puppy.tools.subagent_invocation.emit_warning"))
+        p(patch("code_puppy.agents._builder.emit_warning"))
+        p(patch("code_puppy.tools.subagent_invocation._save_session_history"))
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation._load_session_history",
+                return_value=[],
+            )
+        )
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation._generate_session_hash_suffix",
+                return_value="abc123",
+            )
+        )
+        p(
+            patch(
+                "code_puppy.agents.agent_manager.load_agent",
+                return_value=agent_config,
+            )
+        )
+        p(
+            patch(
+                "code_puppy.model_factory.ModelFactory.load_config",
+                return_value={"global-default-model": {}, "healthy-model": {}},
+            )
+        )
+        p(
+            patch(
+                "code_puppy.model_factory.ModelFactory.get_model",
+                side_effect=fake_get_model,
+            )
+        )
+        p(patch("code_puppy.model_factory.make_model_settings"))
+        p(
+            patch(
+                "code_puppy.agents._builder.get_global_model_name",
+                return_value="global-default-model",
+            )
+        )
+
+        return await invoke(
+            mock_context,
+            agent_name="test-agent",
+            prompt="Hello",
+            model_name=dead_model,
+        )
+
+
+class TestExplicitModelOverrideHardFails:
+    """``invoke_agent_with_model``'s ``model_name`` is an explicit, per-call
+    contract ("run this exactly on this model"), unlike the ambient pinned
+    model. A bad explicit override must raise immediately -- NOT silently
+    substitute a different model the caller never asked for.
+    """
+
+    @pytest.mark.asyncio
+    async def test_bad_explicit_override_raises_instead_of_falling_back(self):
+        out = await _invoke_with_dead_explicit_override()
+
+        # A hard failure surfaced through the tool's normal error contract,
+        # not a silently-substituted model reported as success.
+        assert out.response is None
+        assert out.error is not None
+        assert "dead-model" in out.error
+
+    @pytest.mark.asyncio
+    async def test_error_message_names_available_models(self):
+        out = await _invoke_with_dead_explicit_override()
+
+        assert "healthy-model" in out.error
+        assert "global-default-model" in out.error
+
+    @pytest.mark.asyncio
+    async def test_does_not_touch_the_ambient_fallback_warning_path(self):
+        """The explicit-override hard-fail must not route through, or
+        interfere with, ``load_model_with_fallback``'s dedup state -- it's a
+        different contract entirely.
+        """
+        await _invoke_with_dead_explicit_override(dead_model="another-dead-model")
+
+        # The ambient/pinned path for the same agent+model must still warn
+        # (not be marked "already warned" by the override's hard failure).
+        _out, mock_warning = await _invoke_with_dead_pin(
+            agent_name="test-agent", pinned_model="another-dead-model"
+        )
         assert mock_warning.call_count == 1

--- a/tests/test_pinned_model_fallback.py
+++ b/tests/test_pinned_model_fallback.py
@@ -97,11 +97,11 @@ async def _invoke_with_dead_pin(
     that's where ``load_model_with_fallback`` actually emits the fallback
     warning, not ``subagent_invocation.py``.
 
-    ``conversation_scope`` stands in for the parent conversation's session id
-    (``get_session_context()``, captured by ``_invoke_agent_impl`` BEFORE it
-    overwrites the context with this call's own transient sub-agent session
-    id) -- vary it across calls to simulate two independent conversations
-    (e.g. two concurrent ACP sessions) sharing one process.
+    ``conversation_scope`` stands in for this conversation's root identity
+    (``get_conversation_root_id()``, a ContextVar set once at the true
+    top-level conversation boundary -- e.g. an ACP session's prompt handler)
+    -- vary it across calls to simulate two independent conversations (e.g.
+    two concurrent ACP sessions) sharing one process.
     """
     invoke = _capture_invoke_default()
     mock_context = MagicMock()
@@ -132,10 +132,16 @@ async def _invoke_with_dead_pin(
         p(
             patch(
                 "code_puppy.tools.subagent_invocation.get_session_context",
-                return_value=conversation_scope,
+                return_value="parent",
             )
         )
         p(patch("code_puppy.tools.subagent_invocation.set_session_context"))
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation.get_conversation_root_id",
+                return_value=conversation_scope,
+            )
+        )
         p(patch("code_puppy.tools.subagent_invocation.emit_info"))
         p(patch("code_puppy.tools.subagent_invocation.emit_error"))
         p(patch("code_puppy.tools.subagent_invocation.emit_success"))

--- a/tests/tools/test_subagent_context_conversation_root.py
+++ b/tests/tools/test_subagent_context_conversation_root.py
@@ -1,0 +1,149 @@
+"""Direct coverage of ``subagent_context.py``'s conversation-root ContextVar.
+
+This is the primitive ``load_model_with_fallback``'s ``conversation_scope``
+(see ``_builder.py`` / ``subagent_invocation.py``) is built on, replacing an
+earlier attempt that read ``code_puppy.messaging.bus.get_session_context()``
+-- a plain, lock-protected instance attribute on a process-wide singleton,
+NOT a ``contextvars.ContextVar``, and therefore unsafe for anything
+correctness-sensitive under concurrent asyncio tasks.
+
+These tests exercise the exact two properties a shared-mutable-global cannot
+give you, using the REAL contextvar machinery (no mocking of
+``get_conversation_root_id``/``set_conversation_root_id`` here -- that would
+just prove the mocks agree with themselves):
+
+1. Concurrent sibling tasks (parallel tool calls, or concurrent ACP
+   sessions) never see each other's root id, even when they overlap in
+   wall-clock time on the same event loop.
+2. Nested calls (a coroutine invoked without its own
+   ``set_conversation_root_id`` call) inherit the root id already active in
+   their task, rather than seeing ``None`` or a stale value.
+"""
+
+import asyncio
+
+import pytest
+
+from code_puppy.tools.subagent_context import (
+    get_conversation_root_id,
+    reset_conversation_root_id,
+    set_conversation_root_id,
+)
+
+
+def test_defaults_to_none_outside_any_scope():
+    assert get_conversation_root_id() is None
+
+
+def test_set_and_reset_round_trips():
+    token = set_conversation_root_id("session-a")
+    try:
+        assert get_conversation_root_id() == "session-a"
+    finally:
+        reset_conversation_root_id(token)
+    assert get_conversation_root_id() is None
+
+
+async def _nested_reader() -> str | None:
+    """Simulate a sub-agent invocation nested inside a conversation's root
+    scope: it never calls ``set_conversation_root_id`` itself, it just reads
+    whatever's already active -- exactly what ``_invoke_agent_impl`` does.
+    """
+    await asyncio.sleep(0)  # force a real scheduling point
+    return get_conversation_root_id()
+
+
+async def _run_conversation(root_id: str, delay_before_read: float) -> str | None:
+    """Stand in for one ACP session's ``prompt()`` handler: set the root id
+    once, await something (so a sibling conversation's task can interleave),
+    then read it back through a nested call -- mirroring
+    ``session.py``/``subagent_invocation.py``'s real call shape.
+    """
+    token = set_conversation_root_id(root_id)
+    try:
+        await asyncio.sleep(delay_before_read)
+        return await _nested_reader()
+    finally:
+        reset_conversation_root_id(token)
+
+
+class TestConcurrentConversationsDoNotLeak:
+    """The property Finding 0 (round 3 adversarial review) demanded actual
+    proof of: two conversations running as concurrent asyncio tasks on the
+    SAME event loop must never see each other's root id, regardless of how
+    their awaits interleave.
+    """
+
+    @pytest.mark.asyncio
+    async def test_two_concurrent_tasks_never_cross_contaminate(self):
+        # Deliberately staggered delays so the two tasks' internal awaits
+        # interleave rather than running strictly back-to-back.
+        results = await asyncio.gather(
+            _run_conversation("session-a", delay_before_read=0.02),
+            _run_conversation("session-b", delay_before_read=0.01),
+        )
+        assert results == ["session-a", "session-b"]
+
+    @pytest.mark.asyncio
+    async def test_many_concurrent_tasks_each_keep_their_own_root(self):
+        n = 20
+        results = await asyncio.gather(
+            *[
+                _run_conversation(f"session-{i}", delay_before_read=0.001 * (i % 5))
+                for i in range(n)
+            ]
+        )
+        assert results == [f"session-{i}" for i in range(n)]
+
+    @pytest.mark.asyncio
+    async def test_outer_scope_unaffected_by_a_concurrent_sibling(self):
+        """Setting a root id in one task must not leak into a completely
+        separate task that never set one at all (e.g. the CLI's top-level
+        conversation, which never calls ``set_conversation_root_id``).
+        """
+
+        async def _bystander() -> str | None:
+            await asyncio.sleep(0.015)
+            return get_conversation_root_id()
+
+        results = await asyncio.gather(
+            _run_conversation("session-a", delay_before_read=0.01),
+            _bystander(),
+        )
+        assert results == ["session-a", None]
+
+
+class TestNestedInvocationsInheritTheSameRoot:
+    """Finding 1 (round 3): nested sub-agent invocations (A invokes B invokes
+    C) must all see the SAME root id, not a fresh one per nesting level --
+    otherwise the once-per-conversation warning dedup degrades to
+    once-per-invocation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_two_levels_of_nesting_see_the_same_root(self):
+        async def _level_two() -> str | None:
+            return await _nested_reader()
+
+        async def _level_one() -> str | None:
+            return await _level_two()
+
+        token = set_conversation_root_id("root-conversation")
+        try:
+            result = await _level_one()
+        finally:
+            reset_conversation_root_id(token)
+
+        assert result == "root-conversation"
+
+    @pytest.mark.asyncio
+    async def test_nested_call_does_not_need_to_set_its_own_root(self):
+        """A sub-agent invocation never calls ``set_conversation_root_id``
+        itself (only the true conversation entrypoint does) -- confirm a
+        plain read-only nested call still resolves correctly.
+        """
+        token = set_conversation_root_id("root-conversation")
+        try:
+            assert await _nested_reader() == "root-conversation"
+        finally:
+            reset_conversation_root_id(token)


### PR DESCRIPTION
### Jira
[PUP-585](https://jira.walmart.com/browse/PUP-585)

### Problem
Code Puppy lets you pin a model to an agent (`/pin <agent> <model>`, or the `"model"` field in a JSON agent file). If that pinned model later disappears from config (deleted entry, unsupported type, or fails to instantiate — e.g. expired API key), two code paths handled it inconsistently:

1. The main interactive agent build path (`_builder.py::build_pydantic_agent`) already degraded gracefully via `load_model_with_fallback()`: warn, then fall back to the global default model, then any other configured model.
2. Sub-agent invocation (`subagent_invocation.py::_invoke_agent_impl`) did **not** use that helper — it hand-rolled a check and raised a bare `ValueError`, hard-failing the whole `invoke_agent`/`invoke_agent_with_model` tool call with zero fallback.

Additionally, once the fallback kicked in, the same warning re-fired on every agent rebuild forever, since a stale pin is never auto-cleared (by design — some failures like an expired API key are transient, so silently deleting a user's explicit pin would be actively harmful).

### Fix (1st commit)
- `subagent_invocation.py` now routes the ambient/pinned model path through the same `load_model_with_fallback()` helper the main agent uses.
- `_builder.py::load_model_with_fallback()` gained a warned-combo dedup, `reset_model_fallback_warnings()`, and fix-instruction text appended to the warning. The pin itself is **never auto-cleared** — that stays a deliberate, human-initiated action.
- `/clear` resets the dedup, so a persistently broken pin gets re-flagged in a fresh conversation instead of going silent forever.

### Self-review round 1 (2nd commit)
1. **`invoke_agent_with_model`'s explicit override now hard-fails instead of silently substituting.** A bad explicit override is now a hard, per-call `ValueError` naming the requested + available models. The ambient/pinned path is unaffected.
2. **ACP multi-session warning suppression** (attempted fix): `_make_session` started resetting the warned-combo set on every session, since it previously only reset via the CLI's `/clear`.

### Self-review round 2 (3rd commit)
Round 1's ACP fix for #2 traded one bug for another: the dedup key had no conversation identity (`(agent_name, model)` only), so a blanket reset on every new session wiped *other live sessions'* already-earned warnings too. Fix: `load_model_with_fallback()` gained an explicit `conversation_scope` folded into the key as `(conversation_scope, agent_name, model)`, sourced (at the time) from `get_session_context()`.

### Self-review round 3 (4th commit)
`get_session_context()` turned out to be the wrong primitive: a plain, lock-protected instance attribute on a process-wide singleton, **not** a `contextvars.ContextVar` — zero logical isolation between concurrent asyncio tasks. Fixed by adding `set_conversation_root_id`/`get_conversation_root_id` to `subagent_context.py`, backed by a real `ContextVar`, set once at the true conversation root (ACP's `session.py` prompt handler). Concurrent tasks now correctly get isolated copies of the ContextVar; nested sub-agent invocations correctly inherit the same root. Also added `close_session` purging its own session-scoped bucket via `reset_model_fallback_warnings(scope=session_id)`.

### Self-review round 4 (5th commit)
Round 4 review independently traced the ContextVar propagation claim against the real pydantic-ai/acp library internals (task creation, tool dispatch, parallel-tool-call batching) and confirmed it holds — **verdict: merge-ready, no blockers.** It flagged two non-blocking follow-ups, both closed here:
1. **Narrow close/in-flight-run race**: `close_session`'s bare `session.cancel()` only *requests* cancellation (delivered at the task's next await point, not immediately), then immediately purged the warn-dedup bucket — a still-in-flight run past its `load_model_with_fallback` write could race the purge and leak one `(session_id, agent_name, model)` tuple forever. Fixed with `ACPSession.cancel_and_wait()` (cancel + await the task, bounded by a timeout), wired into `close_session`. New regression test races `close_session` against a genuinely in-flight run.
2. **Doc drift**: `_make_session`'s docstring still described round-2/3 phrasing ("parent conversation's session id"); updated to name the round-3 ContextVar concept correctly.

### Tests
- `tests/test_pinned_model_fallback.py`: ambient-path fallback + warn-once-per-combo + fix instructions + `/clear` re-arm; explicit-override hard-fail; independent conversations don't share warning state; scoped reset doesn't wipe a different scope; direct unit-test class on `load_model_with_fallback`'s scoping/reset semantics.
- `tests/tools/test_subagent_context_conversation_root.py`: real (unmocked) `asyncio.gather`-based tests proving concurrent tasks never cross-contaminate the ContextVar, and nested calls inherit the same root.
- `tests/command_line/test_session_commands.py`: `/clear` calls `reset_model_fallback_warnings()`.
- `tests/test_acp_plugin.py`: `new_session` resets the shared/unscoped bucket; `close_session` purges its own session-scoped bucket; `close_session` waits for a genuinely in-flight run before purging (new race regression test).
- Full suite (7041 tests) passes; `ruff check` clean.

### Acceptance criteria
- [x] A sub-agent pinned to a model no longer in config completes its run on the fallback model instead of erroring out (ambient/pinned path only).
- [x] An explicit `invoke_agent_with_model` override that's unavailable fails loudly and immediately, naming the model and available alternatives — never silently runs a different model than requested.
- [x] The fallback warning names the dead model + agent and gives actionable `/pin`/`/unpin`/`/model` instructions.
- [x] The same (agent, dead-model) combo doesn't repeat the warning within one conversation — true even across concurrent conversations sharing a process, and across nested sub-agent chains within one conversation, backed by a real ContextVar rather than a shared mutable global.
- [x] `/clear` re-arms the warning for a new CLI conversation; ACP session close purges exactly that session's own warning bucket (waiting for any in-flight run to finish first), never another live session's.
- [x] The pinned model config value is never silently modified/cleared by this fallback logic.
