### PR TITLE
fix: recover from corrupted config files

### DIFF
--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 from typing import Any, Optional
 
+from code_puppy.config_file import load_config, mutate_config
 from code_puppy.session_storage import save_session
 
 logger = logging.getLogger(__name__)
@@ -307,6 +308,11 @@ _default_vision_model_cache = None
 _warned_no_model = False
 
 
+def _load_config() -> configparser.ConfigParser:
+    """Load ``CONFIG_FILE`` through the bounded, recoverable I/O layer."""
+    return load_config(CONFIG_FILE)
+
+
 def ensure_config_exists():
     """
     Ensure that XDG directories and puppy.cfg exist, prompting if needed.
@@ -317,15 +323,17 @@ def ensure_config_exists():
         if not os.path.exists(directory):
             os.makedirs(directory, mode=0o700, exist_ok=True)
     exists = os.path.isfile(CONFIG_FILE)
-    config = configparser.ConfigParser()
-    if exists:
-        config.read(CONFIG_FILE)
+    # Skip the read entirely when we already know there's nothing to read --
+    # matches configparser's own no-op-on-missing-file behavior and avoids an
+    # unnecessary open() attempt during first-run setup.
+    config = _load_config() if exists else configparser.ConfigParser()
     missing = []
     if DEFAULT_SECTION not in config:
         config[DEFAULT_SECTION] = {}
     for key in REQUIRED_KEYS:
         if not config[DEFAULT_SECTION].get(key):
             missing.append(key)
+    prompted_values: dict[str, str] = {}
     if missing:
         # Note: Using sys.stdout here for initial setup before messaging system is available
         import sys
@@ -341,22 +349,33 @@ def ensure_config_exists():
                 ).strip()
             else:
                 val = input(f"Enter {key}: ").strip()
+            prompted_values[key] = val
             config[DEFAULT_SECTION][key] = val
 
     # Set default values for important config keys if they don't exist
     if not config[DEFAULT_SECTION].get("auto_save_session"):
         config[DEFAULT_SECTION]["auto_save_session"] = "true"
 
-    # Write the config if we made any changes
+    # Write the config if we made any changes. Re-reads under the config lock
+    # and re-applies the prompted values on top of that fresh snapshot, so a
+    # file that was corrupted or replaced between the read above and now is
+    # quarantined and recovered from rather than blindly overwritten.
     if missing or not exists:
-        with open(CONFIG_FILE, "w", encoding="utf-8") as f:
-            config.write(f)
+
+        def _apply(cfg: configparser.ConfigParser) -> None:
+            if DEFAULT_SECTION not in cfg:
+                cfg[DEFAULT_SECTION] = {}
+            for key, val in prompted_values.items():
+                cfg[DEFAULT_SECTION][key] = val
+            if not cfg[DEFAULT_SECTION].get("auto_save_session"):
+                cfg[DEFAULT_SECTION]["auto_save_session"] = "true"
+
+        config = mutate_config(CONFIG_FILE, _apply)
     return config
 
 
 def get_value(key: str):
-    config = configparser.ConfigParser()
-    config.read(CONFIG_FILE)
+    config = _load_config()
     val = config.get(DEFAULT_SECTION, key, fallback=None)
     return val
 
@@ -492,8 +511,7 @@ def get_config_keys():
     default_keys.append("retry_subagent_strategy")
     default_keys.append("retry_subagent_max_attempts")
 
-    config = configparser.ConfigParser()
-    config.read(CONFIG_FILE)
+    config = _load_config()
     keys = set(config[DEFAULT_SECTION].keys()) if DEFAULT_SECTION in config else set()
     keys.update(default_keys)
     return sorted(keys)
@@ -503,13 +521,13 @@ def set_config_value(key: str, value: str):
     """
     Sets a config value in the persistent config file.
     """
-    config = configparser.ConfigParser()
-    config.read(CONFIG_FILE)
-    if DEFAULT_SECTION not in config:
-        config[DEFAULT_SECTION] = {}
-    config[DEFAULT_SECTION][key] = value
-    with open(CONFIG_FILE, "w", encoding="utf-8") as f:
-        config.write(f)
+
+    def _apply(config: configparser.ConfigParser) -> None:
+        if DEFAULT_SECTION not in config:
+            config[DEFAULT_SECTION] = {}
+        config[DEFAULT_SECTION][key] = value
+
+    mutate_config(CONFIG_FILE, _apply)
 
 
 # Alias for API compatibility
@@ -520,12 +538,14 @@ def set_value(key: str, value: str) -> None:
 
 def reset_value(key: str) -> None:
     """Remove a key from the config file, resetting it to default."""
-    config = configparser.ConfigParser()
-    config.read(CONFIG_FILE)
-    if DEFAULT_SECTION in config and key in config[DEFAULT_SECTION]:
-        del config[DEFAULT_SECTION][key]
-        with open(CONFIG_FILE, "w", encoding="utf-8") as f:
-            config.write(f)
+
+    def _apply(config: configparser.ConfigParser) -> bool:
+        if DEFAULT_SECTION in config and key in config[DEFAULT_SECTION]:
+            del config[DEFAULT_SECTION][key]
+            return True
+        return False  # nothing to remove -- skip the write entirely
+
+    mutate_config(CONFIG_FILE, _apply)
 
 
 # --- MODEL STICKY EXTENSION STARTS HERE ---
@@ -854,13 +874,12 @@ def set_model_name(model: str):
     _SESSION_MODEL = model
 
     # Also persist to file for new terminal sessions
-    config = configparser.ConfigParser()
-    config.read(CONFIG_FILE)
-    if DEFAULT_SECTION not in config:
-        config[DEFAULT_SECTION] = {}
-    config[DEFAULT_SECTION]["model"] = model or ""
-    with open(CONFIG_FILE, "w", encoding="utf-8") as f:
-        config.write(f)
+    def _apply(config: configparser.ConfigParser) -> None:
+        if DEFAULT_SECTION not in config:
+            config[DEFAULT_SECTION] = {}
+        config[DEFAULT_SECTION]["model"] = model or ""
+
+    mutate_config(CONFIG_FILE, _apply)
 
     # Clear model cache when switching models to ensure fresh validation
     clear_model_cache()
@@ -1056,13 +1075,10 @@ def get_all_model_settings(model_name: str) -> dict:
     Returns:
         Dictionary of setting_name -> value for all configured settings.
     """
