### PR TITLE
Keep compacted history provider-valid + assorted robustness fixes

### DIFF
--- a/code_puppy/agents/_compaction.py
+++ b/code_puppy/agents/_compaction.py
@@ -29,6 +29,7 @@ from pydantic_ai.messages import (
 
 from code_puppy.agents._history import (
     _classify_tool_part,
+    _is_repairable_return,
     estimate_tokens_for_message,
     filter_huge_messages,
     has_pending_tool_calls,
@@ -70,10 +71,12 @@ def _find_safe_split_index(messages: List[ModelMessage], initial_split_idx: int)
     protected_tool_return_ids: Set[str] = set()
     for msg in messages[initial_split_idx:]:
         for part in getattr(msg, "parts", []) or []:
-            if getattr(part, "part_kind", None) == "tool-return":
-                tcid = getattr(part, "tool_call_id", None)
-                if tcid:
-                    protected_tool_return_ids.add(tcid)
+            # A tool-bound RetryPromptPart answers a call just as a ToolReturnPart
+            # does (per _is_repairable_return), so both must pull the call's
+            # ModelResponse back across the split — else the call is severed and
+            # dropped by the final prune.
+            if _is_repairable_return(part):
+                protected_tool_return_ids.add(part.tool_call_id)
 
     if not protected_tool_return_ids:
         return initial_split_idx
@@ -251,7 +254,10 @@ def _merge_consecutive_same_role(messages: List[ModelMessage]) -> List[ModelMess
             parts = [*previous.parts, *message.parts]
             parts.sort(
                 key=lambda x: (
-                    0 if isinstance(x, ToolReturnPart | RetryPromptPart) else 1
+                    0
+                    if isinstance(x, ToolReturnPart)
+                    or (isinstance(x, RetryPromptPart) and x.tool_name is not None)
+                    else 1
                 )
             )
             merged[-1] = dataclasses.replace(
@@ -356,7 +362,14 @@ def _run_summarization_core(
 
     compacted: List[ModelMessage] = [system_message] + list(new_messages)
     compacted.extend(msg for msg in protected_messages if msg is not system_message)
-    return prune_interrupted_tool_calls(compacted), messages_to_summarize
+    compacted = prune_interrupted_tool_calls(compacted)
+    # Collapse any same-role adjacency the assembly introduced — the summary
+    # request meeting a user-role protected head, or two responses left adjacent
+    # by a dropped orphan request — so compact() never returns consecutive
+    # same-role turns (rejected by Bedrock/compat surfaces). Merge from index 1
+    # so the system message is never folded into the summary request.
+    merged = [compacted[0], *_merge_consecutive_same_role(compacted[1:])]
+    return merged, messages_to_summarize
 
 
 def _log_summarization_failure(error: Exception, fallback_note: str = "") -> None:

--- a/code_puppy/agents/_history.py
+++ b/code_puppy/agents/_history.py
@@ -389,8 +389,9 @@ def prune_interrupted_tool_calls(
       or a trailing request when none follows — so the model sees that the
       call was interrupted instead of losing the whole turn;
     - an orphaned return (no matching call) drops only that part, keeping
-      the rest of its message. An interior request emptied this way is
-      dropped; a trailing one is kept so the history still ends on a turn.
+      the rest of its message. A request emptied of every part this way is
+      dropped wherever it sits — a kept trailing empty request would make the
+      wire history end on the assistant turn, which providers reject.
 
     Builtin (provider-executed) tool calls are left alone: their results
     arrive from the provider in a later turn, so a missing return is not a
@@ -455,8 +456,13 @@ def prune_interrupted_tool_calls(
         ]
 
         if len(kept_parts) != len(original_parts):
-            if not kept_parts and index != len(messages) - 1:
-                # An interior request emptied of parts carries nothing.
+            if not kept_parts:
+                # A request emptied of every part carries nothing — drop it
+                # wherever it sits, tail included. Provider mappers skip a
+                # zero-part request, so a kept trailing empty request would end
+                # the wire history on the assistant turn (prefill), which
+                # Anthropic/Bedrock reject, and would slip past
+                # make_history_processor's trailing-ModelResponse trim.
                 continue
             msg = dataclasses.replace(msg, parts=kept_parts)
 
@@ -483,14 +489,64 @@ def has_pending_tool_calls(messages: List[ModelMessage]) -> bool:
     return bool(tool_call_ids - tool_return_ids)
 
 
+_OVERSIZED_TOOL_RETURN_CONTENT = (
+    "[Tool result omitted: it exceeded the per-message size limit and was "
+    "dropped from history. The tool DID run and completed — do not re-issue "
+    "the same call.]"
+)
+
+
+def _shrink_oversized_tool_returns(
+    message: ModelMessage, model_name: Optional[str]
+) -> Optional[ModelMessage]:
+    """Replace an oversized message's tool-return bodies with a placeholder.
+
+    A >50k-token ``ModelRequest`` is almost always a bulky tool result. Dropping
+    the whole message would leave its ``tool-call`` dangling, and prune would
+    then close it with an ``interrupted`` return — telling the model the tool
+    never ran, so it re-issues the identical oversized call (infinite re-read
+    loop). Swapping each ``tool-return`` body for a short placeholder keeps the
+    pair intact and records that the tool completed. Returns ``None`` when the
+    message has no tool return to shrink, or stays over budget afterwards — the
+    caller then drops it as before.
+    """
+    new_parts: List[Any] = []
+    shrank = False
+    for part in getattr(message, "parts", []) or []:
+        if getattr(part, "part_kind", None) == "tool-return":
+            new_parts.append(
+                dataclasses.replace(part, content=_OVERSIZED_TOOL_RETURN_CONTENT)
+            )
+            shrank = True
+        else:
+            new_parts.append(part)
+    if not shrank:
+        return None
+    shrunk = dataclasses.replace(message, parts=new_parts)
+    if estimate_tokens_for_message(shrunk, model_name) >= 50000:
+        return None
+    return shrunk
+
+
 def filter_huge_messages(
     messages: List[ModelMessage],
     model_name: Optional[str] = None,
 ) -> List[ModelMessage]:
-    """Drop individual messages above a 50k-token budget, then repair pairing."""
-    filtered = [
-        m for m in messages if estimate_tokens_for_message(m, model_name) < 50000
-    ]
+    """Cap individual messages at a 50k-token budget, then repair pairing.
+
+    An oversized tool-result message is shrunk in place (body replaced with a
+    placeholder) rather than dropped, so a completed call is never mistaken for
+    an interrupted one; anything still over budget is dropped, then pruning
+    repairs any pairing the drop broke.
+    """
+    filtered: List[ModelMessage] = []
+    for m in messages:
+        if estimate_tokens_for_message(m, model_name) < 50000:
+            filtered.append(m)
+            continue
+        shrunk = _shrink_oversized_tool_returns(m, model_name)
+        if shrunk is not None:
+            filtered.append(shrunk)
     return prune_interrupted_tool_calls(filtered)
 
 

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -2884,12 +2884,16 @@ def load_api_keys_to_environment():
     # is a redirect target, not a credential.
     cfg_only_names = ["AZURE_OPENAI_ENDPOINT"]
 
-    # Include env vars referenced by configured models (e.g. FIREWORKS_API_KEY
-    # for local custom providers) so puppy.cfg keys hydrate at startup. Best-effort.
+    # Include api-key env vars referenced by configured models (e.g.
+    # FIREWORKS_API_KEY for local custom providers) so puppy.cfg keys hydrate at
+    # startup. Best-effort. Only api-key vars — never custom_endpoint.headers
+    # vars: a header value is spliced into outgoing request headers, so
+    # hydrating it from a project dot-env would let an untrusted repo set request
+    # headers/routing (same redirect concern as an endpoint).
     try:
-        from code_puppy.provider_credentials import all_required_env_vars
+        from code_puppy.provider_credentials import all_api_key_env_vars
 
-        for env_var in all_required_env_vars():
+        for env_var in all_api_key_env_vars():
             if env_var not in api_key_names and env_var not in cfg_only_names:
                 api_key_names.append(env_var)
     except Exception:

--- a/code_puppy/hook_engine/executor.py
+++ b/code_puppy/hook_engine/executor.py
@@ -328,14 +328,21 @@ def _interpolate_placeholders(template: str, values: Dict[str, str]) -> str:
         value = str(values[name])
         quote = stack[-1][1]
         if quote is None:
-            pieces.append(shlex.quote(value))
+            piece = shlex.quote(value)
         elif quote == "'":
             # Inside the author's single quotes only a single quote is
             # special: splice each one as close-quote + escaped quote +
             # reopen (''' idiom) so the value stays literal text.
-            pieces.append(value.replace("'", "'\\''"))
+            piece = value.replace("'", "'\\''")
         else:
-            pieces.append(_double_quote_escape(value))
+            piece = _double_quote_escape(value)
+        # A raw backtick closes an enclosing `...` command substitution even
+        # from inside quotes -- the shell scans for the closer before quote
+        # removal, and shlex.quote never escapes it. Escape for every open
+        # backtick layer so the value cannot terminate the substitution.
+        if any(frame[0] == "`" for frame in stack):
+            piece = piece.replace("\\", "\\\\").replace("`", "\\`")
+        pieces.append(piece)
     pieces.append(template[position:])
     return "".join(pieces)
 
@@ -351,6 +358,12 @@ def _cmd_quote_state(text: str, in_quotes: bool) -> bool:
     return in_quotes
 
 
+# A ``#`` starts a comment only at a word boundary in an unquoted context;
+# after an ordinary word character it is a literal ``#``. These are the chars
+# that leave the shell expecting a fresh word.
+_COMMENT_BOUNDARY = frozenset({" ", "\t", "\n", ";", "&", "|", "(", ")", "<", ">"})
+
+
 def _scan_quote_stack(text: str, stack: List[List[Optional[str]]]) -> None:
     """Advance the shell context stack across a literal template segment.
 
@@ -364,6 +377,7 @@ def _scan_quote_stack(text: str, stack: List[List[Optional[str]]]) -> None:
     keeps the value an inert argument instead of a live command.
     """
     i = 0
+    prev: Optional[str] = None
     while i < len(text):
         char = text[i]
         top = stack[-1]
@@ -371,6 +385,16 @@ def _scan_quote_stack(text: str, stack: List[List[Optional[str]]]) -> None:
         if quote is None:
             if char == top[0]:  # matching closer ends this substitution frame
                 stack.pop()
+            elif char == "#" and (prev is None or prev in _COMMENT_BOUNDARY):
+                # A comment runs to end of line; its body -- quote chars
+                # included -- is inert, so skip it without disturbing the
+                # tracked quote state (an apostrophe in a comment must not flip
+                # the scanner into single-quote mode and mis-quote a later
+                # placeholder).
+                while i < len(text) and text[i] != "\n":
+                    i += 1
+                prev = "\n"
+                continue
             elif char in ("'", '"'):
                 top[1] = char
             elif char == "\\":
@@ -393,6 +417,7 @@ def _scan_quote_stack(text: str, stack: List[List[Optional[str]]]) -> None:
                 i += 1
             elif char == "`":
                 stack.append(["`", None])
+        prev = char
         i += 1
 
 
@@ -418,12 +443,13 @@ def _build_environment(
     event_data: EventData,
     env_vars: Optional[Dict[str, str]] = None,
 ) -> Dict[str, str]:
-    from code_puppy.provider_credentials import environment_without_credentials
-
-    # Hooks fire on model-triggered tool calls, so they get the same
-    # credential scrub as child shell commands: the agent's own provider
-    # keys never ride along in the hook environment.
-    env = environment_without_credentials()
+    # Hooks are user-authored config, not model-authored commands, so they
+    # inherit the full environment, provider credentials included. A hook may
+    # legitimately call an LLM (``claude -p '...'``, ``llm -m ...``, an
+    # OpenAI-SDK script) and needs ANTHROPIC_API_KEY/OPENAI_API_KEY to
+    # authenticate. The credential scrub stays on the model's own
+    # run_shell_command (command_runner._child_process_env).
+    env = dict(os.environ)
     env["CLAUDE_PROJECT_DIR"] = os.getcwd()
     env["CLAUDE_TOOL_INPUT"] = json.dumps(event_data.tool_args)
     env["CLAUDE_TOOL_NAME"] = event_data.tool_name

--- a/code_puppy/plugins/__init__.py
+++ b/code_puppy/plugins/__init__.py
@@ -3,6 +3,7 @@ import importlib.abc
 import importlib.machinery
 import importlib.util
 import logging
+import os
 import sys
 from importlib.metadata import entry_points
 import types
@@ -16,11 +17,14 @@ logger = logging.getLogger(__name__)
 # User plugins directory
 USER_PLUGINS_DIR = Path.home() / ".code_puppy" / "plugins"
 
-# Compiled bytecode for project plugins is redirected here, out of the project
-# tree, so a clean load never leaves a __pycache__ entry that the bytecode
-# tripwire below would then refuse next session. Set once when the first trusted
-# plugin loads and left in place (like the meta_path finder) so a later lazy
-# import stays redirected too.
+# Bytecode the *default* loader would emit for a project plugin's eager
+# top-level sibling imports is redirected here, out of the project tree, so a
+# clean load never leaves a __pycache__ entry the tripwire would refuse next
+# session. The redirect is process-wide, so it is applied only around each
+# plugin's exec and restored afterward (see _load_one_project_plugin); leaving
+# it set would divert bytecode for every unrelated import in the process. The
+# source-only loader compiles in memory and writes nothing, so the plugin's own
+# modules never depend on it.
 _PROJECT_PLUGIN_PYCACHE = str(Path.home() / ".code_puppy" / "plugin_bytecode_cache")
 
 
@@ -56,32 +60,52 @@ class _ProjectPluginFinder(importlib.abc.MetaPathFinder):
         for entry in list(path or []):
             base = Path(entry)
             pkg_dir = base / last
-            if pkg_dir.is_dir():
-                init_file = pkg_dir / "__init__.py"
-                if init_file.is_file():
-                    return importlib.util.spec_from_file_location(
-                        fullname,
-                        init_file,
-                        loader=_ProjectPluginLoader(fullname, str(init_file)),
-                        submodule_search_locations=[str(pkg_dir)],
-                    )
-                spec = importlib.machinery.ModuleSpec(fullname, None, is_package=True)
-                spec.submodule_search_locations = [str(pkg_dir)]
-                return spec
+            init_file = pkg_dir / "__init__.py"
             module_file = base / f"{last}.py"
+            # A package: a directory carrying a real __init__.py source file.
+            if init_file.is_file():
+                if pkg_dir.is_symlink():
+                    raise ImportError(
+                        f"Refusing to import {fullname!r} through symlinked "
+                        f"directory {pkg_dir} — the trust hash never saw its target"
+                    )
+                return importlib.util.spec_from_file_location(
+                    fullname,
+                    init_file,
+                    loader=_ProjectPluginLoader(fullname, str(init_file)),
+                    submodule_search_locations=[str(pkg_dir)],
+                )
+            # A module: <last>.py wins over a same-named directory, matching
+            # CPython precedence (a source file beats a bare namespace portion).
+            # The default finder does this too; inverting it here would let an
+            # empty <last>/ dir silently shadow a trusted <last>.py.
             if module_file.is_file():
                 return importlib.util.spec_from_file_location(
                     fullname,
                     module_file,
                     loader=_ProjectPluginLoader(fullname, str(module_file)),
                 )
-            # No source, but planted bytecode: own the name and fail closed so
-            # the default finder's SourcelessFileLoader can't execute it.
-            if (base / f"{last}.pyc").is_file():
-                raise ImportError(
-                    f"Refusing to import {fullname!r} from bytecode "
-                    f"{base / f'{last}.pyc'} — project plugins load from source only"
-                )
+            # No source under this name, but a non-source artifact the default
+            # finder would execute (planted bytecode or a compiled extension):
+            # own the name and fail closed instead of falling through.
+            for suffix in (".pyc", *importlib.machinery.EXTENSION_SUFFIXES):
+                artifact = base / f"{last}{suffix}"
+                if artifact.is_file():
+                    raise ImportError(
+                        f"Refusing to import {fullname!r} from non-source file "
+                        f"{artifact} — project plugins load from source only"
+                    )
+            # Only now, with no source file and no planted artifact, honor a bare
+            # namespace portion (a directory with no __init__.py).
+            if pkg_dir.is_dir():
+                if pkg_dir.is_symlink():
+                    raise ImportError(
+                        f"Refusing to import {fullname!r} through symlinked "
+                        f"directory {pkg_dir} — the trust hash never saw its target"
+                    )
+                spec = importlib.machinery.ModuleSpec(fullname, None, is_package=True)
+                spec.submodule_search_locations = [str(pkg_dir)]
+                return spec
         return None
 
 
@@ -393,17 +417,59 @@ def _ensure_plugin_package(plugin_dir: Path, plugin_name: str) -> bool:
 
 
 def _find_plugin_bytecode(plugin_dir: Path) -> Path | None:
-    """Return the first ``.pyc`` file or ``__pycache__`` dir under *plugin_dir*.
+    """Return the first import artifact under *plugin_dir* that trust can't cover.
 
-    ``compute_plugin_hash`` deliberately excludes bytecode from the trust
-    digest, so a trusted-and-unchanged plugin could still gain planted or stale
-    bytecode the digest never saw. Presence of any such artifact beside a source
-    plugin is treated as tampering.
+    ``compute_plugin_hash`` digests only source files, so bytecode (``.pyc`` /
+    ``__pycache__``), compiled extensions (``.so`` / ``.pyd``), and symlinked
+    subdirectories can slip past the trust digest yet still be imported by the
+    machinery. Any of them beside a source plugin is treated as tampering.
+
+    Walks with ``followlinks=False`` so a symlinked subdirectory is reported at
+    its own level — its target lives outside the hashed tree — without being
+    descended into (``rglob`` would silently skip it while ``find_spec`` follows
+    it).
     """
+    binary_suffixes = {".pyc", *importlib.machinery.EXTENSION_SUFFIXES}
     try:
-        for path in plugin_dir.rglob("*"):
-            if path.suffix == ".pyc" or (path.name == "__pycache__" and path.is_dir()):
-                return path
+        for root, dirnames, filenames in os.walk(plugin_dir, followlinks=False):
+            root_path = Path(root)
+            for dirname in dirnames:
+                dir_path = root_path / dirname
+                if dirname == "__pycache__" or dir_path.is_symlink():
+                    return dir_path
+            for filename in filenames:
+                if Path(filename).suffix in binary_suffixes:
+                    return root_path / filename
+    except OSError:
+        return None
+    return None
+
+
+def _find_path_entry_binary(path_entry: Path) -> Path | None:
+    """Return the first sourceless import artifact directly under *path_entry*.
+
+    *path_entry* is the directory a project plugin adds to ``sys.path`` (the
+    plugins root, ``plugin_dir.parent``). A plugin's *top-level* ``import name``
+    resolves against it through the **default** import machinery, which the
+    source-only finder never sees — so loose ``.pyc``/``.so``/``.pyd`` there, or
+    a same-named directory whose only ``__init__`` is bytecode/extension, would
+    execute without ever touching the trust hash. ``_find_plugin_bytecode`` scans
+    only inside each plugin, so this covers the shared import root it cannot.
+
+    Only the direct children of *path_entry* are checked: those are exactly the
+    top-level names an ``import name`` resolves there, and sibling plugin
+    directories carry their own in-tree tripwire.
+    """
+    binary_suffixes = {".pyc", *importlib.machinery.EXTENSION_SUFFIXES}
+    try:
+        for child in path_entry.iterdir():
+            if child.is_file() and child.suffix in binary_suffixes:
+                return child
+            if child.is_dir() and not (child / "__init__.py").is_file():
+                for suffix in binary_suffixes:
+                    init_artifact = child / f"__init__{suffix}"
+                    if init_artifact.is_file():
+                        return init_artifact
     except OSError:
         return None
     return None
@@ -427,19 +493,25 @@ def _load_one_project_plugin(plugin_dir: Path, plugin_name: str) -> bool:
     if not callbacks_file.exists() and not init_file.exists():
         return False
 
-    # Fail closed at the trust boundary: a source plugin has no legitimate
-    # reason to ship bytecode, and the trust hash never covers it, so any
-    # .pyc/__pycache__ in the tree is treated as tampering and the whole plugin
-    # is refused. This is the belt that also covers import paths the meta-path
-    # finder cannot see (e.g. top-level sibling imports).
-    bytecode = _find_plugin_bytecode(plugin_dir)
-    if bytecode is not None:
+    # Fail closed at the trust boundary: a source plugin has no legitimate reason
+    # to ship bytecode or compiled extensions, and the trust hash never covers
+    # them, so any .pyc/__pycache__/.so/.pyd — or a symlinked subdir the digest
+    # never followed — is treated as tampering and the whole plugin is refused.
+    # The scan covers both the plugin's own tree and the plugins root placed on
+    # sys.path below: a trusted plugin's top-level ``import helper`` resolves a
+    # loose helper.pyc there through the default (non-source) loader, an import
+    # path the meta-path finder never sees.
+    binary = _find_plugin_bytecode(plugin_dir)
+    if binary is None:
+        binary = _find_path_entry_binary(plugin_dir.parent)
+    if binary is not None:
         logger.warning(
-            "Refusing to load project plugin '%s': found bytecode at %s. "
-            "Remove all .pyc files and __pycache__ directories from the plugin "
-            "directory, then reload.",
+            "Refusing to load project plugin '%s': found non-source import "
+            "artifact at %s. Remove all .pyc/.so/.pyd files, __pycache__ "
+            "directories, and symlinked subdirectories from the plugin directory "
+            "and the plugins root, then reload.",
             plugin_name,
-            bytecode,
+            binary,
         )
         return False
 
@@ -450,10 +522,15 @@ def _load_one_project_plugin(plugin_dir: Path, plugin_name: str) -> bool:
         sys.path.insert(0, parent_str)
 
     # Route the plugin and every sibling it imports through the source-only
-    # loader, and redirect any bytecode the machinery still emits out of the
-    # project tree. Both are set permanently — like the meta_path finder — so a
-    # lazy import after this returns can't slip through the default loader.
+    # loader. The finder stays installed permanently — it is scoped to the
+    # project_plugins.* namespace, so it is inert for all other imports. The
+    # pycache_prefix redirect is process-wide, so it wraps only this plugin's own
+    # exec and is restored in the finally below: it keeps bytecode the *default*
+    # loader would emit for an eager top-level sibling import out of the project
+    # tree. The source-only loader compiles in memory and writes no cache, so the
+    # plugin's own modules never need the redirect to persist.
     _install_project_plugin_finder()
+    prev_pycache_prefix = sys.pycache_prefix
     sys.pycache_prefix = _PROJECT_PLUGIN_PYCACHE
 
     try:
@@ -505,6 +582,12 @@ def _load_one_project_plugin(plugin_dir: Path, plugin_name: str) -> bool:
             exc_info=True,
         )
         return False
+    finally:
+        # Undo the process-wide redirect. Leaving it set diverts bytecode for
+        # every unrelated import in the process (and never restores the original
+        # cache), which is both a perf regression and a source of cross-test
+        # global-state leaks.
+        sys.pycache_prefix = prev_pycache_prefix
 
 
 def _load_project_plugins(

--- a/code_puppy/provider_credentials.py
+++ b/code_puppy/provider_credentials.py
@@ -57,6 +57,38 @@ def extract_api_key_env_vars_from_model_config(model_config: dict) -> List[str]:
     return names
 
 
+# custom_endpoint.headers whose NAME marks the value as a bearer/API credential.
+# Only these header vars are scrubbed from the model's shell env; a non-secret
+# header like X-Title / HTTP-Referer / $SITE_URL still reaches child commands.
+_SECRET_HEADER_NAMES = frozenset(
+    {"authorization", "proxy-authorization", "x-api-key", "api-key"}
+)
+
+
+def extract_secret_header_env_vars_from_model_config(
+    model_config: dict,
+) -> List[str]:
+    """Every ``$ENV`` name a secret-named ``custom_endpoint.headers`` entry references.
+
+    A header token that authenticates provider calls (``Authorization: Bearer
+    $TOKEN``, ``X-Api-Key: $KEY``) is as sensitive as an api_key and must not
+    ride into a model-triggered child shell. Header names outside
+    :data:`_SECRET_HEADER_NAMES` are treated as non-secret (e.g. ``$SITE_URL``)
+    and left in the child environment.
+    """
+    if not isinstance(model_config, dict):
+        return []
+    names: List[str] = []
+    custom_endpoint = model_config.get("custom_endpoint")
+    if isinstance(custom_endpoint, dict):
+        headers = custom_endpoint.get("headers")
+        if isinstance(headers, dict):
+            for header_name, header_value in headers.items():
+                if str(header_name).lower() in _SECRET_HEADER_NAMES:
+                    _add_env_var_tokens(header_value, names)
+    return names
+
+
 def extract_env_vars_from_model_config(model_config: dict) -> List[str]:
     """Every ``$ENV`` name a single model config depends on.
 
@@ -147,6 +179,17 @@ def all_api_key_env_vars() -> List[str]:
     return sorted(found)
 
 
+def all_secret_header_env_vars() -> List[str]:
+    """Sorted list of every model's secret-header ``$ENV`` var.
+
+    See :func:`extract_secret_header_env_vars_from_model_config`.
+    """
+    found: set = set()
+    for model_config in _load_merged_model_config().values():
+        found.update(extract_secret_header_env_vars_from_model_config(model_config))
+    return sorted(found)
+
+
 def get_credential_value(env_var: str) -> Optional[str]:
     """Resolve a credential exactly like ``model_factory.get_api_key``.
 
@@ -226,12 +269,13 @@ _WELL_KNOWN_CREDENTIAL_ENV_VARS = frozenset(
 def credential_env_var_names() -> frozenset:
     """Every env var name that carries an agent provider credential.
 
-    The well-known provider keys plus every configured model's api_key
-    ``$ENV`` name, so the scrub below cannot miss a custom provider. Header
-    env vars are deliberately excluded: they are often non-secrets (e.g.
-    ``$SITE_URL``) that belong to the user's shell. Recomputed on every call so
-    any catalog change -- including a hand-edit to ``extra_models.json`` --
-    takes effect immediately.
+    The well-known provider keys, every configured model's api_key ``$ENV``
+    name, and every secret-named ``custom_endpoint.headers`` token (an
+    ``Authorization``/``X-Api-Key`` bearer authenticates provider calls just as
+    an api_key does), so the scrub below cannot miss a custom provider.
+    Non-secret header vars (e.g. ``$SITE_URL``) are left out -- they belong to
+    the user's shell. Recomputed on every call so any catalog change --
+    including a hand-edit to ``extra_models.json`` -- takes effect immediately.
 
     Residual: MCP server secrets (``mcp_servers.json`` ``env``/``headers``
     ``$VAR`` references) are not folded in -- there is no clean way to tell a
@@ -241,6 +285,7 @@ def credential_env_var_names() -> frozenset:
     names = set(_WELL_KNOWN_CREDENTIAL_ENV_VARS)
     try:
         names.update(all_api_key_env_vars())
+        names.update(all_secret_header_env_vars())
     except Exception:
         # A broken catalog must not break environment scrubbing.
         pass
@@ -250,11 +295,11 @@ def credential_env_var_names() -> frozenset:
 def environment_without_credentials() -> Dict[str, str]:
     """``os.environ`` minus the agent's own provider credentials.
 
-    Removes the well-known provider keys and every model's api_key ``$ENV``
-    var so a child process cannot inherit and exfiltrate the keys the agent
-    authenticates with. Everything else passes through so routine tooling keeps
-    working: the user's own ``GITHUB_TOKEN``, ``AWS_*`` and proxies, and
-    custom-endpoint header vars, which are commonly non-secrets like
+    Removes the well-known provider keys, every model's api_key ``$ENV`` var,
+    and every secret-named ``custom_endpoint.headers`` token so a child process
+    cannot inherit and exfiltrate the keys the agent authenticates with.
+    Everything else passes through so routine tooling keeps working: the user's
+    own ``GITHUB_TOKEN``, ``AWS_*`` and proxies, and non-secret header vars like
     ``$SITE_URL``.
     """
     credentials = credential_env_var_names()

--- a/code_puppy/session_surrogate_unpickler.py
+++ b/code_puppy/session_surrogate_unpickler.py
@@ -26,22 +26,36 @@ from typing import Any, Callable, Dict, List, Tuple
 
 logger = logging.getLogger(__name__)
 
-# Modules whose classes are safe (and necessary) to unpickle for real.
-# Everything else -- pydantic_ai.*, pydantic.*, unknown user modules --
-# becomes a surrogate. Strictly SAFER than the old bare ``pickle.loads``.
-_ALLOWED_MODULES = frozenset(
-    {
-        "builtins",
-        "collections",
-        "copyreg",
-        "datetime",
-        "decimal",
-        "fractions",
-        "uuid",
-        "zoneinfo",
-        "_codecs",
-    }
-)
+# find_class resolves ONLY these ``module -> {names}`` pairs to the real
+# object; every other global becomes a surrogate. An allowlist, not a denylist
+# -- mirroring how the normalizer allowlists known message classes and degrades
+# the rest. Two threats a module-level denylist could not close:
+#   * re-exported submodules (``collections._sys``, ``uuid.os``) resolved to
+#     live module objects, and a following BUILD opcode wrote into their
+#     ``__dict__`` (e.g. ``sys.path``) -- in-process code execution.
+#   * ``builtins.exit``/``quit``/``help`` resolved to real callables raising
+#     ``SystemExit`` (a BaseException) past the migration's ``except Exception``,
+#     killing the process.
+# Security invariant: no entry resolves to a module or to shared mutable global
+# state. BUILD cannot be intercepted -- pickle binds ``load_build`` in a
+# dispatch table at class-definition time and the C unpickler exposes only
+# ``find_class`` as an override -- so every value BUILD can reach must be made
+# safe here: a surrogate, or a leaf constructor whose instances carry no shared
+# state.
+_ALLOWED_GLOBALS: Dict[str, frozenset] = {
+    "builtins": frozenset(
+        {"set", "frozenset", "bytearray", "complex", "list", "dict", "tuple"}
+    ),
+    "collections": frozenset({"OrderedDict", "defaultdict"}),
+    "datetime": frozenset({"datetime", "date", "time", "timedelta", "timezone"}),
+    "decimal": frozenset({"Decimal"}),
+    "fractions": frozenset({"Fraction"}),
+    "uuid": frozenset({"UUID"}),
+    "zoneinfo": frozenset({"ZoneInfo"}),
+    # ``_codecs.encode`` is a function, not a class: it rebuilds bytes/bytearray
+    # pickled under protocol 2. Kept for legacy sessions -- a safe codec call.
+    "_codecs": frozenset({"encode"}),
+}
 
 
 # Known third-party tzinfo classes rebuilt as stdlib equivalents WITHOUT
@@ -61,26 +75,6 @@ _TZINFO_EQUIVALENTS: Dict[Tuple[str, str], Callable[..., Any]] = {
 # Genuine timezone libraries: unpickle their classes for real when the
 # library is installed; otherwise fall back to surrogates as usual.
 _TZ_LIBRARY_PREFIXES = ("pytz", "dateutil.tz")
-
-
-# Even within builtins, never hand the pickle VM anything executable.
-_BLOCKED_BUILTINS = frozenset(
-    {
-        "eval",
-        "exec",
-        "compile",
-        "open",
-        "input",
-        "breakpoint",
-        "__import__",
-        "getattr",
-        "setattr",
-        "delattr",
-        "vars",
-        "globals",
-        "locals",
-    }
-)
 
 
 class SurrogateBase:
@@ -142,14 +136,11 @@ class SurrogateUnpickler(pickle.Unpickler):
 
     def find_class(self, module: str, name: str) -> Any:  # noqa: D102
         # A dotted ``name`` makes the base unpickler (protocol 4+ STACK_GLOBAL)
-        # walk attributes from the module, which can reach objects the module
-        # allowlist was never meant to expose. Route these to a surrogate.
+        # walk attributes from the module, which can reach objects the allowlist
+        # never names. Route these to a surrogate.
         if "." in name:
             return self._surrogate_for(module, name)
-        root = module.split(".", 1)[0]
-        if root in _ALLOWED_MODULES and not (
-            module == "builtins" and name in _BLOCKED_BUILTINS
-        ):
+        if name in _ALLOWED_GLOBALS.get(module, frozenset()):
             return self._tz_tolerant(super().find_class(module, name))
         equivalent = _TZINFO_EQUIVALENTS.get((module, name))
         if equivalent is not None:

--- a/code_puppy/tools/file_operations.py
+++ b/code_puppy/tools/file_operations.py
@@ -59,6 +59,13 @@ class GrepOutput(BaseModel):
     error: str | None = None
 
 
+# Upper bound on -A/-B/-C context rows returned alongside the (up to 50)
+# matches, so a wide context value can't grow the result without limit.
+# Context never evicts a real match: once this budget is full we keep scanning
+# for matches and simply stop collecting further context.
+_MAX_GREP_CONTEXT_ROWS = 200
+
+
 def is_likely_home_directory(directory):
     """Detect if directory is likely a user's home directory or common home subdirectory"""
     abs_dir = os.path.abspath(directory)
@@ -815,11 +822,13 @@ def _build_grep_args(search_string: str) -> tuple[list[str], str | None]:
         return ["-e", search_string], None
 
     result: list[str] = []
+    has_pattern = False
     index = 0
     while index < len(tokens):
         token = tokens[index]
         if not token.startswith("-"):
             result.append(token)
+            has_pattern = True
             index += 1
             continue
 
@@ -835,6 +844,8 @@ def _build_grep_args(search_string: str) -> tuple[list[str], str | None]:
                 f"{_SUPPORTED_RG_FLAGS_HINT}. Use a plain pattern for "
                 "anything else."
             )
+        if flag in ("-e", "--regexp"):
+            has_pattern = True
         result.extend(pieces)
         # A value-taking flag with no inline value (``=VALUE`` or a ``-C3``
         # cluster) takes the next token as its value, forwarded verbatim so a
@@ -848,6 +859,10 @@ def _build_grep_args(search_string: str) -> tuple[list[str], str | None]:
                 )
             result.append(tokens[index])
         index += 1
+    if not has_pattern:
+        # Match the backend path (_build_backend_matcher), which errors here
+        # instead of letting rg swallow the target directory as the pattern.
+        return [], "no search pattern provided"
     return result, None
 
 
@@ -1154,7 +1169,9 @@ def _grep_via_backend(directory: str, search_string: str) -> "GrepOutput":
 def _carries_type_filter(rg_args: list[str]) -> bool:
     """True when the forwarded ripgrep args already select file types."""
     return any(
-        token == "-t" or token == "--type" or token.startswith("--type=")
+        token in ("-t", "--type")
+        or token.startswith("--type=")
+        or token.startswith("-t=")
         for token in rg_args
     )
 
@@ -1253,6 +1270,7 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
 
         # Parse the JSON output from ripgrep
         real_match_count = 0
+        context_row_count = 0
         for line in result.stdout.strip().split("\n"):
             if not line:
                 continue
@@ -1285,9 +1303,16 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
                             line_content=_sanitize_string(line_content.strip()),
                             is_context=is_context,
                         )
+                        # Context rides along without consuming the 50-match
+                        # budget, but is itself capped so a wide -A/-B/-C can't
+                        # grow the result without bound. Real matches are never
+                        # evicted: once the context budget is full we keep
+                        # scanning for matches and just drop further context.
+                        if is_context:
+                            if context_row_count >= _MAX_GREP_CONTEXT_ROWS:
+                                continue
+                            context_row_count += 1
                         matches.append(match_info)
-                        # Cap at 50 real matches; context lines ride along in
-                        # the output without consuming the budget.
                         if not is_context:
                             real_match_count += 1
                             if real_match_count >= 50:

--- a/code_puppy/tools/tools_content.py
+++ b/code_puppy/tools/tools_content.py
@@ -10,7 +10,7 @@ Woof! 🐶 Here's my complete toolkit! I'm like a Swiss Army knife but way more 
 - **`delete_file(file_path)`** - Remove files when needed (use with caution!)
 
 # **Search & Analysis**
-- **`grep(search_string, directory)`** - Search for text across files recursively using ripgrep (rg) for high-performance searching (up to 50 matches). Searches across all text file types, not just Python files. Supports common ripgrep flags in the search string (-i, -w, -F, -e, -t, -A/-B/-C, -g, -v, -S, ...); -A/-B/-C context lines are honored only on the local rg path (the filesystem-backend path has no context support) and never count toward the 50-match cap. Output-format flags are rejected.
+- **`grep(search_string, directory)`** - Search for text across files recursively using ripgrep (rg) for high-performance searching (up to 50 matches). Searches across all text file types, not just Python files. Supports common ripgrep flags in the search string (-i, -w, -F, -e, -t, -A/-B/-C, -g, -v, -S, ...); -A/-B/-C context lines are honored only on the local rg path (the filesystem-backend path has no context support) and never count toward the 50-match cap, but are themselves limited to 200 rows total so a wide context value can't grow the result without bound. Output-format flags are rejected.
 
 # 💻 **System Operations**
 - **`agent_run_shell_command(command, cwd, timeout)`** - Execute shell commands with full output capture (stdout, stderr, exit codes)

--- a/tests/agents/test_compaction_summarization_ordering.py
+++ b/tests/agents/test_compaction_summarization_ordering.py
@@ -35,6 +35,7 @@ from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
     ModelResponse,
+    RetryPromptPart,
     SystemPromptPart,
     TextPart,
     ThinkingPart,
@@ -393,6 +394,69 @@ def test_merge_keeps_api_responses_separate_and_hoists_tool_results():
     merged_reqs = _compaction._merge_consecutive_same_role([user_req, return_req])
     assert len(merged_reqs) == 1
     assert [p.part_kind for p in merged_reqs[0].parts] == ["tool-return", "user-prompt"]
+
+
+def test_merge_does_not_hoist_nameless_retry():
+    """A nameless retry is validation feedback, not a tool result, so it stays
+    after the user prompt when two same-role requests merge."""
+    merged = _compaction._merge_consecutive_same_role(
+        [
+            ModelRequest(parts=[UserPromptPart(content="USER ASKED")]),
+            ModelRequest(parts=[RetryPromptPart(content="bad", tool_name=None)]),
+        ]
+    )
+
+    assert len(merged) == 1
+    assert [p.part_kind for p in merged[0].parts] == ["user-prompt", "retry-prompt"]
+
+
+def test_merge_hoists_tool_bound_retry():
+    """A tool-bound retry answers a call like a tool result, so it hoists ahead
+    of the user prompt (results must precede prompts for providers)."""
+    merged = _compaction._merge_consecutive_same_role(
+        [
+            ModelRequest(parts=[UserPromptPart(content="USER ASKED")]),
+            ModelRequest(
+                parts=[
+                    RetryPromptPart(content="bad", tool_name="x", tool_call_id="c1")
+                ]
+            ),
+        ]
+    )
+
+    assert len(merged) == 1
+    assert [p.part_kind for p in merged[0].parts] == ["retry-prompt", "user-prompt"]
+
+
+def test_split_protects_call_answered_by_retry():
+    """A tool-bound RetryPromptPart in the protected tail pulls its call back.
+
+    ``_find_safe_split_index`` must treat a tool-bound retry as a return (it
+    answers the call, per ``_is_repairable_return``) and move the split earlier
+    so the call's ``ModelResponse`` joins the protected region — otherwise the
+    call is severed from its answer and dropped by the final prune.
+    """
+    messages: List[ModelMessage] = [
+        ModelRequest(
+            parts=[SystemPromptPart(content="sys"), UserPromptPart(content="open")]
+        ),
+        ModelRequest(parts=[UserPromptPart(content="q")]),
+        ModelResponse(
+            parts=[ToolCallPart(tool_name="read", args={"p": "a"}, tool_call_id="c1")]
+        ),
+        ModelRequest(
+            parts=[
+                RetryPromptPart(content="bad args", tool_name="read", tool_call_id="c1")
+            ]
+        ),
+    ]
+    call_idx = 2
+    # Unadjusted boundary lands after the call (index 3), so the retry that
+    # answers it sits in the protected tail while the call would be summarized.
+    adjusted = _compaction._find_safe_split_index(messages, 3)
+
+    assert adjusted <= call_idx
+    assert messages[call_idx] in messages[adjusted:]
 
 
 def test_split_does_not_drop_messages_in_the_adjusted_gap():

--- a/tests/agents/test_compaction_summarization_ordering.py
+++ b/tests/agents/test_compaction_summarization_ordering.py
@@ -417,9 +417,7 @@ def test_merge_hoists_tool_bound_retry():
         [
             ModelRequest(parts=[UserPromptPart(content="USER ASKED")]),
             ModelRequest(
-                parts=[
-                    RetryPromptPart(content="bad", tool_name="x", tool_call_id="c1")
-                ]
+                parts=[RetryPromptPart(content="bad", tool_name="x", tool_call_id="c1")]
             ),
         ]
     )

--- a/tests/agents/test_history_tool_call_repair.py
+++ b/tests/agents/test_history_tool_call_repair.py
@@ -16,6 +16,8 @@ from pydantic_ai.messages import (
 )
 
 from code_puppy.agents._history import (
+    _OVERSIZED_TOOL_RETURN_CONTENT,
+    filter_huge_messages,
     has_pending_tool_calls,
     prune_interrupted_tool_calls,
 )
@@ -105,7 +107,7 @@ def test_orphaned_return_drops_only_that_part():
     assert request.parts[0].tool_call_id == "a"
 
 
-def test_interior_emptied_request_is_dropped_trailing_kept():
+def test_interior_and_trailing_emptied_requests_are_dropped():
     history = [
         ModelRequest(parts=[UserPromptPart(content="one")]),
         ModelResponse(parts=[_call("a")]),
@@ -118,19 +120,20 @@ def test_interior_emptied_request_is_dropped_trailing_kept():
 
     pruned = prune_interrupted_tool_calls(history)
 
-    # ghost1's interior request is emptied and dropped; ghost2's trailing
-    # request is emptied but kept so the history ends on a turn boundary.
+    # Both ghost requests empty to zero parts and are dropped wherever they
+    # sit — ghost2 included: a kept trailing empty request would end the wire
+    # history on the assistant turn (prefill), which providers reject.
     assert [type(m) for m in pruned] == [
         ModelRequest,
         ModelResponse,
         ModelRequest,
         ModelRequest,
         ModelResponse,
-        ModelRequest,
     ]
     assert pruned[2].parts[0].tool_call_id == "a"
     assert pruned[3].parts[0].content == "two"
-    assert pruned[-1].parts == []
+    assert isinstance(pruned[-1], ModelResponse)
+    assert pruned[-1].parts[0].content == "done"
 
 
 def test_paired_history_returns_input_unchanged():
@@ -193,6 +196,50 @@ def test_retry_prompt_counts_as_return():
     ]
 
     assert prune_interrupted_tool_calls(history) is history
+
+
+def test_oversized_tool_return_is_shrunk_not_interrupted():
+    """An oversized COMPLETED tool result is shrunk in place, not dropped.
+
+    Dropping the message would leave its call dangling, and prune would then
+    close it with an ``interrupted`` return — telling the model the tool never
+    ran, so it re-issues the identical oversized call. Instead the body is
+    swapped for the oversized placeholder and the pair stays intact.
+    """
+    huge = "x" * 200_000  # estimates well over the 50k-token per-message budget
+    history = [
+        ModelRequest(parts=[UserPromptPart(content="read the big file")]),
+        ModelResponse(parts=[_call("c1")]),
+        ModelRequest(
+            parts=[ToolReturnPart(tool_name="edit", content=huge, tool_call_id="c1")]
+        ),
+    ]
+
+    result = filter_huge_messages(history)
+
+    calls = [
+        p
+        for m in result
+        for p in getattr(m, "parts", [])
+        if getattr(p, "part_kind", None) == "tool-call"
+    ]
+    returns = [
+        p
+        for m in result
+        for p in getattr(m, "parts", [])
+        if getattr(p, "part_kind", None) == "tool-return"
+    ]
+
+    assert any(c.tool_call_id == "c1" for c in calls), "the call was erased"
+
+    c1_returns = [r for r in returns if r.tool_call_id == "c1"]
+    assert len(c1_returns) == 1
+    (ret,) = c1_returns
+    assert ret.content == _OVERSIZED_TOOL_RETURN_CONTENT
+    assert ret.content != INTERRUPTED_TOOL_RETURN_CONTENT
+    assert getattr(ret, "outcome", None) != "interrupted"
+
+    assert not has_pending_tool_calls(result)
 
 
 def test_builtin_tool_call_left_alone():

--- a/tests/hook_engine/test_hook_command_substitution.py
+++ b/tests/hook_engine/test_hook_command_substitution.py
@@ -111,6 +111,12 @@ def test_hook_substitution_unknown_placeholder_passthrough():
         ),
         # Nested $( $( ) ) resolves against the innermost context.
         ("echo $(a $(b ${file}) c)", {"file_path": "a; touch /tmp/x"}),
+        # A bare backtick command substitution in the template: the value must
+        # not close it with its own backtick and run trailing commands.
+        ("echo `basename ${file}`", {"file_path": "`; touch /tmp/x; echo `"}),
+        # A comment line's apostrophe must not flip the scanner into single-quote
+        # mode and splice a later placeholder bare on the following line.
+        ("# c't\necho $file", {"file_path": "x; touch /tmp/x; echo INJECTED"}),
     ],
 )
 def test_hook_substitution_is_not_injectable(template, tool_args):

