### PR TITLE
feat: adopt harness ToolOutputLimits for oversized tool returns

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -20,6 +20,7 @@ from pydantic_ai.capabilities import ProcessHistory
 
 from code_puppy.agents._compaction import make_history_processor
 from code_puppy.agents._steer_processor import make_steer_history_processor
+from code_puppy.agents._tool_output_limits import build_tool_output_limits
 from code_puppy.agents.event_stream_handler import event_stream_handler
 from code_puppy.callbacks import (
     on_pre_mcp_autostart,
@@ -635,21 +636,28 @@ def build_pydantic_agent(
     steer_processor = make_steer_history_processor(agent)
 
     def _new_pydantic_agent(toolsets: List[Any]) -> PydanticAgent:
+        # Order matters: compaction first (may trim history to fit
+        # context), THEN steer injection (a fresh steer must not be
+        # compacted away). ProcessHistory capabilities apply in
+        # registration order (replaces the deprecated
+        # `history_processors=` kwarg, removed in pydantic-ai v2).
+        capabilities: List[Any] = [
+            ProcessHistory(history_processor),
+            ProcessHistory(steer_processor),
+        ]
+        # ToolOutputLimits acts at tool-execution time (after_tool_execute),
+        # not on history, so its position in this list is inert. Built fresh
+        # per agent; None when disabled via tool_output_limit_chars=0.
+        tool_output_limits = build_tool_output_limits()
+        if tool_output_limits is not None:
+            capabilities.append(tool_output_limits)
         return PydanticAgent(
             model=model,
             instructions=instructions,
             output_type=output_type,
             retries=3,
             toolsets=toolsets,
-            # Order matters: compaction first (may trim history to fit
-            # context), THEN steer injection (a fresh steer must not be
-            # compacted away). ProcessHistory capabilities apply in
-            # registration order (replaces the deprecated
-            # `history_processors=` kwarg, removed in pydantic-ai v2).
-            capabilities=[
-                ProcessHistory(history_processor),
-                ProcessHistory(steer_processor),
-            ],
+            capabilities=capabilities,
             model_settings=model_settings,
         )
 

--- a/code_puppy/agents/_tool_output_limits.py
+++ b/code_puppy/agents/_tool_output_limits.py
@@ -1,0 +1,73 @@
+"""Oversized tool returns — delegated to pydantic-ai-harness.
+
+An oversized tool return persists in message history and is re-sent on every
+later model request, paying its token cost for the rest of the run. The
+``ToolOutputLimits`` capability from ``pydantic_ai_harness.tool_output_limits``
+intercepts a return when it is produced and reduces it ONCE, so the reduced
+form is what persists.
+
+The default band is ``Spill(then=Truncate())``: the full payload is written to
+a private overflow store and the model gets a handle plus a bounded preview.
+Spilled payloads are read back on demand through the capability's own
+``read_tool_result(handle, offset, limit, from_end, pattern)`` tool — lossless,
+unlike a history-time clamp. When the store write fails, the return is
+truncated instead; never a silent drop.
+
+What lives here is the Code Puppy-specific glue:
+
+  * the threshold comes from ``puppy.cfg`` (``tool_output_limit_chars``,
+    ``/set``-able, 0 disables the capability entirely);
+  * spilled payloads land under ``~/.code_puppy/tool_output_overflow/`` (the
+    config dir, per the runtime-state convention) instead of the harness's
+    shared temp-dir default, with an age-based TTL so the directory does not
+    grow forever.
+
+History-time protection (``_history.filter_huge_messages``) stays: it defends
+against oversized messages that predate this capability — resumed sessions,
+histories imported from other tools — which production-time reduction can
+never see.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+from typing import Optional
+
+from pydantic_ai_harness.tool_output_limits import (
+    Band,
+    LocalFileStore,
+    Spill,
+    ToolOutputLimits,
+    Truncate,
+)
+
+from code_puppy.config import CONFIG_DIR, get_tool_output_limit_chars
+
+# Subdirectory of CONFIG_DIR that holds spilled payloads. Deliberately under
+# ~/.code_puppy so runtime state stays out of project working trees.
+OVERFLOW_DIR_NAME = "tool_output_overflow"
+
+# Spilled files older than this are pruned (best-effort, off the hot path) on
+# the next write. Long enough to outlive any plausible session resume; short
+# enough that the directory cannot grow without bound.
+SPILL_TTL = timedelta(days=7)
+
+
+def build_tool_output_limits() -> Optional[ToolOutputLimits]:
+    """Config → ``ToolOutputLimits`` wiring, or ``None`` when disabled.
+
+    Called per agent build (each pydantic agent gets its own capability
+    instance); the overflow store root is stable across instances, so a
+    ``read_tool_result`` handle minted by one build resolves in the next.
+    """
+    threshold = get_tool_output_limit_chars()
+    if threshold <= 0:
+        return None
+    return ToolOutputLimits(
+        bands=[Band(over=threshold, action=Spill(then=Truncate()))],
+        store=LocalFileStore(
+            base_dir=Path(CONFIG_DIR) / OVERFLOW_DIR_NAME,
+            cleanup_after=SPILL_TTL,
+        ),
+    )

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -488,6 +488,10 @@ def get_config_keys():
     default_keys.append("resume_message_count")
     # Per-file AGENTS.md character cap (see get_agents_md_max_chars()).
     default_keys.append("agents_md_max_chars")
+    # Tool-return overflow threshold in characters (see
+    # get_tool_output_limit_chars()); 0 disables the harness ToolOutputLimits
+    # capability entirely.
+    default_keys.append("tool_output_limit_chars")
     # Add /goal iteration cap (owned by the wiggum plugin, surfaced here so
     # /set autocompletes it). See plugins/wiggum/register_callbacks.py.
     default_keys.append("goal_max_iterations")
@@ -1614,6 +1618,35 @@ def get_agents_md_max_chars() -> int:
         return AGENTS_MD_MAX_CHARS_DEFAULT
     if configured <= 0:
         return AGENTS_MD_MAX_CHARS_DEFAULT
+    return configured
+
+
+# Tool-return overflow threshold in characters, /settable via
+# tool_output_limit_chars. Returns at or above this size are reduced by the
+# harness ToolOutputLimits capability (spilled to a queryable file, with a
+# bounded truncation fallback). 0 disables the capability.
+TOOL_OUTPUT_LIMIT_CHARS_DEFAULT = 10_000
+
+
+def get_tool_output_limit_chars() -> int:
+    """Return the tool-return overflow threshold in characters.
+
+    Read from the ``tool_output_limit_chars`` config key (settable via
+    ``/set tool_output_limit_chars=<int>``). Defaults to
+    ``TOOL_OUTPUT_LIMIT_CHARS_DEFAULT`` (10,000) when unset or unparseable.
+    ``0`` is an explicit opt-out: the ToolOutputLimits capability is not
+    attached at all. Negative values fall back to the default. No upper
+    clamp — large-context models can raise it as far as they like.
+    """
+    val = get_value("tool_output_limit_chars")
+    if val is None or str(val).strip() == "":
+        return TOOL_OUTPUT_LIMIT_CHARS_DEFAULT
+    try:
+        configured = int(val)
+    except (ValueError, TypeError):
+        return TOOL_OUTPUT_LIMIT_CHARS_DEFAULT
+    if configured < 0:
+        return TOOL_OUTPUT_LIMIT_CHARS_DEFAULT
     return configured
 
 

--- a/docs/HARNESS_COMPAT_MATRIX.md
+++ b/docs/HARNESS_COMPAT_MATRIX.md
@@ -1,0 +1,81 @@
+# Harness ↔ Code Puppy Feature Compatibility Matrix
+
+Which `pydantic-ai-harness` Capabilities can replace redundant code in Code
+Puppy? Sweep date: 2025-08-19, against `pydantic-ai-harness==0.23.0` (already a
+direct dependency) and `pydantic-ai-slim==2.31.0`.
+
+**Precedent:** `code_puppy/agents/_compaction.py` already ran this playbook —
+~600 lines of hand-rolled compaction deleted, replaced by
+`pydantic_ai_harness.compaction` (`FallbackCompaction`, `SlidingWindowCompaction`,
+`SummarizingCompaction`, `compact_now`) with a thin config-glue layer. That's
+the template every row below is measured against: **harness owns the
+model-facing mechanics, Code Puppy keeps the TUI/config glue.**
+
+Tiers: **Tier 0** adopted · **Tier 1** adopt now · **Tier 2** adopt with glue ·
+**Tier 3** different philosophy, evaluate · **N/A** new feature, nothing
+redundant to delete · **Keep ours** app/UI concern, out of harness scope
+
+## Tier 0 — Already adopted
+
+| Capability | Code Puppy side | Notes |
+|---|---|---|
+| `FallbackCompaction` / `SlidingWindowCompaction` / `SummarizingCompaction` | `agents/_compaction.py` (13.8 KB glue) | Done. Manual `/compact` + `/truncate` drive harness `compact_now`. |
+
+## Tier 1 — Adopt now (high fit, low UI entanglement)
+
+| Capability | Redundant Code Puppy code | Why it fits | Watch out for |
+|---|---|---|---|
+| `ToolOutputLimits` (Spill/Truncate/Summarize) | `_history.filter_huge_messages` (still hand-rolled after the compaction migration) + the `spill` plugin in core-plugins | Harness Spill is *lossless*: full payload persisted, model reads slices via bounded `read_tool_result(handle, ...)`. Our spill is preview-only, dict-shaped-results-only. Strictly better. | Our spill honors per-agent `tools_config` opt-outs and `puppy.cfg` keys — glue layer keeps those. |
+| `RepoContext` | `agents/_builder.py` AGENTS.md discovery + `_truncate_agents_md` (~150 lines) + `config.get_agents_md_max_chars` | Loading AGENTS.md/AGENT.md is exactly RepoContext's job. | Verify parity: global `~/.code_puppy/AGENTS.md`, the `.code_puppy/AGENTS.md`-preferred lookup order, per-file char cap with labelled truncation notice, UTF-16 BOM tolerance. Any gap = small upstream PR, not a fork. |
+| Compaction stragglers: `ClampOversizedMessages`, `DeduplicateFileReads`, `WarnNearLimits` | remainder of `agents/_history.py` (25.5 KB) | We took the summarizers but left the clamp/dedup/warn logic hand-rolled. Finish the migration `_compaction.py` started. | `_history` also owns tool-call-id sanitizing + message hashing used elsewhere; split before delete. |
+
+## Tier 2 — Adopt with glue (replace the model-facing core, keep the TUI)
+
+| Capability | Redundant Code Puppy code | Gains | Blockers / gaps |
+|---|---|---|---|
+| `SubAgents` | `tools/subagent_invocation.py` (31 KB), `subagent_context.py`, `subagent_usage_metrics.py` | Per-delegate usage budgets, wall-clock timeouts, soft-steering failure messages — all things we hand-roll or lack. | Our `invoke_agent` has session-id continuity and the subagent stream panel; harness delegates are stateless per call. Needs a session-memory shim or upstream proposal. |
+| `Shell` | `tools/command_runner.py` (57.6 KB) + `shell_backgrounding.py` | `start_command`/`check_command`/`stop_command` background processes, allow/deny lists (subsumes `shell_safety` + `destructive_command_guard` plugins), auto-cleanup at run end. | Deepest TUI entanglement in the codebase: streaming output rendering, Ctrl+X chords (kill/background), `run_shell_command` callback hooks with `fail_closed`. The harness toolset would be the *executor core*; every UI affordance must re-attach via events. Highest effort, highest payoff. |
+| `FileSystem` | `tools/file_operations.py` (53.9 KB) + `file_modifications.py` (39.7 KB) | Battle-tested read/write/edit toolset, `READ_ONLY_TOOL_NAMES` split. | Harness FileSystem has **no undo recording** (`UndoManager` hooks), **no permission-callback seam** (`file_permission` hook), **no pluggable backend** (our `fs_access` facade backs ACP host filesystems). Three real gaps — candidates for upstream proposals before we can swap. |
+| `StepPersistence` (+ `ConversationSearch`) | `session_storage.py` (16 KB), `session_lifecycle.py` (13 KB), `session_format_migration.py`, `session_migration.py`, `session_surrogate_unpickler.py` (~55 KB total) | Per-step snapshots give crash-resume *mid-run* (`continue_run(include_interrupted=True)`) and `fork_run` — strictly stronger than our end-of-turn JSON envelope. ConversationSearch comes along free. | Session naming/browsing UX and the legacy `.pkl` migration path stay app-side. Storage format changes = migration number 3; sequence carefully. |
+| `Guardrails` (`ToolGuardrail`) | `hook_engine/` (8 modules) + guard plugins' block logic | One blessed pre/post tool interception model instead of our `pre_tool_call` + `fail_closed` special-casing. | `hook_engine` speaks Claude Code hook config (matchers, aliases); that translation layer is Code Puppy value-add and stays. Guardrails becomes the enforcement backend. |
+
+## Tier 3 — Different philosophy; evaluate, don't rush
+
+| Capability | Code Puppy counterpart | Tension |
+|---|---|---|
+| `BrowserUse` | `tools/browser/` (12 Playwright modules) | Harness wraps the `browser-use` library as a sub-agent; ours is a direct Playwright toolset the main model drives. Swapping changes behavior and dependencies, not just implementation. Bench before deciding. |
+| `Planning` | `agents/agent_planning.py` | Ours is a prompt-shaped planning agent; harness has a real plan store + granular tools + events. Adopting gets us live plan-progress UI (bottom bar!) — attractive but additive rather than deletive. |
+| `Researcher` / `ExaSearch` | `agents/agent_web_retriever.py` | Overlapping intent, different search backends. Low urgency. |
+| `CapabilityCreation` / runtime authoring | `tools/universal_constructor.py` (31 KB) | UC builds Code Puppy tools/plugins at runtime; CapabilityCreation builds harness capabilities. Conceptual cousins, different artifacts. Revisit if Code Puppy agents become harness-capability-native. |
+| `SystemReminders` | `timestamp_heartbeat` plugin, steer-queue nudges | Harness does cadence/conditional reminders without cache busts. Nice-to-have consolidation. |
+
+## N/A — no redundancy; adoption would be a new feature
+
+`Memory`, `Advisor`, `CodeMode`, `DynamicWorkflow`, `SpendLimits`,
+`WarnOnCacheBusts`, `PromptInjectionDefender`, `ModalSandbox`, `LocalStack`,
+`StackOne`, `Macroscope`, `PydanticAIDocs`, `ManagedPrompt`.
+Zero Code Puppy code deleted by adopting these; evaluate on their own merits.
+
+## Keep ours — app/UI concerns out of harness scope
+
+- `messaging/`, `tui/`, `command_line/` — the entire terminal UX.
+- `mcp_/` — dashboard, config wizard, health monitor, circuit breaker (core MCP
+  transport already comes from pydantic-ai).
+- `model_factory.py`, OAuth clients (`claude_cache_client`, `chatgpt_codex_client`,
+  `gemini_*`), `round_robin_model.py`, `secret_store*` — model transport & credentials.
+- `token_usage.py` / `status_display.py` — context badge UI (could someday *feed
+  from* `ReportContextUsage`, but the rendering is ours).
+- `undo_manager.py` + `/undo` — CLI-side file rewind (untested since its test
+  file vanished; see tests/__pycache__ ghost).
+
+## Suggested attack order
+
+1. **`ToolOutputLimits`** — deletes a plugin + `_history` clamp code, zero UI risk.
+2. **`RepoContext`** — small, self-contained, finishes with a parity checklist.
+3. **Compaction stragglers** — completes a migration that's already half-done.
+4. **`SubAgents`** — after upstreaming a session-continuity story.
+5. **`StepPersistence`** — biggest UX win (mid-run crash resume), needs a
+   migration plan.
+6. **`FileSystem` / `Shell`** — the big ones; each needs 1–3 upstream gap
+   proposals (undo seam, permission callbacks, backend facade; UI event taps)
+   through pydantic-ai-notes first.

--- a/tests/agents/test_runtime_pause_leakage.py
+++ b/tests/agents/test_runtime_pause_leakage.py
@@ -298,11 +298,17 @@ def test_steer_processor_is_wired_into_builder_after_compaction():
     # Both processors must be referenced in the builder.
     assert "make_steer_history_processor" in src
     assert "make_history_processor" in src
-    # Order is checked textually against the capabilities list literal;
+    # Order is checked textually against the capabilities list (built as a
+    # local so ToolOutputLimits can be appended conditionally);
     # ProcessHistory capabilities apply in registration order.
-    cap_start = src.find("capabilities=[")
-    assert cap_start >= 0, "builder must register capabilities=[ProcessHistory(...)]"
-    cap_block = src[cap_start : src.find("]", cap_start)]
+    cap_start = src.find("capabilities: List[Any] = [")
+    assert cap_start >= 0, (
+        "builder must build the capabilities list with ProcessHistory entries"
+    )
+    # Slice from after the opening bracket of the list literal (the annotation
+    # itself contains "]", so searching from cap_start would end too early).
+    open_idx = src.find("= [", cap_start) + len("= [")
+    cap_block = src[open_idx : src.find("]", open_idx)]
     # Just sanity-check both names appear and history_processor comes first.
     h_idx = cap_block.find("ProcessHistory(history_processor)")
     s_idx = cap_block.find("ProcessHistory(steer_processor)")

--- a/tests/agents/test_tool_output_limits.py
+++ b/tests/agents/test_tool_output_limits.py
@@ -1,0 +1,239 @@
+"""Tests for code_puppy.agents._tool_output_limits (pydantic-ai-harness backed).
+
+Covers:
+- get_tool_output_limit_chars() — config parsing, defaults, the 0-disables
+  contract, and garbage tolerance
+- build_tool_output_limits() — config → ToolOutputLimits wiring: band
+  threshold, Spill-then-Truncate action shape, store rooted under CONFIG_DIR
+- end-to-end reduction — an agent whose tool returns an oversized payload
+  persists a reduced ToolReturnPart and can read the full payload back
+  through the capability's read_tool_result tool
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from pydantic_ai import Agent as PydanticAgent
+from pydantic_ai.messages import (
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+)
+from pydantic_ai.models.function import FunctionModel
+from pydantic_ai_harness.tool_output_limits import (
+    LocalFileStore,
+    Spill,
+    ToolOutputLimits,
+    Truncate,
+)
+
+from code_puppy.agents import _tool_output_limits
+from code_puppy.agents._tool_output_limits import (
+    OVERFLOW_DIR_NAME,
+    build_tool_output_limits,
+)
+from code_puppy.config import (
+    TOOL_OUTPUT_LIMIT_CHARS_DEFAULT,
+    get_tool_output_limit_chars,
+)
+
+# ---------- get_tool_output_limit_chars() ------------------------------------
+
+
+class TestGetToolOutputLimitChars:
+    def _with_value(self, value):
+        return patch("code_puppy.config.get_value", return_value=value)
+
+    def test_unset_returns_default(self):
+        with self._with_value(None):
+            assert get_tool_output_limit_chars() == TOOL_OUTPUT_LIMIT_CHARS_DEFAULT
+
+    def test_empty_string_returns_default(self):
+        with self._with_value("   "):
+            assert get_tool_output_limit_chars() == TOOL_OUTPUT_LIMIT_CHARS_DEFAULT
+
+    def test_zero_is_explicit_opt_out(self):
+        with self._with_value("0"):
+            assert get_tool_output_limit_chars() == 0
+
+    def test_positive_value_honoured_without_upper_clamp(self):
+        with self._with_value("250000"):
+            assert get_tool_output_limit_chars() == 250_000
+
+    def test_garbage_returns_default(self):
+        with self._with_value("many chars pls"):
+            assert get_tool_output_limit_chars() == TOOL_OUTPUT_LIMIT_CHARS_DEFAULT
+
+    def test_negative_returns_default(self):
+        with self._with_value("-5"):
+            assert get_tool_output_limit_chars() == TOOL_OUTPUT_LIMIT_CHARS_DEFAULT
+
+
+# ---------- build_tool_output_limits() ----------------------------------------
+
+
+class TestBuildToolOutputLimits:
+    def test_disabled_returns_none(self):
+        with patch(
+            "code_puppy.agents._tool_output_limits.get_tool_output_limit_chars",
+            return_value=0,
+        ):
+            assert build_tool_output_limits() is None
+
+    def test_default_shape(self, tmp_path):
+        with (
+            patch(
+                "code_puppy.agents._tool_output_limits.get_tool_output_limit_chars",
+                return_value=12_345,
+            ),
+            patch(
+                "code_puppy.agents._tool_output_limits.CONFIG_DIR",
+                str(tmp_path),
+            ),
+        ):
+            capability = build_tool_output_limits()
+
+        assert isinstance(capability, ToolOutputLimits)
+        assert len(capability.bands) == 1
+        band = capability.bands[0]
+        assert band.over == 12_345
+        # Lossless spill with a bounded truncation fallback — never a
+        # silent drop.
+        assert isinstance(band.action, Spill)
+        assert isinstance(band.action.then, Truncate)
+        # Store rooted under the config dir, not the shared temp default,
+        # with a TTL so the overflow dir cannot grow forever.
+        assert isinstance(capability.store, LocalFileStore)
+        assert capability.store.base_dir == tmp_path / OVERFLOW_DIR_NAME
+        assert capability.store.cleanup_after == _tool_output_limits.SPILL_TTL
+
+    def test_fresh_instance_per_build(self):
+        with patch(
+            "code_puppy.agents._tool_output_limits.get_tool_output_limit_chars",
+            return_value=10_000,
+        ):
+            assert build_tool_output_limits() is not build_tool_output_limits()
+
+
+# ---------- end-to-end reduction ----------------------------------------------
+
+
+BIG_PAYLOAD = "needle-" + ("x" * 50_000)
+
+
+def _make_agent(capability: ToolOutputLimits) -> PydanticAgent:
+    call_count = {"n": 0}
+
+    def model_func(messages, info):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(tool_name="big_tool", args={}, tool_call_id="call_1")
+                ]
+            )
+        return ModelResponse(parts=[TextPart(content="done")])
+
+    agent = PydanticAgent(
+        model=FunctionModel(model_func),
+        capabilities=[capability],
+    )
+
+    @agent.tool_plain
+    def big_tool() -> str:
+        return BIG_PAYLOAD
+
+    return agent
+
+
+class TestEndToEndReduction:
+    async def test_oversized_return_is_reduced_and_readable(self, tmp_path):
+        with (
+            patch(
+                "code_puppy.agents._tool_output_limits.get_tool_output_limit_chars",
+                return_value=10_000,
+            ),
+            patch(
+                "code_puppy.agents._tool_output_limits.CONFIG_DIR",
+                str(tmp_path),
+            ),
+        ):
+            capability = build_tool_output_limits()
+        assert capability is not None
+
+        agent = _make_agent(capability)
+        result = await agent.run("go")
+
+        returns = [
+            part
+            for message in result.all_messages()
+            for part in getattr(message, "parts", [])
+            if isinstance(part, ToolReturnPart) and part.tool_name == "big_tool"
+        ]
+        assert len(returns) == 1
+        persisted = returns[0].model_response_str()
+        # Reduced at production time: the full payload never persists.
+        assert len(persisted) < len(BIG_PAYLOAD)
+        assert BIG_PAYLOAD not in persisted
+
+        # The full payload was spilled to the store under the config dir.
+        overflow_root = tmp_path / OVERFLOW_DIR_NAME
+        spilled = [p for p in overflow_root.rglob("*") if p.is_file()]
+        assert spilled, "expected the oversized payload to be spilled to disk"
+        assert any(BIG_PAYLOAD in p.read_text(errors="ignore") for p in spilled), (
+            "spill must be lossless"
+        )
+
+    async def test_small_return_passes_through(self, tmp_path):
+        with (
+            patch(
+                "code_puppy.agents._tool_output_limits.get_tool_output_limit_chars",
+                return_value=10_000,
+            ),
+            patch(
+                "code_puppy.agents._tool_output_limits.CONFIG_DIR",
+                str(tmp_path),
+            ),
+        ):
+            capability = build_tool_output_limits()
+        assert capability is not None
+
+        call_count = {"n": 0}
+
+        def model_func(messages, info):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return ModelResponse(
+                    parts=[
+                        ToolCallPart(
+                            tool_name="small_tool", args={}, tool_call_id="call_1"
+                        )
+                    ]
+                )
+            return ModelResponse(parts=[TextPart(content="done")])
+
+        agent = PydanticAgent(
+            model=FunctionModel(model_func),
+            capabilities=[capability],
+        )
+
+        @agent.tool_plain
+        def small_tool() -> str:
+            return "tiny result"
+
+        result = await agent.run("go")
+        returns = [
+            part
+            for message in result.all_messages()
+            for part in getattr(message, "parts", [])
+            if isinstance(part, ToolReturnPart) and part.tool_name == "small_tool"
+        ]
+        assert len(returns) == 1
+        assert returns[0].model_response_str() == "tiny result"
+        # Nothing spilled for an under-threshold return.
+        overflow_root = tmp_path / OVERFLOW_DIR_NAME
+        assert not overflow_root.exists() or not any(
+            p.is_file() for p in overflow_root.rglob("*")
+        )


