### PR TITLE
chore(callbacks): type the fail-closed policy set precisely

### DIFF
--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import traceback
-from typing import Any, Callable, Dict, List, Literal, Optional, Set
+from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple
 
 PhaseType = Literal[
     "startup",
@@ -177,7 +177,7 @@ BLOCKING_PHASES: frozenset = frozenset({"pre_tool_call", "run_shell_command"})
 # (phase, callback) pairs registered with fail_closed=True. Keyed by pair, not
 # by callable: the same helper may be registered on several phases with
 # different policies, and one phase's choice must not leak into another.
-_fail_closed_callbacks: Set[tuple] = set()
+_fail_closed_callbacks: Set[Tuple[PhaseType, CallbackFunc]] = set()
 
 
 def _failure_result(


### PR DESCRIPTION
Follow-up to @thomwebb's non-blocking nitpick on #777.

`Set[tuple]` loses the pair's meaning at a glance. `PhaseType` and `CallbackFunc` are both already defined above that line (6 and 76), so naming them costs nothing and documents the key ordering that `unregister_callback`, `clear_callbacks` and both dispatchers depend on.

```diff
-_fail_closed_callbacks: Set[tuple] = set()
+_fail_closed_callbacks: Set[Tuple[PhaseType, CallbackFunc]] = set()
```

No behavior change. `tests/test_callbacks_fail_closed.py` 25/25, ruff clean.