--- a/tests/plugins/test_plugin_bytecode_loading.py
+++ b/tests/plugins/test_plugin_bytecode_loading.py
@@ -1,7 +1,9 @@
 """Project plugins load from source only; any bytecode in the tree is refused."""
 
+import importlib.machinery
 import importlib.util
 import marshal
+import os
 import struct
 import sys
 from pathlib import Path
@@ -14,6 +16,31 @@ from code_puppy.plugins import (
     _ensure_project_ns,
     _load_one_project_plugin,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_import_state():
+    """Pin the process-global import state these tests plant into and mutate.
+
+    ``_write_unchecked_hash_pyc`` places its cache via
+    ``importlib.util.cache_from_source``, which honors ``sys.pycache_prefix``.
+    The in-tree tripwire only sees a planted cache when the prefix is unset, so
+    force it off while planting — otherwise a stray ``PYTHONPYCACHEPREFIX`` (or a
+    prefix leaked by an earlier plugin-loading test) redirects the cache outside
+    the plugin dir and the "refused" assertions silently invert. Also snapshot
+    ``sys.path`` and ``sys.meta_path`` (the loader inserts into both) so nothing
+    leaks in or out of these tests regardless of collection order.
+    """
+    saved_prefix = sys.pycache_prefix
+    saved_path = list(sys.path)
+    saved_meta_path = list(sys.meta_path)
+    sys.pycache_prefix = None
+    try:
+        yield
+    finally:
+        sys.pycache_prefix = saved_prefix
+        sys.path[:] = saved_path
+        sys.meta_path[:] = saved_meta_path
 
 
 def _write_unchecked_hash_pyc(source_path: Path, body: str) -> Path:
@@ -217,3 +244,142 @@ def test_finder_refuses_planted_bytecode_within_namespace(tmp_path):
 
     # A bytecode-only name outside the namespace is still not ours to answer.
     assert finder.find_spec("plug.helper", path=[str(plugin_dir)]) is None
+
+
+def test_sourceless_pyc_in_plugins_root_is_refused(tmp_path):
+    """A sourceless ``.pyc`` on the plugins root (the sys.path entry) is refused.
+
+    A trusted plugin's *top-level* ``import helper`` resolves against the plugins
+    root through the default machinery, which the source-only meta-path finder
+    never sees. ``_find_path_entry_binary`` covers that shared import root, so a
+    loose ``helper.pyc`` there is refused before any code runs.
+    """
+    plugin_name = "root_pyc_plugin"
+    plugin_dir = tmp_path / ".code_puppy" / "plugins" / plugin_name
+    plugin_dir.mkdir(parents=True)
+
+    evil_marker = tmp_path / "root_pyc_ran"
+    (plugin_dir / "register_callbacks.py").write_text("import helper\n")
+    # Planted directly on the plugins root, not inside the plugin dir.
+    _write_sourceless_pyc(
+        plugin_dir.parent / "helper.pyc",
+        f"from pathlib import Path\nPath(r{str(evil_marker)!r}).write_text('evil')\n",
+    )
+
+    try:
+        _ensure_project_ns()
+        loaded = _load_one_project_plugin(plugin_dir, plugin_name)
+    finally:
+        _cleanup(plugin_dir, plugin_name, extra=("helper",))
+
+    assert not loaded
+    assert not evil_marker.exists()
+
+
+def test_compiled_extension_in_plugin_is_refused(tmp_path):
+    """A compiled extension (``.so``/``.pyd``) beside the source is refused.
+
+    The trust hash digests only source, so an extension is refused on its suffix
+    by the tripwire — before any import machinery touches it.
+    """
+    plugin_name = "extension_plugin"
+    plugin_dir = tmp_path / ".code_puppy" / "plugins" / plugin_name
+    plugin_dir.mkdir(parents=True)
+
+    (plugin_dir / "register_callbacks.py").write_text("VALUE = 1\n")
+    ext_suffix = importlib.machinery.EXTENSION_SUFFIXES[0]
+    (plugin_dir / f"native{ext_suffix}").write_bytes(b"")
+
+    try:
+        _ensure_project_ns()
+        loaded = _load_one_project_plugin(plugin_dir, plugin_name)
+    finally:
+        _cleanup(plugin_dir, plugin_name)
+
+    assert not loaded
+
+
+def test_empty_dir_does_not_shadow_source_module(tmp_path):
+    """``<name>.py`` wins over a same-named empty directory (CPython precedence).
+
+    An empty ``state/`` dir must not shadow a trusted ``state.py`` into a
+    loader-less namespace spec — the finder must serve the source module.
+    """
+    finder = _ProjectPluginFinder()
+    plugin_dir = tmp_path / "plug"
+    plugin_dir.mkdir()
+    (plugin_dir / "state.py").write_text("X = 1\n")
+    (plugin_dir / "state").mkdir()  # empty same-named directory
+
+    spec = finder.find_spec("project_plugins.plug.state", path=[str(plugin_dir)])
+    assert spec is not None and spec.loader is not None
+    assert type(spec.loader).__name__ == "_ProjectPluginLoader"
+    assert spec.origin is not None and spec.origin.endswith("state.py")
+
+
+def test_extension_in_namespace_is_refused(tmp_path):
+    """Within the namespace, a name backed only by a compiled extension raises.
+
+    With ``native.<ext>`` present and no ``native.py``, the finder owns the name
+    and fails closed instead of falling through to the default loader.
+    """
+    finder = _ProjectPluginFinder()
+    plugin_dir = tmp_path / "plug"
+    plugin_dir.mkdir()
+    ext_suffix = importlib.machinery.EXTENSION_SUFFIXES[0]
+    (plugin_dir / f"native{ext_suffix}").write_bytes(b"")
+
+    with pytest.raises(ImportError):
+        finder.find_spec("project_plugins.plug.native", path=[str(plugin_dir)])
+
+
+def test_symlinked_subdir_is_refused(tmp_path):
+    """A symlinked subdirectory (target outside the hashed tree) is refused.
+
+    ``os.walk(followlinks=False)`` reports the link at its own level so the
+    tripwire flags it — the trust digest never followed it.
+    """
+    plugin_name = "symlink_plugin"
+    plugin_dir = tmp_path / ".code_puppy" / "plugins" / plugin_name
+    plugin_dir.mkdir(parents=True)
+
+    (plugin_dir / "register_callbacks.py").write_text("VALUE = 1\n")
+
+    outside = tmp_path / "outside_tree"
+    outside.mkdir()
+    try:
+        os.symlink(outside, plugin_dir / "link")
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink creation unsupported on this platform: {exc}")
+
+    try:
+        _ensure_project_ns()
+        loaded = _load_one_project_plugin(plugin_dir, plugin_name)
+    finally:
+        _cleanup(plugin_dir, plugin_name)
+
+    assert not loaded
+
+
+def test_pycache_prefix_restored_after_load(tmp_path):
+    """A clean load restores ``sys.pycache_prefix`` to its pre-load value.
+
+    ``_load_one_project_plugin`` redirects the process-wide prefix during exec
+    and must restore it in a ``finally`` — otherwise every unrelated import in
+    the process is diverted for the rest of the session.
+    """
+    plugin_name = "prefix_restore_plugin"
+    plugin_dir = tmp_path / ".code_puppy" / "plugins" / plugin_name
+    plugin_dir.mkdir(parents=True)
+
+    (plugin_dir / "register_callbacks.py").write_text("VALUE = 1\n")
+
+    prefix_snapshot = sys.pycache_prefix
+    try:
+        _ensure_project_ns()
+        loaded = _load_one_project_plugin(plugin_dir, plugin_name)
+    finally:
+        _cleanup(plugin_dir, plugin_name)
+
+    assert loaded
+    assert sys.pycache_prefix == prefix_snapshot

--- a/tests/test_env_key_loading.py
+++ b/tests/test_env_key_loading.py
@@ -70,6 +70,40 @@ def test_dotenv_does_not_import_endpoints(tmp_path, monkeypatch):
         _restore_env(snapshot)
 
 
+def test_dotenv_does_not_import_custom_endpoint_headers(tmp_path, monkeypatch):
+    """A header var in the project .env must not import: it can reroute requests.
+
+    A ``custom_endpoint.headers`` value is spliced into outgoing request headers,
+    so hydrating it from a repo-local .env would let an untrusted project set
+    request headers/routing — the same redirect concern as an endpoint. Only
+    api_key vars hydrate from a project .env, never header vars.
+    """
+    monkeypatch.setattr(
+        "code_puppy.provider_credentials._load_merged_model_config",
+        lambda: {
+            "custom-model": {
+                "provider": "custom",
+                "custom_endpoint": {"headers": {"X-Route": "$MY_ROUTE"}},
+            }
+        },
+    )
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("MY_ROUTE=https://attacker.invalid\n")
+
+    monkeypatch.chdir(tmp_path)
+
+    snapshot = _snapshot_env()
+    try:
+        os.environ.pop("MY_ROUTE", None)
+
+        cp_config.load_api_keys_to_environment()
+
+        assert os.environ.get("MY_ROUTE") != "https://attacker.invalid"
+    finally:
+        _restore_env(snapshot)
+
+
 def test_endpoint_hydrates_from_config(monkeypatch):
     """The Azure endpoint still loads from the user's trusted config."""
     monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "")

