### PR TITLE
PUP-618: display selected model identifier verbatim in subagent panel

### DIFF
--- a/code_puppy/plugins/subagent_panel/panel_render.py
+++ b/code_puppy/plugins/subagent_panel/panel_render.py
@@ -8,7 +8,6 @@ the frozen transcript records. No I/O, no state mutation — that lives in
 
 from __future__ import annotations
 
-import re
 
 from . import state
 
@@ -53,76 +52,20 @@ def _ordered_tree(rows):
     return out
 
 
-# Preserve tier/variant tokens (e.g. nano, mini) so same-version models do not
-# collapse to one panel label. Keys are lowercased model-id tokens.
-_MODEL_VARIANTS = (
-    ("nano", "Nano"),
-    ("mini", "Mini"),
-    ("micro", "Micro"),
-    ("lite", "Lite"),
-    ("turbo", "Turbo"),
-    ("flash", "Flash"),
-    ("instant", "Instant"),
-    ("sol", "Sol"),
-    ("terra", "Terra"),
-    ("luna", "Luna"),
-    ("codex", "Codex"),
-    ("thinking", "Thinking"),
-    ("reasoning", "Reasoning"),
-    ("preview", "Preview"),
-    ("pro", "Pro"),
-)
-
-
-def _model_variant(m):
-    """Extract a tier/variant qualifier (Nano, Mini, Flash, ...) from a lowercased
-    model id. Matched ONLY as a hyphen/underscore/dot/space-delimited token, so
-    'mini' inside 'gemini' (or 'pro' inside another word) can never false-fire.
-    Returns '' when the id carries no recognised variant."""
-    for key, label in _MODEL_VARIANTS:
-        if re.search(rf"(?:^|[-_. ]){re.escape(key)}(?:$|[-_. ])", m):
-            return label
-    return ""
-
-
-def _model_version(m):
-    """Extract a 'major.minor' version from a lowercased model id, tolerating
-    BOTH separators in the wild: a contiguous decimal ('gpt-5.4' -> '5.4') OR a
-    dash-separated pair ('gpt-5-4', 'claude-4-8-opus' -> '5.4'/'4.8'). Only joins
-    two integer groups when both are short (<=2 digits) so date/snapshot ids like
-    'gpt-4-0125' don't get mangled into '4.0125'. Returns '' when no number."""
-    dec = re.search(r"\d+\.\d+", m)
-    if dec:
-        return dec.group(0)
-    nums = re.findall(r"\d+", m)
-    if not nums:
-        return ""
-    if len(nums) >= 2 and len(nums[0]) <= 2 and len(nums[1]) <= 2:
-        return f"{nums[0]}.{nums[1]}"
-    return nums[0]
-
-
 def _model_short(model):
-    """Human-readable shorthand for a model id, for live readability.
-    e.g. 'claude-4-8-opus' -> 'Opus 4.8', 'claude-sonnet-4-6' -> 'Sonnet 4.6',
-    'gpt-5.5' -> 'GPT 5.5', 'gpt-5.4-nano' -> 'GPT 5.4-Nano'. The tier qualifier
-    is preserved so same-version-different-tier models stay distinct. Falls back
-    to the raw id if unrecognised."""
-    if not model:
-        return ""
+    """Return the model identifier verbatim for the panel display.
 
-    m = str(model).lower()
-    variant = _model_variant(m)
-    suffix = f"-{variant}" if variant else ""
-    ver = _model_version(m)
-    for key, label in (("opus", "Opus"), ("sonnet", "Sonnet"), ("haiku", "Haiku")):
-        if key in m:
-            return f"{label} {ver}{suffix}".strip()
-    if "gpt" in m:
-        return (f"GPT {ver}{suffix}" if ver else f"GPT{suffix}").strip()
-    if "gemini" in m:
-        return (f"Gemini {ver}{suffix}" if ver else f"Gemini{suffix}").strip()
-    return str(model)
+    Deliberately a passthrough: whatever the user picked with ``/model <key>``
+    is what shows up in the subagent panel. No parsing, no title-casing, no
+    tier/env extraction -- previous versions built a curated shorthand from
+    a hard-coded allowlist of tier tokens (nano/mini/flash/...) plus an env
+    allowlist ('stage'), which silently dropped any suffix outside the lists
+    (e.g. -stage). Users would rather see the raw config key and trust their
+    own eyes; that also removes an allowlist maintenance chore forever.
+    Empty / None inputs collapse to an empty string so the panel column
+    doesn't render the literal 'None'.
+    """
+    return str(model) if model else ""
 
 
 def _row_lines(ordered, frame):
