### PR TITLE
feat: allow disabling the interactive ask-user tool

### DIFF
--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -167,6 +167,11 @@ async def main():
         help="Execute a single prompt and exit (no interactive mode)",
     )
     parser.add_argument(
+        "--disable-ask-user-question",
+        action="store_true",
+        help="Disable only the interactive ask_user_question tool",
+    )
+    parser.add_argument(
         "--agent",
         "-a",
         type=str,
@@ -209,6 +214,8 @@ async def main():
     callbacks.on_register_cli_args(parser)
 
     args = parser.parse_args()
+    if args.disable_ask_user_question:
+        os.environ["CODE_PUPPY_DISABLE_ASK_USER_QUESTION"] = "1"
 
     # Plugins may act on parsed args and short-circuit startup; first dict
     # with handled=True wins (exits with its exit_code).

--- a/code_puppy/tools/__init__.py
+++ b/code_puppy/tools/__init__.py
@@ -217,6 +217,14 @@ def register_tools_for_agent(
                 seen.add(extra)
         tool_names = merged
 
+    if os.environ.get("CODE_PUPPY_DISABLE_ASK_USER_QUESTION", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        tool_names = [name for name in tool_names if name != "ask_user_question"]
+
     # Expand compound tools (e.g. "edit_file" → three individual tools)
     expanded_tools: list[str] = []
     seen: set[str] = set()

--- a/tests/test_disable_ask_user_question.py
+++ b/tests/test_disable_ask_user_question.py
@@ -1,0 +1,40 @@
+"""Tests for disabling only the interactive ask-user tool."""
+
+from unittest.mock import MagicMock, patch
+
+from code_puppy.tools import register_tools_for_agent
+
+
+def test_disable_ask_user_question_preserves_other_tools(monkeypatch):
+    ask_register = MagicMock()
+    read_register = MagicMock()
+    monkeypatch.setenv("CODE_PUPPY_DISABLE_ASK_USER_QUESTION", "1")
+
+    with patch.dict(
+        "code_puppy.tools.TOOL_REGISTRY",
+        {
+            "ask_user_question": ask_register,
+            "read_file": read_register,
+        },
+        clear=True,
+    ):
+        agent = MagicMock()
+        register_tools_for_agent(agent, ["ask_user_question", "read_file"])
+
+    ask_register.assert_not_called()
+    read_register.assert_called_once_with(agent)
+
+
+def test_ask_user_question_remains_enabled_by_default(monkeypatch):
+    ask_register = MagicMock()
+    monkeypatch.delenv("CODE_PUPPY_DISABLE_ASK_USER_QUESTION", raising=False)
+
+    with patch.dict(
+        "code_puppy.tools.TOOL_REGISTRY",
+        {"ask_user_question": ask_register},
+        clear=True,
+    ):
+        agent = MagicMock()
+        register_tools_for_agent(agent, ["ask_user_question"])
+
+    ask_register.assert_called_once_with(agent)


### PR DESCRIPTION
## Summary

- add `--disable-ask-user-question` for unattended/headless agent runs
- remove only `ask_user_question` at the shared tool-registration boundary
- preserve every other coding, shell, file, MCP, and skill tool

## Why

Evaluation harnesses such as Harbor may run agents without a human attached. `--no-tools` is much too broad: it prevents the agent from doing the task. This flag disables only the interactive terminal picker so unattended runs cannot stall waiting for stdin.

The filter lives in `register_tools_for_agent()`, so built-in agents, JSON agents, expanded tool lists, and plugin-advertised tool lists all receive consistent behavior.

## Tests

- `uv run pytest -q tests/test_disable_ask_user_question.py tests/test_cli_runner.py tests/test_cli_runner_resume_render.py` — 46 passed
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `git diff --check`