--- a/tests/test_provider_credentials.py
+++ b/tests/test_provider_credentials.py
@@ -74,7 +74,11 @@ class TestExtractSecretHeaderEnvVars:
 
     def test_extracts_only_secret_named_header_vars(self):
         names = extract_secret_header_env_vars_from_model_config(
-            {"custom_endpoint": {"headers": {"Authorization": "Bearer $A", "X-Title": "$B"}}}
+            {
+                "custom_endpoint": {
+                    "headers": {"Authorization": "Bearer $A", "X-Title": "$B"}
+                }
+            }
         )
         assert names == ["A"]
 

--- a/tests/test_provider_credentials.py
+++ b/tests/test_provider_credentials.py
@@ -7,10 +7,12 @@ from unittest.mock import patch
 import pytest
 
 from code_puppy.provider_credentials import (
+    _SECRET_HEADER_NAMES,
     credential_display,
     credential_hint,
     extract_env_var_from_model_config,
     extract_env_vars_from_model_config,
+    extract_secret_header_env_vars_from_model_config,
     get_credential_value,
     is_credential_set,
     mask_secret,
@@ -65,6 +67,25 @@ class TestExtractEnvVarFromModelConfig:
             }
         )
         assert names == ["ENDPOINT_KEY", "TOP_KEY", "MY_SERVICE_TOKEN"]
