### PR TITLE
fix: extend atomic, bounded, locked config I/O to JSON config surfaces

### DIFF
--- a/code_puppy/agents/json_agent.py
+++ b/code_puppy/agents/json_agent.py
@@ -1,9 +1,10 @@
 """JSON-based agent configuration system."""
 
-import json
 import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+from code_puppy import atomic_json
 
 from .base_agent import BaseAgent
 
@@ -25,14 +26,24 @@ class JSONAgent(BaseAgent):
         self._validate_config()
 
     def _load_config(self) -> Dict:
-        """Load configuration from JSON file."""
+        """Load configuration from JSON file.
+
+        Bounded via :mod:`code_puppy.atomic_json` -- a pathologically large
+        agent file dropped in ``~/.code_puppy/agents/`` can no longer
+        balloon memory the way the original ``configparser`` bug did.
+        """
         try:
-            with open(self.json_path, "r", encoding="utf-8") as f:
-                return json.load(f)
-        except (json.JSONDecodeError, FileNotFoundError) as e:
+            data = atomic_json.load_json(self.json_path)
+        except (atomic_json.JsonFileCorrupt, OSError) as e:
             raise ValueError(
                 f"Failed to load JSON agent config from {self.json_path}: {e}"
             ) from e
+        if data is None:
+            raise ValueError(
+                f"Failed to load JSON agent config from {self.json_path}: "
+                "file not found or empty"
+            )
+        return data
 
     def _validate_config(self) -> None:
         """Validate required fields in configuration."""

