### PR TITLE
feat: add model_select hook for per-run model routing

### DIFF
--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -696,6 +696,20 @@ async def _run_with_mcp_impl(
         # Hook failures must never block the run.
         pass
 
+    # Let a ``model_select`` hook route THIS turn to a different model (e.g.
+    # small-vs-large by complexity) before the pydantic agent is built. This
+    # resets any prior turn's auto choice, respects an explicit runtime
+    # override, and invalidates the cached agent when the model changes so the
+    # build below picks it up. No-op (and near-zero cost) if no plugin
+    # registered the hook.
+    try:
+        from code_puppy.model_switching import resolve_run_model_selection
+
+        resolve_run_model_selection(agent, agent._message_history, group_id)
+    except Exception:
+        # Selection must never block a run.
+        pass
+
     if agent._code_generation_agent is None:
         build_pydantic_agent(agent)
     pydantic_agent = agent._code_generation_agent

--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -73,6 +73,11 @@ class BaseAgent(ABC):
         self._code_generation_agent: Any = None
         self._last_model_name: Optional[str] = None
         self._runtime_model_name_override: Optional[str] = None
+        # Model chosen by a ``model_select`` hook for the current run. Slots
+        # BELOW an explicit runtime override but ABOVE pinned/JSON/global, and
+        # is reset at the start of every run (see resolve_run_model_selection),
+        # so it never leaks across turns.
+        self._auto_model_override: Optional[str] = None
         self._puppy_rules: Optional[str] = None
         self._mcp_servers: List[Any] = []
         self.cur_model: Optional[pydantic_ai.models.Model] = None
@@ -127,6 +132,14 @@ class BaseAgent(ABC):
         """
         self._runtime_model_name_override = model_name
 
+    def get_auto_model_override(self) -> Optional[str]:
+        """Return the model chosen by a ``model_select`` hook for this run."""
+        return self._auto_model_override
+
+    def set_auto_model_override(self, model_name: Optional[str]) -> None:
+        """Set the ``model_select``-chosen model for this run (not persisted)."""
+        self._auto_model_override = model_name
+
     @contextmanager
     def temporary_model_name_override(
         self, model_name: Optional[str]
@@ -143,6 +156,9 @@ class BaseAgent(ABC):
         override = self.get_runtime_model_name_override()
         if override:
             return override
+        auto = self.get_auto_model_override()
+        if auto:
+            return auto
         pinned = get_agent_pinned_model(self.name)
         return pinned if pinned else get_global_model_name()
 

--- a/code_puppy/agents/json_agent.py
+++ b/code_puppy/agents/json_agent.py
@@ -210,6 +210,13 @@ class JSONAgent(BaseAgent):
         if override:
             return override
 
+        # A ``model_select`` hook choice outranks the JSON ``model`` field so
+        # per-turn routing works for JSON agents too (see get_model_name in
+        # BaseAgent for the full precedence ladder).
+        auto = self.get_auto_model_override()
+        if auto:
+            return auto
+
         result = self._config.get("model")
         if result is None or (isinstance(result, str) and not result.strip()):
             result = super().get_model_name()

--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -45,6 +45,7 @@ PhaseType = Literal[
     "agent_run_start",
     "agent_run_end",
     "agent_run_result",
+    "model_select",
     "register_mcp_catalog_servers",
     "register_browser_types",
     "register_model_providers",
@@ -130,6 +131,7 @@ _callbacks: Dict[PhaseType, List[CallbackFunc]] = {
     "agent_run_start": [],
     "agent_run_end": [],
     "agent_run_result": [],
+    "model_select": [],
     "register_mcp_catalog_servers": [],
     "register_browser_types": [],
     "register_model_providers": [],
@@ -1050,6 +1052,47 @@ async def on_agent_run_start(
     return await _trigger_callbacks(
         "agent_run_start", agent_name, model_name, session_id
     )
+
+
+def on_model_select(
+    *,
+    agent_name: str,
+    current_model: str | None,
+    messages: List[Any],
+    session_id: str | None = None,
+) -> str | None:
+    """Ask plugins to choose the model for the current run.
+
+    Fires once per run, before the pydantic agent is (re)built. Lets a plugin
+    route each turn to a different model based on the agent, the effective
+    ("would-be") model, and the message history -- e.g. a small model for
+    trivial turns and a frontier model when it matters, or a cost/latency/
+    failover policy.
+
+    Precedence: an explicit runtime override still wins over this hook; this
+    hook wins over the pinned / JSON / global model. The first callback to
+    return a non-empty string wins; return ``None`` to defer.
+
+    Args:
+        agent_name: Name of the agent about to run.
+        current_model: The model that would be used absent any hook.
+        messages: The agent's message history for this run.
+        session_id: Optional per-run identifier.
+
+    Returns:
+        A model name to use for this run, or ``None`` to keep ``current_model``.
+    """
+    results = _trigger_callbacks_sync(
+        "model_select",
+        agent_name=agent_name,
+        current_model=current_model,
+        messages=messages,
+        session_id=session_id,
+    )
+    for result in results:
+        if isinstance(result, str) and result.strip():
+            return result
+    return None
 
 
 async def on_agent_run_end(

--- a/code_puppy/model_switching.py
+++ b/code_puppy/model_switching.py
@@ -2,9 +2,61 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, List, Optional
 
 from code_puppy.config import set_model_name
+
+
+def resolve_run_model_selection(
+    agent: Any,
+    messages: List[Any],
+    session_id: Optional[str] = None,
+) -> Optional[str]:
+    """Apply the ``model_select`` hook for one run and return the chosen model.
+
+    Called once at the start of every run, BEFORE the pydantic agent is built.
+
+    Behaviour / precedence:
+    * The per-run auto override is always cleared first, so a choice never
+      leaks into a later turn.
+    * An explicit runtime override (e.g. ``invoke_agent_with_model``) wins and
+      short-circuits the hook entirely.
+    * Otherwise the hook is asked to pick a model. If it returns a name that
+      differs from the effective model, we install it as the run's auto
+      override and invalidate the cached pydantic agent so the build picks up
+      the new model.
+
+    Returns the chosen model name if the hook changed it, else ``None``.
+    Never raises -- a misbehaving selector must not break a run.
+    """
+    try:
+        # Reset any previous turn's auto choice so it can't leak forward.
+        if agent.get_auto_model_override():
+            agent.set_auto_model_override(None)
+            agent._code_generation_agent = None
+
+        # Explicit runtime override always wins -- don't even ask the hook.
+        if agent.get_runtime_model_name_override():
+            return None
+
+        from code_puppy.callbacks import on_model_select
+
+        current = agent.get_model_name()
+        selected = on_model_select(
+            agent_name=getattr(agent, "name", None),
+            current_model=current,
+            messages=messages or [],
+            session_id=session_id,
+        )
+        if selected and selected != current:
+            agent.set_auto_model_override(selected)
+            # Force a rebuild so the new model is actually used this turn.
+            agent._code_generation_agent = None
+            return selected
+    except Exception:
+        # A broken selector must never block the agent run.
+        pass
+    return None
 
 
 def _get_effective_agent_model(agent) -> Optional[str]:

--- a/tests/test_model_select_hook.py
+++ b/tests/test_model_select_hook.py
@@ -1,0 +1,139 @@
+"""Tests for the ``model_select`` hook and per-run model resolution.
+
+Covers ``callbacks.on_model_select`` and
+``model_switching.resolve_run_model_selection`` -- the two new pieces that let
+a plugin route each turn to a different model (small-vs-large auto mode, cost
+caps, failover, ...).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from code_puppy.callbacks import (
+    clear_callbacks,
+    on_model_select,
+    register_callback,
+)
+from code_puppy.model_switching import resolve_run_model_selection
+
+
+@pytest.fixture(autouse=True)
+def _clean_hook():
+    clear_callbacks("model_select")
+    yield
+    clear_callbacks("model_select")
+
+
+class FakeAgent:
+    """Minimal stand-in exposing the model-override surface resolve() uses."""
+
+    def __init__(self, base="global-model", runtime=None, pinned=None):
+        self.name = "fake"
+        self._base = base
+        self._runtime = runtime
+        self._auto = None
+        self._code_generation_agent = object()  # non-None = "cached build"
+        self._message_history = []
+
+    def get_runtime_model_name_override(self):
+        return self._runtime
+
+    def get_auto_model_override(self):
+        return self._auto
+
+    def set_auto_model_override(self, name):
+        self._auto = name
+
+    def get_model_name(self):
+        # Mirrors BaseAgent precedence: runtime > auto > base.
+        return self._runtime or self._auto or self._base
+
+
+# ---- on_model_select -------------------------------------------------------
+
+
+def test_on_model_select_no_callbacks_returns_none():
+    assert (
+        on_model_select(
+            agent_name="fake", current_model="m", messages=[], session_id=None
+        )
+        is None
+    )
+
+
+def test_on_model_select_returns_first_nonempty():
+    register_callback("model_select", lambda **k: None)
+    register_callback("model_select", lambda **k: "")
+    register_callback("model_select", lambda **k: "small-model")
+    register_callback("model_select", lambda **k: "never-reached")
+    assert (
+        on_model_select(
+            agent_name="fake", current_model="big", messages=[], session_id="s"
+        )
+        == "small-model"
+    )
+
+
+def test_on_model_select_passes_context_to_callback():
+    seen = {}
+
+    def selector(**kwargs):
+        seen.update(kwargs)
+        return None
+
+    register_callback("model_select", selector)
+    on_model_select(
+        agent_name="orch", current_model="big", messages=[1, 2], session_id="x"
+    )
+    assert seen["agent_name"] == "orch"
+    assert seen["current_model"] == "big"
+    assert seen["messages"] == [1, 2]
+    assert seen["session_id"] == "x"
+
+
+# ---- resolve_run_model_selection ------------------------------------------
+
+
+def test_resolve_applies_hook_choice_and_invalidates_cache():
+    register_callback("model_select", lambda **k: "small-model")
+    agent = FakeAgent(base="big-model")
+    chosen = resolve_run_model_selection(agent, [], "s")
+    assert chosen == "small-model"
+    assert agent.get_auto_model_override() == "small-model"
+    assert agent._code_generation_agent is None  # forced rebuild
+
+
+def test_resolve_noop_when_hook_picks_same_model():
+    register_callback("model_select", lambda **k: "big-model")
+    agent = FakeAgent(base="big-model")
+    assert resolve_run_model_selection(agent, [], "s") is None
+    assert agent.get_auto_model_override() is None
+    assert agent._code_generation_agent is not None  # no rebuild
+
+
+def test_explicit_runtime_override_beats_hook():
+    register_callback("model_select", lambda **k: "small-model")
+    agent = FakeAgent(base="big-model", runtime="user-picked")
+    assert resolve_run_model_selection(agent, [], "s") is None
+    assert agent.get_auto_model_override() is None  # hook never consulted
+
+
+def test_prior_auto_choice_is_reset_each_run():
+    # No hook registered this run; a stale auto choice must be cleared.
+    agent = FakeAgent(base="big-model")
+    agent.set_auto_model_override("stale-small")
+    assert resolve_run_model_selection(agent, [], "s") is None
+    assert agent.get_auto_model_override() is None
+    assert agent._code_generation_agent is None  # invalidated on reset
+
+
+def test_broken_selector_never_raises():
+    def boom(**k):
+        raise RuntimeError("selector exploded")
+
+    register_callback("model_select", boom)
+    agent = FakeAgent(base="big-model")
+    # Must swallow the error and leave the run on its normal model.
+    assert resolve_run_model_selection(agent, [], "s") is None
+    assert agent.get_auto_model_override() is None


### PR DESCRIPTION
## Summary

Adds a new `model_select` callback phase that lets a plugin choose the model for
**each run** — e.g. a small model for trivial turns and a frontier model when it
matters (cost control, latency SLAs, and provider failover are other natural
uses). Purely additive: with no plugin registered, behaviour is byte-for-byte
unchanged and the cost is one dict lookup + an empty-list loop per run.

Motivation: today a single agent uses one model for every turn, so trivial edits
burn the same frontier tokens as hard design work. The plumbing to swap the
per-run model already exists (`_runtime_model_name_override`), and
`RoundRobinModel` already exists specifically for "rate-limit mitigation" — but
there's no hook that *decides* which model a turn should use. This fills that gap.

## What changed

| File | Change |
|---|---|
| `callbacks.py` | New `model_select` phase + `on_model_select(...)` trigger (returns the first non-empty model name; `None` = defer). |
| `agents/base_agent.py` | New `_auto_model_override` slot + getter/setter; `get_model_name()` precedence now `runtime override > model_select > pinned > global`. |
| `agents/json_agent.py` | Its `get_model_name()` now honours the auto override **above** the JSON `model` field, so per-turn routing works for JSON agents too. |
| `model_switching.py` | New `resolve_run_model_selection(agent, messages, session_id)`: resets any prior turn's choice, respects an explicit runtime override, calls the hook, and invalidates the cached pydantic agent when the model changes. Never raises. |
| `agents/_runtime.py` | Calls `resolve_run_model_selection(...)` once at the start of every run, before the pydantic agent is (re)built. |
| `tests/test_model_select_hook.py` | 8 tests: hook contract, precedence, cache invalidation, reset-per-run, and error isolation. |

Net: **6 files, +272/-1.**

## Design & precedence

```
explicit runtime override  >  model_select hook  >  pinned / JSON model  >  global
```

- Fires **once per run**, before the build, so the chosen model is actually used.
- Self-cleaning: the auto choice is reset at the start of every run, so it never
  leaks into a later turn — no fragile try/finally around the run body.
- Error-isolated: a selector that raises is swallowed and the run proceeds on its
  normal model (a plugin must never crash the app).

## Hook contract

```python
def on_model_select(
    *,
    agent_name: str,
    current_model: str | None,   # what would be used absent any hook
    messages: list,              # message history for this run
    session_id: str | None,
) -> str | None:                 # a model name for this run, or None to defer
```

## Backward compatibility

Additive only. No existing behaviour changes when the hook is unregistered
(the common case), and the phase short-circuits on an empty callback list.

## Testing

- `tests/test_model_select_hook.py` — **8 passed** (hook + resolver).
- Regression: `tests/test_pinned_model_fallback.py tests/agents/` +
  the new file — **360 passed, 12 skipped, 0 failed**.
- `ruff check` and `ruff format --check` clean on all touched files.

## Decision points I'd love a call on (why this is a Draft)

1. **Hook name** — `model_select` vs `select_model` vs `route_model`?
2. **Precedence** — is `model_select` above pinned/JSON the behaviour you want,
   or should a pinned model win over the hook?
3. **Fire location** — start of `_run_with_mcp_impl` (current) vs inside
   `build_pydantic_agent` (the model choke point, but it isn't called every turn
   because the agent is cached)?
4. **Multiple selectors** — first-non-None wins now; want last-wins or a
   documented priority instead?

## Follow-up (not in this PR)

With this hook, an "auto" model mode becomes a tiny plugin that reuses a
complexity heuristic to return `small`/`large`. I have a working reference
plugin that consumes this hook end-to-end and can follow as a second PR once the
hook shape lands.