+
+
+class TestExtractSecretHeaderEnvVars:
+    """Only header vars whose NAME marks them a credential are secret."""
+
+    def test_extracts_only_secret_named_header_vars(self):
+        names = extract_secret_header_env_vars_from_model_config(
+            {"custom_endpoint": {"headers": {"Authorization": "Bearer $A", "X-Title": "$B"}}}
+        )
+        assert names == ["A"]
+
+    def test_secret_header_name_match_is_case_insensitive(self):
+        # The frozenset stores lowercase names, and the header name is lowered
+        # before the membership test, so an upper-cased header still matches.
+        assert "authorization" in _SECRET_HEADER_NAMES
+        names = extract_secret_header_env_vars_from_model_config(
+            {"custom_endpoint": {"headers": {"AUTHORIZATION": "Bearer $UPPER"}}}
+        )
+        assert names == ["UPPER"]
 
 
 class TestMaskSecret:
@@ -233,6 +254,37 @@ class TestEnvironmentWithoutCredentials:
         env = environment_without_credentials()
 
         assert "OPENROUTER_API_KEY" not in env
+        assert env["SITE_URL"] == "https://example.com"
+
+    def test_scrubs_custom_endpoint_secret_header(self, monkeypatch):
+        """A secret-named header var is scrubbed; a sibling non-secret one stays.
+
+        An ``Authorization: Bearer $TOKEN`` authenticates provider calls just as
+        an api_key does, so its var must not ride into a model-triggered child
+        shell — while a non-secret ``X-Title: $SITE_URL`` still passes through.
+        """
+        from code_puppy.provider_credentials import environment_without_credentials
+
+        monkeypatch.setattr(
+            "code_puppy.provider_credentials._load_merged_model_config",
+            lambda: {
+                "custom-model": {
+                    "provider": "custom",
+                    "custom_endpoint": {
+                        "headers": {
+                            "Authorization": "Bearer $MY_LLM_TOKEN",
+                            "X-Title": "$SITE_URL",
+                        }
+                    },
+                }
+            },
+        )
+        monkeypatch.setenv("MY_LLM_TOKEN", "llm-secret")
+        monkeypatch.setenv("SITE_URL", "https://example.com")
+
+        env = environment_without_credentials()
+
+        assert "MY_LLM_TOKEN" not in env
         assert env["SITE_URL"] == "https://example.com"
 
     def test_catalog_change_applies_to_next_call(self, monkeypatch):

