### PR TITLE
fix(list_files): dedupe raced directory entries against seen_dir_paths

### DIFF
--- a/code_puppy/tools/file_operations.py
+++ b/code_puppy/tools/file_operations.py
@@ -362,7 +362,12 @@ def _list_files(
                                         )
                                     )
 
-                    # Add the entry (file or directory)
+                    # Directories only land here via a TOCTOU race (rg lists files
+                    # only); dedupe against seen_dir_paths like synthesized parents.
+                    if entry_type == "directory":
+                        if file_path in seen_dir_paths:
+                            continue
+                        seen_dir_paths.add(file_path)
                     results.append(
                         ListedFile(
                             path=file_path,

--- a/tests/tools/test_file_operations_coverage.py
+++ b/tests/tools/test_file_operations_coverage.py
@@ -926,6 +926,67 @@ class TestListFilesParentDirectorySynthesis:
         assert dirs.count("holder") == 1, f"expected one 'holder' entry in: {dirs}"
 
 
+class TestListFilesDirectoryToctouRace:
+    """A directory can reach the main append site if rg's listed path turns
+    into a directory before the isfile/isdir recheck. Mock rg's output to
+    force that deterministically and confirm it doesn't duplicate.
+    """
+
+    @staticmethod
+    def _dir_entries(content):
+        entries = []
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped.endswith("/"):
+                entries.append(stripped.rstrip("/"))
+        return entries
+
+    @patch("shutil.which", return_value="rg")
+    @patch("subprocess.run")
+    def test_raced_directory_listed_before_sibling_file(
+        self, mock_run, _mock_which, tmp_path
+    ):
+        """A directory entry from rg, followed by a file under it, dedupes."""
+        shared = tmp_path / "shared"
+        shared.mkdir()
+        (shared / "leaf.txt").write_text("x")
+
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=f"{shared}\n{shared / 'leaf.txt'}\n",
+            stderr="",
+        )
+
+        result = _list_files(None, str(tmp_path), recursive=True)
+        dirs = self._dir_entries(result.content)
+
+        assert dirs.count("shared") == 1, f"expected one 'shared' entry in: {dirs}"
+
+    @patch("shutil.which", return_value="rg")
+    @patch("subprocess.run")
+    def test_raced_directory_listed_after_sibling_file(
+        self, mock_run, _mock_which, tmp_path
+    ):
+        """A file synthesizing the parent first, then rg's own directory
+        entry for it, still dedupes (reverse ordering)."""
+        shared = tmp_path / "shared"
+        shared.mkdir()
+        (shared / "leaf.txt").write_text("x")
+
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=f"{shared / 'leaf.txt'}\n{shared}\n",
+            stderr="",
+        )
+
+        result = _list_files(None, str(tmp_path), recursive=True)
+        dirs = self._dir_entries(result.content)
+
+        assert dirs.count("shared") == 1, f"expected one 'shared' entry in: {dirs}"
+
+
 class TestIgnoreFileCleanup:
     """Test that temporary ignore files are cleaned up."""
 


### PR DESCRIPTION
## Summary

Tiny non-blocking follow-up to #787, flagged during review of that PR.

`_list_files` synthesizes parent-directory entries for a recursive listing and tracks which ones it's already added in a `seen_dir_paths` set (#787 replaced an O(n^2) scan with this set). That set is only populated inside the parent-synthesis branch, though — not at the main append site where each `rg --files` entry gets added.

`rg --files` only ever lists files, so in normal operation the main append site never sees `entry_type == "directory"`. But the code re-checks each path against the live filesystem (`os.path.isfile()` / `os.path.isdir()`) before classifying it, so if something on disk swaps a listed path for a directory between rg's enumeration and that check (TOCTOU), the main site can append a directory entry that `seen_dir_paths` doesn't know about. If a sibling file also references that same path as a parent — in either order — the directory gets listed twice.

The pre-#787 O(n^2) scan happened to avoid this because it checked *all* of `results`, not just synthesized parents, so this is a narrow behavior change introduced by that PR, not a pre-existing bug.

## Fix

Record directory entries added at the main append site in `seen_dir_paths` too, and skip appending if the path is already there. Covers both orderings: directory-in-rg-output-before-the-file, and after.

## Tests

Added `TestListFilesDirectoryToctouRace` with two tests that mock `subprocess.run` to force the race deterministically (a real timing-dependent race isn't reliably testable). Verified both fail on the pre-fix code with a duplicated directory line, and pass after the fix.

## Verification

- `tests/tools/test_file_operations_coverage.py`: 77/77 pass (75 existing + 2 new).
- `tests/tools/`: 609/609 pass.
- `ruff check`: same 27 pre-existing findings on both touched files, before and after — confirmed by diffing against the pre-fix commit. `ruff format --check` clean.

Severity is low (worst case is one cosmetic duplicate line, not a crash or data loss) — flagging as a quick correctness follow-up since it was easy to fix and test properly once identified.
