### PR TITLE
Fix UTF-16 AGENTS.md crash on Windows

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -58,6 +58,48 @@ def _friendly_path(candidate: Path) -> str:
         return str(candidate)
 
 
+# BOM signatures mapped to their codecs. Check UTF-32 before UTF-16:
+# the UTF-32 LE BOM starts with the UTF-16 LE BOM bytes.
+_BOM_CODECS = (
+    (b"\xef\xbb\xbf", "utf-8-sig"),
+    (b"\xff\xfe\x00\x00", "utf-32-le"),
+    (b"\x00\x00\xfe\xff", "utf-32-be"),
+    (b"\xff\xfe", "utf-16-le"),
+    (b"\xfe\xff", "utf-16-be"),
+)
+
+
+def _read_rules_text(candidate: Path) -> Optional[str]:
+    """Read a rules file and detect its encoding from the BOM.
+
+    PowerShell redirection (``echo hi > AGENTS.md``) writes UTF-16 LE
+    with a BOM. A plain UTF-8 read crashes on it. This helper sniffs
+    the BOM, decodes with the correct codec, and never raises. It
+    returns ``None`` when the file is not readable.
+    """
+    try:
+        raw = candidate.read_bytes()
+    except OSError as exc:
+        emit_warning(f"Could not read {candidate}: {exc}")
+        return None
+    for bom, codec in _BOM_CODECS:
+        if raw.startswith(bom):
+            try:
+                text = raw.decode(codec)
+            except UnicodeDecodeError:
+                break
+            # Drop the BOM character that non-sig codecs keep.
+            return text.lstrip("\ufeff")
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        emit_warning(
+            f"{candidate} is not valid UTF-8; bad bytes were replaced. "
+            f"Save the file as UTF-8 to fix this."
+        )
+        return raw.decode("utf-8", errors="replace")
+
+
 def _truncate_agents_md(content: str, source: str, max_chars: int) -> str:
     """Cap one AGENTS.md file at ``max_chars`` with a labelled notice.
 
@@ -110,8 +152,11 @@ def load_puppy_rules() -> Optional[str]:
     for name in _AGENT_RULE_FILES:
         candidate = Path(CONFIG_DIR) / name
         if candidate.exists():
+            text = _read_rules_text(candidate)
+            if text is None:
+                continue
             global_rules = _truncate_agents_md(
-                candidate.read_text(encoding="utf-8-sig"),
+                text,
                 source=f"global {_friendly_path(candidate)}",
                 max_chars=max_chars,
             )
@@ -125,8 +170,11 @@ def load_puppy_rules() -> Optional[str]:
         for name in _AGENT_RULE_FILES:
             candidate = code_puppy_dir / name
             if candidate.exists():
+                text = _read_rules_text(candidate)
+                if text is None:
+                    continue
                 project_rules = _truncate_agents_md(
-                    candidate.read_text(encoding="utf-8-sig"),
+                    text,
                     source=f"project {candidate}",
                     max_chars=max_chars,
                 )
@@ -137,8 +185,11 @@ def load_puppy_rules() -> Optional[str]:
         for name in _AGENT_RULE_FILES:
             candidate = Path(name)
             if candidate.exists():
+                text = _read_rules_text(candidate)
+                if text is None:
+                    continue
                 project_rules = _truncate_agents_md(
-                    candidate.read_text(encoding="utf-8-sig"),
+                    text,
                     source=f"project {candidate}",
                     max_chars=max_chars,
                 )

--- a/tests/test_agents_md_encoding.py
+++ b/tests/test_agents_md_encoding.py
@@ -1,0 +1,71 @@
+"""Tests for AGENTS.md encoding detection in ``_builder``.
+
+Regression for the Windows crash: ``echo hi > AGENTS.md`` in PowerShell
+writes UTF-16 LE with a BOM. A plain ``utf-8-sig`` read raised
+``UnicodeDecodeError`` and killed the agent run.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from code_puppy.agents import _builder
+from code_puppy.agents._builder import _read_rules_text, load_puppy_rules
+
+
+@pytest.mark.parametrize(
+    "encoding",
+    ["utf-16-le", "utf-16-be", "utf-32-le", "utf-32-be"],
+)
+def test_read_rules_text_decodes_bom_encodings(tmp_path, encoding):
+    """Decode BOM-prefixed UTF-16/UTF-32 files without a crash."""
+    path = tmp_path / "AGENTS.md"
+    path.write_bytes("\ufeffhello rules".encode(encoding))
+    assert _read_rules_text(path) == "hello rules"
+
+
+def test_read_rules_text_decodes_powershell_redirect(tmp_path):
+    """Reproduce the exact PowerShell ``echo test > AGENTS.md`` bytes."""
+    path = tmp_path / "AGENTS.md"
+    path.write_bytes(b"\xff\xfe" + "test\r\n".encode("utf-16-le"))
+    assert _read_rules_text(path) == "test\r\n"
+
+
+def test_read_rules_text_decodes_utf8_with_bom(tmp_path):
+    path = tmp_path / "AGENTS.md"
+    path.write_bytes(b"\xef\xbb\xbfplain utf8 sig")
+    assert _read_rules_text(path) == "plain utf8 sig"
+
+
+def test_read_rules_text_decodes_plain_utf8(tmp_path):
+    path = tmp_path / "AGENTS.md"
+    path.write_text("no bom here", encoding="utf-8")
+    assert _read_rules_text(path) == "no bom here"
+
+
+def test_read_rules_text_replaces_invalid_bytes(tmp_path):
+    """Garbage bytes must not raise. Bad bytes become U+FFFD."""
+    path = tmp_path / "AGENTS.md"
+    path.write_bytes(b"ok \x80\x81 bad")
+    result = _read_rules_text(path)
+    assert result is not None
+    assert result.startswith("ok ")
+    assert "\ufffd" in result
+
+
+def test_read_rules_text_returns_none_for_missing_file(tmp_path):
+    assert _read_rules_text(tmp_path / "nope.md") is None
+
+
+def test_load_puppy_rules_survives_utf16_agents_md(tmp_path, monkeypatch):
+    """End-to-end: a UTF-16 project AGENTS.md must load, not crash."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "AGENTS.md").write_bytes(
+        b"\xff\xfe" + "utf16 project rules".encode("utf-16-le")
+    )
+    empty_config = tmp_path / "empty_config"
+    empty_config.mkdir()
+    with patch.object(_builder, "CONFIG_DIR", str(empty_config)):
+        rules = load_puppy_rules()
+    assert rules is not None
+    assert "utf16 project rules" in rules


### PR DESCRIPTION
PowerShell redirection (echo hi > AGENTS.md) writes UTF-16 LE with a BOM. The old utf-8-sig read raised UnicodeDecodeError and killed every agent run.

Add _read_rules_text, a BOM-sniffing reader that never raises. It detects UTF-8, UTF-16, and UTF-32 BOMs. Files with invalid bytes decode with replacement characters and emit a warning. Unreadable files are skipped. All three load_puppy_rules call sites now use the helper.