--- a/tests/test_session_pickle_loading_safety.py
+++ b/tests/test_session_pickle_loading_safety.py
@@ -67,3 +67,54 @@ def test_blocked_builtins_namespace_accessors():
         resolved = unpickler.find_class("builtins", name)
         assert resolved is not getattr(builtins, name), name
         assert issubclass(resolved, SurrogateBase), name
+
+
+def test_build_into_module_namespace_is_refused():
+    """A re-exported submodule must resolve to a surrogate, never a live module.
+
+    ``collections._sys`` is the real ``sys`` module. If it resolved to that live
+    object, a following BUILD opcode could write into its ``__dict__`` (here
+    ``_cp_pwn``) — in-process poisoning. The allowlist routes it to a surrogate,
+    so BUILD can only touch that inert bag, and a hostile payload that raises
+    must still never mutate ``sys``.
+    """
+    import sys
+
+    payload = (
+        pickle.PROTO
+        + bytes([2])
+        + b"ccollections\n_sys\n"
+        + b"}"
+        + b"X"
+        + (7).to_bytes(4, "little")
+        + b"_cp_pwn"
+        + b"\x88"
+        + b"s"
+        + b"b"
+        + b"."
+    )
+
+    assert not hasattr(sys, "_cp_pwn")
+    try:
+        load_surrogate_pickle(payload)
+    except Exception:
+        pass
+    assert not hasattr(sys, "_cp_pwn")
+
+
+def test_exit_quit_help_do_not_resolve_to_real_callables():
+    """builtins.exit/quit/help must resolve to surrogates, not the real callables.
+
+    The real ones raise ``SystemExit`` (a ``BaseException``) past the migration's
+    ``except Exception`` and would kill the process on load.
+    """
+    import builtins
+    import io
+
+    from code_puppy.session_surrogate_unpickler import SurrogateBase, SurrogateUnpickler
+
+    for name in ("exit", "quit", "help"):
+        unpickler = SurrogateUnpickler(io.BytesIO(b""))
+        resolved = unpickler.find_class("builtins", name)
+        assert resolved is not getattr(builtins, name), name
+        assert issubclass(resolved, SurrogateBase), name

