### PR TITLE
feat: make headless runs fully autonomous

### DIFF
--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -71,6 +71,7 @@ class BaseAgent(ABC):
         self._code_generation_agent: Any = None
         self._last_model_name: Optional[str] = None
         self._runtime_model_name_override: Optional[str] = None
+        self._runtime_system_prompt_additions: List[str] = []
         self._puppy_rules: Optional[str] = None
         self._mcp_servers: List[Any] = []
         self.cur_model: Optional[pydantic_ai.models.Model] = None
@@ -136,6 +137,19 @@ class BaseAgent(ABC):
         finally:
             self.set_runtime_model_name_override(previous_model_name)
 
+    @contextmanager
+    def temporary_system_prompt_addition(self, prompt: str) -> Iterator[None]:
+        """Append a system instruction for the duration of one scoped run."""
+        self._runtime_system_prompt_additions.append(prompt)
+        try:
+            yield
+        finally:
+            popped = self._runtime_system_prompt_additions.pop()
+            if popped != prompt:
+                raise RuntimeError(
+                    "Runtime system prompt additions exited out of order"
+                )
+
     def get_model_name(self) -> Optional[str]:
         override = self.get_runtime_model_name_override()
         if override:
@@ -172,6 +186,8 @@ class BaseAgent(ABC):
         prompt_additions = callbacks.on_load_prompt()
         if prompt_additions:
             prompt += "\n" + "\n".join(prompt_additions)
+        if self._runtime_system_prompt_additions:
+            prompt += "\n" + "\n".join(self._runtime_system_prompt_additions)
         return prompt + self.get_identity_prompt()
 
     # ---- Message history (plain dict-level access) ------------------------

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -54,6 +54,13 @@ from code_puppy.version_checker import default_version_mismatch_behavior
 
 plugins.load_plugin_callbacks()
 
+_HEADLESS_AUTONOMY_PROMPT = """\
+This is an unattended, non-interactive run. Never ask for confirmation, approval,
+clarification, or manual verification, including through tools or MCP servers. Use
+reasonable defaults, proceed autonomously, and validate with the tools available to
+you. State any assumptions or optional manual checks only in the final response.\
+"""
+
 
 def _render_turn_exception(exc: Exception) -> None:
     """Render a turn-level exception without ever taking down the REPL.
@@ -1432,12 +1439,13 @@ async def execute_single_prompt(
         agent = get_current_agent()
         # Headless -p mode: no run UI (no bottom bar, no line editor) —
         # output must stay plain for pipes/CI even when stdout is a TTY.
-        result, _agent_task = await run_prompt_with_attachments(
-            agent,
-            prompt,
-            display_console=message_renderer.console,
-            use_run_ui=False,
-        )
+        with agent.temporary_system_prompt_addition(_HEADLESS_AUTONOMY_PROMPT):
+            result, _agent_task = await run_prompt_with_attachments(
+                agent,
+                prompt,
+                display_console=message_renderer.console,
+                use_run_ui=False,
+            )
         if result is None:
             return
 

--- a/tests/test_headless_autonomy_prompt.py
+++ b/tests/test_headless_autonomy_prompt.py
@@ -1,0 +1,43 @@
+"""Tests for the scoped unattended-run system instruction."""
+
+from code_puppy.agents.base_agent import BaseAgent
+from code_puppy.cli_runner import _HEADLESS_AUTONOMY_PROMPT
+
+
+class _TestAgent(BaseAgent):
+    @property
+    def name(self) -> str:
+        return "test-agent"
+
+    @property
+    def display_name(self) -> str:
+        return "Test Agent"
+
+    @property
+    def description(self) -> str:
+        return "Test agent"
+
+    def get_system_prompt(self) -> str:
+        return "Authored prompt."
+
+    def get_available_tools(self) -> list[str]:
+        return []
+
+
+def test_headless_autonomy_prompt_is_scoped_to_the_run(monkeypatch):
+    monkeypatch.setattr("code_puppy.callbacks.on_load_prompt", lambda: [])
+    agent = _TestAgent()
+
+    assert _HEADLESS_AUTONOMY_PROMPT not in agent.get_full_system_prompt()
+
+    with agent.temporary_system_prompt_addition(_HEADLESS_AUTONOMY_PROMPT):
+        full_prompt = agent.get_full_system_prompt()
+        assert _HEADLESS_AUTONOMY_PROMPT in full_prompt
+        assert full_prompt.index("Authored prompt.") < full_prompt.index(
+            _HEADLESS_AUTONOMY_PROMPT
+        )
+        assert full_prompt.index(_HEADLESS_AUTONOMY_PROMPT) < full_prompt.index(
+            "Your ID is"
+        )
+
+    assert _HEADLESS_AUTONOMY_PROMPT not in agent.get_full_system_prompt()


### PR DESCRIPTION
## Summary

- inject a scoped autonomy policy into the system prompt for `-p` runs
- prohibit confirmation, clarification, approval, and manual-verification questions in unattended mode, including via MCP tools
- keep interactive runs unchanged
- add a reusable scoped runtime system-prompt addition API

## Why

`--disable-ask-user-question` removes the built-in TUI tool, but an unattended agent can still call an MCP-provided user tool. In a Harbor run this caused Code Puppy to ask twice for the same manual Live View confirmation despite having enough automated verification.

The policy is a system instruction rather than a user-prompt mutation and exists only for the duration of `execute_single_prompt`.

## Tests

- `uv run pytest -q tests/test_headless_autonomy_prompt.py tests/test_cli_usage_file.py tests/test_cli_runner_resume_render.py`
- `uv run ruff check ...`
- `git diff --check`
