### PR TITLE
fix: classify bare JSONDecodeError as retryable in streaming path

### DIFF
--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -109,14 +109,9 @@ from code_puppy.tools.command_runner import is_awaiting_user_input
 # Provider "please retry" signals or SSE/transport artifacts that reliably
 # succeed on retry. Keep substring-based and lower-case.
 #
-# NOTE: "malformed streamed sse event" and "extra json data in sse payload"
-# below only match *wrapped/reworded* provider messages. A bare stdlib
-# ``json.JSONDecodeError("Extra data: line 1 column ...", ...)`` -- what the
-# installed anthropic SDK's ``ServerSentEvent.json()`` actually raises when a
-# stream ``data:`` line is malformed/concatenated -- does NOT contain either
-# substring. That case is handled separately by the ``json.JSONDecodeError``
-# isinstance check in ``_is_retryable_one`` below; don't assume these two
-# snippets already cover it.
+# NOTE: a bare ``json.JSONDecodeError`` (malformed SSE line) doesn't match
+# "malformed streamed sse event" / "extra json data in sse payload" below --
+# it's classified separately via isinstance in ``_is_retryable_one``.
 _RETRYABLE_SNIPPETS = (
     "streamed response ended without content",
     "malformed streamed sse event",
@@ -311,16 +306,8 @@ def _is_retryable_one(exc: BaseException) -> bool:
         if _matches_retryable_snippet(msg):
             return True
 
-    # A JSONDecodeError escaping the Anthropic stream iterator means the SSE
-    # transport delivered a malformed/concatenated `data:` line (see the
-    # anthropic SDK's ServerSentEvent.json() -> json.loads(self.data)). This is a
-    # transport/framing artifact, not a data-integrity problem with the
-    # conversation itself, so retry it exactly like any other transient
-    # stream corruption. NOTE: the default JSONDecodeError message ("Extra
-    # data: line N column M (char K)") does NOT match the
-    # "malformed streamed sse event" / "extra json data in sse payload"
-    # snippets above -- that's why an isinstance check is required here
-    # rather than relying on snippet matching alone.
+    # Malformed/concatenated SSE line -> bare JSONDecodeError; message won't
+    # match the snippets above, so check the type directly.
     if isinstance(exc, json.JSONDecodeError):
         return True
 

--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -18,6 +18,7 @@ preserved verbatim:
 from __future__ import annotations
 
 import asyncio
+import json
 import re
 import signal
 import threading
@@ -107,6 +108,15 @@ from code_puppy.tools.command_runner import is_awaiting_user_input
 
 # Provider "please retry" signals or SSE/transport artifacts that reliably
 # succeed on retry. Keep substring-based and lower-case.
+#
+# NOTE: "malformed streamed sse event" and "extra json data in sse payload"
+# below only match *wrapped/reworded* provider messages. A bare stdlib
+# ``json.JSONDecodeError("Extra data: line 1 column ...", ...)`` -- what the
+# installed anthropic SDK's ``ServerSentEvent.json()`` actually raises when a
+# stream ``data:`` line is malformed/concatenated -- does NOT contain either
+# substring. That case is handled separately by the ``json.JSONDecodeError``
+# isinstance check in ``_is_retryable_one`` below; don't assume these two
+# snippets already cover it.
 _RETRYABLE_SNIPPETS = (
     "streamed response ended without content",
     "malformed streamed sse event",
@@ -300,6 +310,19 @@ def _is_retryable_one(exc: BaseException) -> bool:
     if ModelAPIError is not None and isinstance(exc, ModelAPIError):
         if _matches_retryable_snippet(msg):
             return True
+
+    # A JSONDecodeError escaping the Anthropic stream iterator means the SSE
+    # transport delivered a malformed/concatenated `data:` line (see the
+    # anthropic SDK's ServerSentEvent.json() -> json.loads(self.data)). This is a
+    # transport/framing artifact, not a data-integrity problem with the
+    # conversation itself, so retry it exactly like any other transient
+    # stream corruption. NOTE: the default JSONDecodeError message ("Extra
+    # data: line N column M (char K)") does NOT match the
+    # "malformed streamed sse event" / "extra json data in sse payload"
+    # snippets above -- that's why an isinstance check is required here
+    # rather than relying on snippet matching alone.
+    if isinstance(exc, json.JSONDecodeError):
+        return True
 
     return False
 

--- a/tests/agents/test_runtime_streaming_retry_classifier.py
+++ b/tests/agents/test_runtime_streaming_retry_classifier.py
@@ -1,22 +1,7 @@
-"""Regression tests for the streaming-retry classifier's JSONDecodeError branch.
+"""Regression tests: bare JSONDecodeError must be classified as retryable.
 
-Covers PUP-634: a bare ``json.decoder.JSONDecodeError`` raised inside the
-installed ``anthropic`` SDK's ``ServerSentEvent.json()`` (malformed/concatenated
-``data:`` line) used to escape ``_is_retryable_one`` entirely -- it isn't an
-``httpx``/``httpcore`` transport error, isn't one of the ``isinstance`` types
-already checked, and its default message doesn't match the
-``_RETRYABLE_SNIPPETS`` substrings. That meant zero retries were attempted and
-the exception crashed the whole interactive session via ``run_agent_task``'s
-``except* Exception`` re-raise.
-
-These tests pin the fix at the two levels that matter:
-1. The leaf classifier (`_is_retryable_one`) recognizes the exception type.
-2. The public entry point (`should_retry_streaming`) still reaches that leaf
-   when the exception arrives wrapped in a ``BaseExceptionGroup`` -- which is
-   how pydantic-ai's anyio TaskGroup actually delivers it in production.
-
-Plus a negative guardrail so the new branch doesn't quietly widen the
-classifier into retrying every deterministic parse error under the sun.
+A malformed SSE line raises ``json.JSONDecodeError``, which used to escape
+``_is_retryable_one`` and crash the session.
 """
 
 from __future__ import annotations
@@ -27,9 +12,7 @@ from code_puppy.agents._runtime import _is_retryable_one, should_retry_streaming
 
 
 def _malformed_sse_json_decode_error() -> json.JSONDecodeError:
-    """Build the same exception shape ``json.loads`` raises on a
-    concatenated SSE ``data:`` payload (two JSON objects on one line).
-    """
+    """Same exception shape as a concatenated SSE ``data:`` payload."""
     doc = '{"ok": 1}{"oops": 2}'
     try:
         json.loads(doc)
@@ -45,10 +28,7 @@ def test_is_retryable_one_recognizes_json_decode_error() -> None:
 
 
 def test_should_retry_streaming_reaches_json_decode_error_inside_group() -> None:
-    """pydantic-ai's anyio TaskGroup wraps stream failures in an
-    ExceptionGroup; ``should_retry_streaming`` must descend into it rather
-    than only inspecting the top-level exception.
-    """
+    """Must unwrap the BaseExceptionGroup pydantic-ai raises in practice."""
     exc = _malformed_sse_json_decode_error()
     group = BaseExceptionGroup("stream failed", [exc])
 
@@ -56,8 +36,5 @@ def test_should_retry_streaming_reaches_json_decode_error_inside_group() -> None
 
 
 def test_is_retryable_one_does_not_widen_to_unrelated_value_errors() -> None:
-    """Regression guard: the new branch is scoped to JSONDecodeError, not to
-    every parse-ish failure. A generic deterministic ValueError must still
-    be treated as non-retryable.
-    """
+    """Guard against over-widening: unrelated ValueErrors stay non-retryable."""
     assert _is_retryable_one(ValueError("nope")) is False

--- a/tests/agents/test_runtime_streaming_retry_classifier.py
+++ b/tests/agents/test_runtime_streaming_retry_classifier.py
@@ -1,0 +1,63 @@
+"""Regression tests for the streaming-retry classifier's JSONDecodeError branch.
+
+Covers PUP-634: a bare ``json.decoder.JSONDecodeError`` raised inside the
+installed ``anthropic`` SDK's ``ServerSentEvent.json()`` (malformed/concatenated
+``data:`` line) used to escape ``_is_retryable_one`` entirely -- it isn't an
+``httpx``/``httpcore`` transport error, isn't one of the ``isinstance`` types
+already checked, and its default message doesn't match the
+``_RETRYABLE_SNIPPETS`` substrings. That meant zero retries were attempted and
+the exception crashed the whole interactive session via ``run_agent_task``'s
+``except* Exception`` re-raise.
+
+These tests pin the fix at the two levels that matter:
+1. The leaf classifier (`_is_retryable_one`) recognizes the exception type.
+2. The public entry point (`should_retry_streaming`) still reaches that leaf
+   when the exception arrives wrapped in a ``BaseExceptionGroup`` -- which is
+   how pydantic-ai's anyio TaskGroup actually delivers it in production.
+
+Plus a negative guardrail so the new branch doesn't quietly widen the
+classifier into retrying every deterministic parse error under the sun.
+"""
+
+from __future__ import annotations
+
+import json
+
+from code_puppy.agents._runtime import _is_retryable_one, should_retry_streaming
+
+
+def _malformed_sse_json_decode_error() -> json.JSONDecodeError:
+    """Build the same exception shape ``json.loads`` raises on a
+    concatenated SSE ``data:`` payload (two JSON objects on one line).
+    """
+    doc = '{"ok": 1}{"oops": 2}'
+    try:
+        json.loads(doc)
+    except json.JSONDecodeError as exc:
+        return exc
+    raise AssertionError("expected json.loads to raise JSONDecodeError")
+
+
+def test_is_retryable_one_recognizes_json_decode_error() -> None:
+    exc = _malformed_sse_json_decode_error()
+
+    assert _is_retryable_one(exc) is True
+
+
+def test_should_retry_streaming_reaches_json_decode_error_inside_group() -> None:
+    """pydantic-ai's anyio TaskGroup wraps stream failures in an
+    ExceptionGroup; ``should_retry_streaming`` must descend into it rather
+    than only inspecting the top-level exception.
+    """
+    exc = _malformed_sse_json_decode_error()
+    group = BaseExceptionGroup("stream failed", [exc])
+
+    assert should_retry_streaming(group) is True
+
+
+def test_is_retryable_one_does_not_widen_to_unrelated_value_errors() -> None:
+    """Regression guard: the new branch is scoped to JSONDecodeError, not to
+    every parse-ish failure. A generic deterministic ValueError must still
+    be treated as non-retryable.
+    """
+    assert _is_retryable_one(ValueError("nope")) is False


### PR DESCRIPTION
> [!NOTE]
> **Verified against this repo's actual pinned versions (pydantic-ai v2) -- this fix is current, not stale.**
> Traced the real installed source directly (not just version numbers): `pydantic-ai-slim==2.31.0`, `anthropic==0.122.0`. `AnthropicStreamedResponse._get_event_iterator()` -- same method name as before the v2 upgrade -- still wraps stream consumption in `_map_api_errors()`, which only catches `APIStatusError`/`APIConnectionError`. A bare `json.JSONDecodeError` from the SDK's `ServerSentEvent.json()` still propagates uncaught, exactly as it did before. **Nothing about the v2 upgrade closed this gap.** Full trace below.

## Post-upgrade verification (pydantic-ai v2)

Confirmed line-by-line against the actual code installed in this repo's `.venv` (`pydantic-ai-slim==2.31.0`, `anthropic==0.122.0`):

1. `anthropic/_streaming.py`'s `SSEDecoder.decode()` joins multiple `data:` field-lines for one SSE event via `"\n".join(self._data)` before constructing the `ServerSentEvent`. `ServerSentEvent.json()` is a bare `return json.loads(self.data)` with zero exception handling.
2. `AsyncStream.__stream__()` (the async path pydantic-ai actually uses) calls `sse.json()` directly, uncaught, for ~40 event types (`completion`, `message_start`, `content_block_delta`, etc.). Only the `error` event type has any try/except near `.json()`, and that's scoped to building a fallback error message, not to suppressing the exception.
3. `pydantic_ai/models/anthropic.py`'s `AnthropicStreamedResponse._get_event_iterator()` wraps stream consumption in `_map_api_errors(self._model_name)`, which only catches `APIStatusError` and `APIConnectionError`. A bare `json.JSONDecodeError` is neither, so it propagates uncaught.

**Trigger, precisely:** more than one `data:` field-line arriving for a single SSE event before the blank-line terminator. They get joined with `\n` and fed to one `json.loads()` call, which raises "Extra data" if the joined string contains multiple JSON values.

**Conclusion:** pydantic-ai v2 did not touch this seam -- same method name, same context-manager-based error mapping, same two narrow `except` clauses, same unguarded `sse.json()` calls in the SDK's SSE loop. This fix is not superseded by the upgrade.

---

## Problem
A bare `json.decoder.JSONDecodeError` raised inside the installed `anthropic` SDK's `ServerSentEvent.json()` (malformed/concatenated SSE `data:` line) escapes the streaming-retry classifier in `code_puppy/agents/_runtime.py`. It isn't an `httpx`/`httpcore` transport error, isn't one of the `isinstance` types already checked in `_is_retryable_one()`, and its default message doesn't match the existing `_RETRYABLE_SNIPPETS` substrings (two of which look like they were added in anticipation of exactly this bug but are currently dead code — nothing in the repo raises those message strings). Net effect: `should_retry_streaming()` returns `False`, zero retries are attempted, and the exception crashes the entire interactive session via `run_agent_task`'s `except* Exception` re-raise.

## Fix
- Added `isinstance(exc, json.JSONDecodeError)` branch to `_is_retryable_one()` in `code_puppy/agents/_runtime.py`, with an explanatory comment.
- Added a clarifying comment near the two previously-dead `_RETRYABLE_SNIPPETS` entries noting they only cover wrapped/reworded messages, not this bare stdlib exception shape.
- No changes to `should_retry_streaming()`, cause-chain/group-unwrapping helpers, `streaming_retry()`, the installed `anthropic` package, or the `pydantic_agent.run(...)` call sites — all already correct and sufficient (both call sites are already wrapped by the streaming-retry decorator).

## Tests
New `tests/agents/test_runtime_streaming_retry_classifier.py`:
- Leaf classifier recognizes the exception.
- `BaseExceptionGroup`-wrapped case still reaches the branch (matches how pydantic-ai's anyio TaskGroup actually delivers this in production).
- Regression guard: unrelated `ValueError` is still non-retryable (classifier isn't over-widened).

Verified against this repo's locked dependency versions (`anthropic==0.122.0`, `pydantic-ai-slim==2.31.0`) — confirmed the bare `json.loads(self.data)` call and lack of any try/except around stream iteration that would otherwise mask this. All 3 new tests plus the adjacent exception-recovery/pause/cancellation test suites (19 tests) pass with zero regressions.