--- a/tests/tools/test_command_runner_env.py
+++ b/tests/tools/test_command_runner_env.py
@@ -144,8 +144,8 @@ async def test_shell_command_env_strips_well_known_provider_keys(monkeypatch):
     assert "MISTRAL_API_KEY" not in captured["env"]
 
 
-def test_hook_environment_excludes_provider_credentials(monkeypatch):
-    """Hook processes see the CLAUDE_* contract variables but not provider keys."""
+def test_hook_environment_includes_provider_credentials(monkeypatch):
+    """Hooks are user config, so provider keys are inherited (a hook may call an LLM)."""
     from code_puppy.hook_engine.executor import _build_environment
     from code_puppy.hook_engine.models import EventData
 
@@ -160,7 +160,7 @@ def test_hook_environment_excludes_provider_credentials(monkeypatch):
         )
     )
 
-    assert "ANTHROPIC_API_KEY" not in env
+    assert env["ANTHROPIC_API_KEY"] == "agent-key"
     assert env["GITHUB_TOKEN"] == "user-token"
     assert env["CLAUDE_TOOL_NAME"] == "Edit"
     assert env["CLAUDE_FILE_PATH"] == "a.py"

--- a/tests/tools/test_grep_flag_validation.py
+++ b/tests/tools/test_grep_flag_validation.py
@@ -1,6 +1,10 @@
 """Flag handling for the local ripgrep grep path (``_build_grep_args``)."""
 