### PR DESCRIPTION
## What

Attaches `pydantic_ai_harness.tool_output_limits.ToolOutputLimits` to every built agent, so oversized tool returns are reduced **once, at production time**, instead of persisting in history and getting re-sent on every later model request.

Continues the harness adoption that #799 (compaction) started — same playbook: harness owns the model-facing mechanics, Code Puppy keeps a thin config-glue module.

## Why

- Today an oversized tool return (huge shell output, giant grep, fat JSON) rides along in history until the history-time clamp (`_history.filter_huge_messages`) shrinks it to a **placeholder** at the 50k-token line — lossy, and the tokens were already paid on every prior request.
- The harness default band is `Spill(then=Truncate())`: **lossless**. The full payload is persisted and the model reads slices back on demand via the capability's bounded `read_tool_result(handle, offset, limit, from_end, pattern)` tool (the Claude Code pattern / pydantic-ai #4352 design). If the store write fails it falls back to bounded truncation — never a silent drop.
- See `docs/HARNESS_COMPAT_MATRIX.md` (included) for the full harness-vs-Code-Puppy redundancy sweep that ranked this as the first adoption target.

## How

- **`agents/_tool_output_limits.py`** (new, mirrors `_compaction.py`): `build_tool_output_limits()` wires config to the capability. Spills land under `~/.code_puppy/tool_output_overflow/` (config-dir convention, not the harness temp-dir default) with a 7-day TTL.
- **`config.py`**: new `/set` knob `tool_output_limit_chars` (default 10,000; `0` disables the capability entirely; garbage/negative fall back to default; no upper clamp).
- **`_builder.py`**: capability appended to the agent's capabilities list, built fresh per agent. Position relative to the `ProcessHistory` entries is inert (it hooks `after_tool_execute`, not history).
- **Kept**: `_history.filter_huge_messages` stays as the history-time backstop — it defends resumed sessions and imported histories that predate production-time reduction.
- **Guard test**: the steer-ordering guard in `test_runtime_pause_leakage.py` tracked the `capabilities=[` literal; updated to track the list built as a local (assertion strength unchanged, plus a fix for the `]`-inside-`List[Any]` slicing footgun).

## Interaction with the `spill` core-plugin

The plugin's `post_tool_call` hook runs inside the tool, before this capability sees the result, and only handles dict-shaped results over 32 KiB. They compose without double-spilling (the plugin's output is under this threshold's preview size). Follow-up in `code_puppy_core_plugins` will deprecate the plugin in favor of this capability, which also covers plain-string returns the plugin never could.

## Tests

- 11 new tests: config parsing, capability wiring shape, and end-to-end reduction through a real `pydantic_ai.Agent` run (oversized return reduced + spilled losslessly; small return untouched).
- Full suite: 7470 passed, 28 skipped, 1 xpassed.