--- a/code_puppy/atomic_io.py
+++ b/code_puppy/atomic_io.py
@@ -1,0 +1,201 @@
+"""Generic, cross-process-safe primitives for user-editable config files.
+
+Extracted from :mod:`code_puppy.config_file` (the PUP-605 config-corruption
+fix) so every corner of the config surface -- not just the INI file -- gets
+the same three guarantees for free:
+
+* **bounded reads** -- a pathological/oversized file can never balloon
+  memory the way it did in the original ``MemoryError`` field report;
+* **one cross-process lock per path** -- concurrent readers/writers on the
+  same file (two terminals, a wizard + a slash-command) serialize instead
+  of racing; and
+* **atomic writes** -- same-directory temp file + ``fsync`` + ``os.replace``,
+  so a crash mid-write can never leave a half-written file behind.
+
+:mod:`code_puppy.config_file` (INI) and :mod:`code_puppy.atomic_json` (JSON)
+both build their format-specific ``load_x``/``mutate_x`` helpers on top of
+these primitives. New config-file-shaped state should use one of those two
+modules rather than hand-rolling ``open()``/``json.load()`` again.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import tempfile
+import time
+import uuid
+from collections.abc import Iterator
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_BYTES = 10 * 1024 * 1024
+DEFAULT_LOCK_TIMEOUT_SECONDS = 30.0
+_LOCK_POLL_SECONDS = 0.05
+
+try:  # POSIX
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
+
+try:  # Windows
+    import msvcrt
+except ImportError:  # pragma: no cover - POSIX
+    msvcrt = None  # type: ignore[assignment]
+
+
+class ContentTooLarge(Exception):
+    """A file exceeded the caller's byte budget, before or during a read."""
+
+
+class LockTimeout(TimeoutError):
+    """Another process held the path lock beyond the bounded wait."""
+
+
+def _try_lock(fd: int) -> bool:
+    if fcntl is not None:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except BlockingIOError:
+            return False
+    if msvcrt is not None:
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError:
+            return False
+    return True
+
+
+def _unlock(fd: int) -> None:
+    if fcntl is not None:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    elif msvcrt is not None:
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+
+
+@contextlib.contextmanager
+def path_lock(
+    path: str, timeout: float = DEFAULT_LOCK_TIMEOUT_SECONDS
+) -> Iterator[None]:
+    """Cross-process advisory lock scoped to a ``{path}.lock`` sidecar file.
+
+    Uses ``fcntl.flock`` on POSIX and ``msvcrt.locking`` on Windows. Raises
+    :class:`LockTimeout` rather than blocking forever if another process
+    (or another lock held by this same process) doesn't release in time.
+    """
+    lock_path = f"{path}.lock"
+    os.makedirs(os.path.dirname(os.path.abspath(lock_path)), exist_ok=True)
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    acquired = False
+    try:
+        if msvcrt is not None:
+            os.write(fd, b"\0")
+        deadline = time.monotonic() + timeout
+        while not (acquired := _try_lock(fd)):
+            if time.monotonic() >= deadline:
+                raise LockTimeout(f"Timed out waiting for lock: {lock_path}")
+            time.sleep(_LOCK_POLL_SECONDS)
+        yield
+    finally:
+        if acquired:
+            try:
+                _unlock(fd)
+            except OSError:
+                logger.debug("Failed to release lock %s", lock_path, exc_info=True)
+        os.close(fd)
+
+
+def read_bounded_bytes(path: str, max_bytes: int = DEFAULT_MAX_BYTES) -> bytes:
+    """Read at most ``max_bytes`` from ``path``.
+
+    Returns ``b""`` for a missing file. Raises :class:`ContentTooLarge` if
+    the file is (or turns out to be, past a lying ``stat`` size) larger than
+    ``max_bytes`` -- without ever buffering more than ``max_bytes + 1`` bytes
+    into memory. This bound is the actual fix for the original field report:
+    stdlib ``configparser``'s buffered line reader ballooning memory on one
+    pathological giant line can only happen if the whole line reaches it
+    first, and it never does now.
+    """
+    try:
+        size = os.path.getsize(path)
+    except FileNotFoundError:
+        return b""
+    if size > max_bytes:
+        raise ContentTooLarge(f"{path} is {size} bytes; maximum is {max_bytes} bytes")
+
+    try:
+        with open(path, "rb") as file:
+            raw = file.read(max_bytes + 1)
+    except FileNotFoundError:
+        return b""
+    if len(raw) > max_bytes:
+        raise ContentTooLarge(f"{path} exceeds {max_bytes} bytes")
+    return raw
+
+
+def quarantine_file(path: str) -> str:
+    """Move a confirmed-corrupt file aside without ever losing user data.
+
+    Uses ``os.link`` (atomic, refuses to overwrite an existing destination)
+    followed by ``os.unlink`` of the original, retried with fresh
+    collision-resistant names so concurrent/rapid recoveries never clobber
+    each other's backup and the original is never deleted before its backup
+    safely exists.
+    """
+    for _ in range(10):
+        quarantine_path = f"{path}.corrupted-{time.time_ns()}-{uuid.uuid4().hex}"
+        try:
+            os.link(path, quarantine_path)
+        except FileExistsError:
+            continue
+        try:
+            os.unlink(path)
+        except BaseException:
+            try:
+                os.unlink(quarantine_path)
+            except OSError:
+                pass
+            raise
+        return quarantine_path
+    raise FileExistsError(f"Could not allocate a unique quarantine path for {path}")
+
+
+def atomic_write_bytes(path: str, data: bytes) -> None:
+    """Durably replace ``path``'s contents.
+
+    Writes to a same-directory temp file, ``fsync``s it, then ``os.replace``s
+    it over the target -- so a crash mid-write can never leave a truncated
+    or half-written file behind, and preserves the original file's
+    permission bits.
+    """
+    target = os.path.realpath(path)
+    directory = os.path.dirname(target) or "."
+    os.makedirs(directory, exist_ok=True)
+
+    mode = None
+    try:
+        mode = os.stat(target).st_mode
+    except OSError:
+        pass
+
+    prefix = f".{os.path.basename(target)}-"
+    fd, temp_path = tempfile.mkstemp(dir=directory, prefix=prefix, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as file:
+            file.write(data)
+            file.flush()
+            os.fsync(file.fileno())
+        if mode is not None:
+            os.chmod(temp_path, mode)
+        os.replace(temp_path, target)
+    except BaseException:
+        try:
+            os.unlink(temp_path)
+        except OSError:
+            pass
+        raise

--- a/code_puppy/atomic_json.py
+++ b/code_puppy/atomic_json.py
@@ -37,13 +37,29 @@ class JsonFileCorrupt(Exception):
     """The file was read successfully but its contents aren't valid JSON."""
 
 
+class _Missing:
+    """Sentinel distinguishing \"file missing/empty\" from a file that
+    legitimately parses to the JSON literal ``null``. ``None`` can't serve
+    as that sentinel here the way it does elsewhere, since ``None`` is
+    itself a valid parsed JSON value.
+    """
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid only
+        return "<MISSING>"
+
+
+_MISSING = _Missing()
+
+
 def _lock(path: str):
     """Serialize read-modify-write operations on ``path`` across processes."""
     return atomic_io.path_lock(path, timeout=_LOCK_TIMEOUT_SECONDS)
 
 
 def _read_unlocked(path: str, max_bytes: int) -> Any:
-    """Return ``None`` for a missing file, or the parsed JSON value.
+    """Return :data:`_MISSING` for a missing/empty file, else the parsed
+    JSON value -- which may legitimately be ``None`` if the file contains
+    the literal ``null``.
 
     Raises :class:`JsonFileCorrupt` for oversize/decode/parse failures;
     propagates genuine filesystem errors untouched.
@@ -53,7 +69,7 @@ def _read_unlocked(path: str, max_bytes: int) -> Any:
     except atomic_io.ContentTooLarge as exc:
         raise JsonFileCorrupt(str(exc)) from exc
     if not raw:
-        return None
+        return _MISSING
     try:
         text = raw.decode("utf-8")
         return json.loads(text)
@@ -77,7 +93,7 @@ def load_json(path: str, default: Any = None, max_bytes: int | None = None) -> A
     if max_bytes is None:
         max_bytes = MAX_JSON_BYTES
     parsed = _read_unlocked(path, max_bytes)
-    return default if parsed is None else parsed
+    return default if parsed is _MISSING else parsed
 
 
 def mutate_json(
@@ -104,7 +120,7 @@ def mutate_json(
         max_bytes = MAX_JSON_BYTES
     with _lock(path):
         current = _read_unlocked(path, max_bytes)
-        if current is None:
+        if current is _MISSING:
             current = default
         updated = mutation(current)
         atomic_io.atomic_write_bytes(

--- a/code_puppy/atomic_json.py
+++ b/code_puppy/atomic_json.py
@@ -1,0 +1,113 @@
+"""Bounded, recoverable I/O for Code Puppy's hand-edited JSON config files.
+
+The JSON counterpart to :mod:`code_puppy.config_file` -- built on the same
+:mod:`code_puppy.atomic_io` primitives -- for state files users are expected
+to hand-edit (``mcp_servers.json``, ``extra_models.json``, ``spinners.json``,
+...). These carry the identical three failure modes the PUP-605 config-file
+fix addressed for the INI config: unbounded reads, torn writes, and no
+cross-process lock, and are arguably more exposed since they're hand-edited.
+
+Unlike INI config (which is exclusively owned by Code Puppy and safe to
+quarantine-and-reset on corruption), a hand-edited JSON file failing to
+parse is far more likely to be a *typo the user just made* than bitrot --
+silently resetting it to ``{}`` would be a worse outcome than the crash this
+module exists to prevent. So corruption here is surfaced to the caller as
+:class:`JsonFileCorrupt` rather than auto-quarantined; each call site keeps
+its own warn-and-fall-back-to-default behavior on top of that.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from code_puppy import atomic_io
+
+logger = logging.getLogger(__name__)
+
+MAX_JSON_BYTES = atomic_io.DEFAULT_MAX_BYTES
+_LOCK_TIMEOUT_SECONDS = atomic_io.DEFAULT_LOCK_TIMEOUT_SECONDS
+
+LockTimeout = atomic_io.LockTimeout
+
+
+class JsonFileCorrupt(Exception):
+    """The file was read successfully but its contents aren't valid JSON."""
+
+
+def _lock(path: str):
+    """Serialize read-modify-write operations on ``path`` across processes."""
+    return atomic_io.path_lock(path, timeout=_LOCK_TIMEOUT_SECONDS)
+
+
+def _read_unlocked(path: str, max_bytes: int) -> Any:
+    """Return ``None`` for a missing file, or the parsed JSON value.
+
+    Raises :class:`JsonFileCorrupt` for oversize/decode/parse failures;
+    propagates genuine filesystem errors untouched.
+    """
+    try:
+        raw = atomic_io.read_bounded_bytes(path, max_bytes=max_bytes)
+    except atomic_io.ContentTooLarge as exc:
+        raise JsonFileCorrupt(str(exc)) from exc
+    if not raw:
+        return None
+    try:
+        text = raw.decode("utf-8")
+        return json.loads(text)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise JsonFileCorrupt(str(exc)) from exc
+
+
+def load_json(path: str, default: Any = None, max_bytes: int | None = None) -> Any:
+    """Load ``path`` as JSON, bounded to ``max_bytes`` before parsing.
+
+    ``max_bytes`` defaults to the current :data:`MAX_JSON_BYTES`, resolved
+    at call time rather than baked in as a parameter default, so tests and
+    callers can override the module-level bound without threading it
+    through every call site.
+
+    Returns ``default`` for a missing file (the caller owns making a fresh
+    copy if ``default`` is mutable). Raises :class:`JsonFileCorrupt` for
+    oversize/decode/parse failures -- see the module docstring for why this
+    doesn't auto-quarantine the way :mod:`code_puppy.config_file` does.
+    """
+    if max_bytes is None:
+        max_bytes = MAX_JSON_BYTES
+    parsed = _read_unlocked(path, max_bytes)
+    return default if parsed is None else parsed
+
+
+def mutate_json(
+    path: str,
+    mutation: Callable[[Any], Any],
+    default: Any = None,
+    max_bytes: int | None = None,
+) -> Any:
+    """Apply one locked read-modify-write transaction against JSON at ``path``.
+
+    ``mutation`` receives the current value (``default`` if the file is
+    missing) and returns the value to persist -- always written, since JSON
+    mutations here are typically cheap dict/list edits rather than a full
+    INI re-serialize, so there's no analogous ``False``-skip-the-write
+    sentinel like :func:`code_puppy.config_file.mutate_config` has.
+
+    Raises :class:`JsonFileCorrupt` if the existing file can't be parsed --
+    unlike the INI config, we never silently discard a hand-edited file the
+    user might have just made one typo in. Callers that want the old
+    "warn and fall back to an empty file" behavior should catch
+    :class:`JsonFileCorrupt` around this call.
+    """
+    if max_bytes is None:
+        max_bytes = MAX_JSON_BYTES
+    with _lock(path):
+        current = _read_unlocked(path, max_bytes)
+        if current is None:
+            current = default
+        updated = mutation(current)
+        atomic_io.atomic_write_bytes(
+            path, json.dumps(updated, indent=2, ensure_ascii=False).encode("utf-8")
+        )
+        return updated

--- a/code_puppy/command_line/add_model_menu.py
+++ b/code_puppy/command_line/add_model_menu.py
@@ -4,11 +4,9 @@ Provides a beautiful split-panel interface for browsing providers and models
 with live preview of model details and one-click addition to extra_models.json.
 """
 
-import json
 import os
 import sys
 import time
-from pathlib import Path
 from typing import List, Optional
 
 from prompt_toolkit.application import Application
@@ -17,6 +15,7 @@ from prompt_toolkit.layout import Dimension, Layout, VSplit, Window
 from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.widgets import Frame
 
+from code_puppy import atomic_json
 from code_puppy.command_line.pagination import (
     ensure_visible_page,
     get_page_bounds,
@@ -36,6 +35,11 @@ from code_puppy.provider_credentials import (
 )
 from code_puppy.tools.command_runner import set_awaiting_user_input
 from code_puppy.callbacks import on_prompt_toolkit_style
+
+
+class _ExtraModelsNotADict(Exception):
+    """Sentinel: extra_models.json parsed to something other than a dict."""
+
 
 PAGE_SIZE = 15  # Items per page
 
@@ -759,54 +763,44 @@ class AddModelMenu:
         The extra_models.json format is a dictionary where:
         - Keys are user-friendly model names (e.g., "provider-model-name")
         - Values contain type, name, custom_endpoint (if needed), and context_length
+
+        Uses :func:`code_puppy.atomic_json.mutate_json` for a bounded,
+        locked, atomically-written read-modify-write -- this file is also
+        touched by the ollama-setup and aws_bedrock/azure_foundry plugins,
+        so an unlocked write here could lose one of those concurrent updates.
         """
+        model_key = f"{provider.id}-{model.model_id}".replace("/", "-").replace(
+            ":", "-"
+        )
+        already_present = False
+
+        def _mutate(current):
+            nonlocal already_present
+            if not isinstance(current, dict):
+                raise _ExtraModelsNotADict()
+            if model_key in current:
+                already_present = True
+                return current
+            current[model_key] = self._build_model_config(model, provider)
+            return current
+
         try:
-            # Load existing extra models (dictionary format)
-            extra_models_path = Path(EXTRA_MODELS_FILE)
-            extra_models: dict = {}
-
-            if extra_models_path.exists():
-                try:
-                    with open(extra_models_path, "r", encoding="utf-8") as f:
-                        extra_models = json.load(f)
-                        if not isinstance(extra_models, dict):
-                            emit_error(
-                                "extra_models.json must be a dictionary, not a list"
-                            )
-                            return False
-                except json.JSONDecodeError as e:
-                    emit_error(f"Error parsing extra_models.json: {e}")
-                    return False
-
-            # Create a unique key for this model (provider-modelname format)
-            model_key = f"{provider.id}-{model.model_id}".replace("/", "-").replace(
-                ":", "-"
-            )
-
-            # Check for duplicates
-            if model_key in extra_models:
-                emit_info(f"Model {model_key} is already in extra_models.json")
-                return True  # Not an error, just already exists
-
-            # Convert to Code Puppy config format (dictionary value)
-            config = self._build_model_config(model, provider)
-            extra_models[model_key] = config
-
-            # Ensure directory exists
-            extra_models_path.parent.mkdir(parents=True, exist_ok=True)
-
-            # Save updated configuration (atomic write)
-            temp_path = extra_models_path.with_suffix(".tmp")
-            with open(temp_path, "w", encoding="utf-8") as f:
-                json.dump(extra_models, f, indent=4, ensure_ascii=False)
-            temp_path.replace(extra_models_path)
-
-            emit_info(f"Added {model_key} to extra_models.json")
-            return True
-
+            atomic_json.mutate_json(EXTRA_MODELS_FILE, _mutate, default={})
+        except _ExtraModelsNotADict:
+            emit_error("extra_models.json must be a dictionary, not a list")
+            return False
+        except atomic_json.JsonFileCorrupt as e:
+            emit_error(f"Error parsing extra_models.json: {e}")
+            return False
         except Exception as e:
             emit_error(f"Error adding model to extra_models.json: {e}")
             return False
+
+        if already_present:
+            emit_info(f"Model {model_key} is already in extra_models.json")
+        else:
+            emit_info(f"Added {model_key} to extra_models.json")
+        return True
 
     def _build_model_config(self, model: ModelInfo, provider: ProviderInfo) -> dict:
         """Build a Code Puppy compatible model configuration.

--- a/code_puppy/command_line/mcp/custom_server_form.py
+++ b/code_puppy/command_line/mcp/custom_server_form.py
@@ -5,7 +5,6 @@ with inline JSON editing and live validation.
 """
 
 import json
-import os
 import sys
 import time
 from typing import List, Optional
@@ -355,7 +354,7 @@ class CustomServerForm:
         Returns:
             True if successful, False otherwise
         """
-        from code_puppy.config import MCP_SERVERS_FILE
+        from code_puppy.command_line.mcp.mcp_servers_store import upsert_mcp_server
         from code_puppy.mcp_.managed_server import ServerConfig
 
         # Validate server name first
@@ -431,32 +430,16 @@ class CustomServerForm:
                     return False
 
             # Save to mcp_servers.json for persistence
-            if os.path.exists(MCP_SERVERS_FILE):
-                with open(MCP_SERVERS_FILE, "r") as f:
-                    data = json.load(f)
-                    servers = data.get("mcp_servers", {})
-            else:
-                servers = {}
-                data = {"mcp_servers": servers}
-
-            # If editing and name changed, remove the old entry
+            save_config = config_dict.copy()
+            save_config["type"] = server_type
+            replace_name = None
             if (
                 self.edit_mode
                 and self.original_name
                 and self.original_name != server_name
             ):
-                if self.original_name in servers:
-                    del servers[self.original_name]
-
-            # Add/update server with type
-            save_config = config_dict.copy()
-            save_config["type"] = server_type
-            servers[server_name] = save_config
-
-            # Save back
-            os.makedirs(os.path.dirname(MCP_SERVERS_FILE), exist_ok=True)
-            with open(MCP_SERVERS_FILE, "w") as f:
-                json.dump(data, f, indent=2)
+                replace_name = self.original_name
+            upsert_mcp_server(server_name, save_config, replace_name=replace_name)
 
             return True
 

--- a/code_puppy/command_line/mcp/custom_server_installer.py
+++ b/code_puppy/command_line/mcp/custom_server_installer.py
@@ -5,7 +5,6 @@ custom MCP servers with JSON configuration.
 """
 
 import json
-import os
 
 from code_puppy.command_line.utils import safe_input
 from code_puppy.messaging import emit_error, emit_info, emit_success, emit_warning
@@ -49,7 +48,7 @@ def prompt_and_install_custom_server(manager) -> bool:
     Returns:
         True if successful, False otherwise
     """
-    from code_puppy.config import MCP_SERVERS_FILE
+    from code_puppy.command_line.mcp.mcp_servers_store import upsert_mcp_server
     from code_puppy.mcp_.managed_server import ServerConfig
 
     from .utils import find_server_id_by_name
@@ -168,25 +167,11 @@ def prompt_and_install_custom_server(manager) -> bool:
             return False
 
         # Save to mcp_servers.json for persistence
-        if os.path.exists(MCP_SERVERS_FILE):
-            with open(MCP_SERVERS_FILE, "r") as f:
-                data = json.load(f)
-                servers = data.get("mcp_servers", {})
-        else:
-            servers = {}
-            data = {"mcp_servers": servers}
-
-        # Add new server with type
         save_config = config_dict.copy()
         save_config["type"] = server_type
-        servers[server_name] = save_config
+        upsert_mcp_server(server_name, save_config)
 
-        # Save back
-        os.makedirs(os.path.dirname(MCP_SERVERS_FILE), exist_ok=True)
-        with open(MCP_SERVERS_FILE, "w") as f:
-            json.dump(data, f, indent=2)
-
-        emit_success(f"\n  ✅ Successfully added custom server '{server_name}'!")
+        emit_success(f"\nSuccessfully added custom server '{server_name}'!")
         emit_info(f"  Use '/mcp start {server_name}' to start the server.\n")
 
         # Strict opt-in: prompt the user to bind this server to agents.

--- a/code_puppy/command_line/mcp/mcp_servers_store.py
+++ b/code_puppy/command_line/mcp/mcp_servers_store.py
@@ -1,0 +1,74 @@
+"""Shared read/write helpers for ``mcp_servers.json``.
+
+Four separate call sites (the install wizard, the custom-server form, the
+custom-server installer, and ``/mcp remove``) used to each hand-roll their
+own ``open("r") -> json.load -> mutate -> open("w") -> json.dump`` against
+this file with no atomicity and no lock -- two wizard flows in different
+terminals (or a wizard racing ``/mcp remove``) could lose each other's
+writes, and a large hand-edited file could balloon ``json.load`` the same
+way ``configparser`` ballooned in the original PUP-605 crash. This module
+collapses all four into one locked, bounded, atomically-written transaction.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from code_puppy import atomic_json
+from code_puppy import config as cp_config
+
+
+def _ensure_wrapper(data: Any) -> Dict[str, Any]:
+    """Normalize whatever was loaded into the canonical ``{"mcp_servers": {}}``
+    shape, tolerating a missing/empty file or an already-wrapped dict."""
+    if not isinstance(data, dict):
+        return {"mcp_servers": {}}
+    if "mcp_servers" not in data or not isinstance(data.get("mcp_servers"), dict):
+        data["mcp_servers"] = {}
+    return data
+
+
+def upsert_mcp_server(
+    server_name: str,
+    server_config: Dict[str, Any],
+    replace_name: str | None = None,
+) -> None:
+    """Add or replace ``server_name`` in ``mcp_servers.json``.
+
+    If ``replace_name`` is given (a server being renamed) and differs from
+    ``server_name``, its old entry is removed in the *same* locked
+    transaction -- matching the single-write semantics the rename+save flow
+    always had, rather than splitting it into two separately-locked writes.
+    """
+
+    def _mutate(data: Any) -> Dict[str, Any]:
+        data = _ensure_wrapper(data)
+        if replace_name and replace_name != server_name:
+            data["mcp_servers"].pop(replace_name, None)
+        data["mcp_servers"][server_name] = server_config
+        return data
+
+    atomic_json.mutate_json(
+        cp_config.MCP_SERVERS_FILE, _mutate, default={"mcp_servers": {}}
+    )
+
+
+def remove_mcp_server(server_name: str) -> bool:
+    """Remove ``server_name`` from ``mcp_servers.json`` if present.
+
+    Returns whether the server was actually present (and thus removed).
+    """
+    removed = False
+
+    def _mutate(data: Any) -> Dict[str, Any]:
+        nonlocal removed
+        data = _ensure_wrapper(data)
+        if server_name in data["mcp_servers"]:
+            del data["mcp_servers"][server_name]
+            removed = True
+        return data
+
+    atomic_json.mutate_json(
+        cp_config.MCP_SERVERS_FILE, _mutate, default={"mcp_servers": {}}
+    )
+    return removed

--- a/code_puppy/command_line/mcp/remove_command.py
+++ b/code_puppy/command_line/mcp/remove_command.py
@@ -2,9 +2,7 @@
 MCP Remove Command - Removes an MCP server.
 """
 
-import json
 import logging
-import os
 from typing import List, Optional
 
 from code_puppy.messaging import emit_error, emit_info
@@ -71,23 +69,14 @@ class RemoveCommand(MCPCommandBase):
                     )
 
                 # Also remove from mcp_servers.json
-                from code_puppy.config import MCP_SERVERS_FILE
+                from code_puppy.command_line.mcp.mcp_servers_store import (
+                    remove_mcp_server,
+                )
 
-                if os.path.exists(MCP_SERVERS_FILE):
-                    try:
-                        with open(MCP_SERVERS_FILE, "r") as f:
-                            data = json.load(f)
-                            servers = data.get("mcp_servers", {})
-
-                        # Remove the server if it exists
-                        if server_name in servers:
-                            del servers[server_name]
-
-                            # Save back
-                            with open(MCP_SERVERS_FILE, "w") as f:
-                                json.dump(data, f, indent=2)
-                    except Exception as e:
-                        logger.warning(f"Could not update mcp_servers.json: {e}")
+                try:
+                    remove_mcp_server(server_name)
+                except Exception as e:
+                    logger.warning(f"Could not update mcp_servers.json: {e}")
             else:
                 emit_info(
                     f"✗ Failed to remove server: {server_name}", message_group=group_id

--- a/code_puppy/command_line/mcp/wizard_utils.py
+++ b/code_puppy/command_line/mcp/wizard_utils.py
@@ -254,10 +254,9 @@ def install_server_from_catalog(
     Returns True if successful, False otherwise.
     """
     try:
-        import json
         import os
 
-        from code_puppy.config import MCP_SERVERS_FILE
+        from code_puppy.command_line.mcp.mcp_servers_store import upsert_mcp_server
         from code_puppy.mcp_.managed_server import ServerConfig
 
         # Set environment variables in the current environment
@@ -296,24 +295,9 @@ def install_server_from_catalog(
             return False
 
         # Save to mcp_servers.json for persistence
-        if os.path.exists(MCP_SERVERS_FILE):
-            with open(MCP_SERVERS_FILE, "r") as f:
-                data = json.load(f)
-                servers = data.get("mcp_servers", {})
-        else:
-            servers = {}
-            data = {"mcp_servers": servers}
-
-        # Add new server
-        # Copy the config dict and add type before saving
         save_config = config_dict.copy()
         save_config["type"] = selected_server.type
-        servers[server_name] = save_config
-
-        # Save back
-        os.makedirs(os.path.dirname(MCP_SERVERS_FILE), exist_ok=True)
-        with open(MCP_SERVERS_FILE, "w") as f:
-            json.dump(data, f, indent=2)
+        upsert_mcp_server(server_name, save_config)
 
         emit_info(
             Text.from_markup(

--- a/code_puppy/config_file.py
+++ b/code_puppy/config_file.py
@@ -1,7 +1,8 @@
 """Bounded, recoverable I/O for Code Puppy's INI configuration file.
 
 The public helpers in this module keep config-file safety concerns out of the
-already-large :mod:`code_puppy.config` module:
+already-large :mod:`code_puppy.config` module. Built on the generic
+primitives in :mod:`code_puppy.atomic_io`:
 
 * reads are size-bounded before parsing, preventing pathological lines from
   exhausting memory;
@@ -15,113 +16,38 @@ already-large :mod:`code_puppy.config` module:
 from __future__ import annotations
 
 import configparser
-import contextlib
 import io
 import logging
-import os
-import tempfile
-import time
-import uuid
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
+
+from code_puppy import atomic_io
 
 logger = logging.getLogger(__name__)
 
-MAX_CONFIG_BYTES = 10 * 1024 * 1024
-_LOCK_TIMEOUT_SECONDS = 30.0
-_LOCK_POLL_SECONDS = 0.05
+MAX_CONFIG_BYTES = atomic_io.DEFAULT_MAX_BYTES
+_LOCK_TIMEOUT_SECONDS = atomic_io.DEFAULT_LOCK_TIMEOUT_SECONDS
 
-try:  # POSIX
-    import fcntl
-except ImportError:  # pragma: no cover - Windows
-    fcntl = None  # type: ignore[assignment]
-
-try:  # Windows
-    import msvcrt
-except ImportError:  # pragma: no cover - POSIX
-    msvcrt = None  # type: ignore[assignment]
+# Re-exported for backwards compatibility -- callers (and this module's own
+# tests) historically imported the lock timeout error from here.
+ConfigLockTimeout = atomic_io.LockTimeout
 
 
 class ConfigFileCorrupt(Exception):
     """The file was read successfully but its contents are not safe INI."""
 
 
-class ConfigLockTimeout(TimeoutError):
-    """Another process held the config lock beyond the bounded wait."""
-
-
-def _try_lock(fd: int) -> bool:
-    if fcntl is not None:
-        try:
-            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            return True
-        except BlockingIOError:
-            return False
-    if msvcrt is not None:
-        try:
-            os.lseek(fd, 0, os.SEEK_SET)
-            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
-            return True
-        except OSError:
-            return False
-    return True
-
-
-def _unlock(fd: int) -> None:
-    if fcntl is not None:
-        fcntl.flock(fd, fcntl.LOCK_UN)
-    elif msvcrt is not None:
-        os.lseek(fd, 0, os.SEEK_SET)
-        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
-
-
-@contextlib.contextmanager
-def _config_lock(path: str) -> Iterator[None]:
+def _config_lock(path: str):
     """Serialize recovery and read-modify-write operations across processes."""
-    lock_path = f"{path}.lock"
-    os.makedirs(os.path.dirname(os.path.abspath(lock_path)), exist_ok=True)
-    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
-    acquired = False
-    try:
-        if msvcrt is not None:
-            os.write(fd, b"\0")
-        deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
-        while not (acquired := _try_lock(fd)):
-            if time.monotonic() >= deadline:
-                raise ConfigLockTimeout(
-                    f"Timed out waiting for config lock: {lock_path}"
-                )
-            time.sleep(_LOCK_POLL_SECONDS)
-        yield
-    finally:
-        if acquired:
-            try:
-                _unlock(fd)
-            except OSError:
-                logger.debug(
-                    "Failed to release config lock %s", lock_path, exc_info=True
-                )
-        os.close(fd)
+    return atomic_io.path_lock(path, timeout=_LOCK_TIMEOUT_SECONDS)
 
 
 def _read_unlocked(path: str) -> configparser.ConfigParser:
     """Read and parse a bounded snapshot; propagate filesystem failures."""
     parser = configparser.ConfigParser()
     try:
-        size = os.path.getsize(path)
-    except FileNotFoundError:
-        return parser
-    if size > MAX_CONFIG_BYTES:
-        raise ConfigFileCorrupt(
-            f"config is {size} bytes; maximum is {MAX_CONFIG_BYTES} bytes"
-        )
-
-    try:
-        with open(path, "rb") as file:
-            raw = file.read(MAX_CONFIG_BYTES + 1)
-    except FileNotFoundError:
-        return parser
-    if len(raw) > MAX_CONFIG_BYTES:
-        raise ConfigFileCorrupt(f"config exceeds {MAX_CONFIG_BYTES} bytes")
+        raw = atomic_io.read_bounded_bytes(path, max_bytes=MAX_CONFIG_BYTES)
+    except atomic_io.ContentTooLarge as exc:
+        raise ConfigFileCorrupt(str(exc)) from exc
 
     try:
         text = raw.decode("utf-8")
@@ -133,26 +59,7 @@ def _read_unlocked(path: str) -> configparser.ConfigParser:
 
 
 def _quarantine_unlocked(path: str) -> str:
-    """Move a confirmed-corrupt file aside without overwriting prior backups."""
-    for _ in range(10):
-        quarantine_path = f"{path}.corrupted-{time.time_ns()}-{uuid.uuid4().hex}"
-        try:
-            # Hard-link creation is atomic and refuses to overwrite an existing
-            # destination. Unlink only after the backup exists, so any failure
-            # leaves the original user data in place.
-            os.link(path, quarantine_path)
-        except FileExistsError:
-            continue
-        try:
-            os.unlink(path)
-        except BaseException:
-            try:
-                os.unlink(quarantine_path)
-            except OSError:
-                pass
-            raise
-        return quarantine_path
-    raise FileExistsError("Could not allocate a unique config quarantine path")
+    return atomic_io.quarantine_file(path)
 
 
 def load_config(path: str) -> configparser.ConfigParser:
@@ -185,31 +92,7 @@ def _atomic_write_unlocked(path: str, parser: configparser.ConfigParser) -> None
     """Durably replace ``path`` with serialized config from a temp file."""
     buffer = io.StringIO()
     parser.write(buffer)
-    target = os.path.realpath(path)
-    directory = os.path.dirname(target) or "."
-    os.makedirs(directory, exist_ok=True)
-
-    mode = None
-    try:
-        mode = os.stat(target).st_mode
-    except OSError:
-        pass
-
-    fd, temp_path = tempfile.mkstemp(dir=directory, prefix=".puppy.cfg-", suffix=".tmp")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as file:
-            file.write(buffer.getvalue())
-            file.flush()
-            os.fsync(file.fileno())
-        if mode is not None:
-            os.chmod(temp_path, mode)
-        os.replace(temp_path, target)
-    except BaseException:
-        try:
-            os.unlink(temp_path)
-        except OSError:
-            pass
-        raise
+    atomic_io.atomic_write_bytes(path, buffer.getvalue().encode("utf-8"))
 
 
 def mutate_config(

--- a/code_puppy/plugins/aws_bedrock/utils.py
+++ b/code_puppy/plugins/aws_bedrock/utils.py
@@ -88,10 +88,15 @@ def add_bedrock_models_to_config(
     aws_region: str | None = None,
     aws_profile: str | None = None,
 ) -> list[str]:
-    """Add Bedrock model configurations (with effort variants) to extra_models.json."""
-    models = load_extra_models()
-    added: list[str] = []
+    """Add Bedrock model configurations (with effort variants) to extra_models.json.
 
+    Uses :func:`code_puppy.atomic_json.mutate_json` so the read and write
+    happen inside one locked transaction -- extra_models.json is also
+    touched by add_model_menu.py and the ollama_setup/azure_foundry
+    plugins, so a read-then-write split across two unlocked calls could
+    lose one of those concurrent updates.
+    """
+    entries: dict[str, dict[str, Any]] = {}
     for spec in MODELS:
         base_key = spec["base_key"]
         model_id = spec["model_id"]
@@ -107,7 +112,7 @@ def add_bedrock_models_to_config(
                     key = f"{base_key}-{variant}"
                     effort = variant
 
-                models[key] = _build_model_entry(
+                entries[key] = _build_model_entry(
                     model_id=model_id,
                     context_length=context_length,
                     has_effort=True,
@@ -115,36 +120,57 @@ def add_bedrock_models_to_config(
                     aws_region=aws_region,
                     aws_profile=aws_profile,
                 )
-                added.append(key)
         else:
-            models[base_key] = _build_model_entry(
+            entries[base_key] = _build_model_entry(
                 model_id=model_id,
                 context_length=context_length,
                 has_effort=False,
                 aws_region=aws_region,
                 aws_profile=aws_profile,
             )
-            added.append(base_key)
 
-    if added and save_extra_models(models):
-        return added
-    return []
+    if not entries:
+        return []
+
+    def _mutate(models: dict[str, Any]) -> dict[str, Any]:
+        models.update(entries)
+        return models
+
+    extra_models_path = str(get_extra_models_path())
+    try:
+        atomic_json.mutate_json(extra_models_path, _mutate, default={})
+    except (atomic_json.JsonFileCorrupt, OSError) as e:
+        logger.error("Error saving extra_models.json: %s", e)
+        return []
+
+    return list(entries.keys())
 
 
 def remove_bedrock_models_from_config() -> list[str]:
-    """Remove all Bedrock model configurations from extra_models.json."""
-    models = load_extra_models()
-    removed = [
-        key
-        for key, cfg in models.items()
-        if isinstance(cfg, dict) and cfg.get("type") == "aws_bedrock"
-    ]
+    """Remove all Bedrock model configurations from extra_models.json.
 
-    for key in removed:
-        del models[key]
+    Uses :func:`code_puppy.atomic_json.mutate_json` so the read and write
+    happen inside one locked transaction (see :func:`add_bedrock_models_to_config`).
+    """
+    extra_models_path = str(get_extra_models_path())
+    removed: list[str] = []
 
-    if removed and not save_extra_models(models):
-        logger.error("Failed to save extra_models.json after removing Bedrock models")
+    def _mutate(models: dict[str, Any]) -> dict[str, Any]:
+        removed[:] = [
+            key
+            for key, cfg in models.items()
+            if isinstance(cfg, dict) and cfg.get("type") == "aws_bedrock"
+        ]
+        for key in removed:
+            del models[key]
+        return models
+
+    try:
+        atomic_json.mutate_json(extra_models_path, _mutate, default={})
+    except (atomic_json.JsonFileCorrupt, OSError) as e:
+        logger.error(
+            "Failed to save extra_models.json after removing Bedrock models: %s", e
+        )
         return []
 
     return removed

--- a/code_puppy/plugins/aws_bedrock/utils.py
+++ b/code_puppy/plugins/aws_bedrock/utils.py
@@ -6,6 +6,8 @@ import json
 import logging
 from typing import Any
 
+from code_puppy import atomic_io, atomic_json
+
 from .config import (
     MODELS,
     get_extra_models_path,
@@ -15,29 +17,32 @@ logger = logging.getLogger(__name__)
 
 
 def load_extra_models() -> dict[str, Any]:
-    """Load the extra_models.json configuration file."""
-    extra_models_path = get_extra_models_path()
-    if not extra_models_path.exists():
-        return {}
+    """Load the extra_models.json configuration file.
 
+    Bounded and lock-aware via :mod:`code_puppy.atomic_json` -- a large or
+    concurrently-being-written file can no longer balloon memory or read a
+    torn write. Preserves the original never-raise contract: any failure
+    (missing file, invalid JSON, oversized file, I/O error) logs and
+    returns ``{}`` rather than propagating.
+    """
+    extra_models_path = str(get_extra_models_path())
     try:
-        with open(extra_models_path, "r", encoding="utf-8") as f:
-            return json.load(f)
-    except (json.JSONDecodeError, OSError) as e:
+        return atomic_json.load_json(extra_models_path, default={})
+    except (atomic_json.JsonFileCorrupt, OSError) as e:
         logger.error("Error loading extra_models.json: %s", e)
         return {}
 
 
 def save_extra_models(models: dict[str, Any]) -> bool:
-    """Save model configurations to extra_models.json (atomic write)."""
-    extra_models_path = get_extra_models_path()
+    """Save model configurations to extra_models.json (atomic, locked write)."""
+    extra_models_path = str(get_extra_models_path())
 
     try:
-        extra_models_path.parent.mkdir(parents=True, exist_ok=True)
-        temp_path = extra_models_path.with_suffix(".tmp")
-        with open(temp_path, "w", encoding="utf-8") as f:
-            json.dump(models, f, indent=2, ensure_ascii=False)
-        temp_path.replace(extra_models_path)
+        with atomic_io.path_lock(extra_models_path):
+            atomic_io.atomic_write_bytes(
+                extra_models_path,
+                json.dumps(models, indent=2, ensure_ascii=False).encode("utf-8"),
+            )
         return True
     except Exception as e:
         logger.error("Error saving extra_models.json: %s", e)

--- a/code_puppy/plugins/azure_foundry/utils.py
+++ b/code_puppy/plugins/azure_foundry/utils.py
@@ -117,7 +117,7 @@ def load_extra_models() -> dict[str, Any]:
     except atomic_json.JsonFileCorrupt as e:
         logger.error(f"Invalid JSON in extra_models.json: {e}")
         return {}
-    except Exception as e:
+    except OSError as e:
         logger.error(f"Error loading extra_models.json: {e}")
         return {}
 
@@ -210,34 +210,46 @@ def add_foundry_models_to_config(
 
     Returns:
         List of model keys that were added.
-    """
-    models = load_extra_models()
-    added_models: list[str] = []
 
+    Uses :func:`code_puppy.atomic_json.mutate_json` so the read and write
+    happen inside one locked transaction -- extra_models.json is also
+    touched by add_model_menu.py and the ollama_setup/aws_bedrock plugins,
+    so a read-then-write split across two unlocked calls could lose one of
+    those concurrent updates.
+    """
     deployments = [
         ("opus", opus_deployment, "foundry-claude-opus"),
         ("sonnet", sonnet_deployment, "foundry-claude-sonnet"),
         ("haiku", haiku_deployment, "foundry-claude-haiku"),
     ]
 
+    entries: dict[str, dict[str, Any]] = {}
     for tier, deployment, model_key in deployments:
         if deployment:
             # Parse context window suffix (Claude Code format: [200k], [1m], etc.)
             actual_deployment, context_length = parse_context_window_suffix(deployment)
-
-            config = build_foundry_model_config(
+            entries[model_key] = build_foundry_model_config(
                 deployment_name=actual_deployment,
                 model_tier=tier,
                 foundry_resource=resource_name,
                 context_length=context_length,
             )
-            models[model_key] = config
-            added_models.append(model_key)
 
-    if added_models and save_extra_models(models):
-        return added_models
+    if not entries:
+        return []
 
-    return []
+    def _mutate(models: dict[str, Any]) -> dict[str, Any]:
+        models.update(entries)
+        return models
+
+    extra_models_path = str(get_extra_models_path())
+    try:
+        atomic_json.mutate_json(extra_models_path, _mutate, default={})
+    except (atomic_json.JsonFileCorrupt, OSError) as e:
+        logger.error(f"Error saving extra_models.json: {e}")
+        return []
+
+    return list(entries.keys())
 
 
 FOUNDRY_TYPES = {"azure_foundry", "azure_foundry_openai"}
@@ -270,11 +282,13 @@ def add_discovered_models_to_config(
 
     Classifies each deployment by model format (Anthropic vs OpenAI)
     and creates the appropriate model config.
+
+    Uses :func:`code_puppy.atomic_json.mutate_json` so the read and write
+    happen inside one locked transaction (see :func:`add_foundry_models_to_config`).
     """
     from .discovery import AzureDeployment
 
-    models = load_extra_models()
-    added: list[str] = []
+    entries: dict[str, dict[str, Any]] = {}
 
     for d in deployments:
         if not isinstance(d, AzureDeployment):
@@ -288,15 +302,14 @@ def add_discovered_models_to_config(
                 if t in d.model_name.lower():
                     tier = t
                     break
-            models[key] = build_foundry_model_config(
+            entries[key] = build_foundry_model_config(
                 deployment_name=d.name,
                 model_tier=tier,
                 foundry_resource=resource_name,
             )
-            added.append(key)
 
         elif d.model_format == "OpenAI":
-            models[key] = {
+            entries[key] = {
                 "type": "azure_foundry_openai",
                 "provider": "azure_foundry_openai",
                 "name": d.name,
@@ -306,32 +319,49 @@ def add_discovered_models_to_config(
                     d.model_name
                 ),
             }
-            added.append(key)
 
-    if added and save_extra_models(models):
-        return added
-    return []
+    if not entries:
+        return []
+
+    def _mutate(models: dict[str, Any]) -> dict[str, Any]:
+        models.update(entries)
+        return models
+
+    extra_models_path = str(get_extra_models_path())
+    try:
+        atomic_json.mutate_json(extra_models_path, _mutate, default={})
+    except (atomic_json.JsonFileCorrupt, OSError) as e:
+        logger.error(f"Error saving extra_models.json: {e}")
+        return []
+
+    return list(entries.keys())
 
 
 def remove_foundry_models_from_config() -> list[str]:
-    """Remove all Azure Foundry model configurations from extra_models.json."""
-    models = load_extra_models()
+    """Remove all Azure Foundry model configurations from extra_models.json.
+
+    Uses :func:`code_puppy.atomic_json.mutate_json` so the read and write
+    happen inside one locked transaction (see :func:`add_foundry_models_to_config`).
+    """
+    extra_models_path = str(get_extra_models_path())
     removed_models: list[str] = []
 
-    keys_to_remove = [
-        key
-        for key, config in models.items()
-        if isinstance(config, dict) and config.get("type") in FOUNDRY_TYPES
-    ]
+    def _mutate(models: dict[str, Any]) -> dict[str, Any]:
+        keys_to_remove = [
+            key
+            for key, config in models.items()
+            if isinstance(config, dict) and config.get("type") in FOUNDRY_TYPES
+        ]
+        for key in keys_to_remove:
+            del models[key]
+            removed_models.append(key)
+        return models
 
-    for key in keys_to_remove:
-        del models[key]
-        removed_models.append(key)
-
-    if removed_models:
-        if not save_extra_models(models):
-            logger.error("Failed to persist model removal")
-            return []
+    try:
+        atomic_json.mutate_json(extra_models_path, _mutate, default={})
+    except (atomic_json.JsonFileCorrupt, OSError) as e:
+        logger.error(f"Failed to persist model removal: {e}")
+        return []
 
     return removed_models
 

--- a/code_puppy/plugins/azure_foundry/utils.py
+++ b/code_puppy/plugins/azure_foundry/utils.py
@@ -18,6 +18,7 @@ from .config import (
     get_extra_models_path,
     get_openai_context_length,
 )
+from code_puppy import atomic_io, atomic_json
 
 logger = logging.getLogger(__name__)
 
@@ -102,18 +103,18 @@ def resolve_env_var(value: str) -> str:
 def load_extra_models() -> dict[str, Any]:
     """Load the extra_models.json configuration file.
 
+    Bounded and lock-aware via :mod:`code_puppy.atomic_json` -- a large or
+    concurrently-being-written file can no longer balloon memory or read a
+    torn write.
+
     Returns:
         Dictionary containing model configurations, or empty dict if file
         doesn't exist or is invalid.
     """
-    extra_models_path = get_extra_models_path()
-    if not extra_models_path.exists():
-        return {}
-
+    extra_models_path = str(get_extra_models_path())
     try:
-        with open(extra_models_path, "r", encoding="utf-8") as f:
-            return json.load(f)
-    except json.JSONDecodeError as e:
+        return atomic_json.load_json(extra_models_path, default={})
+    except atomic_json.JsonFileCorrupt as e:
         logger.error(f"Invalid JSON in extra_models.json: {e}")
         return {}
     except Exception as e:
@@ -130,17 +131,14 @@ def save_extra_models(models: dict[str, Any]) -> bool:
     Returns:
         True if save succeeded, False otherwise.
     """
-    extra_models_path = get_extra_models_path()
+    extra_models_path = str(get_extra_models_path())
 
     try:
-        # Ensure directory exists
-        extra_models_path.parent.mkdir(parents=True, exist_ok=True)
-
-        # Atomic write using temp file
-        temp_path = extra_models_path.with_suffix(".tmp")
-        with open(temp_path, "w", encoding="utf-8") as f:
-            json.dump(models, f, indent=2, ensure_ascii=False)
-        temp_path.replace(extra_models_path)
+        with atomic_io.path_lock(extra_models_path):
+            atomic_io.atomic_write_bytes(
+                extra_models_path,
+                json.dumps(models, indent=2, ensure_ascii=False).encode("utf-8"),
+            )
 
         logger.info(f"Saved {len(models)} models to extra_models.json")
         return True

--- a/code_puppy/plugins/ollama_setup/register_callbacks.py
+++ b/code_puppy/plugins/ollama_setup/register_callbacks.py
@@ -9,13 +9,12 @@ Cloud models supported (the Ollama "Recommended Models" cloud tier):
 
 from __future__ import annotations
 
-import json
 import logging
 import shutil
 import subprocess
-from pathlib import Path
 from typing import Any, Optional
 
+from code_puppy import atomic_json
 from code_puppy.callbacks import register_callback
 from code_puppy.config import EXTRA_MODELS_FILE
 from code_puppy.messaging import emit_error, emit_info, emit_success, emit_warning
@@ -103,54 +102,55 @@ def _pull_model(model_tag: str) -> bool:
         return False
 
 
+class _ExtraModelsNotADict(Exception):
+    """Sentinel: extra_models.json parsed to something other than a dict."""
+
+
 def _register_model(model_tag: str) -> bool:
     """Write (or update) the model entry in extra_models.json.
 
-    Uses atomic-write via a temp file, same pattern as add_model_menu.py.
+    Uses :func:`code_puppy.atomic_json.mutate_json` for a bounded, locked,
+    atomically-written read-modify-write -- this file is also touched by
+    add_model_menu.py and the aws_bedrock/azure_foundry plugins, so an
+    unlocked write here could lose one of those concurrent updates.
     Returns True on success.
     """
     meta = CLOUD_MODELS[model_tag]
     key = _model_key(model_tag)
+    already_registered = False
 
-    extra_path = Path(EXTRA_MODELS_FILE)
-    extra_models: dict[str, Any] = {}
+    def _mutate(current: Any) -> dict[str, Any]:
+        nonlocal already_registered
+        if not isinstance(current, dict):
+            raise _ExtraModelsNotADict()
+        already_registered = key in current
+        current[key] = {
+            "type": "custom_openai",
+            "name": model_tag,
+            "custom_endpoint": {
+                "url": OLLAMA_ENDPOINT,
+                "api_key": OLLAMA_API_KEY,
+            },
+            "context_length": meta["context_length"],
+            "supported_settings": ["temperature", "top_p"],
+        }
+        return current
 
-    if extra_path.exists():
-        try:
-            with open(extra_path, "r", encoding="utf-8") as fh:
-                extra_models = json.load(fh)
-                if not isinstance(extra_models, dict):
-                    emit_error("extra_models.json must be a dict, not a list")
-                    return False
-        except json.JSONDecodeError as exc:
-            emit_error(f"Corrupt extra_models.json: {exc}")
-            return False
-
-    if key in extra_models:
-        emit_info(f"Model {key} already registered — updating entry")
-
-    extra_models[key] = {
-        "type": "custom_openai",
-        "name": model_tag,
-        "custom_endpoint": {
-            "url": OLLAMA_ENDPOINT,
-            "api_key": OLLAMA_API_KEY,
-        },
-        "context_length": meta["context_length"],
-        "supported_settings": ["temperature", "top_p"],
-    }
-
-    extra_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = extra_path.with_suffix(".tmp")
     try:
-        with open(tmp, "w", encoding="utf-8") as fh:
-            json.dump(extra_models, fh, indent=4, ensure_ascii=False)
-        tmp.replace(extra_path)
+        atomic_json.mutate_json(EXTRA_MODELS_FILE, _mutate, default={})
+    except _ExtraModelsNotADict:
+        emit_error("extra_models.json must be a dict, not a list")
+        return False
+    except atomic_json.JsonFileCorrupt as exc:
+        emit_error(f"Corrupt extra_models.json: {exc}")
+        return False
     except Exception as exc:
         emit_error(f"Failed to write extra_models.json: {exc}")
         return False
 
-    emit_success(f"✅ Registered {key} in extra_models.json")
+    if already_registered:
+        emit_info(f"Model {key} already registered \u2014 updating entry")
+    emit_success(f"Registered {key} in extra_models.json")
     return True
 
 

--- a/code_puppy/plugins/puppy_spinner/spinners.py
+++ b/code_puppy/plugins/puppy_spinner/spinners.py
@@ -43,6 +43,7 @@ from typing import Dict, Optional, Tuple
 
 from rich.cells import cell_len
 
+from code_puppy import atomic_io, atomic_json
 from code_puppy.config import CONFIG_DIR, get_value, set_value
 
 from .builtin_frames import EXTRA_SPECS
@@ -240,14 +241,20 @@ def _parse_user_spinner(name: str, spec: object) -> Optional[Spinner]:
     )
 
 
+class _SpinnersNotADict(Exception):
+    """Sentinel: spinners.json parsed to something other than a dict."""
+
+
 def load_user_spinners() -> Dict[str, Spinner]:
-    """Read + validate the user spinner file. Missing/broken file = {}."""
-    if not os.path.isfile(USER_SPINNERS_FILE):
-        return {}
+    """Read + validate the user spinner file. Missing/broken file = {}.
+
+    Bounded and lock-aware via :mod:`code_puppy.atomic_json` -- a large or
+    concurrently-being-written file can no longer balloon memory or read a
+    torn write.
+    """
     try:
-        with open(USER_SPINNERS_FILE, encoding="utf-8") as fh:
-            data = json.load(fh)
-    except (OSError, json.JSONDecodeError) as exc:
+        data = atomic_json.load_json(USER_SPINNERS_FILE, default={})
+    except (OSError, atomic_json.JsonFileCorrupt) as exc:
         logger.warning("Could not read %s: %s", USER_SPINNERS_FILE, exc)
         return {}
     if not isinstance(data, dict):
@@ -291,35 +298,28 @@ def save_interval_tweak(name: str, interval: float) -> bool:
     description) are preserved; only ``interval`` changes.
 
     Returns False (and logs) when the file can't be read or written --
-    we never overwrite a file we couldn't parse.
+    we never overwrite a file we couldn't parse. Uses
+    :func:`code_puppy.atomic_json.mutate_json` for a bounded, locked,
+    atomically-written read-modify-write.
     """
     interval = clamp_interval(interval)
-    data: dict = {}
-    if os.path.isfile(USER_SPINNERS_FILE):
-        try:
-            with open(USER_SPINNERS_FILE, encoding="utf-8") as fh:
-                data = json.load(fh)
-        except (OSError, json.JSONDecodeError) as exc:
-            logger.warning(
-                "Not saving speed: %s is unreadable (%s)", USER_SPINNERS_FILE, exc
-            )
-            return False
+
+    def _mutate(data):
         if not isinstance(data, dict):
-            logger.warning(
-                "Not saving speed: %s is not a JSON object", USER_SPINNERS_FILE
-            )
-            return False
-    entry = data.get(name)
-    if not isinstance(entry, dict):
-        entry = {}
-    entry["interval"] = interval
-    data[name] = entry
+            raise _SpinnersNotADict()
+        entry = data.get(name)
+        if not isinstance(entry, dict):
+            entry = {}
+        entry["interval"] = interval
+        data[name] = entry
+        return data
+
     try:
-        os.makedirs(CONFIG_DIR, exist_ok=True)
-        with open(USER_SPINNERS_FILE, "w", encoding="utf-8") as fh:
-            json.dump(data, fh, indent=2)
-            fh.write("\n")
-    except OSError as exc:
+        atomic_json.mutate_json(USER_SPINNERS_FILE, _mutate, default={})
+    except _SpinnersNotADict:
+        logger.warning("Not saving speed: %s is not a JSON object", USER_SPINNERS_FILE)
+        return False
+    except (OSError, atomic_json.JsonFileCorrupt) as exc:
         logger.warning("Could not save speed to %s: %s", USER_SPINNERS_FILE, exc)
         return False
     return True
@@ -432,11 +432,16 @@ _TEMPLATE = {
 
 
 def write_template() -> bool:
-    """Write a starter spinners.json. Returns False if one already exists."""
-    if os.path.isfile(USER_SPINNERS_FILE):
-        return False
-    os.makedirs(CONFIG_DIR, exist_ok=True)
-    with open(USER_SPINNERS_FILE, "w", encoding="utf-8") as fh:
-        json.dump(_TEMPLATE, fh, indent=2)
-        fh.write("\n")
+    """Write a starter spinners.json. Returns False if one already exists.
+
+    Locked so two concurrent first-runs (e.g. two terminals) can't both
+    pass the existence check and race each other's write.
+    """
+    with atomic_io.path_lock(USER_SPINNERS_FILE):
+        if os.path.isfile(USER_SPINNERS_FILE):
+            return False
+        atomic_io.atomic_write_bytes(
+            USER_SPINNERS_FILE,
+            (json.dumps(_TEMPLATE, indent=2) + "\n").encode("utf-8"),
+        )
     return True

--- a/tests/agents/test_json_agent_corruption_resilience.py
+++ b/tests/agents/test_json_agent_corruption_resilience.py
@@ -1,0 +1,84 @@
+"""Regression tests for JSONAgent's config-load corruption resilience.
+
+Part of the PUP-605 follow-up (Andrew Tilson's review on #757 flagged
+``~/.code_puppy/agents/*.json`` reads at startup as another unbounded-read
+site). ``_load_config`` now delegates to :mod:`code_puppy.atomic_json`,
+which bounds the read before parsing and raises ``ValueError`` (matching
+the pre-existing public contract) instead of letting a pathological file
+balloon memory.
+"""
+
+import json
+
+import pytest
+
+from code_puppy.agents.json_agent import JSONAgent
+
+VALID_CONFIG = {
+    "name": "test-agent",
+    "description": "A test agent",
+    "system_prompt": "You are a helpful test agent.",
+    "tools": ["list_files"],
+}
+
+
+@pytest.fixture
+def agent_path(tmp_path):
+    return tmp_path / "agent.json"
+
+
+def test_loads_valid_config(agent_path):
+    agent_path.write_text(json.dumps(VALID_CONFIG))
+
+    agent = JSONAgent(str(agent_path))
+
+    assert agent._config["name"] == "test-agent"
+
+
+def test_missing_file_raises_value_error(agent_path):
+    # agent_path was never created.
+    with pytest.raises(ValueError, match="Failed to load JSON agent config"):
+        JSONAgent(str(agent_path))
+
+
+def test_malformed_json_raises_value_error(agent_path):
+    agent_path.write_text("{not valid json at all")
+
+    with pytest.raises(ValueError, match="Failed to load JSON agent config"):
+        JSONAgent(str(agent_path))
+
+
+def test_oversized_file_raises_value_error_without_full_parse(agent_path, monkeypatch):
+    """Pins the actual field-report shape this closes off: a pathologically
+    large agent file dropped in the agents directory must never reach a
+    full in-memory JSON parse."""
+    from code_puppy import atomic_json
+
+    monkeypatch.setattr(atomic_json, "MAX_JSON_BYTES", 1024)
+    agent_path.write_text(json.dumps({**VALID_CONFIG, "padding": "x" * 4096}))
+
+    with pytest.raises(ValueError, match="Failed to load JSON agent config"):
+        JSONAgent(str(agent_path))
+
+
+def test_discover_json_agents_skips_corrupt_files_without_raising(
+    tmp_path, monkeypatch
+):
+    """The existing discover_json_agents contract: one bad file must not
+    prevent the others from loading."""
+    from code_puppy.agents.json_agent import discover_json_agents
+
+    good = tmp_path / "good.json"
+    good.write_text(json.dumps(VALID_CONFIG))
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not valid json")
+
+    monkeypatch.setattr(
+        "code_puppy.config.get_user_agents_directory", lambda: str(tmp_path)
+    )
+    monkeypatch.setattr("code_puppy.config.get_project_agents_directory", lambda: None)
+
+    agents = discover_json_agents()
+
+    assert agents.get("test-agent") == str(good)
+    assert len(agents) == 1

--- a/tests/command_line/mcp/test_custom_server_form.py
+++ b/tests/command_line/mcp/test_custom_server_form.py
@@ -1,7 +1,7 @@
 """Tests for code_puppy/command_line/mcp/custom_server_form.py"""
 
 import json
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, patch
 
 MODULE = "code_puppy.command_line.mcp.custom_server_form"
 
@@ -398,43 +398,41 @@ class TestInstallServer:
         assert form._install_server() is False
         assert form.status_is_error is True
 
-    @patch(f"{MODULE}.os.path.exists", return_value=False)
-    @patch(f"{MODULE}.os.makedirs")
-    @patch("builtins.open", new_callable=mock_open)
-    def test_install_new_server_success(self, m_open, m_makedirs, m_exists):
+    def test_install_new_server_success(self, tmp_path):
         from code_puppy.command_line.mcp.custom_server_form import CustomServerForm
 
+        mcp_file = tmp_path / "mcp_servers.json"
         mgr = MagicMock()
         mgr.register_server.return_value = "new-id"
         form = CustomServerForm(mgr)
         form.server_name = "my-server"
         form.json_config = json.dumps({"command": "npx", "args": []})
-        assert form._install_server() is True
 
-    @patch(f"{MODULE}.os.path.exists", return_value=False)
-    @patch(f"{MODULE}.os.makedirs")
-    @patch("builtins.open", new_callable=mock_open)
-    def test_install_new_server_register_fails(self, m_open, m_makedirs, m_exists):
+        with patch("code_puppy.config.MCP_SERVERS_FILE", str(mcp_file)):
+            assert form._install_server() is True
+
+        data = json.loads(mcp_file.read_text())
+        assert "my-server" in data["mcp_servers"]
+
+    def test_install_new_server_register_fails(self, tmp_path):
         from code_puppy.command_line.mcp.custom_server_form import CustomServerForm
 
+        mcp_file = tmp_path / "mcp_servers.json"
         mgr = MagicMock()
         mgr.register_server.return_value = None
         form = CustomServerForm(mgr)
         form.server_name = "my-server"
         form.json_config = json.dumps({"command": "npx"})
-        assert form._install_server() is False
+
+        with patch("code_puppy.config.MCP_SERVERS_FILE", str(mcp_file)):
+            assert form._install_server() is False
         assert form.status_is_error is True
 
-    @patch(f"{MODULE}.os.path.exists", return_value=True)
-    @patch(f"{MODULE}.os.makedirs")
-    @patch(
-        "builtins.open",
-        new_callable=mock_open,
-        read_data=json.dumps({"mcp_servers": {"old": {}}}),
-    )
-    def test_install_edit_mode_existing_found(self, m_open, m_makedirs, m_exists):
+    def test_install_edit_mode_existing_found(self, tmp_path):
         from code_puppy.command_line.mcp.custom_server_form import CustomServerForm
 
+        mcp_file = tmp_path / "mcp_servers.json"
+        mcp_file.write_text(json.dumps({"mcp_servers": {"old": {}}}))
         mgr = MagicMock()
         existing = MagicMock()
         existing.id = "old-id"
@@ -448,14 +446,14 @@ class TestInstallServer:
         )
         form.server_name = "new-name"
         form.json_config = json.dumps({"command": "npx"})
-        assert form._install_server() is True
 
-    @patch(f"{MODULE}.os.path.exists", return_value=False)
-    @patch(f"{MODULE}.os.makedirs")
-    @patch("builtins.open", new_callable=mock_open)
-    def test_install_edit_mode_existing_not_found(self, m_open, m_makedirs, m_exists):
+        with patch("code_puppy.config.MCP_SERVERS_FILE", str(mcp_file)):
+            assert form._install_server() is True
+
+    def test_install_edit_mode_existing_not_found(self, tmp_path):
         from code_puppy.command_line.mcp.custom_server_form import CustomServerForm
 
+        mcp_file = tmp_path / "mcp_servers.json"
         mgr = MagicMock()
         mgr.get_server_by_name.return_value = None
         mgr.register_server.return_value = "new-id"
@@ -466,18 +464,15 @@ class TestInstallServer:
         )
         form.server_name = "my-server"
         form.json_config = json.dumps({"command": "npx"})
-        assert form._install_server() is True
 
-    @patch(f"{MODULE}.os.path.exists", return_value=True)
-    @patch(f"{MODULE}.os.makedirs")
-    @patch(
-        "builtins.open",
-        new_callable=mock_open,
-        read_data=json.dumps({"mcp_servers": {}}),
-    )
-    def test_install_edit_mode_update_fails(self, m_open, m_makedirs, m_exists):
+        with patch("code_puppy.config.MCP_SERVERS_FILE", str(mcp_file)):
+            assert form._install_server() is True
+
+    def test_install_edit_mode_update_fails(self, tmp_path):
         from code_puppy.command_line.mcp.custom_server_form import CustomServerForm
 
+        mcp_file = tmp_path / "mcp_servers.json"
+        mcp_file.write_text(json.dumps({"mcp_servers": {}}))
         mgr = MagicMock()
         existing = MagicMock()
         existing.id = "old-id"
@@ -490,35 +485,38 @@ class TestInstallServer:
         )
         form.server_name = "my-server"
         form.json_config = json.dumps({"command": "npx"})
-        assert form._install_server() is False
 
-    @patch(f"{MODULE}.os.path.exists", return_value=True)
-    @patch(f"{MODULE}.os.makedirs")
-    @patch("builtins.open", side_effect=PermissionError("no access"))
-    def test_install_exception_during_save(self, m_open, m_makedirs, m_exists):
+        with patch("code_puppy.config.MCP_SERVERS_FILE", str(mcp_file)):
+            assert form._install_server() is False
+
+    def test_install_exception_during_save(self, tmp_path):
+        """_install_server must report failure (not raise) if persisting to
+        mcp_servers.json blows up -- the underlying I/O failure modes
+        themselves are covered by test_atomic_io.py / test_atomic_json.py,
+        this just pins _install_server's own error handling."""
         from code_puppy.command_line.mcp.custom_server_form import CustomServerForm
 
+        mcp_file = tmp_path / "mcp_servers.json"
         mgr = MagicMock()
         mgr.register_server.return_value = "new-id"
         form = CustomServerForm(mgr)
         form.server_name = "my-server"
         form.json_config = json.dumps({"command": "npx"})
-        assert form._install_server() is False
+
+        with patch("code_puppy.config.MCP_SERVERS_FILE", str(mcp_file)):
+            with patch(
+                "code_puppy.command_line.mcp.mcp_servers_store.upsert_mcp_server",
+                side_effect=PermissionError("no access"),
+            ):
+                assert form._install_server() is False
         assert form.status_is_error is True
 
-    @patch(f"{MODULE}.os.path.exists", return_value=True)
-    @patch(f"{MODULE}.os.makedirs")
-    @patch(
-        "builtins.open",
-        new_callable=mock_open,
-        read_data=json.dumps({"mcp_servers": {"old-name": {}}}),
-    )
-    def test_install_edit_mode_name_changed_removes_old(
-        self, m_open, m_makedirs, m_exists
-    ):
+    def test_install_edit_mode_name_changed_removes_old(self, tmp_path):
         """When editing and name changes, old entry should be removed from persisted file."""
         from code_puppy.command_line.mcp.custom_server_form import CustomServerForm
 
+        mcp_file = tmp_path / "mcp_servers.json"
+        mcp_file.write_text(json.dumps({"mcp_servers": {"old-name": {}}}))
         mgr = MagicMock()
         existing = MagicMock()
         existing.id = "old-id"
@@ -531,11 +529,11 @@ class TestInstallServer:
         )
         form.server_name = "new-name"
         form.json_config = json.dumps({"command": "npx"})
-        assert form._install_server() is True
-        # Verify JSON written includes new name and not old
-        written = m_open().write.call_args_list
-        written_str = "".join(c[0][0] for c in written)
-        data = json.loads(written_str)
+
+        with patch("code_puppy.config.MCP_SERVERS_FILE", str(mcp_file)):
+            assert form._install_server() is True
+
+        data = json.loads(mcp_file.read_text())
         assert "new-name" in data["mcp_servers"]
         assert "old-name" not in data["mcp_servers"]
 

--- a/tests/plugins/test_aws_bedrock.py
+++ b/tests/plugins/test_aws_bedrock.py
@@ -223,11 +223,46 @@ class TestAddBedrockModelsToConfig:
         from code_puppy.plugins.aws_bedrock.utils import add_bedrock_models_to_config
 
         with patch(
-            "code_puppy.plugins.aws_bedrock.utils.save_extra_models",
-            return_value=False,
+            "code_puppy.plugins.aws_bedrock.utils.atomic_json.mutate_json",
+            side_effect=OSError("disk full"),
         ):
             result = add_bedrock_models_to_config()
             assert result == []
+
+    def test_concurrent_calls_do_not_lose_updates(self, tmp_extra_models):
+        """Pins the adversarial-review finding: add/remove used to split the
+        read and write across two unlocked calls, so a concurrent writer to
+        the same extra_models.json (e.g. ollama-setup) could lose an update.
+        add_bedrock_models_to_config now goes through one locked
+        atomic_json.mutate_json transaction, same as the other writers.
+        """
+        import threading
+
+        from code_puppy.plugins.aws_bedrock.utils import add_bedrock_models_to_config
+
+        def _add_other_entry(name):
+            from code_puppy import atomic_json
+
+            def _mutate(data):
+                data[name] = {"type": "custom_openai"}
+                return data
+
+            atomic_json.mutate_json(str(tmp_extra_models), _mutate, default={})
+
+        threads = [
+            threading.Thread(target=_add_other_entry, args=(f"other_{i}",))
+            for i in range(8)
+        ]
+        for t in threads:
+            t.start()
+        add_bedrock_models_to_config(aws_region="us-east-1")
+        for t in threads:
+            t.join(timeout=10)
+
+        data = json.loads(tmp_extra_models.read_text())
+        assert "bedrock-opus-4-7" in data
+        for i in range(8):
+            assert f"other_{i}" in data
 
 
 class TestRemoveBedrockModelsFromConfig:
@@ -253,8 +288,8 @@ class TestRemoveBedrockModelsFromConfig:
         )
 
         with patch(
-            "code_puppy.plugins.aws_bedrock.utils.save_extra_models",
-            return_value=False,
+            "code_puppy.plugins.aws_bedrock.utils.atomic_json.mutate_json",
+            side_effect=OSError("disk full"),
         ):
             result = remove_bedrock_models_from_config()
             assert result == []

--- a/tests/plugins/test_azure_foundry.py
+++ b/tests/plugins/test_azure_foundry.py
@@ -454,6 +454,54 @@ class TestAddRemoveFoundryModels:
                 remaining = json.load(f)
             assert "foundry-claude-opus" not in remaining
 
+    def test_add_foundry_models_concurrent_with_another_writer_does_not_lose_updates(
+        self, tmp_path
+    ):
+        """Pins the adversarial-review finding: add_foundry_models_to_config
+        used to split the read and write across two unlocked calls, so a
+        concurrent writer to the same extra_models.json (e.g. ollama-setup,
+        or the aws_bedrock plugin) could lose an update. It now goes
+        through one locked atomic_json.mutate_json transaction.
+        """
+        import threading
+
+        from code_puppy.plugins.azure_foundry.utils import (
+            add_foundry_models_to_config,
+        )
+
+        models_path = tmp_path / "models.json"
+
+        def _add_other_entry(name):
+            from code_puppy import atomic_json
+
+            def _mutate(data):
+                data[name] = {"type": "custom_openai"}
+                return data
+
+            atomic_json.mutate_json(str(models_path), _mutate, default={})
+
+        threads = [
+            threading.Thread(target=_add_other_entry, args=(f"other_{i}",))
+            for i in range(8)
+        ]
+        with patch(
+            "code_puppy.plugins.azure_foundry.utils.get_extra_models_path",
+            return_value=models_path,
+        ):
+            for t in threads:
+                t.start()
+            add_foundry_models_to_config(
+                resource_name="my-resource",
+                opus_deployment="it-entra-claude-opus-4-6",
+            )
+            for t in threads:
+                t.join(timeout=10)
+
+        data = json.loads(models_path.read_text())
+        assert "foundry-claude-opus" in data
+        for i in range(8):
+            assert f"other_{i}" in data
+
 
 class TestGetFoundryModelsFromConfig:
     """Test getting Foundry models from configuration."""

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -1,0 +1,203 @@
+"""Direct tests for code_puppy.atomic_io -- the shared bounded-read /
+cross-process-lock / atomic-write primitives that code_puppy.config_file
+(INI) and code_puppy.atomic_json (JSON) both build on.
+
+These pin the generic contract independent of any file format, since a bug
+here would silently affect every config surface built on top.
+"""
+
+import glob
+import os
+import time
+from unittest.mock import patch
+
+import pytest
+
+from code_puppy import atomic_io
+
+
+@pytest.fixture
+def target_path(tmp_path):
+    return tmp_path / "state.bin"
+
+
+class TestReadBoundedBytes:
+    def test_missing_file_returns_empty_bytes(self, target_path):
+        assert atomic_io.read_bounded_bytes(str(target_path)) == b""
+
+    def test_reads_small_file_fully(self, target_path):
+        target_path.write_bytes(b"hello world")
+
+        assert atomic_io.read_bounded_bytes(str(target_path)) == b"hello world"
+
+    def test_oversized_file_raises_without_reading_it_all(self, target_path):
+        target_path.write_bytes(b"z" * 4096)
+
+        with pytest.raises(atomic_io.ContentTooLarge):
+            atomic_io.read_bounded_bytes(str(target_path), max_bytes=1024)
+
+    def test_read_call_itself_is_bounded_even_if_stat_lies(
+        self, target_path, monkeypatch
+    ):
+        """A sparse file or unreliable stat() must not defeat the bound --
+        the actual read() call is capped independent of the size pre-check."""
+        target_path.write_bytes(b"y" * (5 * 1024 * 1024))
+        monkeypatch.setattr(atomic_io.os.path, "getsize", lambda _p: 10)
+
+        real_open = open
+        captured = []
+
+        class _Tracking:
+            def __init__(self, fh):
+                self._fh = fh
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                self._fh.close()
+                return False
+
+            def read(self, n=-1):
+                data = self._fh.read(n)
+                captured.append(len(data))
+                return data
+
+        def _tracking_open(path, mode="r"):
+            if mode == "rb":
+                return _Tracking(real_open(path, mode))
+            return real_open(path, mode)
+
+        with patch("code_puppy.atomic_io.open", _tracking_open, create=True):
+            with pytest.raises(atomic_io.ContentTooLarge):
+                atomic_io.read_bounded_bytes(str(target_path), max_bytes=1024)
+
+        assert captured
+        assert all(n <= 1025 for n in captured)
+
+
+class TestQuarantineFile:
+    def test_moves_original_and_returns_new_path(self, target_path):
+        target_path.write_bytes(b"corrupt payload")
+
+        quarantine_path = atomic_io.quarantine_file(str(target_path))
+
+        assert not target_path.exists()
+        assert os.path.exists(quarantine_path)
+        assert open(quarantine_path, "rb").read() == b"corrupt payload"
+
+    def test_never_overwrites_a_prior_backup(self, target_path):
+        target_path.write_bytes(b"first")
+        first_backup = atomic_io.quarantine_file(str(target_path))
+
+        target_path.write_bytes(b"second")
+        second_backup = atomic_io.quarantine_file(str(target_path))
+
+        assert first_backup != second_backup
+        assert open(first_backup, "rb").read() == b"first"
+        assert open(second_backup, "rb").read() == b"second"
+
+    def test_forced_name_collision_retries_instead_of_overwriting(self, target_path):
+        target_path.write_bytes(b"my payload")
+        real_link = os.link
+        call_count = {"n": 0}
+
+        def _flaky_link(src, dst):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                with open(dst, "wb") as f:
+                    f.write(b"someone else's backup")
+                raise FileExistsError(dst)
+            return real_link(src, dst)
+
+        with patch("os.link", side_effect=_flaky_link):
+            atomic_io.quarantine_file(str(target_path))
+
+        backups = glob.glob(f"{target_path}.corrupted-*")
+        assert len(backups) == 2
+        contents = {open(b, "rb").read() for b in backups}
+        assert contents == {b"someone else's backup", b"my payload"}
+
+
+class TestAtomicWriteBytes:
+    def test_write_then_read_roundtrips(self, target_path):
+        atomic_io.atomic_write_bytes(str(target_path), b"payload")
+
+        assert target_path.read_bytes() == b"payload"
+
+    def test_creates_parent_directories(self, tmp_path):
+        nested = tmp_path / "a" / "b" / "c.bin"
+
+        atomic_io.atomic_write_bytes(str(nested), b"payload")
+
+        assert nested.read_bytes() == b"payload"
+
+    def test_preserves_existing_file_permissions(self, target_path):
+        target_path.write_bytes(b"old")
+        os.chmod(target_path, 0o640)
+
+        atomic_io.atomic_write_bytes(str(target_path), b"new")
+
+        assert target_path.read_bytes() == b"new"
+        assert (os.stat(target_path).st_mode & 0o777) == 0o640
+
+    def test_failure_mid_write_leaves_original_untouched_and_no_temp_litter(
+        self, target_path
+    ):
+        target_path.write_bytes(b"original")
+
+        with patch("os.fsync", side_effect=OSError("disk full")):
+            with pytest.raises(OSError):
+                atomic_io.atomic_write_bytes(str(target_path), b"new")
+
+        assert target_path.read_bytes() == b"original"
+        leftovers = [
+            f for f in os.listdir(target_path.parent) if f.startswith(".state.bin-")
+        ]
+        assert leftovers == []
+
+
+class TestPathLock:
+    def test_lock_is_reentrant_safe_after_release(self, target_path):
+        with atomic_io.path_lock(str(target_path)):
+            pass
+        # A second, independent acquisition after release must not hang.
+        with atomic_io.path_lock(str(target_path)):
+            pass
+
+    def test_contended_lock_times_out_instead_of_hanging_forever(self, target_path):
+        with atomic_io.path_lock(str(target_path)):
+            with pytest.raises(atomic_io.LockTimeout):
+                with atomic_io.path_lock(str(target_path), timeout=0.2):
+                    pass  # pragma: no cover - should never be reached
+
+    def test_lock_file_created_alongside_target(self, target_path):
+        with atomic_io.path_lock(str(target_path)):
+            assert os.path.exists(f"{target_path}.lock")
+
+
+class TestConcurrentWritersDoNotLoseUpdates:
+    def test_eight_threads_racing_a_lock_protected_counter_dont_lose_increments(
+        self, target_path
+    ):
+        target_path.write_bytes(b"0")
+
+        def _increment():
+            with atomic_io.path_lock(str(target_path)):
+                current = int(target_path.read_bytes())
+                # Give a competing thread a real chance to interleave if the
+                # lock weren't actually exclusive.
+                time.sleep(0.001)
+                atomic_io.atomic_write_bytes(
+                    str(target_path), str(current + 1).encode()
+                )
+
+        import threading
+
+        threads = [threading.Thread(target=_increment) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert int(target_path.read_bytes()) == 8

--- a/tests/test_atomic_json.py
+++ b/tests/test_atomic_json.py
@@ -28,7 +28,6 @@ class TestLoadJson:
         json_path.write_text('{"mcp_servers": {"foo": {"type": "stdio"}}}')
 
         data = atomic_json.load_json(str(json_path), default={})
-
         assert data == {"mcp_servers": {"foo": {"type": "stdio"}}}
 
     def test_malformed_json_raises_corrupt_not_silently_discarded(self, json_path):
@@ -127,3 +126,31 @@ class TestMutateJson:
 
         final = atomic_json.load_json(str(json_path), default={})
         assert set(final["mcp_servers"]) == {f"server_{i}" for i in range(8)}
+
+
+class TestNullIsNotConflatedWithMissing:
+    """A file containing the literal JSON ``null`` is a real (if unusual)
+    parsed value, not the same thing as "file doesn't exist" -- conflating
+    the two would mean a hand-edited file legitimately containing ``null``
+    gets silently swapped for the caller's ``default`` instead of the
+    actual on-disk content."""
+
+    def test_missing_file_returns_default(self, json_path):
+        assert atomic_json.load_json(str(json_path), default={"x": 1}) == {"x": 1}
+
+    def test_null_file_returns_none_even_with_a_different_default(self, json_path):
+        json_path.write_text("null")
+
+        assert atomic_json.load_json(str(json_path), default={"x": 1}) is None
+
+    def test_mutate_json_sees_null_content_not_the_default(self, json_path):
+        json_path.write_text("null")
+        seen = []
+
+        def _mutate(current):
+            seen.append(current)
+            return {"replaced": True}
+
+        atomic_json.mutate_json(str(json_path), _mutate, default={"x": 1})
+
+        assert seen == [None]

--- a/tests/test_atomic_json.py
+++ b/tests/test_atomic_json.py
@@ -1,0 +1,129 @@
+"""Tests for code_puppy.atomic_json -- the JSON counterpart to config_file's
+corruption resilience, per the PUP-605 follow-up review (Andrew Tilson's
+comment on #757 flagged mcp_servers.json / extra_models.json / spinners.json
+as sharing the same unbounded-read / torn-write / no-lock failure modes)."""
+
+import glob
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from code_puppy import atomic_json
+
+
+@pytest.fixture
+def json_path(tmp_path):
+    return tmp_path / "state.json"
+
+
+class TestLoadJson:
+    def test_missing_file_returns_default(self, json_path):
+        assert atomic_json.load_json(str(json_path), default={}) == {}
+
+    def test_missing_file_returns_none_without_default(self, json_path):
+        assert atomic_json.load_json(str(json_path)) is None
+
+    def test_loads_valid_json(self, json_path):
+        json_path.write_text('{"mcp_servers": {"foo": {"type": "stdio"}}}')
+
+        data = atomic_json.load_json(str(json_path), default={})
+
+        assert data == {"mcp_servers": {"foo": {"type": "stdio"}}}
+
+    def test_malformed_json_raises_corrupt_not_silently_discarded(self, json_path):
+        """Unlike the INI config, a hand-edited JSON file with one typo must
+        not be silently reset -- that would destroy the user's other edits."""
+        json_path.write_text('{"mcp_servers": {oops not json')
+
+        with pytest.raises(atomic_json.JsonFileCorrupt):
+            atomic_json.load_json(str(json_path), default={})
+
+        # And, critically, the file itself must still be there untouched.
+        assert json_path.exists()
+        assert not glob.glob(f"{json_path}.corrupted-*")
+
+    def test_oversized_file_raises_corrupt_without_full_parse(self, json_path):
+        json_path.write_text('{"k": "' + "x" * 4096 + '"}')
+
+        with pytest.raises(atomic_json.JsonFileCorrupt):
+            atomic_json.load_json(str(json_path), default={}, max_bytes=1024)
+
+    def test_transient_os_error_propagates_not_treated_as_corrupt(self, json_path):
+        json_path.write_text('{"ok": true}')
+
+        with patch("builtins.open", side_effect=PermissionError("locked by AV")):
+            with pytest.raises(PermissionError):
+                atomic_json.load_json(str(json_path), default={})
+
+
+class TestMutateJson:
+    def test_creates_file_from_default_when_missing(self, json_path):
+        result = atomic_json.mutate_json(
+            str(json_path), lambda d: {**d, "added": True}, default={}
+        )
+
+        assert result == {"added": True}
+        assert atomic_json.load_json(str(json_path), default={}) == {"added": True}
+
+    def test_mutates_existing_content(self, json_path):
+        json_path.write_text('{"mcp_servers": {"foo": {"type": "stdio"}}}')
+
+        def _add_bar(data):
+            data["mcp_servers"]["bar"] = {"type": "sse"}
+            return data
+
+        result = atomic_json.mutate_json(str(json_path), _add_bar, default={})
+
+        assert set(result["mcp_servers"]) == {"foo", "bar"}
+        persisted = atomic_json.load_json(str(json_path), default={})
+        assert set(persisted["mcp_servers"]) == {"foo", "bar"}
+
+    def test_corrupt_existing_file_raises_and_does_not_overwrite_it(self, json_path):
+        """Mutating a file with one hand-edit typo must fail loudly rather
+        than silently clobbering the rest of the user's config with just
+        the new key."""
+        json_path.write_text('{"mcp_servers": {oops not json')
+
+        with pytest.raises(atomic_json.JsonFileCorrupt):
+            atomic_json.mutate_json(
+                str(json_path), lambda d: {**d, "added": True}, default={}
+            )
+
+        assert json_path.read_text() == '{"mcp_servers": {oops not json'
+
+    def test_write_failure_leaves_original_untouched(self, json_path):
+        json_path.write_text('{"mcp_servers": {}}')
+
+        with patch("os.fsync", side_effect=OSError("disk full")):
+            with pytest.raises(OSError):
+                atomic_json.mutate_json(
+                    str(json_path), lambda d: {**d, "added": True}, default={}
+                )
+
+        assert json_path.read_text() == '{"mcp_servers": {}}'
+
+    def test_concurrent_mutations_do_not_lose_updates(self, json_path):
+        """This is exactly Andrew's Tier 1 scenario: two wizard flows (or a
+        wizard + /mcp remove) racing mcp_servers.json must not stomp each
+        other's server entry."""
+        json_path.write_text('{"mcp_servers": {}}')
+
+        def _add_server(name):
+            def _mutate(data):
+                data["mcp_servers"][name] = {"type": "stdio"}
+                return data
+
+            atomic_json.mutate_json(str(json_path), _mutate, default={})
+
+        threads = [
+            threading.Thread(target=_add_server, args=(f"server_{i}",))
+            for i in range(8)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        final = atomic_json.load_json(str(json_path), default={})
+        assert set(final["mcp_servers"]) == {f"server_{i}" for i in range(8)}

--- a/tests/test_config_corruption_resilience.py
+++ b/tests/test_config_corruption_resilience.py
@@ -26,7 +26,7 @@ from unittest.mock import patch
 import configparser
 import pytest
 
-from code_puppy import config as cp_config
+from code_puppy import atomic_io, config as cp_config
 from code_puppy import config_file
 
 
@@ -105,12 +105,13 @@ class TestOversizedConfigIsBoundedNotBallooned:
         call itself must still be bounded rather than pulling the whole
         pathological file into memory. This directly targets the field
         report's failure mode: stdlib configparser's buffered readline
-        ballooning memory on a giant unterminated line."""
+        ballooning memory on a giant unterminated line. The bound now lives
+        in the shared ``code_puppy.atomic_io`` primitive."""
         monkeypatch.setattr(config_file, "MAX_CONFIG_BYTES", 1024)
         cfg_path.write_bytes(b"y" * (5 * 1024 * 1024))
         # Make the pre-flight os.path.getsize check lie about the size so
         # execution reaches the actual bounded read() call below.
-        monkeypatch.setattr(config_file.os.path, "getsize", lambda _p: 10)
+        monkeypatch.setattr(atomic_io.os.path, "getsize", lambda _p: 10)
 
         real_open = open
         captured_sizes = []
@@ -136,7 +137,7 @@ class TestOversizedConfigIsBoundedNotBallooned:
                 return _TrackingFile(real_open(path, mode))
             return real_open(path, mode)
 
-        with patch("code_puppy.config_file.open", _tracking_open, create=True):
+        with patch("code_puppy.atomic_io.open", _tracking_open, create=True):
             config_file.load_config(str(cfg_path))
 
         assert captured_sizes, "expected the bounded read to be exercised"


### PR DESCRIPTION
Jira: [PUP-607](https://jira.walmart.com/browse/PUP-607)

## Follow-up to #757

Andrew Tilson's review comment on #757 approved the INI config fix but flagged that several adjacent JSON config files share the same three failure modes the original crash exposed: unbounded reads, torn writes, and no cross-process lock -- and noted these are arguably more exposed since users hand-edit them directly.

This PR closes that gap.

### What changed

**Extracted the shared primitives.** `config_file.py`'s bounded-read / cross-process-lock / atomic-write logic is now a generic module, `code_puppy/atomic_io.py`. `config_file.py` is rebuilt on top of it with no behavior change -- the existing 17 regression tests from #757 pass unmodified against the new internals.

**Added the JSON counterpart.** `code_puppy/atomic_json.py` provides `load_json` / `mutate_json`, mirroring `config_file.py`'s API. One deliberate difference: a hand-edited JSON file that fails to parse is surfaced to the caller as `JsonFileCorrupt` rather than auto-quarantined. A user's one-typo mistake is far more likely than bitrot here, and silently resetting the file would destroy the rest of their hand-edited config -- a worse outcome than the crash this is meant to prevent.

**Migrated every site from the review, by tier:**

- **Tier 1 -- `mcp_servers.json`** (4 concurrent writers): the install wizard, the custom-server form (including the rename-in-place case), the custom-server installer, and `/mcp remove` all used to hand-roll `open->json.load->mutate->open->json.dump`. Collapsed into one shared `code_puppy/command_line/mcp/mcp_servers_store.py` built on `mutate_json`, so two wizard flows (or a wizard racing `/mcp remove`) can no longer lose each other's writes.
- **Tier 2 -- `extra_models.json`** (3 different write patterns across `aws_bedrock`, `azure_foundry`, `ollama_setup`, and `add_model_menu.py`): all four now go through `load_json` / `mutate_json` / locked `atomic_write_bytes`, closing the "closest to correct but no fsync/lock" gap and the two fully-unlocked writers.
- **Tier 3 -- cheap fixes**: `puppy_spinner`'s `load_user_spinners` / `save_interval_tweak` / `write_template`, and `JSONAgent._load_config`'s startup read of `~/.code_puppy/agents/*.json` (an unbounded read at every CLI startup).

### Post-review fixes

An adversarial self-review pass (see PR comments) caught a lost-update race: `aws_bedrock` and `azure_foundry`'s add/remove functions were splitting the read and write across two unlocked calls, so a concurrent writer to the same `extra_models.json` could have its update silently overwritten. All 5 affected functions now go through one locked `atomic_json.mutate_json()` transaction, with real-thread concurrency tests pinning the fix. Also tightened a `null`-vs-missing ambiguity in `atomic_json.load_json`/`mutate_json` (private sentinel) and aligned `azure_foundry`'s exception handling with `aws_bedrock`'s.

### Testing

- `tests/test_atomic_io.py` and `tests/test_atomic_json.py`: direct coverage of the primitives (bounded reads, oversize handling even when `stat` lies, quarantine collision safety, atomic write failure/rollback, lock contention/timeout, concurrent-writer safety).
- `tests/agents/test_json_agent_corruption_resilience.py`: pins the JSON-agent bounded-read fix specifically.
- Updated `tests/test_config_corruption_resilience.py` and `tests/command_line/mcp/test_custom_server_form.py` where internals moved (patches now target `atomic_io`/`mcp_servers_store` instead of the old raw `os`/`open` call sites); all previously-covered behavior still holds.
- Full suite: **7182 passed, 23 skipped, 1 xpassed**, no regressions.
- `ruff check` and `ruff format --check` both clean.

cc @AndrewTilson -- thanks for the thorough review, this should close out the loose ends you flagged.
