### PR TITLE
fix: /model suggestions now reflect models added via /add_model

### DIFF
--- a/code_puppy/command_line/model_picker_completion.py
+++ b/code_puppy/command_line/model_picker_completion.py
@@ -63,8 +63,10 @@ def set_active_model(model_name: str):
 
 class ModelNameCompleter(Completer):
     """
-    A completer that triggers on '/model' to show available models from models.json.
-    Only '/model' (not just '/') will trigger the dropdown.
+    A completer that triggers on '/model' to show available models from the
+    merged model config (bundled models.json + extra_models.json + OAuth
+    model files + plugin models). Only '/model' (not just '/') will trigger
+    the dropdown.
 
     When ``prefix`` is set (e.g. ``"@"``), it also matches patterns like
     ``/fork @agent @model`` — the text after the last ``@`` following the
@@ -74,7 +76,6 @@ class ModelNameCompleter(Completer):
     def __init__(self, trigger: str = "/model", prefix: str = ""):
         self.trigger = trigger
         self.prefix = prefix
-        self.model_names = load_model_names()
 
     def get_completions(
         self, document: Document, complete_event
@@ -111,8 +112,11 @@ class ModelNameCompleter(Completer):
             ].lstrip()
             start_position = -len(text_after_prefix)
 
-        # Filter model names based on what's typed (case-insensitive)
-        for model_name in self.model_names:
+        # Filter model names based on what's typed (case-insensitive).
+        # Iterate the freshly loaded config -- NOT a snapshot from __init__:
+        # long-lived completer stacks (persistent prompt caches them once)
+        # must see models added later via /add_model -> extra_models.json.
+        for model_name in models_config:
             if text_after_prefix and not query_matches_text(
                 text_after_prefix, model_name
             ):

--- a/code_puppy/command_line/model_picker_completion.py
+++ b/code_puppy/command_line/model_picker_completion.py
@@ -1,6 +1,6 @@
+import logging
 import os
 import sys
-import logging
 from typing import Iterable, Optional
 
 from prompt_toolkit import Application, PromptSession
@@ -11,12 +11,14 @@ from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.layout import Layout, Window
 from prompt_toolkit.layout.controls import FormattedTextControl
 
+from code_puppy.callbacks import on_prompt_toolkit_style
 from code_puppy.command_line.pagination import (
     ensure_visible_page,
     get_page_bounds,
     get_page_for_index,
     get_total_pages,
 )
+from code_puppy.command_line.utils import safe_input
 from code_puppy.config import get_global_model_name
 from code_puppy.list_filtering import query_matches_text
 from code_puppy.model_switching import set_model_and_reload_agent
@@ -26,8 +28,6 @@ from code_puppy.provider_credentials import (
     required_env_var_for_model,
     save_credential,
 )
-from code_puppy.command_line.utils import safe_input
-from code_puppy.callbacks import on_prompt_toolkit_style
 
 logger = logging.getLogger(__name__)
 

--- a/tests/command_line/test_model_picker_completion.py
+++ b/tests/command_line/test_model_picker_completion.py
@@ -125,6 +125,49 @@ class TestModelNameCompleter:
             assert len(completions) == 1
             assert completions[0].text == "claude-3"
 
+    def test_sees_model_added_after_construction(self):
+        """Regression: /add_model writes extra_models.json, but completer
+        stacks (the persistent prompt caches its stack for the whole
+        session) were built before the add -- completions must reflect the
+        config as of *each keystroke*, not as of construction time."""
+        from code_puppy.command_line.model_picker_completion import ModelNameCompleter
+
+        before_add = {"gpt-4o": {}, "claude-3": {}}
+        after_add = {**before_add, "xai-grok-4": {}}
+        states = iter([before_add, after_add])
+
+        def _load():
+            try:
+                return next(states)
+            except StopIteration:
+                raise AssertionError(
+                    "_load_models_config called more times than expected"
+                ) from None
+
+        with (
+            patch(
+                "code_puppy.command_line.model_picker_completion._load_models_config",
+                side_effect=_load,
+            ),
+            patch(
+                "code_puppy.command_line.model_picker_completion.get_active_model",
+                return_value="gpt-4o",
+            ),
+        ):
+            completer = ModelNameCompleter(trigger="/model")
+
+            # Before /add_model: no grok suggestions.
+            completions = list(
+                completer.get_completions(self._make_doc("/model grok"), None)
+            )
+            assert completions == []
+
+            # After /add_model: the newly added model is suggested immediately.
+            completions = list(
+                completer.get_completions(self._make_doc("/model grok"), None)
+            )
+            assert [c.text for c in completions] == ["xai-grok-4"]
+
 
 class TestFindMatchingModel:
     @pytest.mark.parametrize(

--- a/tests/test_prompt_toolkit_completion.py
+++ b/tests/test_prompt_toolkit_completion.py
@@ -72,8 +72,12 @@ def test_fork_model_completion_with_prefix():
 
     with (
         patch(
-            "code_puppy.command_line.model_picker_completion.load_model_names",
-            return_value=["codex-gpt-5.6-luna", "gpt-4o", "claude-sonnet"],
+            "code_puppy.command_line.model_picker_completion._load_models_config",
+            return_value={
+                "codex-gpt-5.6-luna": {},
+                "gpt-4o": {},
+                "claude-sonnet": {},
+            },
         ),
         patch(
             "code_puppy.command_line.model_picker_completion.get_active_model",
@@ -102,8 +106,8 @@ def test_fork_model_completion_requires_at_prefix():
     )
 
     with patch(
-        "code_puppy.command_line.model_picker_completion.load_model_names",
-        return_value=["gpt-4o"],
+        "code_puppy.command_line.model_picker_completion._load_models_config",
+        return_value={"gpt-4o": {}},
     ):
         models = list(
             ModelNameCompleter(trigger="/fork", prefix="@").get_completions(
@@ -123,8 +127,8 @@ def test_fork_model_completion_no_prefix_still_works():
 
     with (
         patch(
-            "code_puppy.command_line.model_picker_completion.load_model_names",
-            return_value=["gpt-4o", "claude-sonnet"],
+            "code_puppy.command_line.model_picker_completion._load_models_config",
+            return_value={"gpt-4o": {}, "claude-sonnet": {}},
         ),
         patch(
             "code_puppy.command_line.model_picker_completion.get_active_model",


### PR DESCRIPTION
## Problem

When a user runs `/add_model`, the newly added model does not appear in the `/model` suggestion dropdown until the app is restarted.

## Root cause

`ModelNameCompleter` snapshotted the model list once at construction:

```python
self.model_names = load_model_names()   # stale forever after this
```

and `get_completions` iterated that snapshot — even though it *already* loaded a fresh `models_config` on every call just to render descriptions. Two sources of truth, one of them rotting.

The broken path is the **persistent prompt**, which builds its completer stack once per session (`editor_completion.py` caches it behind `if self._completer is None`). Models written to `extra_models.json` by `/add_model` therefore never reached the dropdown. The classic prompt was not affected — it rebuilds its stack every input turn — which is why the bug was easy to miss.

## Fix

- Iterate the freshly loaded `models_config` instead of the construction-time snapshot: one source of truth, and *less* I/O (each stack build previously did 3 redundant `ModelFactory.load_config()` loads at construction).
- Import reordering (pre-commit isort churn) split into its own commit so the behavioral diff stays minimal.

## Verification

- New regression test `test_sees_model_added_after_construction`: constructs the completer *before* the model exists, asserts it is suggested after. Confirmed it fails on pre-fix code (with a readable `AssertionError`, via a stateful mock that names the exact stale-load mechanism).
- `1291 passed, 1 xpassed` (pre-existing, unrelated xfail) across `tests/command_line/`, `test_prompt_toolkit_completion.py`, `test_command_handler.py`, `test_acp_plugin.py`, `tests/messaging/test_editor_completion.py` on top of current `main`.
- E2E simulation: build completer → write `extra_models.json` (as `/add_model` does) → `/model grok` suggests the new model immediately.
- Behavior preservation: `load_model_names()` was literally `list(models_config.keys())`, so name set, ordering, filtering, and `start_position` semantics are unchanged; `/model`, `/m`, and `/fork @agent @model` prefix paths all funnel through the same loop.