### PR TITLE
fix: bound remaining mcp_servers.json reads and close fifth unlocked writer

### DIFF
--- a/code_puppy/atomic_io.py
+++ b/code_puppy/atomic_io.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import stat
 import tempfile
 import time
 import uuid
@@ -87,6 +88,15 @@ def path_lock(
     Uses ``fcntl.flock`` on POSIX and ``msvcrt.locking`` on Windows. Raises
     :class:`LockTimeout` rather than blocking forever if another process
     (or another lock held by this same process) doesn't release in time.
+
+    Not reentrant: ``flock`` is scoped per *open file description*, not per
+    process or thread, so a second ``path_lock(path)`` (directly, or via
+    ``mutate_config``/``mutate_json`` on the same ``path``) taken from
+    *inside* an already-held lock on that same path will not recognize the
+    outer lock as "ours" -- it will block for the full ``timeout`` and then
+    raise :class:`LockTimeout`, rather than deadlock forever, but still not
+    proceed. Do not call ``mutate_config``/``mutate_json`` for a path from
+    within a ``mutation``/``mutate`` callback already locking that path.
     """
     lock_path = f"{path}.lock"
     os.makedirs(os.path.dirname(os.path.abspath(lock_path)), exist_ok=True)
@@ -179,7 +189,7 @@ def atomic_write_bytes(path: str, data: bytes) -> None:
 
     mode = None
     try:
-        mode = os.stat(target).st_mode
+        mode = stat.S_IMODE(os.stat(target).st_mode)
     except OSError:
         pass
 

--- a/code_puppy/command_line/mcp/trust_command.py
+++ b/code_puppy/command_line/mcp/trust_command.py
@@ -173,9 +173,11 @@ class TrustCommand(MCPCommandBase):
     def _safe_load_servers(config_file) -> dict:
         """Parse the project config for display only; never raise."""
         try:
+            from code_puppy import atomic_io
             from code_puppy.config import _parse_mcp_servers_mapping
 
-            return _parse_mcp_servers_mapping(config_file.read_text(encoding="utf-8"))
+            raw = atomic_io.read_bounded_bytes(str(config_file))
+            return _parse_mcp_servers_mapping(raw.decode("utf-8"))
         except Exception:
             return {}
 

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 from typing import Any, Optional
 
+from code_puppy import atomic_io
 from code_puppy.config_file import load_config, mutate_config
 from code_puppy.session_storage import save_session
 
@@ -590,8 +591,8 @@ def load_mcp_server_configs():
     # 1. User-level config (global, implicitly trusted).
     try:
         if pathlib.Path(MCP_SERVERS_FILE).exists():
-            with open(MCP_SERVERS_FILE, "r", encoding="utf-8") as f:
-                configs.update(_parse_mcp_servers_mapping(f.read()))
+            raw = atomic_io.read_bounded_bytes(MCP_SERVERS_FILE)
+            configs.update(_parse_mcp_servers_mapping(raw.decode("utf-8")))
     except Exception as e:
         emit_error(f"Failed to load MCP servers - {str(e)}")
 

--- a/code_puppy/mcp_/config_wizard.py
+++ b/code_puppy/mcp_/config_wizard.py
@@ -6,7 +6,6 @@ Note: This module imports ServerConfig and get_mcp_manager directly from
 """
 
 import re
-from pathlib import Path
 from typing import Dict, Optional
 from urllib.parse import urlparse
 
@@ -495,30 +494,19 @@ def run_add_wizard(group_id: str = None) -> bool:
                 message_group=group_id,
             )
 
-            # Also save to mcp_servers.json for persistence
-            import json
-            import os
-
+            # Also save to mcp_servers.json for persistence -- via the
+            # shared locked/bounded/atomic store, not a hand-rolled
+            # read-modify-write. This used to be its own unlocked writer,
+            # meaning it could clobber a concurrent update from the other
+            # four mcp_servers.json writers (the custom-server form, the
+            # custom-server installer, and /mcp remove) even though those
+            # four correctly serialize on each other.
+            from code_puppy.command_line.mcp.mcp_servers_store import (
+                upsert_mcp_server,
+            )
             from code_puppy.config import MCP_SERVERS_FILE
 