-from code_puppy.tools.file_operations import _build_backend_matcher, _build_grep_args
+from code_puppy.tools.file_operations import (
+    _build_backend_matcher,
+    _build_grep_args,
+    _carries_type_filter,
+)
 
 
 def test_build_grep_args_rejects_unsupported_flags():
@@ -96,6 +100,24 @@ def test_build_grep_args_value_keeps_cluster_literal():
     args, error = _build_grep_args("-e '-C3'")
     assert error is None
     assert args == ["-e", "-C3"]
+
+
+def test_build_grep_args_flag_only_errors():
+    """A supported flag with no pattern errors, and both paths agree verbatim."""
+    args, error = _build_grep_args("-w")
+    assert args == []
+    assert error == "no search pattern provided"
+
+    _pattern, _exts, backend_error = _build_backend_matcher("-w")
+    assert backend_error == error
+
+
+def test_carries_type_filter_matches_short_equals():
+    """``-t=VALUE`` counts as a type filter, alongside the other type forms."""
+    assert _carries_type_filter(["-t=py", "def"]) is True
+    assert _carries_type_filter(["-t", "py", "def"]) is True
+    assert _carries_type_filter(["--type=py", "def"]) is True
+    assert _carries_type_filter(["-e", "def foo"]) is False
 
 
 def test_build_backend_matcher_value_not_shredded():

