### PR TITLE
fix(callbacks): a security callback that crashes must not read as approval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,12 @@ and skills (`<CWD>/.code_puppy/skills/`).
 
 `register_callback("<hook>", func)` — deduplicated, async hooks accept sync or async functions.
 
+`register_callback("<hook>", func, fail_closed=True)` — for security callbacks on `pre_tool_call`
+and `run_shell_command` only. Error isolation normally reports a crashed callback as `None`, and
+both of those consumers read `None` as "no objection", so a guard that raises currently reads as
+approval. With `fail_closed=True` its exception is reported as a block instead. Defaults to
+`False`; the flag is rejected on other hooks, whose consumers would misread a block result.
+
 | Hook | When | Signature |
 |------|------|-----------|
 | `startup` | App boot | `() -> None` |

--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -169,6 +169,42 @@ logger = logging.getLogger(__name__)
 # Populated by register_callback() when a loading context is active.
 _callback_owners: Dict[CallbackFunc, str] = {}
 
+# Phases whose consumers act on a {"blocked": True} result. fail_closed is only
+# meaningful there, so asking for it elsewhere is rejected rather than injecting
+# a dict into a phase with an unrelated return protocol.
+BLOCKING_PHASES: frozenset = frozenset({"pre_tool_call", "run_shell_command"})
+
+# (phase, callback) pairs registered with fail_closed=True. Keyed by pair, not
+# by callable: the same helper may be registered on several phases with
+# different policies, and one phase's choice must not leak into another.
+_fail_closed_callbacks: Set[tuple] = set()
+
+
+def _failure_result(
+    callback: CallbackFunc, phase: PhaseType, error: Exception
+) -> Dict[str, Any]:
+    """Build the block result standing in for a callback that could not decide.
+
+    Shaped for the existing {"blocked": True} consumers so none of them needs to
+    learn a new result type. The message is [BLOCKED]-tagged because
+    pydantic_patches strips everything before that marker when rendering.
+
+    The exception's text is deliberately omitted: this string reaches the user
+    and the model, and an exception may carry paths, command lines, or tokens.
+    The full traceback is already in the log line beside the caller.
+    """
+    name = getattr(callback, "__name__", repr(callback))
+    return {
+        "blocked": True,
+        "error_message": (
+            f"[BLOCKED] Security callback {name} failed in phase '{phase}' "
+            f"({type(error).__name__}); denying because a check that could not "
+            f"complete is not an approval. See the log for details."
+        ),
+        "reasoning": f"Fail-closed callback {name} raised {type(error).__name__}.",
+    }
+
+
 # Set by the plugin loader before importing each plugin's register_callbacks.py,
 # cleared immediately after.  register_callback() reads this to record ownership.
 _current_loading_plugin: Optional[str] = None
@@ -211,7 +247,26 @@ def _get_disabled_plugins() -> Set[str]:
         return set()
 
 
