### PR TITLE
fix: support property-based headless run usage

### DIFF
--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -1445,7 +1445,8 @@ async def execute_single_prompt(
             AgentResponseMessage(content=result.output, is_markdown=True)
         )
         if usage_file is not None:
-            _write_usage_file(usage_file, result.usage())
+            usage = result.usage
+            _write_usage_file(usage_file, usage() if callable(usage) else usage)
 
         # The runtime result includes the final assistant response that the
         # incremental history can otherwise miss.

--- a/tests/test_cli_usage_file.py
+++ b/tests/test_cli_usage_file.py
@@ -49,7 +49,7 @@ async def test_execute_single_prompt_writes_result_usage(tmp_path):
         cost=None,
     )
     result = MagicMock(output="done")
-    result.usage.return_value = usage
+    result.usage = usage
     result.all_messages.return_value = []
     agent = MagicMock()
     renderer = MagicMock()
@@ -74,7 +74,6 @@ async def test_execute_single_prompt_writes_result_usage(tmp_path):
     ):
         await execute_single_prompt("do it", renderer, usage_file=target)
 
-    result.usage.assert_called_once_with()
     assert json.loads(target.read_text())["input_tokens"] == 10
 
 


### PR DESCRIPTION
## Summary

- support Pydantic AI versions where `AgentRunResult.usage` is a `RunUsage` property
- retain compatibility with versions exposing a callable usage accessor
- update the integration test to use the production property shape

## Why

`code-puppy --usage-file ...` on 0.0.742 completed the agent task, then failed with:

```text
'RunUsage' object is not callable
```

The previous test used a `MagicMock` method and therefore did not match the runtime API.

## Tests

- `uv run pytest -q tests/test_cli_usage_file.py tests/test_cli_runner_resume_render.py`
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `git diff --check`
