### PR TITLE
test: robust port occupancy check and DBOS optional skip

### DIFF
--- a/tests/integration/test_dbos_enabled.py
+++ b/tests/integration/test_dbos_enabled.py
@@ -1,12 +1,20 @@
+import importlib.util
 import time
 from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("dbos") is None,
+    reason="DBOS optional dependency is not installed",
+)
 
 
 def test_dbos_initializes_and_creates_db(spawned_cli):
     # spawned_cli fixture starts the app and waits until interactive mode
     # Confirm DBOS initialization message appeared
     log = spawned_cli.read_log()
-    assert "Initializing DBOS with database at:" in log or "DBOS is disabled" not in log
+    assert "Initializing DBOS with database at:" in log
 
     # Database path should be under temp HOME/.code_puppy by default
     home = Path(spawned_cli.temp_home)

--- a/tests/test_http_utils_full_coverage.py
+++ b/tests/test_http_utils_full_coverage.py
@@ -480,16 +480,12 @@ class TestFindAvailablePort:
     def test_returns_none_when_all_busy(self):
         from code_puppy.http_utils import find_available_port
 
-        # Use a very narrow range and bind to all ports
-        socks = []
+        occupied = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
-            for p in range(49900, 49903):
-                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                s.bind(("127.0.0.1", p))
-                socks.append(s)
-            result = find_available_port(start_port=49900, end_port=49902)
+            occupied.bind(("127.0.0.1", 0))
+            occupied.listen(1)
+            port = occupied.getsockname()[1]
+            result = find_available_port(start_port=port, end_port=port)
             assert result is None
         finally:
-            for s in socks:
-                s.close()
+            occupied.close()


### PR DESCRIPTION
Two test-only robustness fixes, both verified broken on `main` today.

## 1. `test_returns_none_when_all_busy` fails deterministically on macOS

The test binds three sockets with `SO_REUSEADDR` but never `listen()`s. On macOS (and Linux with permissive reuse semantics) a second `bind()` with `SO_REUSEADDR` succeeds, so the "occupied" port still reads as available and the test fails:

```
1 failed   # ×3 consecutive runs, deterministic
```

This file is in CI scope (`uv run pytest tests/ --ignore tests/integration`), so the macOS matrix lane is affected.

**Fix:** bind a single socket to an ephemeral port and `listen()` on it, then probe exactly that port — no `SO_REUSEADDR`, no fixed-port collisions with parallel runs.

## 2. `test_dbos_enabled` hard-fails without the optional `durable` extra

The test spawns the CLI and asserts the DBOS database appears within 10s. Without `dbos` installed the plugin never initializes and the test fails after the timeout (reproduced: ~40s wall, assertion on the missing file). CI doesn't see it because `tests/integration` is excluded — but any full local run (or anyone wiring integration tests into CI) hits it.

**Fix:** module-level `skipif` via `importlib.util.find_spec("dbos") is None`. When DBOS *is* installed, all assertions remain hard — the skip only covers the genuinely-absent dependency, never a startup regression.

## Verification

`tests/test_http_utils_full_coverage.py` + `tests/integration/test_dbos_enabled.py`: `39 passed, 1 skipped` (the skip being the DBOS case, as designed).

No production changes. Split out of #772 (which carries the same content, so its diff will simply shrink once this merges — no conflict).