-            # Load existing configs
-            if os.path.exists(MCP_SERVERS_FILE):
-                with open(MCP_SERVERS_FILE, "r") as f:
-                    data = json.load(f)
-                    servers = data.get("mcp_servers", {})
-            else:
-                servers = {}
-                data = {"mcp_servers": servers}
-
-            # Add new server
-            servers[config.name] = config.config
-
-            # Save back
-            os.makedirs(os.path.dirname(MCP_SERVERS_FILE), exist_ok=True)
-            temp_path = Path(MCP_SERVERS_FILE).with_suffix(".tmp")
-            with open(temp_path, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2)
-            temp_path.replace(MCP_SERVERS_FILE)
+            upsert_mcp_server(config.name, config.config)
 
             emit_info(
                 Text.from_markup(

--- a/code_puppy/mcp_/project_config.py
+++ b/code_puppy/mcp_/project_config.py
@@ -250,9 +250,11 @@ def load_project_mcp_server_configs(
 
     # Trusted: parse via the same chokepoint the user-level loader uses.
     try:
+        from code_puppy import atomic_io
         from code_puppy.config import _parse_mcp_servers_mapping
 
-        return _parse_mcp_servers_mapping(config_file.read_text(encoding="utf-8"))
+        raw = atomic_io.read_bounded_bytes(str(config_file))
+        return _parse_mcp_servers_mapping(raw.decode("utf-8"))
     except Exception as exc:
         from code_puppy.messaging.message_queue import emit_error
 

--- a/tests/mcp/test_config_wizard.py
+++ b/tests/mcp/test_config_wizard.py
@@ -15,6 +15,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+import json
+
 from code_puppy.mcp_.config_wizard import (
     MCPConfigWizard,
     confirm_ask,
@@ -904,21 +906,20 @@ class TestRunAddWizard:
     @patch("code_puppy.mcp_.config_wizard.get_mcp_manager")
     @patch("code_puppy.mcp_.config_wizard.emit_success")
     @patch("code_puppy.mcp_.config_wizard.emit_info")
-    @patch("builtins.open", create=True)
-    @patch("os.path.exists", return_value=False)
-    @patch("os.makedirs")
-    @patch("json.dump")
     def test_run_add_wizard_success(
         self,
-        mock_json_dump,
-        mock_makedirs,
-        mock_exists,
-        mock_open,
         mock_info,
         mock_success,
         mock_get_manager,
+        tmp_path,
     ):
-        """Test successful wizard completion and registration."""
+        """Test successful wizard completion and registration.
+
+        Persists via the shared, locked mcp_servers_store rather than the
+        wizard's old hand-rolled open/json.dump -- uses a real tmp_path file
+        instead of mocking open()/os.path.exists()/json.dump so the test
+        actually exercises that write path (and any regression in it).
+        """
         config = ServerConfig(
             id="test-1",
             name="test-server",
@@ -930,14 +931,17 @@ class TestRunAddWizard:
         mock_manager.register_server.return_value = "test-1"
         mock_get_manager.return_value = mock_manager
 
+        mcp_servers_file = tmp_path / "mcp_servers.json"
         with patch.object(MCPConfigWizard, "run_wizard", return_value=config):
-            with patch("code_puppy.config.MCP_SERVERS_FILE", "/tmp/mcp_servers.json"):
-                with patch("pathlib.Path.replace"):
-                    result = run_add_wizard()
+            with patch("code_puppy.config.MCP_SERVERS_FILE", str(mcp_servers_file)):
+                result = run_add_wizard()
 
         assert result is True
         mock_manager.register_server.assert_called_once_with(config)
         mock_success.assert_called()
+
+        saved = json.loads(mcp_servers_file.read_text())
+        assert saved["mcp_servers"]["test-server"] == {"command": "python"}
 
     @patch("code_puppy.mcp_.config_wizard.get_mcp_manager")
     @patch("code_puppy.mcp_.config_wizard.emit_error")

--- a/tests/mcp/test_project_config.py
+++ b/tests/mcp/test_project_config.py
@@ -101,6 +101,24 @@ def test_malformed_trusted_config_fails_closed(project):
     assert pc.load_project_mcp_server_configs() == {}
 
 
+def test_oversized_trusted_config_fails_closed_without_full_read(project, monkeypatch):
+    """Project-level mcp_servers.json is repo-supplied input -- whatever repo
+    you ``cd`` into -- so an oversized file must be rejected via a bounded
+    read the same way the user-level loader is, not fully buffered first.
+    """
+    _write_project_config(project, {"s": "http://localhost"})
+    assert pc.trust_project_mcp() is True
+
+    from code_puppy import atomic_io
+
+    monkeypatch.setattr(
+        atomic_io,
+        "read_bounded_bytes",
+        lambda *a, **kw: (_ for _ in ()).throw(atomic_io.ContentTooLarge("too big")),
+    )
+    assert pc.load_project_mcp_server_configs() == {}
+
+
 # ---------- merge precedence in the top-level loader -------------------------
 
 

--- a/tests/test_config_full_coverage.py
+++ b/tests/test_config_full_coverage.py
@@ -662,6 +662,26 @@ class TestMCPServerConfigs:
                 result = cp_config.load_mcp_server_configs()
                 assert result == {}
 
+    def test_oversized_file_is_rejected_without_full_read(self, tmp_path):
+        """Pins the Andrew Tilson PUP-605-follow-up finding on the merged
+        PR #761: this startup read was the one spot missed when every other
+        MCP/config JSON read got bounded via atomic_io. A file over the
+        bound must be rejected -- caught and reported like any other bad
+        config -- rather than read in full first (the original MemoryError
+        crash shape).
+        """
+        f = tmp_path / "mcp_servers.json"
+        f.write_text('{"mcp_servers": {}}')
+        with patch.object(cp_config, "MCP_SERVERS_FILE", str(f)):
+            with patch(
+                "code_puppy.config.atomic_io.read_bounded_bytes",
+                side_effect=cp_config.atomic_io.ContentTooLarge("too big"),
+            ):
+                with patch("code_puppy.messaging.message_queue.emit_error") as err:
+                    result = cp_config.load_mcp_server_configs()
+                    assert result == {}
+                    err.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # Config keys


### PR DESCRIPTION
Jira: [PUP-610](https://jira.walmart.com/browse/PUP-610)

## Second follow-up to PUP-605, per Andrew Tilson's post-merge review of #761

After #761 merged (extending bounded/atomic/locked I/O to `mcp_servers.json`, `extra_models.json`, `spinners.json`, and agent JSON files), Andrew left a further comment identifying two remaining gaps specific to `mcp_servers.json` -- the exact file this whole line of fixes exists to protect.

### HIGH: `config.py`'s `load_mcp_server_configs()` was still an unbounded read, and it's on the startup path

Reached at every CLI startup via `MCPManager.__init__` -> `sync_from_config()`, and again from `agents/_builder.py`. This is the original PUP-605 `MemoryError` crash shape, unfixed, on a startup path, for the very file `mcp_servers_store.py`'s own docstring already warned could "balloon `json.load` the same way `configparser` ballooned in the original PUP-605 crash." The sibling `JSONAgent` startup read was correctly bounded in #761 -- this one looked like a straightforward oversight.

**Fixed** via `atomic_io.read_bounded_bytes`, matching every other call site.

### MEDIUM-HIGH: a fifth, previously unidentified `mcp_servers.json` writer

`mcp_/config_wizard.py::run_add_wizard()` (public API, exported from `mcp_/__init__.py`) was still doing an unlocked, unbounded read-modify-write with a fixed (collision-prone) temp filename and no `fsync`. #761 correctly collapsed the four writers flagged in #757's original review into one locked `mcp_servers_store.py` module -- but this fifth writer was missed. A lock only buys mutual exclusion if *every* writer participates; this one unlocked writer could silently void the safety guarantee the other four now have, which is arguably worse than before the fix, since the other four now *look* safe.

**Fixed** by migrating to the same shared `mcp_servers_store.upsert_mcp_server()` the other four use.

### Also from the same review comment

- Bounded two lower-priority project-level `mcp_servers.json` reads (`mcp_/project_config.py`, `command_line/mcp/trust_command.py`) -- project config is repo-supplied input (whatever repo you `cd` into), so these were flagged as next-most-wanted after the two items above.
- `atomic_io.atomic_write_bytes` now masks stat mode bits via `stat.S_IMODE` before `chmod`, rather than passing `os.stat()`'s raw `st_mode` (which includes file-type bits) straight through. Harmless today since `chmod` masks it anyway, but worth doing properly now that it's a shared primitive.
- `path_lock`'s docstring now documents that it is **not reentrant** (`flock` is scoped per open-file-description, not per-process/thread) -- a sentence to keep it that way rather than a real bug found today.

One nit from the same comment -- documenting or dropping `aws_bedrock`/`azure_foundry`'s now-dead `save_extra_models()` -- turned out to be moot: those plugins were relocated to the separate `code_puppy_core_plugins` package in the interim (`27efe8f5`) and no longer exist in this repo.

### Testing

- Added regression tests pinning both bounded-read fixes (`tests/test_config_full_coverage.py`, `tests/mcp/test_project_config.py`).
- Rewrote the wizard-save test in `tests/mcp/test_config_wizard.py` to use a real `tmp_path` file instead of mocking `open()`/`os.path.exists()`/`json.dump` internals that no longer exist post-refactor -- that stale mocking had been silently letting a real file write leak to `/tmp/mcp_servers.json` on every test run (cleaned up).
- Full suite: **7461 passed, 28 skipped, 1 xpassed** (rebased onto the current `main` tip, including the `code_puppy_core_plugins` extraction and the session-persistence migration).
- `ruff check` and `ruff format --check` both clean.

cc @AndrewTilson -- both flagged gaps should be closed now.