-def register_callback(phase: PhaseType, func: CallbackFunc) -> None:
+def register_callback(
+    phase: PhaseType, func: CallbackFunc, fail_closed: bool = False
+) -> None:
+    """Register ``func`` for ``phase``.
+
+    Args:
+        phase: Hook phase to register on.
+        func: Sync or async callable.
+        fail_closed: Opt-in for security callbacks on a phase in
+            :data:`BLOCKING_PHASES`. Error isolation normally turns a crashed
+            callback into ``None``, which those consumers read as approval;
+            with this set, a raised exception is reported as a block instead.
+            Defaults to ``False``, so every existing callback keeps its current
+            behavior.
+
+    Raises:
+        ValueError: unknown phase, or ``fail_closed`` on a phase whose
+            consumers do not act on a block result.
+        TypeError: ``func`` is not callable.
+    """
     if phase not in _callbacks:
         raise ValueError(
             f"Unsupported phase: {phase}. Supported phases: {list(_callbacks.keys())}"
@@ -220,15 +275,29 @@ def register_callback(phase: PhaseType, func: CallbackFunc) -> None:
     if not callable(func):
         raise TypeError(f"Callback must be callable, got {type(func)}")
 
+    if fail_closed and phase not in BLOCKING_PHASES:
+        raise ValueError(
+            f"fail_closed=True is only meaningful on phases whose consumers act on "
+            f"a block result ({sorted(BLOCKING_PHASES)}); phase '{phase}' would "
+            f"receive a dict it does not understand."
+        )
+
     # Prevent duplicate registration of the same callback function
     # This can happen if plugins are accidentally loaded multiple times
     if func in _callbacks[phase]:
+        # A repeat registration may still be tightening the policy; honor that
+        # rather than silently keeping the weaker fail-open behavior.
+        if fail_closed:
+            _fail_closed_callbacks.add((phase, func))
         logger.debug(
             f"Callback {func.__name__} already registered for phase '{phase}', skipping"
         )
         return
 
     _callbacks[phase].append(func)
+
+    if fail_closed:
+        _fail_closed_callbacks.add((phase, func))
 
     # Record ownership if we know which plugin is loading.
     if _current_loading_plugin is not None:
@@ -243,6 +312,7 @@ def unregister_callback(phase: PhaseType, func: CallbackFunc) -> bool:
 
     try:
         _callbacks[phase].remove(func)
+        _fail_closed_callbacks.discard((phase, func))
         logger.debug(
             f"Unregistered async callback {func.__name__} from phase '{phase}'"
         )
@@ -255,10 +325,13 @@ def clear_callbacks(phase: Optional[PhaseType] = None) -> None:
     if phase is None:
         for p in _callbacks:
             _callbacks[p].clear()
+        _fail_closed_callbacks.clear()
         logger.debug("Cleared all async callbacks")
     else:
         if phase in _callbacks:
             _callbacks[phase].clear()
+            for entry in [e for e in _fail_closed_callbacks if e[0] == phase]:
+                _fail_closed_callbacks.discard(entry)
             logger.debug(f"Cleared async callbacks for phase '{phase}'")
 
 
@@ -346,7 +419,20 @@ def _trigger_callbacks_sync(
                     # Can't await with the loop running; close the coroutine to
                     # avoid an unawaited-coroutine warning.
                     result.close()
-                    results.append(None)
+                    # Undecided, not unopposed: a fail-closed callback that
+                    # could not run must not read as approval here either.
+                    if (phase, callback) in _fail_closed_callbacks:
+                        results.append(
+                            _failure_result(
+                                callback,
+                                phase,
+                                RuntimeError(
+                                    "async callback reached the sync trigger from a running loop"
+                                ),
+                            )
+                        )
+                    else:
+                        results.append(None)
                     continue
                 except RuntimeError:
                     # No running loop — isolated thread, so asyncio.run() is safe.
@@ -360,7 +446,10 @@ def _trigger_callbacks_sync(
             )
             if raise_on_error:
                 raise
-            results.append(None)
+            if (phase, callback) in _fail_closed_callbacks:
+                results.append(_failure_result(callback, phase, e))
+            else:
+                results.append(None)
 
     return results
 
@@ -387,7 +476,10 @@ async def _trigger_callbacks(phase: PhaseType, *args, **kwargs) -> List[Any]:
                 f"Async callback {callback.__name__} failed in phase '{phase}': {e}\n"
                 f"{traceback.format_exc()}"
             )
-            results.append(None)
+            if (phase, callback) in _fail_closed_callbacks:
+                results.append(_failure_result(callback, phase, e))
+            else:
+                results.append(None)
 
     return results
 

--- a/code_puppy/pydantic_patches.py
+++ b/code_puppy/pydantic_patches.py
@@ -213,6 +213,36 @@ def _writeback_tool_args(call: Any, tool_args: dict, mode: str | None) -> None:
         pass  # never block tool execution on writeback failure
 
 
+#: Shown when a hook denies without a usable reason, or when producing its
+#: reason fails. A deny always renders as a deny — never as an allow.
+_GENERIC_BLOCK_REASON = "Tool execution blocked by hook"
+
+
+def _block_reason(callback_result: dict) -> str:
+    """Render a hook's deny reason, tolerating any value it supplied.
+
+    `error_message`/`reason` come from plugin code and are not guaranteed to be
+    strings. A non-string previously raised inside the caller's broad `except`,
+    which silently turned an explicit deny into an allow.
+
+    Total by construction: extraction is inside the guard too, because `.get`
+    and the truthiness of a plugin's own object can raise just as easily as
+    `__str__`, and none of that may escape into the caller.
+    """
+    try:
+        raw = (
+            callback_result.get("error_message") or callback_result.get("reason") or ""
+        )
+        if not isinstance(raw, str):
+            raw = str(raw)
+        marker = raw.find("[BLOCKED]")
+        if marker != -1:
+            return raw[marker:].strip() or _GENERIC_BLOCK_REASON
+        return raw.strip() or _GENERIC_BLOCK_REASON
+    except Exception:
+        return _GENERIC_BLOCK_REASON
+
+
 def patch_tool_call_callbacks() -> bool:
     """Patch pydantic-ai tool handling to support callbacks and Claude Code tool names.
 
@@ -342,48 +372,42 @@ def patch_tool_call_callbacks() -> bool:
             # --- pre_tool_call (with blocking support) ---
             # Block returns a string result so pydantic-ai sees a clean "BLOCKED: ..."
             # instead of crashing with UnexpectedModelBehavior.
+            # Dispatching is isolated, but the block decision below is NOT: an
+            # error while rendering a deny must not silently become an allow.
+            callback_results: list = []
             try:
                 from code_puppy import callbacks
-                from code_puppy.messaging import emit_warning
 
                 callback_results = await callbacks.on_pre_tool_call(
                     tool_name, tool_args
                 )
-
-                # Collect non-blocking hook context messages (e.g. PreToolUse
-                # stdout) so the model sees them — otherwise they're lost.
-                for callback_result in callback_results:
-                    if isinstance(callback_result, dict) and not callback_result.get(
-                        "blocked"
-                    ):
-                        ctx_msg = callback_result.get("context_message")
-                        if isinstance(ctx_msg, str) and ctx_msg.strip():
-                            hook_context_messages.append(ctx_msg.strip())
-
-                for callback_result in callback_results:
-                    if (
-                        callback_result
-                        and isinstance(callback_result, dict)
-                        and callback_result.get("blocked")
-                    ):
-                        raw_reason = (
-                            callback_result.get("error_message")
-                            or callback_result.get("reason")
-                            or ""
-                        )
-                        if "[BLOCKED]" in raw_reason:
-                            clean_reason = raw_reason[
-                                raw_reason.index("[BLOCKED]") :
-                            ].strip()
-                        else:
-                            clean_reason = (
-                                raw_reason.strip() or "Tool execution blocked by hook"
-                            )
-                        block_msg = f"🚫 Hook blocked this tool call: {clean_reason}"
-                        emit_warning(block_msg)
-                        return f"ERROR: {block_msg}\n\nThe hook policy prevented this tool from running. Please inform the user and do not retry this specific command."
             except Exception:
-                pass  # other errors don't block tool execution
+                pass  # import/dispatch failure leaves nothing to act on
+
+            # Collect non-blocking hook context messages (e.g. PreToolUse
+            # stdout) so the model sees them — otherwise they're lost.
+            for callback_result in callback_results:
+                if isinstance(callback_result, dict) and not callback_result.get(
+                    "blocked"
+                ):
+                    ctx_msg = callback_result.get("context_message")
+                    if isinstance(ctx_msg, str) and ctx_msg.strip():
+                        hook_context_messages.append(ctx_msg.strip())
+
+            for callback_result in callback_results:
+                if (
+                    callback_result
+                    and isinstance(callback_result, dict)
+                    and callback_result.get("blocked")
+                ):
+                    block_msg = f"🚫 Hook blocked this tool call: {_block_reason(callback_result)}"
+                    try:
+                        from code_puppy.messaging import emit_warning
+
+                        emit_warning(block_msg)
+                    except Exception:
+                        pass  # surfacing the warning is best-effort; the deny stands
+                    return f"ERROR: {block_msg}\n\nThe hook policy prevented this tool from running. Please inform the user and do not retry this specific command."
 
             # Write pre_tool_call mutations back to call.args so message
             # history sees them (execution itself reads validated.validated_args,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,6 +126,10 @@ def isolate_global_state_between_tests(tmp_path_factory):
     original_config_dir = cp_config.CONFIG_DIR
     original_history_file = cp_config.COMMAND_HISTORY_FILE
     original_callbacks = deepcopy(cp_callbacks._callbacks)
+    # The fail-closed policy set is keyed by (phase, callback) and lives
+    # beside the registry; restoring one without the other would hand the
+    # next test callbacks whose security policy silently went missing.
+    original_fail_closed = set(cp_callbacks._fail_closed_callbacks)
 
     # Create a completely separate temp directory for config isolation
     # (not using tmp_path which tests may use for their own purposes).
@@ -160,6 +164,8 @@ def isolate_global_state_between_tests(tmp_path_factory):
     cp_config.COMMAND_HISTORY_FILE = original_history_file
     cp_callbacks._callbacks.clear()
     cp_callbacks._callbacks.update(original_callbacks)
+    cp_callbacks._fail_closed_callbacks.clear()
+    cp_callbacks._fail_closed_callbacks.update(original_fail_closed)
     _ensure_builtin_plugin_callback_registrations()
 
     # Clear cache again after test.

--- a/tests/test_callbacks_fail_closed.py
+++ b/tests/test_callbacks_fail_closed.py
@@ -1,0 +1,250 @@
+"""A security callback that crashes must not read as approval.
+
+`_trigger_callbacks` isolates errors by reporting a crashed callback as `None`.
+The two phases carrying a `{"blocked": True}` protocol read `None` as "no
+objection" — `command_runner.py` says so in a comment: *"Callbacks can return
+None (allow) or a dict with blocked=True (reject)."*
+
+So a plugin that guards tool or shell execution is indistinguishable, on crash,
+from one that approved. `register_callback(..., fail_closed=True)` lets such a
+callback declare that its failure means deny.
+
+A second, independent path is covered here too: a plugin returning an explicit
+`{"blocked": True}` with a non-string reason used to raise inside the caller's
+broad `except Exception: pass`, and the tool ran anyway.
+"""
+
+import pytest
+
+from code_puppy import callbacks
+
+
+@pytest.fixture(autouse=True)
+def _isolate_blocking_phases():
+    for phase in callbacks.BLOCKING_PHASES:
+        callbacks.clear_callbacks(phase)
+    yield
+    for phase in callbacks.BLOCKING_PHASES:
+        callbacks.clear_callbacks(phase)
+
+
+def _boom(*_args, **_kwargs):
+    raise RuntimeError("detector exploded on /home/alice/secret-token-abc")
+
+
+async def _async_boom(*_args, **_kwargs):
+    raise RuntimeError("async detector exploded")
+
+
+class TestDefaultBehaviorUnchanged:
+    """Existing callbacks must keep the behavior they were written for."""
+
+    async def test_a_crashed_callback_still_reports_none_by_default(self):
+        callbacks.register_callback("pre_tool_call", _boom)
+
+        assert await callbacks.on_pre_tool_call("some_tool", {}) == [None]
+
+    def test_fail_closed_defaults_to_false(self):
+        callbacks.register_callback("pre_tool_call", _boom)
+
+        assert ("pre_tool_call", _boom) not in callbacks._fail_closed_callbacks
+
+
+class TestFailClosedBlocksOnCrash:
+    async def test_the_async_dispatcher_reports_a_block(self):
+        callbacks.register_callback("pre_tool_call", _async_boom, fail_closed=True)
+
+        results = await callbacks.on_pre_tool_call("dangerous_tool", {})
+
+        assert len(results) == 1
+        assert results[0]["blocked"] is True
+        assert "_async_boom" in results[0]["error_message"]
+        assert "RuntimeError" in results[0]["error_message"]
+
+    async def test_a_sync_callback_on_an_async_phase_reports_a_block(self):
+        callbacks.register_callback("run_shell_command", _boom, fail_closed=True)
+
+        results = await callbacks.on_run_shell_command(None, "rm -rf /", None, 60)
+
+        assert results[0]["blocked"] is True
+
+    def test_the_sync_dispatcher_reports_a_block(self):
+        callbacks.register_callback("run_shell_command", _boom, fail_closed=True)
+
+        results = callbacks._trigger_callbacks_sync("run_shell_command", None, "cmd")
+
+        assert results[0]["blocked"] is True
+
+    async def test_the_message_carries_the_marker_the_renderer_strips_to(self):
+        callbacks.register_callback("pre_tool_call", _boom, fail_closed=True)
+
+        results = await callbacks.on_pre_tool_call("t", {})
+
+        assert "[BLOCKED]" in results[0]["error_message"]
+
+    async def test_the_exception_text_is_not_shown_to_the_user_or_model(self):
+        callbacks.register_callback("pre_tool_call", _boom, fail_closed=True)
+
+        results = await callbacks.on_pre_tool_call("t", {})
+
+        rendered = results[0]["error_message"] + results[0]["reasoning"]
+        assert "secret-token-abc" not in rendered
+        assert "/home/alice" not in rendered
+
+    async def test_one_crashed_guard_does_not_suppress_the_others(self):
+        def observer(*_args, **_kwargs):
+            return {"context_message": "still ran"}
+
+        callbacks.register_callback("pre_tool_call", _boom, fail_closed=True)
+        callbacks.register_callback("pre_tool_call", observer)
+
+        results = await callbacks.on_pre_tool_call("t", {})
+
+        assert results[0]["blocked"] is True
+        assert results[1] == {"context_message": "still ran"}
+
+    async def test_a_healthy_fail_closed_callback_is_untouched(self):
+        def allows(*_args, **_kwargs):
+            return None
+
+        callbacks.register_callback("pre_tool_call", allows, fail_closed=True)
+
+        assert await callbacks.on_pre_tool_call("t", {}) == [None]
+
+    def test_raise_on_error_still_wins_in_the_sync_dispatcher(self):
+        callbacks.register_callback("run_shell_command", _boom, fail_closed=True)
+
+        with pytest.raises(RuntimeError):
+            callbacks._trigger_callbacks_sync(
+                "run_shell_command", None, "cmd", raise_on_error=True
+            )
+
+    async def test_an_unawaitable_async_callback_also_denies(self):
+        """The sync trigger cannot await from a running loop; that is undecided,
+        not unopposed."""
+        callbacks.register_callback("run_shell_command", _async_boom, fail_closed=True)
+
+        results = callbacks._trigger_callbacks_sync("run_shell_command", None, "cmd")
+
+        assert results[0]["blocked"] is True
+
+
+class TestPhaseRestriction:
+    def test_rejected_on_a_phase_that_cannot_act_on_a_block(self):
+        with pytest.raises(ValueError, match="only meaningful on phases"):
+            callbacks.register_callback("startup", _boom, fail_closed=True)
+
+    def test_the_rejected_registration_leaves_no_trace(self):
+        with pytest.raises(ValueError):
+            callbacks.register_callback("startup", _boom, fail_closed=True)
+
+        assert _boom not in callbacks.get_callbacks("startup")
+
+
+class TestPolicyIsPerPhaseNotPerCallable:
+    async def test_one_phase_opting_in_does_not_bind_another(self):
+        callbacks.register_callback("pre_tool_call", _boom, fail_closed=True)
+        callbacks.register_callback("run_shell_command", _boom)
+
+        blocking = await callbacks.on_pre_tool_call("t", {})
+        permissive = await callbacks.on_run_shell_command(None, "ls", None, 60)
+
+        assert blocking[0]["blocked"] is True
+        assert permissive == [None]
+
+    async def test_a_repeat_registration_can_tighten_the_policy(self):
+        callbacks.register_callback("pre_tool_call", _boom)
+        callbacks.register_callback("pre_tool_call", _boom, fail_closed=True)
+
+        results = await callbacks.on_pre_tool_call("t", {})
+
+        assert len(results) == 1, "the duplicate must not register twice"
+        assert results[0]["blocked"] is True
+
+
+class TestRegistryHousekeeping:
+    def test_unregister_drops_the_marking(self):
+        callbacks.register_callback("pre_tool_call", _boom, fail_closed=True)
+        callbacks.unregister_callback("pre_tool_call", _boom)
+
+        assert ("pre_tool_call", _boom) not in callbacks._fail_closed_callbacks
+
+    def test_unregister_leaves_another_phase_alone(self):
+        callbacks.register_callback("pre_tool_call", _boom, fail_closed=True)
+        callbacks.register_callback("run_shell_command", _boom, fail_closed=True)
+
+        callbacks.unregister_callback("pre_tool_call", _boom)
+
+        assert ("run_shell_command", _boom) in callbacks._fail_closed_callbacks
+
+    def test_clearing_one_phase_drops_only_its_markings(self):
+        callbacks.register_callback("pre_tool_call", _boom, fail_closed=True)
+        callbacks.register_callback("run_shell_command", _boom, fail_closed=True)
+
+        callbacks.clear_callbacks("pre_tool_call")
+
+        assert ("pre_tool_call", _boom) not in callbacks._fail_closed_callbacks
+        assert ("run_shell_command", _boom) in callbacks._fail_closed_callbacks
+
+    def test_unregistering_an_unknown_callback_is_false(self):
+        assert callbacks.unregister_callback("pre_tool_call", _boom) is False
+
+
+class TestBlockReasonRendering:
+    """An explicit deny must render as a deny whatever the plugin supplied."""
+
+    def test_a_non_string_reason_still_renders_a_deny(self):
+        from code_puppy.pydantic_patches import _block_reason
+
+        assert _block_reason({"blocked": True, "reason": 123}) == "123"
+
+    def test_a_reason_whose_str_raises_falls_back_to_generic_text(self):
+        from code_puppy.pydantic_patches import _GENERIC_BLOCK_REASON, _block_reason
+
+        class Hostile:
+            def __str__(self):
+                raise RuntimeError("nope")
+
+            def __bool__(self):
+                return True
+
+        assert (
+            _block_reason({"blocked": True, "reason": Hostile()})
+            == _GENERIC_BLOCK_REASON
+        )
+
+    def test_a_reason_whose_truthiness_raises_still_renders_a_deny(self):
+        from code_puppy.pydantic_patches import _GENERIC_BLOCK_REASON, _block_reason
+
+        class Unbooleanable:
+            def __bool__(self):
+                raise RuntimeError("nope")
+
+        assert (
+            _block_reason({"blocked": True, "error_message": Unbooleanable()})
+            == _GENERIC_BLOCK_REASON
+        )
+
+    def test_the_marker_still_trims_the_prefix(self):
+        from code_puppy.pydantic_patches import _block_reason
+
+        assert (
+            _block_reason({"blocked": True, "reason": "noise [BLOCKED] the real one"})
+            == "[BLOCKED] the real one"
+        )
+
+    def test_error_message_wins_over_reason(self):
+        from code_puppy.pydantic_patches import _block_reason
+
+        assert (
+            _block_reason(
+                {"blocked": True, "error_message": "from error_message", "reason": "x"}
+            )
+            == "from error_message"
+        )
+
+    def test_an_absent_or_blank_reason_gets_the_generic_text(self):
+        from code_puppy.pydantic_patches import _GENERIC_BLOCK_REASON, _block_reason
+
+        assert _block_reason({"blocked": True}) == _GENERIC_BLOCK_REASON
+        assert _block_reason({"blocked": True, "reason": " "}) == _GENERIC_BLOCK_REASON


### PR DESCRIPTION
Moved here from the Walmart-internal fork at the maintainers' request — the defect is entirely in open-source code.

## Problem

`_trigger_callbacks` isolates callback errors: it logs the exception and appends `None` to the results. The two phases that carry a `{"blocked": True}` protocol read `None` as approval. `code_puppy/tools/command_runner.py` states it outright:

```python
# Callbacks can return None (allow) or a dict with blocked=True (reject)
```

A security callback that fails to complete is therefore indistinguishable from one that approved.

Today the outcome depends only on whether each plugin remembered to wrap itself, and the three guards in `code_puppy_core_plugins` disagree:

| Guard | Handles its own exceptions | On crash |
|---|---|---|
| `shell_safety` | yes — returns `{"blocked": True}` | **deny** |
| `force_push_guard` | only `AttributeError`/`OSError` | **allow** |
| `destructive_command_guard` | no | **allow** |

Two of those are deliberate. `shell_safety` chose deny in code. `destructive_command_guard/AGENTS.md` chose allow in writing — *"fail closed on ambiguity, fail open on our own errors."* `force_push_guard` states nothing. The framework gives no way to express the choice.

It is reachable, not theoretical. `shell_safety_callback` reads three config values before its own `try`. `ConfigParser` interpolates lazily, so a value like `yolo_mode=%` parses cleanly — the corruption quarantine never sees it — and raises only when the option is read. I verified each of these raises rather than returning a default:

```
yolo_mode=%                      -> get_yolo_mode()               InterpolationSyntaxError
model=%(missing)s                -> get_global_model_name()       InterpolationMissingOptionError
safety_permission_level=%(nope)s -> get_safety_permission_level()  InterpolationMissingOptionError
```

The guard raises, the dispatcher returns `None`, and the command runs with no safety assessment.

## Change

`register_callback(phase, func, fail_closed=True)` lets a callback declare that its failure means deny. The default is unchanged, so every existing registration behaves exactly as before.

- **Reported as a result, not by re-raising.** The existing `raise_on_error` cannot serve this: `pydantic_patches` wrapped the pre_tool_call block in `except Exception: pass`, so a raised deny was swallowed and the tool ran anyway.
- **Keyed by `(phase, callback)`**, so one callable registered on several phases can hold a different policy on each.
- **Rejected on phases whose consumers do not act on a block result**, rather than injecting a dict that `load_prompt` or `git_branch_provider` would misread.
- **The synthesized message omits the exception text**, which reaches the user and the model and may carry paths, command lines, or tokens. Callback name and exception type are included; the full traceback stays in the log.
- The sync trigger's *"async callback reached from a running loop"* branch is covered too — undecided is not unopposed.

## Second, independent fail-open

A hook could already return an explicit `{"blocked": True}` and still have the tool run, with no crash involved: a non-string `reason` made `"[BLOCKED]" in raw_reason` raise inside the same broad `except`. Reproduced against the pre-change logic:

```
{"blocked": True, "reason": 123}   -> TOOL ACTUALLY RAN
{"blocked": True, "reason": "..."} -> ERROR: blocked: ...
```

`_block_reason` is now total. Extraction, coercion and rendering are all inside the guard, because `.get` and a plugin object's truthiness can raise as easily as `__str__`. The block decision moved out of the broad `except`, so a failure while emitting the warning no longer turns a deny into an allow.

## Scope

No plugin in this repository opts in — the guards live in `code_puppy_core_plugins`, so wiring `shell_safety` is a separate change I'm happy to open next.

`destructive_command_guard` should stay as it is regardless: its fail-open is a documented product decision for its owners, not something to change from an infrastructure PR.

## Testing

- `tests/test_callbacks_fail_closed.py` — 25 cases: default behavior unchanged, both dispatchers plus the unawaitable-async branch, phase restriction, per-phase policy isolation, repeat-registration tightening, `raise_on_error` precedence, no exception text in user-facing output, registry housekeeping, and `_block_reason` against non-string reasons, a hostile `__str__`, and a hostile `__bool__`.
- `tests/conftest.py` now snapshots and restores `_fail_closed_callbacks` beside `_callbacks`; restoring one without the other would hand the next test callbacks whose policy had quietly gone missing.
- Full suite: **7335 passed, 28 skipped**. One failure, `tests/plugins/test_aws_bedrock.py::TestSupportsAdaptiveThinking::test_supports_adaptive_thinking[opus_4_5_minor_version_not_adaptive]`, is pre-existing and order-dependent: a clean `main` full run reproduces it (7310 passed, same 1 failure), while running that file alone passes on both.
- `ruff check` and `ruff format` clean on the changed files.