### PR TITLE
Fix summarization-compaction reliability + assorted robustness fixes

### DIFF
--- a/code_puppy/agents/_compaction.py
+++ b/code_puppy/agents/_compaction.py
@@ -20,6 +20,7 @@ from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
     ModelResponse,
+    TextPart,
     ThinkingPart,
     UserPromptPart,
 )
@@ -178,6 +179,68 @@ def truncate(
     return prune_interrupted_tool_calls(result)
 
 
+def _framing_request() -> ModelRequest:
+    """A short neutral user-role message used to repair request boundaries."""
+    return ModelRequest(
+        parts=[UserPromptPart(content="Conversation history to summarize:")]
+    )
+
+
+def _framing_response() -> ModelResponse:
+    """A short neutral assistant-role message used to repair request boundaries."""
+    return ModelResponse(parts=[TextPart(content="Acknowledged; continuing.")])
+
+
+def _same_role(left: ModelMessage, right: ModelMessage) -> bool:
+    """True iff both messages are assistant turns or both are user turns."""
+    return isinstance(left, ModelResponse) == isinstance(right, ModelResponse)
+
+
+def _normalize_for_summarization(
+    messages: List[ModelMessage],
+) -> List[ModelMessage]:
+    """Shape a summarization slice into a provider-valid request body.
+
+    Providers such as Anthropic require a request to open on a user-role
+    message and never place two same-role messages adjacently. A slice taken
+    from the middle of a conversation — then trimmed by orphan-pruning — can
+    open on an assistant turn, carry an internal same-role adjacency, or end on
+    a user turn. The trailing case matters because ``run_summarization_sync``
+    appends the summarization instruction as a trailing user-role message; a
+    slice that already ends on a user turn would collide with it, producing a
+    user→user adjacency the provider rejects. Any such rejection makes the
+    summarization request fail and compaction silently fall back to truncation.
+
+    Each boundary is repaired by inserting a short neutral framing message
+    rather than dropping real content, so the summary still sees every step.
+    Returns the slice unchanged when it is empty.
+    """
+    if not messages:
+        return messages
+
+    normalized: List[ModelMessage] = []
+    if isinstance(messages[0], ModelResponse):
+        normalized.append(_framing_request())
+
+    for msg in messages:
+        if normalized and _same_role(normalized[-1], msg):
+            filler = (
+                _framing_request()
+                if isinstance(msg, ModelResponse)
+                else _framing_response()
+            )
+            normalized.append(filler)
+        normalized.append(msg)
+
+    # run_summarization_sync appends the instruction as a trailing user-role
+    # message; cap a user-ending slice with an assistant turn so that append
+    # continues the alternation instead of colliding.
+    if isinstance(normalized[-1], ModelRequest):
+        normalized.append(_framing_response())
+
+    return normalized
+
+
 def _run_summarization_core(
     messages: List[ModelMessage],
     protected_tokens: int,
@@ -210,6 +273,8 @@ def _run_summarization_core(
     pruned = prune_interrupted_tool_calls(messages_to_summarize)
     if not pruned:
         return prune_interrupted_tool_calls(messages), []
+
+    pruned = _normalize_for_summarization(pruned)
 
     summary_text = run_summarization_sync(
         _SUMMARIZATION_INSTRUCTIONS, message_history=pruned

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -2886,17 +2886,22 @@ def load_api_keys_to_environment():
         pass
 
     # Step 1: Load from .env file if it exists (highest priority)
-    # Look for .env in current working directory
+    # Only the known API-key names are imported from a project-local .env;
+    # unrelated names (base URLs, proxies, CODE_PUPPY_* toggles) are ignored so
+    # a project's .env cannot redirect requests or change runtime settings.
     env_file = Path.cwd() / ".env"
     if env_file.exists():
         try:
-            from dotenv import load_dotenv
-
-            # override=True means .env values take precedence over existing env vars
-            load_dotenv(env_file, override=True)
+            from dotenv import dotenv_values
         except ImportError:
             # python-dotenv not installed, skip .env loading
-            pass
+            dotenv_values = None
+        if dotenv_values is not None:
+            env_values = dotenv_values(env_file)
+            for key_name in api_key_names:
+                value = env_values.get(key_name)
+                if value:
+                    os.environ[key_name] = value
 
     # Step 2: Load from puppy.cfg, but only if not already set
     # This ensures .env has priority over puppy.cfg

--- a/code_puppy/hook_engine/executor.py
+++ b/code_puppy/hook_engine/executor.py
@@ -24,6 +24,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -259,8 +260,12 @@ def _substitute_variables(
 
     result = command
     for var, value in substitutions.items():
-        result = result.replace(f"${{{var}}}", str(value))
-        result = re.sub(rf"\${re.escape(var)}(?=\W|$)", lambda m: str(value), result)
+        # Quote each interpolated value so a normal path/value is spliced in
+        # unchanged while shell metacharacters in the value are treated as
+        # literal text by the shell rather than as syntax.
+        quoted = shlex.quote(str(value))
+        result = result.replace(f"${{{var}}}", quoted)
+        result = re.sub(rf"\${re.escape(var)}(?=\W|$)", lambda m: quoted, result)
     return result
 
 

--- a/code_puppy/plugins/__init__.py
+++ b/code_puppy/plugins/__init__.py
@@ -14,6 +14,12 @@ logger = logging.getLogger(__name__)
 # User plugins directory
 USER_PLUGINS_DIR = Path.home() / ".code_puppy" / "plugins"
 
+# Out-of-repo location for compiled bytecode of project plugins. Redirecting the
+# cache here keeps the import machinery from consulting or writing a __pycache__
+# entry inside the project tree, so a project plugin always runs from the source
+# that was reviewed and trusted.
+_PROJECT_PLUGIN_PYCACHE = str(Path.home() / ".code_puppy" / "plugin_bytecode_cache")
+
 PLUGIN_ENTRY_POINT_GROUP = "code_puppy.plugins"
 
 # Track if plugins have already been loaded to prevent duplicate registration
@@ -339,6 +345,12 @@ def _load_one_project_plugin(plugin_dir: Path, plugin_name: str) -> bool:
     if parent_str not in sys.path:
         sys.path.insert(0, parent_str)
 
+    # Compile from the reviewed source: redirect the bytecode cache out of the
+    # project tree so any in-repo __pycache__ entry is never consulted or
+    # written back. Restored in ``finally`` so unrelated imports are unaffected.
+    previous_pycache_prefix = sys.pycache_prefix
+    sys.pycache_prefix = _PROJECT_PLUGIN_PYCACHE
+
     try:
         if callbacks_file.exists():
             # Register parent package so relative imports resolve
@@ -384,6 +396,8 @@ def _load_one_project_plugin(plugin_dir: Path, plugin_name: str) -> bool:
             exc_info=True,
         )
         return False
+    finally:
+        sys.pycache_prefix = previous_pycache_prefix
 
 
 def _load_project_plugins(

--- a/code_puppy/session_surrogate_unpickler.py
+++ b/code_puppy/session_surrogate_unpickler.py
@@ -139,6 +139,11 @@ class SurrogateUnpickler(pickle.Unpickler):
         self.created_surrogates = False
 
     def find_class(self, module: str, name: str) -> Any:  # noqa: D102
+        # A dotted ``name`` makes the base unpickler (protocol 4+ STACK_GLOBAL)
+        # walk attributes from the module, which can reach objects the module
+        # allowlist was never meant to expose. Route these to a surrogate.
+        if "." in name:
+            return self._surrogate_for(module, name)
         root = module.split(".", 1)[0]
         if root in _ALLOWED_MODULES and not (
             module == "builtins" and name in _BLOCKED_BUILTINS

--- a/code_puppy/tools/command_runner.py
+++ b/code_puppy/tools/command_runner.py
@@ -1067,6 +1067,22 @@ def _normalize_cwd(cwd: str | None) -> str | None:
     return stripped
 
 
+_SECRET_ENV_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET")
+
+
+def _child_process_env() -> dict[str, str]:
+    """Environment for spawned shell commands.
+
+    Copies the current environment but drops the agent's own provider
+    credentials so a child command does not inherit them.
+    """
+    env = dict(os.environ)
+    for name in list(env):
+        if name.upper().endswith(_SECRET_ENV_SUFFIXES):
+            del env[name]
+    return env
+
+
 async def run_shell_command(
     context: RunContext,
     command: str,
@@ -1139,6 +1155,7 @@ async def run_shell_command(
                     stderr=subprocess.STDOUT,
                     stdin=subprocess.DEVNULL,
                     cwd=cwd,
+                    env=_child_process_env(),
                     creationflags=creationflags,
                 )
             else:
@@ -1149,6 +1166,7 @@ async def run_shell_command(
                     stderr=subprocess.STDOUT,
                     stdin=subprocess.DEVNULL,
                     cwd=cwd,
+                    env=_child_process_env(),
                     start_new_session=True,  # Fully detach on POSIX
                 )
 
@@ -1440,6 +1458,7 @@ def _run_command_sync(
         stderr=subprocess.PIPE,
         stdin=subprocess.DEVNULL,
         cwd=cwd,
+        env=_child_process_env(),
         bufsize=0,  # Unbuffered for real-time output
         preexec_fn=preexec_fn,
         creationflags=creationflags,

--- a/code_puppy/tools/file_operations.py
+++ b/code_puppy/tools/file_operations.py
@@ -708,6 +708,58 @@ def _tokenize_flag_string(search_string: str) -> list[str] | None:
         return None
 
 
+# Flags the local ripgrep path forwards. Only content/context flags the tool
+# understands are allowed through; anything else -- including flags that run a
+# command per file (``--pre``) or read patterns from a file (``-f``) -- is
+# rejected so an unexpected flag can't reshape the ripgrep invocation.
+_SUPPORTED_RG_FLAGS = frozenset(
+    {
+        "-i",
+        "--ignore-case",
+        "-s",
+        "--case-sensitive",
+        "-w",
+        "--word-regexp",
+        "-F",
+        "--fixed-strings",
+        "-e",
+        "--regexp",
+        "-t",
+        "--type",
+        "-A",
+        "--after-context",
+        "-B",
+        "--before-context",
+        "-C",
+        "--context",
+        "-g",
+        "--glob",
+    }
+)
+
+# Supported flags whose following token is their value. That value is forwarded
+# verbatim and never checked against the flag allowlist, so patterns and globs
+# may themselves begin with ``-`` (e.g. ``-e '->foo'``).
+_RG_FLAGS_WITH_VALUE = frozenset(
+    {
+        "-e",
+        "--regexp",
+        "-t",
+        "--type",
+        "-A",
+        "--after-context",
+        "-B",
+        "--before-context",
+        "-C",
+        "--context",
+        "-g",
+        "--glob",
+    }
+)
+
+_SUPPORTED_RG_FLAGS_HINT = "-i, -s, -w, -F, -e, -t/--type, -A, -B, -C, -g"
+
+
 def _build_grep_args(search_string: str) -> tuple[list[str], str | None]:
     """Convert ``search_string`` into ripgrep arguments, identically on all OSes.
 
@@ -723,8 +775,11 @@ def _build_grep_args(search_string: str) -> tuple[list[str], str | None]:
       Windows paths (``\\b``, ``C:\\Users``) are never mangled; quotes
       group words and one surrounding pair is stripped per token.
 
-    Returns ``(args, error)``. ``error`` is set when an unsupported
-    output-format flag is requested.
+    In flag mode only the flags in :data:`_SUPPORTED_RG_FLAGS` are forwarded;
+    any other flag is rejected with an ``error`` string.
+
+    Returns ``(args, error)``. ``error`` is set when an unsupported flag is
+    requested.
     """
     if not search_string.startswith("-"):
         return ["-e", search_string], None
@@ -735,15 +790,22 @@ def _build_grep_args(search_string: str) -> tuple[list[str], str | None]:
         # treat the whole string as a literal pattern.
         return ["-e", search_string], None
 
-    for token in tokens:
-        flag = token.split("=", 1)[0]
-        if flag in _INCOMPATIBLE_RG_FLAGS:
-            return [], (
-                f"ripgrep flag '{flag}' is not supported: this tool parses "
-                "per-match JSON output, and that flag changes the output "
-                "format (it would silently return zero matches). Use a plain "
-                "pattern, or content flags like -i, -w, -F, --type instead."
-            )
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token.startswith("-"):
+            flag = token.split("=", 1)[0]
+            if flag not in _SUPPORTED_RG_FLAGS:
+                return [], (
+                    f"grep flag '{flag}' is not supported. Supported flags: "
+                    f"{_SUPPORTED_RG_FLAGS_HINT}. Use a plain pattern for "
+                    "anything else."
+                )
+            if flag in _RG_FLAGS_WITH_VALUE and "=" not in token:
+                # Skip the value token so a pattern/glob beginning with ``-``
+                # is not mistaken for an unsupported flag.
+                index += 1
+        index += 1
     return tokens, None
 
 

--- a/tests/agents/test_compaction_summarization_ordering.py
+++ b/tests/agents/test_compaction_summarization_ordering.py
@@ -1,0 +1,300 @@
+"""Ordering guarantees for the summarization compaction path.
+
+Some providers (Anthropic among them) require the message list of a request to
+open with a user-role message and to alternate roles thereafter. A summarization
+slice taken from the middle of a conversation naturally begins on an assistant
+turn, and orphan-pruning can further leave it ending on a user turn or carrying
+an internal same-role adjacency. On top of that, ``run_summarization_sync``
+appends the summarization instruction as a trailing user-role message. The full
+request the summarization model receives must therefore still open on a user
+turn and alternate roles end to end — otherwise the provider rejects it and
+compaction silently falls back to hard truncation instead of producing a real
+summary.
+
+These tests drive the real ``compact`` -> ``summarize`` ->
+``run_summarization_sync`` path with a ``FunctionModel`` standing in for the
+summarization model. The stand-in mirrors the provider contract: it inspects the
+full incoming request and refuses one whose first message is an assistant turn
+or that places two same-role messages next to each other, exactly as the
+provider would.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from unittest.mock import patch
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    SystemPromptPart,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+
+import code_puppy.summarization_agent as summarization_agent
+from code_puppy.agents import _compaction
+
+_SUMMARY_MARKER = "COMPACTED_SUMMARY_APPLIED"
+
+
+def _roles(messages: List[ModelMessage]) -> List[str]:
+    return ["assistant" if isinstance(m, ModelResponse) else "user" for m in messages]
+
+
+def _realistic_history(
+    n_turns: int = 20, payload_chars: int = 400
+) -> List[ModelMessage]:
+    """Build a history shaped like a live pydantic-ai run.
+
+    The first message is a single ``ModelRequest`` carrying both the system
+    prompt and the opening user prompt (how pydantic-ai composes the first
+    request). Every following turn is an assistant ``ModelResponse`` paired with
+    a user ``ModelRequest``, so the slice that gets summarized begins on an
+    assistant turn.
+    """
+    payload = "x" * payload_chars
+    history: List[ModelMessage] = [
+        ModelRequest(
+            parts=[
+                SystemPromptPart(content="You are a helpful test agent."),
+                UserPromptPart(content=f"opening question: {payload}"),
+            ]
+        )
+    ]
+    for i in range(n_turns):
+        call_id = f"call_{i}"
+        history.append(
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="read_file",
+                        args={"path": f"/tmp/file_{i}.txt"},
+                        tool_call_id=call_id,
+                    )
+                ]
+            )
+        )
+        history.append(
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name="read_file",
+                        content=f"contents {i}: {payload}",
+                        tool_call_id=call_id,
+                    )
+                ]
+            )
+        )
+        history.append(ModelResponse(parts=[TextPart(content=f"answer {i}")]))
+        history.append(
+            ModelRequest(parts=[UserPromptPart(content=f"question {i}: {payload}")])
+        )
+    return history
+
+
+def _user_ending_history(payload_chars: int = 400) -> List[ModelMessage]:
+    """A tool-free history whose summarizable slice ends on a user turn.
+
+    With the protected budget squeezed to a single token (see
+    ``_run_compaction``), only the system message stays protected and the whole
+    remainder becomes summarization fodder. That remainder both opens on an
+    assistant turn and ends on a user turn, so it exercises the leading-role and
+    trailing-adjacency repairs at once. No tool calls appear, so nothing is
+    pruned and compaction is never deferred for a pending call.
+    """
+    payload = "x" * payload_chars
+    return [
+        ModelRequest(
+            parts=[
+                SystemPromptPart(content="You are a helpful test agent."),
+                UserPromptPart(content=f"opening question: {payload}"),
+            ]
+        ),
+        ModelResponse(parts=[TextPart(content=f"answer a: {payload}")]),
+        ModelRequest(parts=[UserPromptPart(content=f"question b: {payload}")]),
+        ModelResponse(parts=[TextPart(content=f"answer b: {payload}")]),
+        ModelRequest(parts=[UserPromptPart(content=f"question c: {payload}")]),
+    ]
+
+
+def _make_capturing_summarization_agent(
+    capture: Dict[str, List[ModelMessage]],
+) -> Agent:
+    """A summarization agent whose model records the request and enforces the
+    provider's ordering contract.
+
+    The model captures the exact message list it is handed, then refuses (the
+    way the provider would) any request whose first message is an assistant turn
+    or that places two same-role messages adjacently. A well-formed request
+    returns a recognizable summary string.
+    """
+
+    def _model_fn(messages: List[ModelMessage], info: AgentInfo) -> ModelResponse:
+        capture["messages"] = list(messages)
+        roles = _roles(messages)
+        if roles and roles[0] != "user":
+            raise RuntimeError("messages: first message must use the 'user' role")
+        if any(roles[i] == roles[i + 1] for i in range(len(roles) - 1)):
+            raise RuntimeError(
+                "messages: roles must alternate; two same-role messages were adjacent"
+            )
+        return ModelResponse(parts=[TextPart(content=_SUMMARY_MARKER)])
+
+    return Agent(model=FunctionModel(_model_fn), output_type=str)
+
+
+def _run_compaction(
+    capture: Dict[str, List[ModelMessage]],
+    history: List[ModelMessage] | None = None,
+    protected_tokens: int = 500,
+):
+    if history is None:
+        history = _realistic_history()
+    with (
+        patch.object(
+            summarization_agent,
+            "get_summarization_agent",
+            lambda *a, **kw: _make_capturing_summarization_agent(capture),
+        ),
+        patch.object(
+            summarization_agent,
+            "get_summarization_model_name",
+            lambda: "function-model",
+        ),
+        patch.multiple(
+            _compaction,
+            get_compaction_threshold=lambda: 0.01,
+            get_compaction_strategy=lambda: "summarization",
+            get_protected_token_count=lambda: protected_tokens,
+        ),
+    ):
+        new_messages, dropped = _compaction.compact(
+            agent=None, messages=history, model_max=10_000, context_overhead=0
+        )
+    return history, new_messages, dropped
+
+
+@pytest.fixture
+def capture() -> Dict[str, List[ModelMessage]]:
+    return {}
+
+
+def _assert_valid_provider_ordering(messages: List[ModelMessage]) -> None:
+    """The full request must open on a user turn and never repeat a role."""
+    assert messages, "summarization model was never invoked"
+
+    first = messages[0]
+    assert isinstance(first, ModelRequest) and not isinstance(first, ModelResponse), (
+        "summarization request must begin with a user-role message, not an "
+        f"assistant turn (got {type(first).__name__})"
+    )
+
+    roles = _roles(messages)
+    assert roles[0] == "user"
+    adjacent_same = [i for i in range(len(roles) - 1) if roles[i] == roles[i + 1]]
+    assert not adjacent_same, (
+        f"summarization request placed same-role messages adjacently at {adjacent_same}"
+    )
+
+
+def test_summarization_request_starts_with_user_message(capture):
+    """The full request the summarization model receives — including the
+    instruction ``run_summarization_sync`` appends — must open on a user-role
+    message and never place two same-role messages next to each other,
+    regardless of where the slice boundary lands."""
+    _run_compaction(capture)
+    _assert_valid_provider_ordering(capture.get("messages"))
+
+
+def test_summarization_request_valid_for_user_ending_slice(capture):
+    """End-to-end guard for a slice that both opens on an assistant turn and
+    ends on a user turn. The full request handed to the model must still be well
+    ordered, and the summary must be applied rather than dropped to a truncation
+    fallback, regardless of where the boundary lands."""
+    history, new_messages, dropped = _run_compaction(
+        capture, history=_user_ending_history(), protected_tokens=1
+    )
+
+    _assert_valid_provider_ordering(capture.get("messages"))
+    # Confirm the appended instruction actually rode along on this request.
+    assert _roles(capture["messages"])[-1] == "user", "trailing instruction missing"
+    assert any(
+        getattr(part, "content", None) == _SUMMARY_MARKER
+        for message in new_messages
+        for part in message.parts
+    ), "summary was not applied — compaction fell back to truncation"
+    assert dropped, "no messages recorded as dropped"
+
+
+def test_compaction_applies_summary_not_truncation(capture):
+    """A well-formed summarization request must actually shrink history via the
+    produced summary rather than silently falling back to truncation."""
+    history, new_messages, dropped = _run_compaction(capture)
+
+    assert len(new_messages) < len(history), "history was not compacted"
+    assert dropped, "no messages recorded as dropped"
+    assert new_messages[0] is history[0], "system message must be preserved"
+    assert any(
+        getattr(part, "content", None) == _SUMMARY_MARKER
+        for message in new_messages
+        for part in message.parts
+    ), "summary was not applied — compaction fell back to truncation"
+
+
+def _assistant(text: str) -> ModelResponse:
+    return ModelResponse(parts=[TextPart(content=text)])
+
+
+def _user(text: str) -> ModelRequest:
+    return ModelRequest(parts=[UserPromptPart(content=text)])
+
+
+# Adversarial slices covering every boundary the normalizer must repair. Each
+# starts and/or ends and/or bends in a way a raw provider request would reject.
+# Two adjacent assistant turns are the case pydantic-ai's own consecutive-message
+# merge leaves alone for real (API-sourced) responses, so it must be repaired
+# here rather than relied upon downstream.
+_ADVERSARIAL_SLICES = {
+    "leading_assistant": [_assistant("a0"), _user("u0")],
+    "trailing_user": [_user("u0"), _assistant("a0"), _user("u1")],
+    "adjacent_assistants": [_user("u0"), _assistant("a0"), _assistant("a1")],
+    "adjacent_users": [_assistant("a0"), _user("u0"), _user("u1")],
+    "already_valid": [_user("u0"), _assistant("a0")],
+    "single_assistant": [_assistant("a0")],
+    "single_user": [_user("u0")],
+}
+
+
+@pytest.mark.parametrize("slice_key", sorted(_ADVERSARIAL_SLICES))
+def test_normalize_for_summarization_yields_appendable_alternation(slice_key):
+    """``_normalize_for_summarization`` must return a body that opens on a user
+    turn, ends on an assistant turn, and never repeats a role — so the trailing
+    user instruction ``run_summarization_sync`` appends continues to alternate —
+    while preserving every original message (framing is inserted, never
+    substituted for real content)."""
+    original = _ADVERSARIAL_SLICES[slice_key]
+    normalized = _compaction._normalize_for_summarization(list(original))
+
+    assert isinstance(normalized[0], ModelRequest), "must open on a user turn"
+    assert isinstance(normalized[-1], ModelResponse), (
+        "must end on an assistant turn so the appended user instruction alternates"
+    )
+
+    # No two adjacent messages share a role, and appending a trailing user
+    # request keeps that true.
+    full = [*normalized, _user("trailing instruction")]
+    roles = _roles(full)
+    assert roles[0] == "user"
+    assert not [i for i in range(len(roles) - 1) if roles[i] == roles[i + 1]]
+
+    # Every original message survives, in order (framing is additive).
+    kept = [m for m in normalized if any(m is o for o in original)]
+    assert kept == original, "a real message was dropped or reordered"

--- a/tests/hook_engine/test_hook_command_substitution.py
+++ b/tests/hook_engine/test_hook_command_substitution.py
@@ -1,0 +1,44 @@
+"""Variable substitution in hook command templates."""
+
+import json
+import shlex
+
+from code_puppy.hook_engine.executor import _substitute_variables
+from code_puppy.hook_engine.models import EventData
+
+
+def test_hook_substitution_quotes_file_value():
+    event = EventData(
+        event_type="PreToolUse",
+        tool_name="Edit",
+        tool_args={"file_path": "a b; touch x"},
+    )
+
+    result = _substitute_variables("process ${file}", event, {})
+
+    assert result == f"process {shlex.quote('a b; touch x')}"
+
+
+def test_hook_substitution_quotes_tool_input():
+    event = EventData(
+        event_type="PreToolUse",
+        tool_name="Bash",
+        tool_args={"command": "$(touch y)"},
+    )
+
+    result = _substitute_variables("log ${CLAUDE_TOOL_INPUT}", event, {})
+
+    expected = shlex.quote(json.dumps({"command": "$(touch y)"}))
+    assert result == f"log {expected}"
+
+
+def test_hook_substitution_leaves_plain_value_unchanged():
+    event = EventData(
+        event_type="PreToolUse",
+        tool_name="Edit",
+        tool_args={"file_path": "src/main.py"},
+    )
+
+    result = _substitute_variables("cat ${file}", event, {})
+
+    assert result == "cat src/main.py"

--- a/tests/plugins/test_plugin_bytecode_loading.py
+++ b/tests/plugins/test_plugin_bytecode_loading.py
@@ -1,0 +1,74 @@
+"""Project plugin import runs the on-disk source, not a stale cache."""
+
+import importlib.util
+import marshal
+import struct
+import sys
+from pathlib import Path
+
+from code_puppy.plugins import (
+    _ensure_project_ns,
+    _load_one_project_plugin,
+)
+
+
+def _write_unchecked_hash_pyc(source_path: Path, body: str) -> Path:
+    """Write an unchecked hash-based ``.pyc`` beside *source_path*.
+
+    The cached bytecode carries *body* (distinct from the source file) and is
+    marked unchecked so the interpreter would use it without comparing against
+    the source.
+    """
+    code = compile(body, str(source_path), "exec")
+    data = bytearray(importlib.util.MAGIC_NUMBER)
+    flags = 0b01  # hash-based, unchecked
+    data += struct.pack("<I", flags)
+    data += b"\x00" * 8
+    data += marshal.dumps(code)
+
+    pyc_path = Path(importlib.util.cache_from_source(str(source_path)))
+    pyc_path.parent.mkdir(parents=True, exist_ok=True)
+    pyc_path.write_bytes(bytes(data))
+    return pyc_path
+
+
+def test_project_plugin_loads_from_source_not_stale_cache(tmp_path):
+    plugin_name = "cache_probe_plugin"
+    plugin_dir = tmp_path / ".code_puppy" / "plugins" / plugin_name
+    plugin_dir.mkdir(parents=True)
+
+    source_marker = tmp_path / "source_ran"
+    cache_marker = tmp_path / "cache_ran"
+
+    callbacks = plugin_dir / "register_callbacks.py"
+    callbacks.write_text(
+        "from pathlib import Path\n"
+        f"Path(r{str(source_marker)!r}).write_text('source')\n"
+    )
+
+    _write_unchecked_hash_pyc(
+        callbacks,
+        "from pathlib import Path\n"
+        f"Path(r{str(cache_marker)!r}).write_text('cache')\n",
+    )
+
+    module_name = f"project_plugins.{plugin_name}.register_callbacks"
+    dont_write = sys.dont_write_bytecode
+    sys.dont_write_bytecode = True
+    try:
+        _ensure_project_ns()
+        loaded = _load_one_project_plugin(plugin_dir, plugin_name)
+    finally:
+        sys.dont_write_bytecode = dont_write
+        for name in (
+            module_name,
+            f"project_plugins.{plugin_name}",
+        ):
+            sys.modules.pop(name, None)
+        parent = str(plugin_dir.parent)
+        if parent in sys.path:
+            sys.path.remove(parent)
+
+    assert loaded
+    assert source_marker.exists()
+    assert not cache_marker.exists()

--- a/tests/plugins/test_plugin_bytecode_loading.py
+++ b/tests/plugins/test_plugin_bytecode_loading.py
@@ -48,8 +48,7 @@ def test_project_plugin_loads_from_source_not_stale_cache(tmp_path):
 
     _write_unchecked_hash_pyc(
         callbacks,
-        "from pathlib import Path\n"
-        f"Path(r{str(cache_marker)!r}).write_text('cache')\n",
+        f"from pathlib import Path\nPath(r{str(cache_marker)!r}).write_text('cache')\n",
     )
 
     module_name = f"project_plugins.{plugin_name}.register_callbacks"

--- a/tests/test_env_key_loading.py
+++ b/tests/test_env_key_loading.py
@@ -1,0 +1,47 @@
+"""Tests for how ``load_api_keys_to_environment`` treats a project-local .env."""
+
+import os
+
+from code_puppy import config as cp_config
+
+
+def _snapshot_env():
+    return dict(os.environ)
+
+
+def _restore_env(snapshot):
+    os.environ.clear()
+    os.environ.update(snapshot)
+
+
+def test_dotenv_only_loads_known_api_keys(tmp_path, monkeypatch):
+    """A .env in the working directory hydrates known API keys but nothing else.
+
+    Only allowlisted API-key names are imported; unrelated names such as base
+    URLs or CODE_PUPPY_* toggles in the .env must not reach the environment.
+    """
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "ANTHROPIC_API_KEY=key-from-dotenv\n"
+        "ANTHROPIC_BASE_URL=http://example.invalid\n"
+        "CODE_PUPPY_DISABLE_RETRY_TRANSPORT=1\n"
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    snapshot = _snapshot_env()
+    try:
+        os.environ.pop("ANTHROPIC_API_KEY", None)
+        os.environ.pop("ANTHROPIC_BASE_URL", None)
+        os.environ.pop("CODE_PUPPY_DISABLE_RETRY_TRANSPORT", None)
+
+        cp_config.load_api_keys_to_environment()
+
+        # The allowlisted API key still loads from the .env.
+        assert os.environ.get("ANTHROPIC_API_KEY") == "key-from-dotenv"
+
+        # Non-allowlisted names never enter the environment via the .env.
+        assert os.environ.get("ANTHROPIC_BASE_URL") != "http://example.invalid"
+        assert "CODE_PUPPY_DISABLE_RETRY_TRANSPORT" not in os.environ
+    finally:
+        _restore_env(snapshot)

--- a/tests/test_session_pickle_loading_safety.py
+++ b/tests/test_session_pickle_loading_safety.py
@@ -37,9 +37,7 @@ def _dotted_global_call_pickle(module: str, name: str, argument: str) -> bytes:
 
 def test_surrogate_unpickler_does_not_resolve_dotted_names(tmp_path):
     marker = tmp_path / "marker.txt"
-    payload = _dotted_global_call_pickle(
-        "uuid", "os.system", f"touch {marker}"
-    )
+    payload = _dotted_global_call_pickle("uuid", "os.system", f"touch {marker}")
 
     result = None
     try:

--- a/tests/test_session_pickle_loading_safety.py
+++ b/tests/test_session_pickle_loading_safety.py
@@ -1,0 +1,52 @@
+"""Behavior of ``SurrogateUnpickler`` on globals whose name is dotted.
+
+Protocol 4+ pickles reference globals with a STACK_GLOBAL opcode carrying a
+(module, name) pair, and the stdlib unpickler resolves a dotted ``name`` by
+walking attributes from the module. ``uuid`` re-exports ``os``, so a name like
+``os.system`` reachable from an allowlisted module must not resolve to the real
+callable.
+"""
+
+import pickle
+
+from code_puppy.session_surrogate_unpickler import (
+    is_surrogate,
+    load_surrogate_pickle,
+)
+
+
+def _short_binunicode(text: str) -> bytes:
+    encoded = text.encode("utf-8")
+    return pickle.SHORT_BINUNICODE + bytes([len(encoded)]) + encoded
+
+
+def _dotted_global_call_pickle(module: str, name: str, argument: str) -> bytes:
+    """A protocol-4 pickle that calls ``module.name(argument)`` on load."""
+    return (
+        pickle.PROTO
+        + bytes([4])
+        + _short_binunicode(module)
+        + _short_binunicode(name)
+        + pickle.STACK_GLOBAL
+        + _short_binunicode(argument)
+        + pickle.TUPLE1
+        + pickle.REDUCE
+        + pickle.STOP
+    )
+
+
+def test_surrogate_unpickler_does_not_resolve_dotted_names(tmp_path):
+    marker = tmp_path / "marker.txt"
+    payload = _dotted_global_call_pickle(
+        "uuid", "os.system", f"touch {marker}"
+    )
+
+    result = None
+    try:
+        result, _had_surrogates = load_surrogate_pickle(payload)
+    except Exception:
+        result = None
+
+    assert not marker.exists()
+    if result is not None:
+        assert is_surrogate(result)

--- a/tests/tools/test_command_runner_env.py
+++ b/tests/tools/test_command_runner_env.py
@@ -1,0 +1,48 @@
+"""Tests for the environment handed to child shell processes."""
+
+from unittest.mock import MagicMock
+
+from code_puppy.tools import command_runner
+
+
+class _StopPopen(Exception):
+    """Sentinel raised by the fake Popen once the env has been captured."""
+
+
+async def test_shell_command_env_excludes_api_keys(monkeypatch):
+    """Child shell processes run without the agent's credential env vars.
+
+    A fake API key set on the parent environment must not appear in the env
+    passed to the spawned process, while PATH and other non-secret variables
+    are preserved so commands still work.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "should-not-leak")
+
+    captured = {}
+
+    def fake_popen(*args, **kwargs):
+        captured["env"] = kwargs.get("env")
+        raise _StopPopen()
+
+    monkeypatch.setattr(command_runner.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        command_runner, "get_command_executor", lambda: None, raising=False
+    )
+
+    async def _no_callbacks(*args, **kwargs):
+        return []
+
+    monkeypatch.setattr(
+        "code_puppy.callbacks.on_run_shell_command", _no_callbacks
+    )
+
+    result = await command_runner.run_shell_command(
+        MagicMock(), "echo hi", None, 5, False
+    )
+
+    assert result.success is False
+    assert "env" in captured
+    env = captured["env"]
+    assert env is not None
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "PATH" in env

--- a/tests/tools/test_command_runner_env.py
+++ b/tests/tools/test_command_runner_env.py
@@ -32,9 +32,7 @@ async def test_shell_command_env_excludes_api_keys(monkeypatch):
     async def _no_callbacks(*args, **kwargs):
         return []
 
-    monkeypatch.setattr(
-        "code_puppy.callbacks.on_run_shell_command", _no_callbacks
-    )
+    monkeypatch.setattr("code_puppy.callbacks.on_run_shell_command", _no_callbacks)
 
     result = await command_runner.run_shell_command(
         MagicMock(), "echo hi", None, 5, False

--- a/tests/tools/test_grep_flag_validation.py
+++ b/tests/tools/test_grep_flag_validation.py
@@ -1,0 +1,34 @@
+"""Flag handling for the local ripgrep grep path (``_build_grep_args``)."""
+
+from code_puppy.tools.file_operations import _build_grep_args
+
+
+def test_build_grep_args_rejects_unsupported_flags():
+    """A flag the tool does not understand is dropped, not forwarded to ripgrep."""
+    args, error = _build_grep_args("--pre echo hi")
+    assert "--pre" not in args
+    assert error is not None
+    assert "--pre" in error
+
+
+def test_build_grep_args_rejects_unsupported_flags_with_inline_value():
+    """The ``--flag=value`` form is evaluated on its flag part, then rejected."""
+    args, error = _build_grep_args("--pre=echo")
+    assert "--pre=echo" not in args
+    assert "--pre" not in args
+    assert error is not None
+    assert "--pre" in error
+
+
+def test_build_grep_args_allows_supported_flag():
+    """A supported content flag still reaches ripgrep unchanged."""
+    args, error = _build_grep_args("-i foo")
+    assert error is None
+    assert args == ["-i", "foo"]
+
+
+def test_build_grep_args_plain_pattern_unaffected():
+    """A normal search string is still passed verbatim via ``-e``."""
+    args, error = _build_grep_args("foo bar")
+    assert error is None
+    assert args == ["-e", "foo bar"]


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David.

Primary fix: summarization-based history **compaction** now normalizes the message slice it sends to the summarization model into a provider-valid shape — it always opens on a user turn, ends on an assistant turn, and never places two same-role messages adjacently (accounting for the trailing instruction the summarization run appends). Previously a slice that opened on an assistant turn, or contained a same-role adjacency (e.g. after orphaned-tool-call pruning), could be rejected by providers like Anthropic, causing compaction to silently fall back to hard truncation instead of producing a summary.

Also included — small, independently-tested robustness fixes:
- **grep**: forward only recognized ripgrep flags from the search string; reject unknown flags rather than passing them through.
- **legacy sessions**: route pickled globals with a dotted name to a surrogate so loading never resolves attributes reachable from an allowlisted module.
- **project `.env`**: import only known API-key names; ignore unrelated names.
- **child processes**: run shell commands with the agent's own provider credentials removed from their environment.
- **hooks**: quote interpolated hook-command variables so metacharacters are passed literally.
- **project plugins**: load trusted plugins from their reviewed source by keeping compiled bytecode outside the project tree.

All changes ship with new tests; the full suite passes (7332 passed).