-    import configparser
-
     sanitized_name = _sanitize_model_name_for_key(model_name)
     prefix = f"model_settings_{sanitized_name}_"
 
-    config = configparser.ConfigParser()
-    config.read(CONFIG_FILE)
+    config = _load_config()
 
     settings = {}
     if DEFAULT_SECTION in config:
@@ -1130,23 +1146,20 @@ def clear_model_settings(model_name: str) -> None:
     Args:
         model_name: The model name
     """
-    import configparser
-
     sanitized_name = _sanitize_model_name_for_key(model_name)
     prefix = f"model_settings_{sanitized_name}_"
 
-    config = configparser.ConfigParser()
-    config.read(CONFIG_FILE)
-
-    if DEFAULT_SECTION in config:
+    def _apply(config: configparser.ConfigParser) -> bool:
+        if DEFAULT_SECTION not in config:
+            return False
         keys_to_remove = [
             key for key in config[DEFAULT_SECTION] if key.startswith(prefix)
         ]
         for key in keys_to_remove:
             del config[DEFAULT_SECTION][key]
+        return bool(keys_to_remove)  # nothing matched -- skip the write entirely
 
-        with open(CONFIG_FILE, "w", encoding="utf-8") as f:
-            config.write(f)
+    mutate_config(CONFIG_FILE, _apply)
 
 
 def get_effective_model_settings(model_name: Optional[str] = None) -> dict:
@@ -1772,8 +1785,7 @@ def get_all_agent_pinned_models() -> dict:
         Dict mapping agent names to their pinned model names.
         Only includes agents that have a pinned model (non-empty value).
     """
