### PR TITLE
fix(list_files): replace O(n^2) parent-directory dedup with a set

### DIFF
--- a/code_puppy/tools/file_operations.py
+++ b/code_puppy/tools/file_operations.py
@@ -209,6 +209,10 @@ def _list_files(
     import sys
 
     results = []
+    # Synthesized parent directories already added to ``results``. Membership is
+    # checked once per path component of every file, so this has to be O(1);
+    # rescanning ``results`` made the loop O(n^2) and hung large listings.
+    seen_dir_paths = set()
     directory = resolve_path(directory)
 
     # Plain text output for LLM consumption
@@ -344,10 +348,8 @@ def _list_files(
                             for i in range(len(path_parts)):
                                 partial_path = os.sep.join(path_parts[: i + 1])
                                 # Check if we already added this directory
-                                if not any(
-                                    f.path == partial_path and f.type == "directory"
-                                    for f in results
-                                ):
+                                if partial_path not in seen_dir_paths:
+                                    seen_dir_paths.add(partial_path)
                                     results.append(
                                         ListedFile(
                                             path=partial_path,

--- a/tests/tools/test_file_operations_coverage.py
+++ b/tests/tools/test_file_operations_coverage.py
@@ -832,6 +832,100 @@ class TestEdgeCasesInListFiles:
         assert "test.txt" in result.content
 
 
+class TestListFilesParentDirectorySynthesis:
+    """Test the synthesized parent-directory entries in recursive listings.
+
+    ``ripgrep --files`` returns files only, so ``_list_files`` derives the
+    intermediate directory entries itself and de-duplicates them. These tests
+    pin that behaviour down: every ancestor must appear, and each must appear
+    exactly once no matter how many files share it.
+    """
+
+    @staticmethod
+    def _dir_entries(content):
+        """Directory paths from a listing, in order of appearance."""
+        entries = []
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped.endswith("/"):
+                entries.append(stripped.rstrip("/"))
+        return entries
+
+    def test_shared_parents_are_not_duplicated(self, tmp_path):
+        """Many files under one directory yield a single entry for it."""
+        shared = tmp_path / "pkg" / "sub"
+        shared.mkdir(parents=True)
+        for i in range(5):
+            (shared / f"file{i}.py").write_text("x")
+
+        result = _list_files(None, str(tmp_path), recursive=True)
+        dirs = self._dir_entries(result.content)
+
+        assert len(dirs) == len(set(dirs)), f"duplicate directories: {dirs}"
+
+    def test_all_ancestors_are_present(self, tmp_path):
+        """Every level of a deep path shows up in the listing, exactly once."""
+        deep = tmp_path / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+        (deep / "leaf.txt").write_text("x")
+
+        result = _list_files(None, str(tmp_path), recursive=True)
+        dirs = self._dir_entries(result.content)
+
+        assert dirs == ["a", "b", "c"], f"expected synthesized chain a/b/c, got: {dirs}"
+        assert "leaf.txt" in result.content
+
+    def test_sibling_branches_each_appear_once(self, tmp_path):
+        """Separate branches sharing a prefix are each listed once."""
+        for branch in ("one", "two"):
+            leaf = tmp_path / "common" / branch
+            leaf.mkdir(parents=True)
+            (leaf / "f.txt").write_text("x")
+
+        result = _list_files(None, str(tmp_path), recursive=True)
+        dirs = self._dir_entries(result.content)
+
+        assert len(dirs) == len(set(dirs)), f"duplicate directories: {dirs}"
+        for name in ("common", "one", "two"):
+            assert name in dirs, f"missing directory {name!r} in: {dirs}"
+
+    def test_files_at_mixed_depths_are_all_listed(self, tmp_path):
+        """Files at the root and nested levels coexist without loss."""
+        (tmp_path / "root.txt").write_text("x")
+        mid = tmp_path / "mid"
+        mid.mkdir()
+        (mid / "mid.txt").write_text("x")
+        deep = mid / "deeper"
+        deep.mkdir()
+        (deep / "deep.txt").write_text("x")
+
+        result = _list_files(None, str(tmp_path), recursive=True)
+        dirs = self._dir_entries(result.content)
+
+        assert len(dirs) == len(set(dirs)), f"duplicate directories: {dirs}"
+        for name in ("root.txt", "mid.txt", "deep.txt"):
+            assert name in result.content
+
+    def test_parent_referenced_at_multiple_depths_appears_once(self, tmp_path):
+        """A parent named by files at different depths is synthesized once.
+
+        ``holder`` is a path component of ``holder/c.txt`` (depth 1) and of
+        ``holder/inner/a.txt`` / ``holder/inner/b.txt`` (depth 2), so the
+        de-duplication sees it repeatedly and must still emit a single entry.
+        """
+        nested = tmp_path / "holder" / "inner"
+        nested.mkdir(parents=True)
+        (nested / "a.txt").write_text("x")
+        (nested / "b.txt").write_text("x")
+        (tmp_path / "holder" / "c.txt").write_text("x")
+
+        result = _list_files(None, str(tmp_path), recursive=True)
+        dirs = self._dir_entries(result.content)
+
+        assert len(dirs) == len(set(dirs)), f"duplicate directories: {dirs}"
+        assert dirs.count("holder") == 1, f"expected one 'holder' entry in: {dirs}"
+
+
 class TestIgnoreFileCleanup:
     """Test that temporary ignore files are cleaned up."""
 


### PR DESCRIPTION
## Summary

`_list_files` de-duplicates synthesized parent-directory entries with a linear scan over the
results list, executed once per path component of every file. That makes recursive listings
**O(n²)**.

On large trees the agent session freezes completely: one thread at 100% CPU, no output, no
error, and **no timeout** — the existing `subprocess.run(..., timeout=30)` bounds only ripgrep's
enumeration, not the Python loop that processes its output. Because the loop holds the GIL, the
asyncio loop, message bus, and renderer threads are all starved, so the TUI locks up rather than
showing a slow tool.

This replaces the scan with a set. Output is unchanged.

## Reproducing

Any `list_files` call on a directory tree with tens of thousands of files after ignore
filtering. `list_files` defaults to `recursive=True` and is typically the first tool an agent
reaches for, so this usually lands on the first tool call of a session.

The severe case is launching code-puppy from a home directory that looks like a project.
`_list_files` guards against recursing `$HOME`:

```python
if context is not None and is_likely_home_directory(directory) and recursive:
    if not is_project_directory(directory):
        recursive = False
```

but `is_project_directory()` returns true if **any** of `package.json`, `pyproject.toml`,
`Cargo.toml`, `.git`, `Makefile`, `requirements.txt`, `setup.py`, `go.mod`, `Gemfile`,
`pom.xml`, `build.gradle`, `CMakeLists.txt`, or `composer.json` is present. A single stray
`~/package.json` from an accidental `npm install` disables the guard. In the case that led to
this PR, a 53-byte `package.json` exposed a 560,987-file recursive walk.

The hang is not limited to the launch directory — the model supplies the `directory` argument,
so it can wedge a session by listing a large path even when code-puppy was started somewhere
small.

`py-spy dump` of a hung process (captured on 0.0.531, where this code sat at lines 278–279;
it is unchanged on current `main` at lines 347–348, with `list_files` calling in at 1145):

```
Thread 0x176E93000 (active+gil)
    <genexpr> (code_puppy/tools/file_operations.py:279)
    _list_files (code_puppy/tools/file_operations.py:278)
    list_files (code_puppy/tools/file_operations.py:762)
    run (anyio/_backends/_asyncio.py:1002)
```

## Root cause

`code_puppy/tools/file_operations.py`, in `_list_files()`:

```python
for i in range(len(path_parts)):
    partial_path = os.sep.join(path_parts[: i + 1])
    # Check if we already added this directory
    if not any(
        f.path == partial_path and f.type == "directory"
        for f in results
    ):
        results.append(ListedFile(path=partial_path, type="directory", ...))
```

`rg --files` returns files only, so the intermediate directory entries are synthesized here. The
duplicate check scans all of `results`, which grows as the walk proceeds — O(k) for the k-th
entry, repeated per path component. Total work is O(n²), with every comparison a Python-level
attribute read on a Pydantic model.

### Measured scaling

Synthetic trees, before vs after (measured on stock 0.0.676/0.0.728; the function is unchanged
on current `main`):

| files  | before | after | speedup |
|-------:|-------:|------:|--------:|
|  1,000 |  0.11s | 0.03s |      3x |
|  5,000 |  1.76s | 0.12s |     14x |
| 10,000 |  7.01s | 0.20s |     35x |
| 20,000 | 28.64s | 0.45s |     63x |

Runtime quadruples as the file count doubles. Extrapolating from 20k, the 560,987-file case
needs several hours of CPU — indistinguishable from a permanent hang.

## The fix

Track already-added directory paths in a `set` and test membership against it: O(1) instead of
O(n), making the listing O(n) overall.

```diff
     results = []
+    # Synthesized parent directories already added to ``results``. Membership is
+    # checked once per path component of every file, so this has to be O(1);
+    # rescanning ``results`` made the loop O(n^2) and hung large listings.
+    seen_dir_paths = set()
     directory = resolve_path(directory)
@@
                                 # Check if we already added this directory
-                                if not any(
-                                    f.path == partial_path and f.type == "directory"
-                                    for f in results
-                                ):
+                                if partial_path not in seen_dir_paths:
+                                    seen_dir_paths.add(partial_path)
                                     results.append(
```

The set only needs the synthesized parents. In the recursive branch every entry originates from
`rg --files`, so `entry_type` is always `"file"` there — I verified this rather than assuming it,
and deliberately did not add a `seen_dir_paths` update at the main append site: it would be
unreachable in practice (only a race between rg's enumeration and the later stat could produce a
directory there, with a one-line cosmetic duplicate as the worst outcome), and no test could
exercise it.

The non-recursive branch is untouched; it does not use this de-duplication path.

## Tests

Adds `TestListFilesParentDirectorySynthesis` to
`tests/tools/test_file_operations_coverage.py` — 5 tests using `tmp_path`, following the existing
conventions in that file (small hand-built trees, no timing assertions, milliseconds to run):

- shared parents are not duplicated
- all ancestors of a deep path are present, exactly once, in order
- sibling branches sharing a prefix each appear once
- files at mixed depths are all listed
- a parent referenced by files at multiple depths is synthesized exactly once

The de-duplication itself had no coverage before (an existing test covers that nested
directories appear in a recursive listing, but nothing exercised the duplicate check).

**On what these tests do and don't do.** They pin the *behaviour* of the parent-directory
synthesis, which is what this change puts at risk — the fix alters complexity, not output, so the
real hazard is silently changing a listing. They do **not** fail on the pre-fix code, because the
old and new implementations produce identical output. A guard against reintroducing the quadratic
scan would have to assert on complexity, which means either wall-clock timing (machine-dependent,
flaky in CI) or counting operations through white-box instrumentation. Both seemed worse than the
code comment for a repo whose test suite is deterministic throughout. Happy to add one if you'd
prefer.

## Verification

- **Output equivalence:** old and new implementations loaded side by side and run against the
  same directories — `ListFileOutput.content` byte-identical on `code_puppy/`, `tests/`, the repo
  root, and synthetic trees at 1k/5k/10k/20k files.
- **Full suite:** 7,316 passed, 28 skipped, 1 xpassed. (Three integration modules fail to collect without
  `pexpect` / `pytest-asyncio`; identical on unmodified HEAD.)
- **Lint:** `ruff check` reports 27 pre-existing issues on these two files both before and after —
  none introduced. `ruff format --check` clean.
