### PR TITLE
PUP-622: Keep home user plugins out of project trust flow

### DIFF
--- a/code_puppy/plugins/__init__.py
+++ b/code_puppy/plugins/__init__.py
@@ -486,9 +486,22 @@ def get_project_plugins_directory() -> Path | None:
         Path to the project's plugins directory if it exists, or None.
     """
     project_plugins_dir = Path.cwd() / ".code_puppy" / "plugins"
-    if project_plugins_dir.is_dir():
-        return project_plugins_dir
-    return None
+    if not project_plugins_dir.is_dir():
+        return None
+
+    try:
+        if project_plugins_dir.samefile(USER_PLUGINS_DIR):
+            logger.debug(
+                "Ignoring project plugins directory because it is the user plugins directory: %s",
+                project_plugins_dir,
+            )
+            return None
+    except OSError:
+        # A missing/unreadable user directory cannot be the discovered project
+        # directory, so retain normal project discovery.
+        pass
+
+    return project_plugins_dir
 
 
 def load_plugin_callbacks() -> dict[str, list[str]]:

--- a/tests/test_project_plugins.py
+++ b/tests/test_project_plugins.py
@@ -302,6 +302,38 @@ class TestGetProjectPluginsDirectory:
             assert result is not None
             assert result == plugins_dir
 
+    def test_home_user_plugins_are_not_treated_as_project_plugins(self, tmp_path: Path):
+        """Launching from home must not scan the user tier as a project tier."""
+        import code_puppy.plugins as plugins_module
+
+        plugins_dir = tmp_path / ".code_puppy" / "plugins"
+        plugins_dir.mkdir(parents=True)
+
+        with (
+            patch("code_puppy.plugins.Path.cwd", return_value=tmp_path),
+            patch.object(plugins_module, "USER_PLUGINS_DIR", plugins_dir),
+        ):
+            assert get_project_plugins_directory() is None
+
+    def test_user_plugins_path_alias_is_not_a_project(self, tmp_path: Path):
+        """Physical identity, not path spelling, determines the plugin tier."""
+        import code_puppy.plugins as plugins_module
+
+        home = tmp_path / "home"
+        plugins_dir = home / ".code_puppy" / "plugins"
+        plugins_dir.mkdir(parents=True)
+        home_alias = tmp_path / "home-alias"
+        try:
+            home_alias.symlink_to(home, target_is_directory=True)
+        except (NotImplementedError, OSError):
+            pytest.skip("directory symlinks are unavailable on this platform")
+
+        with (
+            patch("code_puppy.plugins.Path.cwd", return_value=home_alias),
+            patch.object(plugins_module, "USER_PLUGINS_DIR", plugins_dir),
+        ):
+            assert get_project_plugins_directory() is None
+
 
 # ---------------------------------------------------------------------------
 # 8. load_plugin_callbacks() includes "project" key in result dict


### PR DESCRIPTION
## Summary
- do not treat `~/.code_puppy/plugins` as a project plugin tier when the working directory resolves to the user home directory
- compare physical directory identity, so path aliases and symlinks cannot reintroduce the false project-plugin warning

## Validation
- `uv run --frozen --index-url https://pypi.ci.artifacts.walmart.com/artifactory/api/pypi/external-pypi/simple --allow-insecure-host pypi.ci.artifacts.walmart.com pytest -q tests/test_project_plugins.py` (38 passed)
- Ruff check and format check passed for changed files

## Related companion-package PR
The remote-catalog startup-noise correction belongs in the companion package after upstream moved `agent_skills` out of core: https://github.com/mpfaffenberger/code_puppy_core_plugins/pull/1

## Tracking
[Jira PUP-622](https://jira.walmart.com/browse/PUP-622)