### PR TITLE
feat: export headless usage for Harbor cost reporting

### DIFF
--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -10,6 +10,7 @@ apply_all_patches()
 
 import argparse
 import asyncio
+import json
 import os
 import signal
 import sys
@@ -170,6 +171,12 @@ async def main():
         "--disable-ask-user-question",
         action="store_true",
         help="Disable only the interactive ask_user_question tool",
+    )
+    parser.add_argument(
+        "--usage-file",
+        type=Path,
+        metavar="PATH",
+        help="Write aggregate headless model usage as JSON",
     )
     parser.add_argument(
         "--agent",
@@ -519,6 +526,7 @@ async def main():
                 initial_command,
                 message_renderer,
                 session_name=resolved_resume_session,
+                usage_file=args.usage_file,
             )
         else:
             # Default to interactive mode (no args = same as -i)
@@ -1339,11 +1347,33 @@ async def run_prompt_with_attachments(
     return await _await_agent()
 
 
+def _write_usage_file(path: Path, usage) -> None:
+    """Atomically serialize authoritative model usage for automation clients."""
+    cost = getattr(usage, "cost", None)
+    payload = {
+        "input_tokens": getattr(usage, "input_tokens", 0),
+        "output_tokens": getattr(usage, "output_tokens", 0),
+        "cache_read_tokens": getattr(usage, "cache_read_tokens", 0),
+        "cache_write_tokens": getattr(usage, "cache_write_tokens", 0),
+        "requests": getattr(usage, "requests", 0),
+        "tool_calls": getattr(usage, "tool_calls", 0),
+        "cost_usd": float(cost) if cost is not None else None,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        temporary.write_text(json.dumps(payload, indent=2) + "\n")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
 async def execute_single_prompt(
     prompt: str,
     message_renderer,
     *,
     session_name: str | None = None,
+    usage_file: Path | None = None,
 ) -> None:
     """Execute one headless ``-p`` prompt, dispatching commands and autosaving.
 
@@ -1414,6 +1444,8 @@ async def execute_single_prompt(
         get_message_bus().emit(
             AgentResponseMessage(content=result.output, is_markdown=True)
         )
+        if usage_file is not None:
+            _write_usage_file(usage_file, result.usage())
 
         # The runtime result includes the final assistant response that the
         # incremental history can otherwise miss.

--- a/tests/test_cli_usage_file.py
+++ b/tests/test_cli_usage_file.py
@@ -1,0 +1,94 @@
+"""Tests for machine-readable headless usage output."""
+
+import json
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from code_puppy.cli_runner import _write_usage_file, execute_single_prompt
+
+
+def test_write_usage_file_creates_parent_and_serializes_fields(tmp_path):
+    target = tmp_path / "nested" / "usage.json"
+    usage = SimpleNamespace(
+        input_tokens=120,
+        output_tokens=34,
+        cache_read_tokens=56,
+        cache_write_tokens=7,
+        requests=3,
+        tool_calls=9,
+        cost=Decimal("0.0125"),
+    )
+
+    _write_usage_file(target, usage)
+
+    assert json.loads(target.read_text()) == {
+        "input_tokens": 120,
+        "output_tokens": 34,
+        "cache_read_tokens": 56,
+        "cache_write_tokens": 7,
+        "requests": 3,
+        "tool_calls": 9,
+        "cost_usd": 0.0125,
+    }
+    assert list(target.parent.glob("*.tmp")) == []
+
+
+@pytest.mark.anyio
+async def test_execute_single_prompt_writes_result_usage(tmp_path):
+    target = tmp_path / "usage.json"
+    usage = SimpleNamespace(
+        input_tokens=10,
+        output_tokens=4,
+        cache_read_tokens=3,
+        cache_write_tokens=2,
+        requests=1,
+        tool_calls=2,
+        cost=None,
+    )
+    result = MagicMock(output="done")
+    result.usage.return_value = usage
+    result.all_messages.return_value = []
+    agent = MagicMock()
+    renderer = MagicMock()
+
+    with (
+        patch(
+            "code_puppy.command_line.shell_passthrough.is_shell_passthrough",
+            return_value=False,
+        ),
+        patch(
+            "code_puppy.cli_runner.parse_prompt_attachments",
+            return_value=SimpleNamespace(prompt="do it"),
+        ),
+        patch("code_puppy.cli_runner.get_current_agent", return_value=agent),
+        patch(
+            "code_puppy.cli_runner.run_prompt_with_attachments",
+            new=AsyncMock(return_value=(result, MagicMock())),
+        ),
+        patch("code_puppy.messaging.get_message_bus"),
+        patch("code_puppy.session_lifecycle.persist_named_session"),
+        patch("code_puppy.config.record_quick_resume_sessions"),
+    ):
+        await execute_single_prompt("do it", renderer, usage_file=target)
+
+    result.usage.assert_called_once_with()
+    assert json.loads(target.read_text())["input_tokens"] == 10
+
+
+def test_write_usage_file_allows_unknown_cost(tmp_path):
+    target = tmp_path / "usage.json"
+
+    _write_usage_file(target, SimpleNamespace())
+
+    assert json.loads(target.read_text()) == {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "requests": 0,
+        "tool_calls": 0,
+        "cost_usd": None,
+    }


### PR DESCRIPTION
## Summary

- add `--usage-file PATH` for headless `code-puppy --prompt` runs
- serialize authoritative `AgentRunResult.usage()` token, cache, request, tool-call, and cost fields
- write the JSON artifact atomically and create parent directories as needed
- preserve `null` cost when the provider does not expose pricing

## Why

Harbor agent adapters need machine-readable aggregate usage to populate input/output/cache token totals and `cost_usd`. Code Puppy already receives the authoritative Pydantic AI `RunUsage`, but its headless CLI previously discarded it after rendering the final response. Parsing the pretty terminal stream is incomplete and can double-count incremental token indicators.

Example:

```bash
code-puppy \
  --prompt "Instrument this app" \
  --model codex-gpt-5.6-sol \
  --usage-file /logs/agent/code-puppy-usage.json
```

```json
{
  "input_tokens": 120,
  "output_tokens": 34,
  "cache_read_tokens": 56,
  "cache_write_tokens": 7,
  "requests": 3,
  "tool_calls": 9,
  "cost_usd": 0.0125
}
```

## Behavior

The artifact is only written after a real agent result. Handled slash commands, shell passthrough, cancellation, and no-result paths do not manufacture zero-usage files.

## Tests

- `uv run pytest -q tests/test_cli_usage_file.py tests/test_cli_runner.py tests/test_cli_runner_resume_render.py tests/test_cli_runner_full_coverage.py` — 111 passed
- `uv run ruff check code_puppy/cli_runner.py tests/test_cli_usage_file.py`
- `uv run ruff format --check code_puppy/cli_runner.py tests/test_cli_usage_file.py`
- `git diff --check`
