### PR TITLE
test: cover malformed provider SSE retry recovery

### DIFF
--- a/tests/agents/test_runtime_streaming_retry_classifier.py
+++ b/tests/agents/test_runtime_streaming_retry_classifier.py
@@ -1,14 +1,22 @@
-"""Regression tests: bare JSONDecodeError must be classified as retryable.
+"""Regression tests for malformed provider SSE retry recovery.
 
-A malformed SSE line raises ``json.JSONDecodeError``, which used to escape
-``_is_retryable_one`` and crash the session.
+A malformed SSE ``data:`` payload can raise ``json.JSONDecodeError`` from the
+OpenAI or Anthropic SDK. The runtime must recognize that exception through an
+``ExceptionGroup`` and retry the turn from its last completed step.
 """
 
 from __future__ import annotations
 
+import importlib
 import json
 
-from code_puppy.agents._runtime import _is_retryable_one, should_retry_streaming
+import pytest
+
+from code_puppy.agents._runtime import (
+    _is_retryable_one,
+    should_retry_streaming,
+    streaming_retry,
+)
 
 
 def _malformed_sse_json_decode_error() -> json.JSONDecodeError:
@@ -38,3 +46,42 @@ def test_should_retry_streaming_reaches_json_decode_error_inside_group() -> None
 def test_is_retryable_one_does_not_widen_to_unrelated_value_errors() -> None:
     """Guard against over-widening: unrelated ValueErrors stay non-retryable."""
     assert _is_retryable_one(ValueError("nope")) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "streaming_module_path,event_name",
+    [
+        ("openai._streaming", "response.output_item.added"),
+        ("anthropic._streaming", "content_block_delta"),
+    ],
+)
+async def test_streaming_retry_recovers_from_provider_sse_extra_data(
+    monkeypatch: pytest.MonkeyPatch,
+    streaming_module_path: str,
+    event_name: str,
+) -> None:
+    """Exercise each SDK's real SSE exception through the real retry loop."""
+    streaming = importlib.import_module(streaming_module_path)
+    malformed_event = streaming.ServerSentEvent(
+        event=event_name,
+        data='{"ok": 1}{"oops": 2}',
+    )
+    attempts = 0
+
+    async def run_once() -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            malformed_event.json()
+        return "recovered"
+
+    monkeypatch.setattr(
+        "code_puppy.error_logging.log_error", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr("code_puppy.agents._runtime.emit_warning", lambda *args: None)
+
+    run_with_retry = streaming_retry(max_attempts=2, delays=(0,))(run_once)
+
+    assert await run_with_retry() == "recovered"
+    assert attempts == 2


### PR DESCRIPTION
## Problem

Some upstream gateways/proxies occasionally emit a malformed streamed SSE event—most often two JSON objects concatenated onto one `data:` payload, such as `{"ok": 1}{"oops": 2}`. Both the OpenAI and Anthropic SDKs surface that provider response as `json.JSONDecodeError: Extra data` from `ServerSentEvent.json()`.

Code Puppy already has the correct production behavior: `_is_retryable_one()` classifies `JSONDecodeError` as transient, `should_retry_streaming()` reaches it through an `ExceptionGroup`, and `streaming_retry()` re-runs the turn from its last completed step. Existing tests covered the predicates but not actual retry-loop recovery using each provider SDK's concrete SSE event shape.

## Change

This deliberately YAGNI-sized PR adds one parameterized async regression test that:

1. constructs a malformed `ServerSentEvent` using the real OpenAI or Anthropic SDK class;
2. lets the SDK raise the real `JSONDecodeError` on attempt one;
3. runs it through the existing `streaming_retry(max_attempts=2, delays=(0,))` mechanism;
4. verifies attempt two succeeds and exactly two attempts occurred.

No production code, SDK monkey-patches, payload logging, or duplicate retry machinery are added.

## Verification

- `pytest tests/agents/test_runtime_streaming_retry_classifier.py tests/test_pydantic_patches.py -q --no-cov` — 18 passed
- `ruff check` — passed
- `ruff format --check` — passed
- `git diff --check upstream/main` — passed

## Tracking

- [PUP-645](https://jira.walmart.com/browse/PUP-645)