@@ -197,8 +140,6 @@ def _row_lines(ordered, frame):
 __all__ = [
     "_banner_color",
     "_model_short",
-    "_model_variant",
-    "_model_version",
     "_ordered_tree",
     "_row_lines",
 ]

--- a/code_puppy/plugins/subagent_panel/register_callbacks.py
+++ b/code_puppy/plugins/subagent_panel/register_callbacks.py
@@ -95,8 +95,6 @@ _PARENT_SID: ContextVar = ContextVar("subagent_panel_parent_sid", default=None)
 # Shared rendering helpers are re-exported from panel_render for compatibility.
 from .panel_render import (  # noqa: E402
     _model_short as _model_short,  # noqa: F401  (re-export)
-    _model_variant as _model_variant,  # noqa: F401  (re-export)
-    _model_version as _model_version,  # noqa: F401  (re-export)
     _ordered_tree,
     _row_lines,
 )

--- a/tests/plugins/subagent_panel/test_panel_lines.py
+++ b/tests/plugins/subagent_panel/test_panel_lines.py
@@ -63,7 +63,8 @@ def test_single_agent_renders_one_styled_line():
     plain = line.plain
     assert "INVOKE AGENT" in plain
     assert "qa-kitten" in plain
-    assert "Opus 4.8" in plain
+    # Passthrough contract: raw model id, not a curated shorthand.
+    assert "claude-4-8-opus" in plain
     assert "starting" in plain
     assert "\x1b" not in plain  # no in-band ANSI in the content
     assert any(span.style for span in line.spans)  # styling present


### PR DESCRIPTION
## Ticket
[PUP-618](https://jira.walmart.com/browse/PUP-618) — [Bug] subagent_panel drops `-stage` from model display

## Problem
The subagent panel showed `GPT 5.1` when the parent agent was running the `stage-gpt-5.1` model — the `-stage` suffix disappeared. Same for `stage-gpt-5.4-mini` → `GPT 5.4-Mini`, etc.

## Root cause (and why an allowlist-based fix is the wrong shape)
`code_puppy/plugins/subagent_panel/panel_render.py::_model_short` composed a curated shorthand (`GPT 5.4-Nano`, `Opus 4.8`, ...) from two hard-coded allowlists:
- `_MODEL_VARIANTS` — tier tokens (`nano`, `mini`, `flash`, `sol`, `luna`, ...).
- `_ENV_QUALIFIERS` — env tokens (previously just `stage` in an earlier draft of this PR).

Any suffix not in either list was silently dropped from the display. Fixing this bug by adding `stage` to a list would just kick the problem down the road for the next suffix that ever gets added upstream (dev, canary, shadow, whatever).

## Fix
Delete the whole curated-shorthand machinery:
- `_MODEL_VARIANTS`, `_ENV_QUALIFIERS`
- `_first_qualifier_label`, `_model_variant`, `_model_env`, `_model_version`
- Family-branch logic (`opus`/`sonnet`/`haiku`/`gpt`/`gemini`) in `_model_short`
- Their re-exports in `register_callbacks.py`
- Their entries in `__all__`
- Their tests

`_model_short` is now a 3-line passthrough:
```python
def _model_short(model):
    return str(model) if model else ""
```

Whatever identifier the user selected with `/model <key>` (e.g. `stage-gpt-5.1`, `gpt-5.4-mini`, `some-team-custom-model_v3.beta`) is what the panel shows. Empty / None inputs collapse to `""` so the column never renders the literal `None`.

## Diff shape
- **Private:** 3 files, +59 / -163 (net **-104 lines**).
- **Public:** 2 files, +13 / -74 (net **-61 lines**).

## Tests (in the private-repo companion PR)
`tests/plugins/test_subagent_panel_model_short.py` rewritten to pin the passthrough contract. Public repo has no equivalent test file, so no test changes here.

## Scope discipline
- Display-only change. Zero routing / backend / callback / network impact.
- No new dependencies, no env vars, no config keys.

## History note
An earlier version of this PR added `_ENV_QUALIFIERS = (("stage", "Stage"),)` to the allowlist. Force-pushed and replaced with the passthrough approach after reviewer feedback flagged the ongoing allowlist maintenance tax.

<img width="603" height="95" alt="image" src="https://github.com/user-attachments/assets/03bc42ce-491f-4d3a-8f33-daa45eb77c10" />
