### PR TITLE
web-retriever: ask before persisting extracted data to a file

### DIFF
--- a/code_puppy/agents/agent_web_retriever.py
+++ b/code_puppy/agents/agent_web_retriever.py
@@ -188,10 +188,35 @@ the content.
    from snapshot/locator results.
 6. **Paginate/crawl**: repeat navigate -> snapshot -> extract across a
    URL list or "next page" control as needed.
-7. **Persist**: write extracted data to a file the user can actually use
-   - `create_file`/`replace_in_file` for JSON, CSV, or markdown tables,
-   matching whatever format was requested (default to JSON if unspecified).
-   Tell the user exactly where the file landed.
+7. **Confirm before persisting -- don't silently drop files on disk.**
+   Writing an unrequested file is a surprising side effect, not a free
+   convenience. Before calling `create_file`/`replace_in_file`, check in
+   this order:
+   - Did the user explicitly ask for a file (any format)? Always create
+     it -- this wins over everything below. You may still add a brief
+     inline summary alongside it.
+   - Otherwise, did the user (or the task itself) already specify an
+     inline output format -- an inline answer, a specific field to
+     report, a yes/no, a single value? If so, just answer inline. Skip
+     the rest of this step; don't ask, don't write a file.
+   - Otherwise, is the result small enough to read comfortably in chat (a
+     handful of fields, one item, a short list)? Answer inline.
+   - Otherwise (genuinely open-ended extraction that produced a
+     multi-row/structured result with no inline format specified and no
+     explicit file request): try `ask_user_question` to check whether
+     they want it saved to a file (and in what format) before writing
+     anything. `ask_user_question` returns an error instead of prompting
+     when interactive tools are unavailable (sub-agent invocation,
+     autonomous-loop mode, non-interactive/CI environment) -- if you get
+     that error, do NOT retry the call. Fall back to answering inline
+     (report the full extracted data as text/markdown) and note briefly
+     that you defaulted to inline output because file confirmation
+     wasn't available.
+   - If the user confirmed a file via `ask_user_question`, or explicitly
+     asked for one up front, use `create_file`/`replace_in_file` for
+     JSON, CSV, or markdown tables, matching whatever format was
+     requested (default to JSON if unspecified). Tell the user exactly
+     where the file landed.
 8. **Save the recipe**: `browser_save_workflow` after a non-trivial
    multi-step scrape/automation succeeds, so the next run doesn't start
    from zero. Name workflows descriptively (include the domain and goal).


### PR DESCRIPTION
## What

web-retriever's core workflow had an unconditional step: always write
extracted data to a file. This changes that step to **ask before
persisting** instead of always writing.

## Why

Benchmarking web-retriever against qa-kitten (same model, same tasks, only
the agent differs) showed the unconditional persist step firing even on
open-ended extraction tasks with no requested output format, silently
writing a JSON file to disk the user never asked for. Confirmed
independently on two different models -- not a one-off fluke.

## How

New decision logic in `code_puppy/agents/agent_web_retriever.py`, checked
in this order:
1. User explicitly requested a file (any format) -> always create it; this
   takes precedence over everything below (may still add a brief inline
   summary alongside it).
2. Task/user already specified an inline output format (a single answer, a
   specific field, yes/no) -> answer inline, skip file logic entirely.
3. Result is small enough to read comfortably in chat -> answer inline.
4. Otherwise (genuinely open-ended, large/structured extraction with no
   explicit file request) -> ask via `ask_user_question` whether to save to
   a file (and in what format) before writing anything.

`ask_user_question` hard-errors instead of prompting when interactive tools
are unavailable (sub-agent invocation via `invoke_agent`, autonomous-loop
mode, non-interactive/CI) -- and sub-agent invocation is web-retriever's
primary advertised path. The prompt explicitly tells the model not to retry
on that error and to fall back to inline output instead, so this doesn't
turn into a dead-end tool call in the most common real invocation path.

## Testing

Re-ran the exact scenario that originally exposed the bug (same task, same
model, open-ended multi-product extraction against a local mock fixture):
previously produced an unrequested JSON file; after this change,
`file_tool_calls=0`, full data answered inline as a table. Did not attempt
to force-trigger the actual `ask_user_question` branch through an automated
script -- there's no human on the other end to answer it in a scripted run.
The zero-file-write result on the known repro is the meaningful
confirmation. Also independently verified (by reading, not assuming) that
`ask_user_question`'s `handler.py` does call `is_subagent()` and returns an
error response rather than raising when true, and that `invoke_agent`'s
sub-agent path wraps the whole run in that subagent context -- confirming
the fallback guidance in the prompt is addressing a real, not hypothetical,
failure mode.

Local checks: `ruff check` / `ruff format --check` on the changed file --
both clean.

## Scope

Single file: `code_puppy/agents/agent_web_retriever.py`. No behavior change
to qa-kitten or any other agent.

Internal tracking: https://jira.walmart.com/browse/PUP-637