-    config = configparser.ConfigParser()
-    config.read(CONFIG_FILE)
+    config = _load_config()
 
     pinnings = {}
     if DEFAULT_SECTION in config:

--- a/code_puppy/config_file.py
+++ b/code_puppy/config_file.py
@@ -1,0 +1,239 @@
+"""Bounded, recoverable I/O for Code Puppy's INI configuration file.
+
+The public helpers in this module keep config-file safety concerns out of the
+already-large :mod:`code_puppy.config` module:
+
+* reads are size-bounded before parsing, preventing pathological lines from
+  exhausting memory;
+* only confirmed content corruption is quarantined -- ordinary I/O failures
+  still propagate;
+* recovery and writes share a cross-process lock;
+* quarantine names are collision-resistant and never overwrite a backup; and
+* writes use a same-directory temporary file followed by atomic replacement.
+"""
+
+from __future__ import annotations
+
+import configparser
+import contextlib
+import io
+import logging
+import os
+import tempfile
+import time
+import uuid
+from collections.abc import Callable, Iterator
+
+logger = logging.getLogger(__name__)
+
+MAX_CONFIG_BYTES = 10 * 1024 * 1024
+_LOCK_TIMEOUT_SECONDS = 30.0
+_LOCK_POLL_SECONDS = 0.05
+
+try:  # POSIX
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
+
+try:  # Windows
+    import msvcrt
+except ImportError:  # pragma: no cover - POSIX
+    msvcrt = None  # type: ignore[assignment]
+
+
+class ConfigFileCorrupt(Exception):
+    """The file was read successfully but its contents are not safe INI."""
+
+
+class ConfigLockTimeout(TimeoutError):
+    """Another process held the config lock beyond the bounded wait."""
+
+
+def _try_lock(fd: int) -> bool:
+    if fcntl is not None:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except BlockingIOError:
+            return False
+    if msvcrt is not None:
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError:
+            return False
+    return True
+
+
+def _unlock(fd: int) -> None:
+    if fcntl is not None:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    elif msvcrt is not None:
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+
+
+@contextlib.contextmanager
+def _config_lock(path: str) -> Iterator[None]:
+    """Serialize recovery and read-modify-write operations across processes."""
+    lock_path = f"{path}.lock"
+    os.makedirs(os.path.dirname(os.path.abspath(lock_path)), exist_ok=True)
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    acquired = False
+    try:
+        if msvcrt is not None:
+            os.write(fd, b"\0")
+        deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
+        while not (acquired := _try_lock(fd)):
+            if time.monotonic() >= deadline:
+                raise ConfigLockTimeout(
+                    f"Timed out waiting for config lock: {lock_path}"
+                )
+            time.sleep(_LOCK_POLL_SECONDS)
+        yield
+    finally:
+        if acquired:
+            try:
+                _unlock(fd)
+            except OSError:
+                logger.debug(
+                    "Failed to release config lock %s", lock_path, exc_info=True
+                )
+        os.close(fd)
+
+
+def _read_unlocked(path: str) -> configparser.ConfigParser:
+    """Read and parse a bounded snapshot; propagate filesystem failures."""
+    parser = configparser.ConfigParser()
+    try:
+        size = os.path.getsize(path)
+    except FileNotFoundError:
+        return parser
+    if size > MAX_CONFIG_BYTES:
+        raise ConfigFileCorrupt(
+            f"config is {size} bytes; maximum is {MAX_CONFIG_BYTES} bytes"
+        )
+
+    try:
+        with open(path, "rb") as file:
+            raw = file.read(MAX_CONFIG_BYTES + 1)
+    except FileNotFoundError:
+        return parser
+    if len(raw) > MAX_CONFIG_BYTES:
+        raise ConfigFileCorrupt(f"config exceeds {MAX_CONFIG_BYTES} bytes")
+
+    try:
+        text = raw.decode("utf-8")
+        if text:
+            parser.read_string(text, source=path)
+    except (UnicodeDecodeError, configparser.Error) as exc:
+        raise ConfigFileCorrupt(str(exc)) from exc
+    return parser
+
+
+def _quarantine_unlocked(path: str) -> str:
+    """Move a confirmed-corrupt file aside without overwriting prior backups."""
+    for _ in range(10):
+        quarantine_path = f"{path}.corrupted-{time.time_ns()}-{uuid.uuid4().hex}"
+        try:
+            # Hard-link creation is atomic and refuses to overwrite an existing
+            # destination. Unlink only after the backup exists, so any failure
+            # leaves the original user data in place.
+            os.link(path, quarantine_path)
+        except FileExistsError:
+            continue
+        try:
+            os.unlink(path)
+        except BaseException:
+            try:
+                os.unlink(quarantine_path)
+            except OSError:
+                pass
+            raise
+        return quarantine_path
+    raise FileExistsError("Could not allocate a unique config quarantine path")
+
+
+def load_config(path: str) -> configparser.ConfigParser:
+    """Load config, quarantining only confirmed content corruption.
+
+    A second read under the process lock closes the read/quarantine TOCTOU
+    window between cooperating Code Puppy processes. If another process fixed
+    or replaced the file first, its healthy version wins and is returned.
+    Filesystem errors and genuine ``MemoryError`` conditions propagate; neither
+    proves that user data is corrupt.
+    """
+    try:
+        return _read_unlocked(path)
+    except ConfigFileCorrupt as first_error:
+        with _config_lock(path):
+            try:
+                return _read_unlocked(path)
+            except ConfigFileCorrupt as confirmed_error:
+                quarantine_path = _quarantine_unlocked(path)
+                logger.warning(
+                    "Corrupted config %s was quarantined to %s: %s",
+                    path,
+                    quarantine_path,
+                    confirmed_error or first_error,
+                )
+                return configparser.ConfigParser()
+
+
+def _atomic_write_unlocked(path: str, parser: configparser.ConfigParser) -> None:
+    """Durably replace ``path`` with serialized config from a temp file."""
+    buffer = io.StringIO()
+    parser.write(buffer)
+    target = os.path.realpath(path)
+    directory = os.path.dirname(target) or "."
+    os.makedirs(directory, exist_ok=True)
+
+    mode = None
+    try:
+        mode = os.stat(target).st_mode
+    except OSError:
+        pass
+
+    fd, temp_path = tempfile.mkstemp(dir=directory, prefix=".puppy.cfg-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as file:
+            file.write(buffer.getvalue())
+            file.flush()
+            os.fsync(file.fileno())
+        if mode is not None:
+            os.chmod(temp_path, mode)
+        os.replace(temp_path, target)
+    except BaseException:
+        try:
+            os.unlink(temp_path)
+        except OSError:
+            pass
+        raise
+
+
+def mutate_config(
+    path: str, mutation: Callable[[configparser.ConfigParser], bool | None]
+) -> configparser.ConfigParser:
+    """Apply one locked read-modify-write transaction.
+
+    ``mutation`` may return ``False`` to skip an unnecessary write. A corrupt
+    file is quarantined while the same lock remains held; if quarantine fails,
+    the exception propagates and the mutation is never written over user data.
+    """
+    with _config_lock(path):
+        try:
+            parser = _read_unlocked(path)
+        except ConfigFileCorrupt as exc:
+            quarantine_path = _quarantine_unlocked(path)
+            logger.warning(
+                "Corrupted config %s was quarantined to %s: %s",
+                path,
+                quarantine_path,
+                exc,
+            )
+            parser = configparser.ConfigParser()
+        should_write = mutation(parser)
+        if should_write is not False:
+            _atomic_write_unlocked(path, parser)
+        return parser

--- a/tests/test_config_corruption_resilience.py
+++ b/tests/test_config_corruption_resilience.py
@@ -1,0 +1,307 @@
+"""Regression tests for code_puppy.config_file's corruption tolerance.
+
+Background: a user hit an uncaught ``MemoryError`` bubbling out of
+``configparser.ConfigParser().read(CONFIG_FILE)`` deep inside a startup
+callback (theme plugin -> set_config_value -> config.read). The first pass
+at a fix (catch-and-quarantine around a raw ``config.read()``) survived an
+adversarial review that found it would misclassify transient I/O errors as
+corruption, race with concurrent processes between read and quarantine, and
+let same-instant quarantine attempts clobber each other. This suite pins the
+hardened design in :mod:`code_puppy.config_file`:
+
+* reads are byte-bounded, so a pathological file can never balloon memory;
+* only confirmed parse/decode/oversize corruption is quarantined;
+* transient OSError (e.g. permission errors) propagates untouched;
+* quarantine is collision-resistant and never overwrites a prior backup;
+* recovery re-checks under a cross-process lock before moving anything; and
+* writes go through a locked, atomic temp-file-then-replace transaction.
+"""
+
+import glob
+import os
+import threading
+import time
+from unittest.mock import patch
+
+import configparser
+import pytest
+
+from code_puppy import config as cp_config
+from code_puppy import config_file
+
+
+@pytest.fixture
+def cfg_path(tmp_path, monkeypatch):
+    """Point CONFIG_FILE at a real (temp) path so os.link/replace behave."""
+    cfg_dir = tmp_path / "cfgdir"
+    cfg_dir.mkdir()
+    path = cfg_dir / "puppy.cfg"
+    monkeypatch.setattr(cp_config, "CONFIG_FILE", str(path))
+    return path
+
+
+class TestLoadConfigCorruption:
+    def test_malformed_ini_does_not_raise(self, cfg_path):
+        cfg_path.write_text("this is not [valid ini at all\nnope=nope=nope\n")
+
+        config = config_file.load_config(str(cfg_path))
+
+        assert isinstance(config, configparser.ConfigParser)
+
+    def test_malformed_ini_gets_quarantined_not_deleted(self, cfg_path):
+        cfg_path.write_text("this is not [valid ini at all\nnope=nope=nope\n")
+
+        config_file.load_config(str(cfg_path))
+
+        assert not cfg_path.exists()
+        backups = glob.glob(f"{cfg_path}.corrupted-*")
+        assert len(backups) == 1
+        assert "not [valid ini" in open(backups[0]).read()
+
+    def test_invalid_utf8_is_quarantined(self, cfg_path):
+        cfg_path.write_bytes(b"\xff\xfe garbage \x00\x00 noutf8 [[[")
+
+        config = config_file.load_config(str(cfg_path))
+
+        assert isinstance(config, configparser.ConfigParser)
+        assert glob.glob(f"{cfg_path}.corrupted-*")
+
+    def test_healthy_config_is_left_untouched(self, cfg_path):
+        cfg_path.write_text("[puppy]\npuppy_name = leoncito\n")
+
+        config = config_file.load_config(str(cfg_path))
+
+        assert config.get("puppy", "puppy_name") == "leoncito"
+        assert not glob.glob(f"{cfg_path}.corrupted-*")
+
+    def test_missing_file_returns_empty_config_without_error(self, cfg_path):
+        # cfg_path was never created.
+        config = config_file.load_config(str(cfg_path))
+
+        assert isinstance(config, configparser.ConfigParser)
+        assert config.sections() == []
+
+
+class TestOversizedConfigIsBoundedNotBallooned:
+    """Pins the actual field-report scenario: a pathological file must never
+    reach configparser's own unbounded line reader in the first place."""
+
+    def test_oversized_file_is_quarantined_without_full_read(
+        self, cfg_path, monkeypatch
+    ):
+        monkeypatch.setattr(config_file, "MAX_CONFIG_BYTES", 1024)
+        # One giant unterminated "line" -- the exact shape that made stdlib
+        # configparser's buffered readline balloon memory in the field report.
+        cfg_path.write_bytes(b"x" * 4096)
+
+        config = config_file.load_config(str(cfg_path))
+
+        assert isinstance(config, configparser.ConfigParser)
+        assert glob.glob(f"{cfg_path}.corrupted-*")
+
+    def test_read_never_buffers_past_the_bound(self, cfg_path, monkeypatch):
+        """Even if the file's reported size lies (e.g. a sparse file, or a
+        pipe/device whose ``stat`` size is unreliable), the actual ``read()``
+        call itself must still be bounded rather than pulling the whole
+        pathological file into memory. This directly targets the field
+        report's failure mode: stdlib configparser's buffered readline
+        ballooning memory on a giant unterminated line."""
+        monkeypatch.setattr(config_file, "MAX_CONFIG_BYTES", 1024)
+        cfg_path.write_bytes(b"y" * (5 * 1024 * 1024))
+        # Make the pre-flight os.path.getsize check lie about the size so
+        # execution reaches the actual bounded read() call below.
+        monkeypatch.setattr(config_file.os.path, "getsize", lambda _p: 10)
+
+        real_open = open
+        captured_sizes = []
+
+        class _TrackingFile:
+            def __init__(self, fh):
+                self._fh = fh
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                self._fh.close()
+                return False
+
+            def read(self, n=-1):
+                data = self._fh.read(n)
+                captured_sizes.append(len(data))
+                return data
+
+        def _tracking_open(path, mode="r"):
+            if mode == "rb":
+                return _TrackingFile(real_open(path, mode))
+            return real_open(path, mode)
+
+        with patch("code_puppy.config_file.open", _tracking_open, create=True):
+            config_file.load_config(str(cfg_path))
+
+        assert captured_sizes, "expected the bounded read to be exercised"
+        assert all(size <= 1025 for size in captured_sizes)
+
+
+class TestQuarantineCollisionSafety:
+    """Pins the reviewer's collision finding: two recoveries landing on the
+    same name must never clobber each other's backup."""
+
+    def test_repeated_corruption_never_overwrites_prior_backup(self, cfg_path):
+        cfg_path.write_text("first corrupt payload [[[")
+        config_file.load_config(str(cfg_path))
+        first_backup = glob.glob(f"{cfg_path}.corrupted-*")
+        assert len(first_backup) == 1
+
+        cfg_path.write_text("second corrupt payload [[[")
+        config_file.load_config(str(cfg_path))
+
+        backups = sorted(glob.glob(f"{cfg_path}.corrupted-*"))
+        assert len(backups) == 2
+        contents = {open(b).read() for b in backups}
+        assert contents == {"first corrupt payload [[[", "second corrupt payload [[["}
+
+    def test_forced_name_collision_retries_instead_of_overwriting(self, cfg_path):
+        """Simulates two processes computing the identical quarantine name."""
+        cfg_path.write_text("corrupt payload [[[")
+
+        real_link = os.link
+        call_count = {"n": 0}
+
+        def _flaky_link(src, dst):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # Pre-create the "colliding" destination as another process
+                # would have, forcing our retry loop to pick a new name.
+                with open(dst, "w") as f:
+                    f.write("someone else's backup")
+                raise FileExistsError(dst)
+            return real_link(src, dst)
+
+        with patch("os.link", side_effect=_flaky_link):
+            config_file.load_config(str(cfg_path))
+
+        backups = glob.glob(f"{cfg_path}.corrupted-*")
+        # The pre-created collision file plus our own successfully-retried backup.
+        assert len(backups) == 2
+        contents = {open(b).read() for b in backups}
+        assert "someone else's backup" in contents
+        assert "corrupt payload [[[" in contents
+
+
+class TestTransientIoErrorsPropagate:
+    """A permissions blip or flaky network mount is not proof of corruption;
+    quarantining (and silently losing) a healthy file on transient I/O
+    failure was one of the reviewer's HIGH findings."""
+
+    def test_permission_error_on_read_propagates_and_is_not_quarantined(self, cfg_path):
+        cfg_path.write_text("[puppy]\npuppy_name = leoncito\n")
+
+        with patch("builtins.open", side_effect=PermissionError("locked by AV")):
+            with pytest.raises(PermissionError):
+                config_file.load_config(str(cfg_path))
+
+        # The healthy file must still be exactly where it was.
+        assert cfg_path.exists()
+        assert not glob.glob(f"{cfg_path}.corrupted-*")
+
+    def test_get_value_does_not_swallow_transient_os_errors(self, cfg_path):
+        """Public accessors should not pretend a disk hiccup means 'no value'."""
+        cfg_path.write_text("[puppy]\npuppy_name = leoncito\n")
+
+        with patch("builtins.open", side_effect=OSError("device not ready")):
+            with pytest.raises(OSError):
+                cp_config.get_value("puppy_name")
+
+
+class TestRecoveryTocTou:
+    """Pins the reviewer's race finding: if another process fixes the file
+    between our first bad read and quarantine, we must not clobber the fix."""
+
+    def test_second_read_under_lock_wins_over_stale_corruption(self, cfg_path):
+        original_read_unlocked = config_file._read_unlocked
+        call_count = {"n": 0}
+
+        def _fake_read(path):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise config_file.ConfigFileCorrupt("simulated first-pass failure")
+            # Simulate a concurrent process having repaired the file just
+            # before we acquired the lock for the confirming re-read.
+            return original_read_unlocked(path)
+
+        cfg_path.write_text("[puppy]\npuppy_name = fixed-by-another-process\n")
+
+        with patch.object(config_file, "_read_unlocked", side_effect=_fake_read):
+            config = config_file.load_config(str(cfg_path))
+
+        assert config.get("puppy", "puppy_name") == "fixed-by-another-process"
+        assert not glob.glob(f"{cfg_path}.corrupted-*")
+        assert cfg_path.exists()
+
+
+class TestAtomicWriteAndLocking:
+    def test_set_config_value_survives_corrupted_config(self, cfg_path):
+        """The exact field-report call chain: theme plugin -> _apply_theme
+        -> set_config_value -> config read/write."""
+        cfg_path.write_text("not\nvalid\nini\n[[[")
+
+        cp_config.set_config_value("active_theme", "dracula")
+
+        assert cp_config.get_value("active_theme") == "dracula"
+
+    def test_write_failure_never_touches_the_original_file(self, cfg_path):
+        cfg_path.write_text("[puppy]\npuppy_name = leoncito\n")
+
+        with patch("os.fsync", side_effect=OSError("disk full")):
+            with pytest.raises(OSError):
+                cp_config.set_config_value("active_theme", "dracula")
+
+        # Original content must be intact -- no partial/truncated write.
+        assert cfg_path.read_text() == "[puppy]\npuppy_name = leoncito\n"
+        # And no stray temp files left behind in the config directory.
+        leftovers = [
+            f for f in os.listdir(cfg_path.parent) if f.startswith(".puppy.cfg-")
+        ]
+        assert leftovers == []
+
+    def test_concurrent_mutations_do_not_lose_updates(self, cfg_path):
+        """Two threads racing set_config_value must not stomp each other --
+        this is what the shared cross-process lock in mutate_config buys us."""
+        cfg_path.write_text("[puppy]\npuppy_name = leoncito\n")
+
+        def _writer(key, value):
+            cp_config.set_config_value(key, value)
+
+        threads = [
+            threading.Thread(target=_writer, args=(f"key_{i}", f"value_{i}"))
+            for i in range(8)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        for i in range(8):
+            assert cp_config.get_value(f"key_{i}") == f"value_{i}"
+
+    def test_reset_value_skips_write_when_key_absent(self, cfg_path):
+        """mutate_config's False-return short-circuit must avoid a no-op write."""
+        cfg_path.write_text("[puppy]\npuppy_name = leoncito\n")
+        original_mtime_ns = os.stat(cfg_path).st_mtime_ns
+        time.sleep(0.01)
+
+        cp_config.reset_value("does_not_exist")
+
+        assert os.stat(cfg_path).st_mtime_ns == original_mtime_ns
+
+    def test_lock_timeout_raises_rather_than_hanging_forever(self, cfg_path):
+        cfg_path.write_text("[puppy]\npuppy_name = leoncito\n")
+
+        with patch.object(config_file, "_LOCK_TIMEOUT_SECONDS", 0.2):
+            with config_file._config_lock(str(cfg_path)):
+                # Lock is held (this thread simulates "another process") for
+                # longer than the bounded wait attempted below.
+                with pytest.raises(config_file.ConfigLockTimeout):
+                    with config_file._config_lock(str(cfg_path)):
+                        pass  # pragma: no cover - should never be reached


### PR DESCRIPTION
**Jira:** [PUP-605](https://jira.walmart.com/browse/PUP-605)

## Problem

A user hit an uncaught `MemoryError` traceback on startup:

```
_apply_default_theme_on_first_run -> _apply_theme -> set_config_value
  -> configparser.ConfigParser().read(CONFIG_FILE) -> MemoryError
```

`config.py` had ~10 call sites doing raw `configparser.ConfigParser(); config.read(CONFIG_FILE)` / `open(CONFIG_FILE, "w")` with zero error handling. A malformed or pathologically-shaped `puppy.cfg` (e.g. one giant line with no newline -- plausible from AV/EDR interference or a flaky network-mounted home directory, which the reporter's VDI-style hostname suggests) makes stdlib `configparser`'s buffered line reader balloon memory instead of raising a clean parse error, crashing whatever caller touches config next.

## Fix

New `code_puppy/config_file.py` centralizes all config I/O behind two entry points; `config.py` no longer opens `CONFIG_FILE` directly anywhere:

- **`load_config()`** -- reads are byte-bounded *before* parsing, so a pathological file can never reach the unbounded stdlib reader in the first place. Only confirmed parse/decode/oversize corruption is quarantined (renamed aside with a collision-resistant name, never deleted, never overwrites a prior backup). Ordinary `OSError` (permissions, transient network-mount hiccups) propagates untouched instead of being misclassified as corruption and silently discarded. A second read happens under a cross-process lock before anything is quarantined, closing the read/quarantine TOCTOU race -- if another process already fixed the file, its healthy version wins.
- **`mutate_config()`** -- every write (`set_config_value`, `reset_value`, `set_model_name`, `clear_model_settings`, `ensure_config_exists`) is now one locked read-modify-write transaction using a same-directory temp file + `fsync` + atomic `os.replace`, so concurrent writers can't lose updates and a crash mid-write can't reintroduce corruption.

This design went through an internal adversarial review pass; the first draft (a simpler catch-and-quarantine wrapper) was rejected for treating *any* `OSError` as corruption, having a read/quarantine race, and using collision-prone quarantine filenames. All three are addressed above.

## Tests

`tests/test_config_corruption_resilience.py` covers the original crash chain plus the hardening: bounded reads (including a "lying" file-size case), oversized-file handling, quarantine collision safety, transient-I/O propagation, the TOCTOU recovery race, atomic-write failure safety, and lock-timeout behavior.

Full suite: **7120 passed, 0 failed** (`uv run pytest tests/ -q`).