--- a/tests/tools/test_grep_live_behavior.py
+++ b/tests/tools/test_grep_live_behavior.py
@@ -6,7 +6,12 @@ silently re-scoping the search.
 """
 
 from code_puppy.tools import file_operations
-from code_puppy.tools.file_operations import MatchInfo, _emit_grep_result, _grep
+from code_puppy.tools.file_operations import (
+    _MAX_GREP_CONTEXT_ROWS,
+    MatchInfo,
+    _emit_grep_result,
+    _grep,
+)
 
 
 def _setup(tmp_path):
@@ -62,6 +67,26 @@ def test_grep_context_lines_do_not_evict_real_matches(tmp_path):
     assert all(m.line_content == "target" for m in real)
     # Context lines are still surfaced, just never counted as matches.
     assert context
+
+
+def test_wide_context_is_capped_without_evicting_matches(tmp_path):
+    """A wide -C caps context rows separately; real matches still fill the budget.
+
+    Context is bounded by ``_MAX_GREP_CONTEXT_ROWS`` so an enormous -C can't grow
+    the output without limit, yet the 50 real matches are never evicted.
+    """
+    # A large filler preamble sits within a huge context radius of the first
+    # match, so the raw context stream far exceeds the cap; the 60 matches then
+    # exceed the 50-match budget.
+    lines = ["filler"] * 400 + ["target", "filler"] * 60
+    (tmp_path / "big.py").write_text("\n".join(lines) + "\n")
+
+    out = _grep(None, "-C 9999 target", str(tmp_path))
+
+    assert out.error is None
+    real = [m for m in out.matches if not m.is_context]
+    assert len(real) == 50
+    assert len(out.matches) <= 50 + _MAX_GREP_CONTEXT_ROWS
 
 
 def test_emit_grep_result_excludes_context_from_counts(monkeypatch):


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David.

David directed this work and reviewed the approach at a high level; the individual changes are AI-authored (light review).

Fixes #779.

Follow-up hardening after the parallel tool-call pruning work (#790).

Primary fix: history **compaction** now assembles a provider-valid message array. The shipped compacted history is run through the same-role merge, so it never emits two adjacent same-role turns, and a request emptied of every part during pruning is dropped wherever it sits — so the history never ends on an assistant turn. Previously either shape could be rejected by providers like Anthropic/Bedrock, and compaction silently fell back to hard truncation instead of producing a summary.

Also included — small, independently-tested robustness fixes:

- **compaction/history**: shrink an oversized *completed* tool result in place rather than reporting it as interrupted (which made the model re-issue the same oversized call in a loop); protect a call answered by a validation retry across the summarization split so the pair is not severed and then dropped.
- **grep**: cap `-A/-B/-C` context rows so a wide context value can't grow the result without bound; return a clear error on a flag-only search instead of searching the working directory as the pattern; stop a default `--type=all` from diluting an explicit `-t=VALUE`.
- **hooks**: escape interpolated values that land inside a `` `...` `` command substitution and make the quote scanner comment-aware, so metacharacters in a value stay literal in the hook's own shell; inherit the full environment so a hook that shells out to another tool keeps its own credentials.
- **project `.env`**: import only api-key names — a custom endpoint's header vars hydrate from `puppy.cfg` only, never from a project dot-env.
- **child shell**: also drop secret-named endpoint header tokens from the environment the model's shell commands inherit.
- **legacy sessions**: resolve pickled globals through an explicit allowlist, so migration only reconstructs known leaf types.
- **project plugins**: extend the source-only guard to compiled extensions and symlinked directories, and scope the bytecode-cache redirect to each plugin's own load instead of leaving it set process-wide.

All changes ship with tests; the full suite passes.
