### PR TITLE
feat: finish compaction migration — oversized-payload guards as pure harness capabilities

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -19,6 +19,10 @@ from pydantic_ai import Agent as PydanticAgent
 from pydantic_ai.capabilities import ProcessHistory
 
 from code_puppy.agents._compaction import make_history_processor
+from code_puppy.agents._output_limits import (
+    build_response_clamp,
+    build_tool_output_limits,
+)
 from code_puppy.agents._steer_processor import make_steer_history_processor
 from code_puppy.agents.event_stream_handler import event_stream_handler
 from code_puppy.callbacks import (
@@ -646,9 +650,15 @@ def build_pydantic_agent(
             # compacted away). ProcessHistory capabilities apply in
             # registration order (replaces the deprecated
             # `history_processors=` kwarg, removed in pydantic-ai v2).
+            # ToolOutputLimits reduces oversized tool returns on a different
+            # hook (after_tool_execute), so its position is inert; the
+            # response clamp runs before_model_request and sits LAST so it
+            # sees the final, steer-injected history.
             capabilities=[
+                *build_tool_output_limits(),
                 ProcessHistory(history_processor),
                 ProcessHistory(steer_processor),
+                build_response_clamp(),
             ],
             model_settings=model_settings,
         )

--- a/code_puppy/agents/_compaction.py
+++ b/code_puppy/agents/_compaction.py
@@ -37,7 +37,6 @@ from pydantic_ai_harness.compaction import (
 
 from code_puppy.agents._history import (
     estimate_tokens_for_message,
-    filter_huge_messages,
     hash_message,
     sanitize_tool_call_ids,
 )
@@ -212,19 +211,19 @@ async def compact(
         # Hooks must never break compaction.
         pass
 
-    # Shrink/drop individual >50k-token monsters first — a runaway tool
-    # return in the protected tail would otherwise survive every strategy.
-    filtered = filter_huge_messages(messages, model_name)
-
+    # Oversized-payload guarding is no longer done here: ToolOutputLimits
+    # bounds tool returns at production time and ClampOversizedMessages
+    # clamps runaway response parts at request time (see _output_limits.py),
+    # both wired as pure capabilities in _builder.py.
     try:
         strategy = build_compaction_strategy()
-        result = await strategy.compact(list(filtered), ctx)
+        result = await strategy.compact(list(messages), ctx)
     except Exception as e:
         emit_error(f"Compaction failed: [{type(e).__name__}] {e}")
         return messages, []
 
     result_hashes = {hash_message(m) for m in result}
-    dropped = [m for m in filtered if hash_message(m) not in result_hashes]
+    dropped = [m for m in messages if hash_message(m) not in result_hashes]
 
     final_token_count = sum(estimate_tokens_for_message(m, model_name) for m in result)
     update_spinner_context(

--- a/code_puppy/agents/_history.py
+++ b/code_puppy/agents/_history.py
@@ -489,67 +489,6 @@ def has_pending_tool_calls(messages: List[ModelMessage]) -> bool:
     return bool(tool_call_ids - tool_return_ids)
 
 
-_OVERSIZED_TOOL_RETURN_CONTENT = (
-    "[Tool result omitted: it exceeded the per-message size limit and was "
-    "dropped from history. The tool DID run and completed — do not re-issue "
-    "the same call.]"
-)
-
-
-def _shrink_oversized_tool_returns(
-    message: ModelMessage, model_name: Optional[str]
-) -> Optional[ModelMessage]:
-    """Replace an oversized message's tool-return bodies with a placeholder.
-
-    A >50k-token ``ModelRequest`` is almost always a bulky tool result. Dropping
-    the whole message would leave its ``tool-call`` dangling, and prune would
-    then close it with an ``interrupted`` return — telling the model the tool
-    never ran, so it re-issues the identical oversized call (infinite re-read
-    loop). Swapping each ``tool-return`` body for a short placeholder keeps the
-    pair intact and records that the tool completed. Returns ``None`` when the
-    message has no tool return to shrink, or stays over budget afterwards — the
-    caller then drops it as before.
-    """
-    new_parts: List[Any] = []
-    shrank = False
-    for part in getattr(message, "parts", []) or []:
-        if getattr(part, "part_kind", None) == "tool-return":
-            new_parts.append(
-                dataclasses.replace(part, content=_OVERSIZED_TOOL_RETURN_CONTENT)
-            )
-            shrank = True
-        else:
-            new_parts.append(part)
-    if not shrank:
-        return None
-    shrunk = dataclasses.replace(message, parts=new_parts)
-    if estimate_tokens_for_message(shrunk, model_name) >= 50000:
-        return None
-    return shrunk
-
-
-def filter_huge_messages(
-    messages: List[ModelMessage],
-    model_name: Optional[str] = None,
-) -> List[ModelMessage]:
-    """Cap individual messages at a 50k-token budget, then repair pairing.
-
-    An oversized tool-result message is shrunk in place (body replaced with a
-    placeholder) rather than dropped, so a completed call is never mistaken for
-    an interrupted one; anything still over budget is dropped, then pruning
-    repairs any pairing the drop broke.
-    """
-    filtered: List[ModelMessage] = []
-    for m in messages:
-        if estimate_tokens_for_message(m, model_name) < 50000:
-            filtered.append(m)
-            continue
-        shrunk = _shrink_oversized_tool_returns(m, model_name)
-        if shrunk is not None:
-            filtered.append(shrunk)
-    return prune_interrupted_tool_calls(filtered)
-
-
 # Anthropic requires tool_use IDs to match this pattern; other providers
 # (Kimi, etc.) may emit IDs with dots/colons that violate it. Those dirty IDs
 # persist through mid-conversation model switches and cause 400 errors.

--- a/code_puppy/agents/_output_limits.py
+++ b/code_puppy/agents/_output_limits.py
@@ -1,0 +1,78 @@
+"""Harness output-limit capabilities: bound oversized payloads at the source.
+
+Finishes the compaction migration started in ``_compaction.py``. The
+hand-rolled ``filter_huge_messages`` pass (shrink/drop >50k-token messages
+inside the history processor) is replaced by two pure pydantic-ai-harness
+capabilities:
+
+* ``ToolOutputLimits`` -- reduces an oversized tool return when it is
+  produced (``after_tool_execute``), so it never enters history at all. The
+  default band spills the full payload to a private file -- losslessly
+  readable back through the harness ``read_tool_result`` tool -- and falls
+  back to a bounded truncation when the store write fails.
+* ``ClampOversizedMessages`` -- head/tail-clamps a runaway model-response
+  part (degenerate generation, giant tool-call args) at request time
+  (``before_model_request``). Clamping keeps the message intact where the
+  old filter dropped it outright.
+
+Neither capability touches user prompts, and tool errors (``ModelRetry``)
+bypass reduction entirely, so recovery payloads stay intact.
+
+Transitional note: a >50k-token tool return already sitting in a *restored
+legacy session's* recent tail is no longer shrunk (that was the old filter's
+job). New sessions cannot produce one -- ``ToolOutputLimits`` bounds every
+tool return at production time.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+from typing import List
+
+from pydantic_ai_harness.compaction import ClampOversizedMessages
+from pydantic_ai_harness.tool_output_limits import (
+    Band,
+    LocalFileStore,
+    Spill,
+    ToolOutputLimits,
+    Truncate,
+)
+
+from code_puppy.config import CONFIG_DIR, get_tool_output_limit_chars
+
+# Same per-part budget the old filter_huge_messages enforced per message.
+CLAMP_MAX_PART_TOKENS = 50_000
+
+# Spilled payloads live under the config dir (runtime state never sits in the
+# project tree) and expire after a week -- long enough to cover a resumed
+# session, short enough that the directory cannot grow without bound.
+SPILL_DIR_NAME = "tool_output_spill"
+SPILL_TTL = timedelta(days=7)
+
+
+def build_tool_output_limits() -> List[ToolOutputLimits]:
+    """Build the production-time tool-return reducer, or ``[]`` when disabled.
+
+    The threshold comes from the ``tool_output_limit_chars`` config key
+    (default 10,000 chars; zero or negative disables). Returned as a list so
+    the caller can splice it into ``capabilities=[...]`` unconditionally.
+    """
+    threshold = get_tool_output_limit_chars()
+    if threshold <= 0:
+        return []
+    store = LocalFileStore(
+        base_dir=Path(CONFIG_DIR) / SPILL_DIR_NAME,
+        cleanup_after=SPILL_TTL,
+    )
+    return [
+        ToolOutputLimits(
+            bands=[Band(over=threshold, action=Spill(then=Truncate()))],
+            store=store,
+        )
+    ]
+
+
+def build_response_clamp() -> ClampOversizedMessages:
+    """Build the request-time clamp for runaway model-response parts."""
+    return ClampOversizedMessages(max_part_tokens=CLAMP_MAX_PART_TOKENS)

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -488,6 +488,9 @@ def get_config_keys():
     default_keys.append("resume_message_count")
     # Per-file AGENTS.md character cap (see get_agents_md_max_chars()).
     default_keys.append("agents_md_max_chars")
+    # Tool-output reduction threshold in chars for the harness ToolOutputLimits
+    # capability (see get_tool_output_limit_chars()). 0 or negative disables.
+    default_keys.append("tool_output_limit_chars")
     # Add /goal iteration cap (owned by the wiggum plugin, surfaced here so
     # /set autocompletes it). See plugins/wiggum/register_callbacks.py.
     default_keys.append("goal_max_iterations")
@@ -1573,6 +1576,31 @@ def get_protected_token_count():
         model_context_length = get_model_context_length()
         max_protected_tokens = int(model_context_length * 0.75)
         return min(50000, max_protected_tokens)
+
+
+# Char threshold above which a tool return is reduced (spilled to a file the
+# model can read back through the harness read_tool_result tool, truncated as
+# fallback). Matches the pydantic-ai-harness ToolOutputLimits default.
+TOOL_OUTPUT_LIMIT_CHARS_DEFAULT = 10_000
+
+
+def get_tool_output_limit_chars() -> int:
+    """Return the tool-output reduction threshold in characters.
+
+    Read from the ``tool_output_limit_chars`` config key (settable via
+    ``/set tool_output_limit_chars=<int>``). Defaults to
+    ``TOOL_OUTPUT_LIMIT_CHARS_DEFAULT`` (10,000) when unset or non-numeric.
+    Zero or negative disables tool-output reduction entirely — no clamp is
+    applied here because "disable" is a legitimate choice, unlike the
+    compaction knobs where a bad value would wedge the run.
+    """
+    val = get_value("tool_output_limit_chars")
+    if not val:
+        return TOOL_OUTPUT_LIMIT_CHARS_DEFAULT
+    try:
+        return int(val)
+    except (ValueError, TypeError):
+        return TOOL_OUTPUT_LIMIT_CHARS_DEFAULT
 
 
 def get_resume_message_count() -> int:

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -1595,7 +1595,10 @@ def get_tool_output_limit_chars() -> int:
     compaction knobs where a bad value would wedge the run.
     """
     val = get_value("tool_output_limit_chars")
-    if not val:
+    # `val is None`-style unset check (not `if not val:`): get_value returns
+    # str | None today, but a falsy non-None value (int 0 through a future
+    # cache) must stay an explicit opt-out, never a fallback to the default.
+    if val is None or not str(val).strip():
         return TOOL_OUTPUT_LIMIT_CHARS_DEFAULT
     try:
         return int(val)

--- a/tests/agents/test_history_tool_call_repair.py
+++ b/tests/agents/test_history_tool_call_repair.py
@@ -16,8 +16,6 @@ from pydantic_ai.messages import (
 )
 
 from code_puppy.agents._history import (
-    _OVERSIZED_TOOL_RETURN_CONTENT,
-    filter_huge_messages,
     has_pending_tool_calls,
     prune_interrupted_tool_calls,
 )
@@ -196,50 +194,6 @@ def test_retry_prompt_counts_as_return():
     ]
 
     assert prune_interrupted_tool_calls(history) is history
-
-
-def test_oversized_tool_return_is_shrunk_not_interrupted():
-    """An oversized COMPLETED tool result is shrunk in place, not dropped.
-
-    Dropping the message would leave its call dangling, and prune would then
-    close it with an ``interrupted`` return — telling the model the tool never
-    ran, so it re-issues the identical oversized call. Instead the body is
-    swapped for the oversized placeholder and the pair stays intact.
-    """
-    huge = "x" * 200_000  # estimates well over the 50k-token per-message budget
-    history = [
-        ModelRequest(parts=[UserPromptPart(content="read the big file")]),
-        ModelResponse(parts=[_call("c1")]),
-        ModelRequest(
-            parts=[ToolReturnPart(tool_name="edit", content=huge, tool_call_id="c1")]
-        ),
-    ]
-
-    result = filter_huge_messages(history)
-
-    calls = [
-        p
-        for m in result
-        for p in getattr(m, "parts", [])
-        if getattr(p, "part_kind", None) == "tool-call"
-    ]
-    returns = [
-        p
-        for m in result
-        for p in getattr(m, "parts", [])
-        if getattr(p, "part_kind", None) == "tool-return"
-    ]
-
-    assert any(c.tool_call_id == "c1" for c in calls), "the call was erased"
-
-    c1_returns = [r for r in returns if r.tool_call_id == "c1"]
-    assert len(c1_returns) == 1
-    (ret,) = c1_returns
-    assert ret.content == _OVERSIZED_TOOL_RETURN_CONTENT
-    assert ret.content != INTERRUPTED_TOOL_RETURN_CONTENT
-    assert getattr(ret, "outcome", None) != "interrupted"
-
-    assert not has_pending_tool_calls(result)
 
 
 def test_builtin_tool_call_left_alone():

--- a/tests/agents/test_output_limits.py
+++ b/tests/agents/test_output_limits.py
@@ -6,6 +6,14 @@ see ``code_puppy/agents/_output_limits.py`` for the migration story.
 
 from pathlib import Path
 
+from pydantic_ai import Agent as PydanticAgent
+from pydantic_ai.messages import (
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+)
+from pydantic_ai.models.function import FunctionModel
 from pydantic_ai_harness.compaction import ClampOversizedMessages
 from pydantic_ai_harness.tool_output_limits import Spill, ToolOutputLimits, Truncate
 
@@ -82,3 +90,88 @@ def test_config_non_numeric_falls_back(monkeypatch):
 def test_config_explicit_zero_means_disabled(monkeypatch):
     monkeypatch.setattr("code_puppy.config.get_value", lambda key: "0")
     assert get_tool_output_limit_chars() == 0
+
+
+def test_config_negative_passes_through_as_disable(monkeypatch):
+    """Pin the negative-disables semantic: a cleanup that normalizes negatives
+    back to the default would silently re-enable an explicit opt-out."""
+    monkeypatch.setattr("code_puppy.config.get_value", lambda key: "-5")
+    assert get_tool_output_limit_chars() == -5
+
+
+def test_config_whitespace_only_falls_back(monkeypatch):
+    monkeypatch.setattr("code_puppy.config.get_value", lambda key: "   ")
+    assert get_tool_output_limit_chars() == TOOL_OUTPUT_LIMIT_CHARS_DEFAULT
+
+
+# ---------- end-to-end: a real agent run spills losslessly --------------------
+
+
+BIG_PAYLOAD = "needle-" + ("x" * 50_000)
+
+
+def _spilling_agent(cap: ToolOutputLimits, tool_result: str) -> PydanticAgent:
+    """One-tool agent: first model turn calls big_tool, second returns text."""
+    calls = {"n": 0}
+
+    def model_func(messages, info):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return ModelResponse(
+                parts=[ToolCallPart(tool_name="big_tool", args={}, tool_call_id="c1")]
+            )
+        return ModelResponse(parts=[TextPart(content="done")])
+
+    agent = PydanticAgent(model=FunctionModel(model_func), capabilities=[cap])
+
+    @agent.tool_plain
+    def big_tool() -> str:
+        return tool_result
+
+    return agent
+
+
+def _big_tool_returns(result) -> list[ToolReturnPart]:
+    return [
+        p
+        for m in result.all_messages()
+        for p in getattr(m, "parts", [])
+        if isinstance(p, ToolReturnPart) and p.tool_name == "big_tool"
+    ]
+
+
+async def test_oversized_return_is_reduced_and_spilled_losslessly(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(_output_limits, "get_tool_output_limit_chars", lambda: 10_000)
+    monkeypatch.setattr(_output_limits, "CONFIG_DIR", str(tmp_path))
+    (cap,) = build_tool_output_limits()
+
+    result = await _spilling_agent(cap, BIG_PAYLOAD).run("go")
+
+    (ret,) = _big_tool_returns(result)
+    persisted = ret.model_response_str()
+    # Reduced at production time: the full payload never enters history.
+    assert len(persisted) < len(BIG_PAYLOAD)
+    assert BIG_PAYLOAD not in persisted
+
+    # Lossless: the full payload is recoverable from the spill store.
+    spill_root = tmp_path / _output_limits.SPILL_DIR_NAME
+    spilled = [p for p in spill_root.rglob("*") if p.is_file()]
+    assert spilled, "expected the oversized payload to be spilled to disk"
+    assert any(BIG_PAYLOAD in p.read_text(errors="ignore") for p in spilled)
+
+
+async def test_small_return_passes_through_untouched(monkeypatch, tmp_path):
+    monkeypatch.setattr(_output_limits, "get_tool_output_limit_chars", lambda: 10_000)
+    monkeypatch.setattr(_output_limits, "CONFIG_DIR", str(tmp_path))
+    (cap,) = build_tool_output_limits()
+
+    result = await _spilling_agent(cap, "tiny result").run("go")
+
+    (ret,) = _big_tool_returns(result)
+    assert ret.model_response_str() == "tiny result"
+    spill_root = tmp_path / _output_limits.SPILL_DIR_NAME
+    assert not spill_root.exists() or not any(
+        p.is_file() for p in spill_root.rglob("*")
+    )

--- a/tests/agents/test_output_limits.py
+++ b/tests/agents/test_output_limits.py
@@ -1,0 +1,84 @@
+"""Unit tests for the harness output-limit capability builders.
+
+These capabilities replaced the hand-rolled ``filter_huge_messages`` pass;
+see ``code_puppy/agents/_output_limits.py`` for the migration story.
+"""
+
+from pathlib import Path
+
+from pydantic_ai_harness.compaction import ClampOversizedMessages
+from pydantic_ai_harness.tool_output_limits import Spill, ToolOutputLimits, Truncate
+
+from code_puppy.agents import _output_limits
+from code_puppy.agents._output_limits import (
+    CLAMP_MAX_PART_TOKENS,
+    build_response_clamp,
+    build_tool_output_limits,
+)
+from code_puppy.config import (
+    TOOL_OUTPUT_LIMIT_CHARS_DEFAULT,
+    get_tool_output_limit_chars,
+)
+
+
+def test_default_threshold_builds_lossless_spill_band(monkeypatch):
+    monkeypatch.setattr(_output_limits, "get_tool_output_limit_chars", lambda: 10_000)
+    (cap,) = build_tool_output_limits()
+    assert isinstance(cap, ToolOutputLimits)
+    (band,) = list(cap.bands)
+    assert band.over == 10_000
+    assert isinstance(band.action, Spill)
+    assert isinstance(band.action.then, Truncate)
+
+
+def test_custom_threshold_is_honoured(monkeypatch):
+    monkeypatch.setattr(_output_limits, "get_tool_output_limit_chars", lambda: 42)
+    (cap,) = build_tool_output_limits()
+    (band,) = list(cap.bands)
+    assert band.over == 42
+
+
+def test_zero_threshold_disables(monkeypatch):
+    monkeypatch.setattr(_output_limits, "get_tool_output_limit_chars", lambda: 0)
+    assert build_tool_output_limits() == []
+
+
+def test_negative_threshold_disables(monkeypatch):
+    monkeypatch.setattr(_output_limits, "get_tool_output_limit_chars", lambda: -5)
+    assert build_tool_output_limits() == []
+
+
+def test_spill_store_lives_under_config_dir(monkeypatch):
+    monkeypatch.setattr(_output_limits, "get_tool_output_limit_chars", lambda: 123)
+    (cap,) = build_tool_output_limits()
+    base = cap.store.base_dir
+    assert base is not None
+    assert base.name == _output_limits.SPILL_DIR_NAME
+    assert str(base).startswith(str(Path(_output_limits.CONFIG_DIR)))
+
+
+def test_spill_store_has_ttl(monkeypatch):
+    monkeypatch.setattr(_output_limits, "get_tool_output_limit_chars", lambda: 123)
+    (cap,) = build_tool_output_limits()
+    assert cap.store.cleanup_after == _output_limits.SPILL_TTL
+
+
+def test_response_clamp_budget_matches_legacy_filter():
+    clamp = build_response_clamp()
+    assert isinstance(clamp, ClampOversizedMessages)
+    assert clamp.max_part_tokens == CLAMP_MAX_PART_TOKENS == 50_000
+
+
+def test_config_default_when_unset(monkeypatch):
+    monkeypatch.setattr("code_puppy.config.get_value", lambda key: None)
+    assert get_tool_output_limit_chars() == TOOL_OUTPUT_LIMIT_CHARS_DEFAULT
+
+
+def test_config_non_numeric_falls_back(monkeypatch):
+    monkeypatch.setattr("code_puppy.config.get_value", lambda key: "many")
+    assert get_tool_output_limit_chars() == TOOL_OUTPUT_LIMIT_CHARS_DEFAULT
+
+
+def test_config_explicit_zero_means_disabled(monkeypatch):
+    monkeypatch.setattr("code_puppy.config.get_value", lambda key: "0")
+    assert get_tool_output_limit_chars() == 0

--- a/tests/integration/test_compaction_live.py
+++ b/tests/integration/test_compaction_live.py
@@ -157,7 +157,7 @@ def _build_huge_history(
       - Alternating user prompts, tool_call/tool_return pairs, assistant text
       - Every tool_call has its matching tool_return (no orphans)
       - Payloads distributed so each individual message is well under the
-        50k-token filter_huge_messages cutoff
+        50k-token per-part clamp budget (see _output_limits.py)
 
     Returns a history that will come in close to but not exceeding the target.
     """


### PR DESCRIPTION
## What

Completes the harness compaction migration that #799 started. The last hand-rolled compaction subroutine — `filter_huge_messages` (shrink/drop >50k-token messages inside the history-processor closure) — is retired in favor of two pure `pydantic-ai-harness` capabilities wired straight into `Agent(capabilities=[...])`:

| Capability | Hook | Replaces |
|---|---|---|
| `ToolOutputLimits` | `after_tool_execute` (production time) | the request-side tool-return shrink: an oversized tool return is now reduced **before it ever enters history** — spilled losslessly to `~/.code_puppy/tool_output_spill/` (7-day TTL) and readable back via the harness `read_tool_result` tool, with bounded truncation as fallback |
| `ClampOversizedMessages` | `before_model_request` (request time) | the drop-if-still-huge path for response messages: runaway generations / giant tool-call args are head/tail-clamped under the same 50k-token budget — clamped, not dropped |

## Why this shape

- `filter_huge_messages` shrank a giant tool return to a placeholder *after* it had already been paid for once. `ToolOutputLimits` bounds it at the source and is **lossless** (the model can slice/grep the spilled payload on demand).
- The old filter **dropped** oversized response messages outright; the clamp keeps head+tail with a marker — strictly gentler, and it composes with the summarize/sliding-window strategies already adopted in #799.
- Capability ordering: the clamp sits after both `ProcessHistory` entries so it sees the final steer-injected history; `ToolOutputLimits` hooks a different phase so its position is inert (commented in `_builder.py`).

## Config

- `/set tool_output_limit_chars=<int>` — reduction threshold (default 10,000 chars; `0`/negative disables the capability entirely).
- Clamp budget stays hard-wired at the legacy 50k-token figure.

## Deleted

- `_history.filter_huge_messages` + `_shrink_oversized_tool_returns` + placeholder constant (−61 lines)
- their call site in `compact()`

## Transitional note

A >50k-token tool return already sitting in a **restored legacy session's recent tail** is no longer shrunk (new sessions can't produce one — returns are bounded at production). If that bites in practice, the harness-side fix is a request-side clamp option on `ClampOversizedMessages`, which I'd propose upstream via pydantic-ai-notes rather than resurrect the local filter.

## Follow-up (separate repos)

- `code_puppy_core_plugins`: deprecate the `spill` plugin (subsumed by `ToolOutputLimits`; harmless if both run — the plugin fires first and the reduced result passes under the harness threshold).

## Tests

- New `tests/agents/test_output_limits.py` (10 tests: bands, disable path, store location/TTL, clamp budget, config parsing)
- Removed the `filter_huge_messages` shrink test with the code it covered
- Full suite: **7468 passed, 10 skipped** locally