### PR TITLE
Add /new alias for /clear

### DIFF
--- a/code_puppy/command_line/session_commands.py
+++ b/code_puppy/command_line/session_commands.py
@@ -93,7 +93,7 @@ def handle_session_command(command: str) -> bool:
     name="clear",
     description="Clear conversation history (rotates autosave; agent forgets prior turns)",
     usage="/clear",
-    aliases=["cls"],
+    aliases=["cls", "new"],
     category="session",
     detailed_help="""
     Wipe the current conversation history so the agent starts fresh.

--- a/tests/test_command_handler.py
+++ b/tests/test_command_handler.py
@@ -958,6 +958,7 @@ class TestCommandRegistry:
             ("exit", "quit"),
             ("model", "m"),
             ("agent", "a"),
+            ("clear", "new"),
         ],
     )
     def test_aliased_command_registered(self, name, alias):


### PR DESCRIPTION
Adds `/new` as a visible alias for `/clear`, so starting a fresh conversation can use the shorter command.

Tests: `pytest tests/test_command_handler.py -k "aliased_command_registered or registry_command_and_alias"`