### PR TITLE
feat: neon Pydantic pyramid splash animation during cold start

### DIFF
--- a/code_puppy/main.py
+++ b/code_puppy/main.py
@@ -1,10 +1,23 @@
 """Main entry point for Code Puppy CLI.
 
-This module re-exports the main_entry function from cli_runner for backwards compatibility.
-All the actual logic lives in cli_runner.py.
+This module re-exports the main_entry function from cli_runner for backwards
+compatibility. All the actual logic lives in cli_runner.py.
+
+The neon splash starts BEFORE the cli_runner import below: that import pulls
+in pydantic-ai, prompt_toolkit, rich, and friends (~seconds of cold start),
+which is exactly the window the shimmer covers. ``code_puppy.splash`` is
+stdlib-only by design -- keep it that way, and keep it first.
 """
 
-from code_puppy.cli_runner import main_entry
+from code_puppy.splash import start_splash
+
+_splash = start_splash()
+try:
+    from code_puppy.cli_runner import main_entry
+finally:
+    _splash.stop()
+
+__all__ = ["main_entry"]
 
 if __name__ == "__main__":
     main_entry()

--- a/code_puppy/splash.py
+++ b/code_puppy/splash.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import os
 import sys
 import threading
+import time
 
 # Pyramid raster, 20 rows x <=44 cols. Digits are glow tiers:
 # 0 = empty, 1 = outer halo, 2 = inner glow, 3 = neon core.
@@ -70,6 +71,9 @@ _FALLBACK_HOT = ("", "\x1b[95m", "\x1b[1;95m", "\x1b[1;97m")
 _SHEEN_PERIOD = 70
 _SHEEN_WIDTH = 7
 _FRAME_SECONDS = 0.033
+# Keep the shimmer on screen at least this long, even if imports finish
+# early -- a sub-second flash reads as a glitch, not a splash.
+_MIN_SHOW_SECONDS = 2.0
 
 # argv values that still mean "interactive boot" (splash-worthy).
 _INTERACTIVE_ARGS = frozenset({"-i", "--interactive"})
@@ -111,8 +115,10 @@ class _NullSplash:
 
 
 class _Splash:
-    def __init__(self, stream) -> None:
+    def __init__(self, stream, min_seconds: float = _MIN_SHOW_SECONDS) -> None:
         self._stream = stream
+        self._min_seconds = min_seconds
+        self._started = time.monotonic()
         self._stop_event = threading.Event()
         self._truecolor = _truecolor()
         self._thread = threading.Thread(
@@ -136,10 +142,17 @@ class _Splash:
             pass  # a dying terminal must never take the CLI down
 
     def stop(self) -> None:
-        """Stop the animation and erase it so real output starts clean."""
+        """Stop the animation and erase it so real output starts clean.
+
+        Honors the minimum showtime: if imports finished early, the caller
+        blocks here while the shimmer finishes its contractual screen time.
+        """
         if self._stopped:
             return
         self._stopped = True
+        remaining = self._min_seconds - (time.monotonic() - self._started)
+        if remaining > 0:
+            time.sleep(remaining)  # animation thread keeps shimmering meanwhile
         self._stop_event.set()
         self._thread.join(timeout=1.0)
         try:
@@ -178,20 +191,25 @@ def _enable_windows_vt(stream) -> bool:
         return False
 
 
-def start_splash(stream=None, force: bool = False):
+def start_splash(
+    stream=None, force: bool = False, min_seconds: float = _MIN_SHOW_SECONDS
+):
     """Start the shimmer if the terminal deserves it; else return a no-op.
 
-    ``force=True`` bypasses the argv/env gating (used by tests and demos)
-    but still requires a usable stream.
+    ``force=True`` bypasses ALL gating -- TTY detection included -- and is
+    strictly for tests and demos; you get ANSI in whatever stream you gave
+    us. ``min_seconds`` is the guaranteed on-screen time: ``stop()`` blocks
+    until it has elapsed.
     """
     stream = stream if stream is not None else sys.stdout
     try:
-        if not (hasattr(stream, "isatty") and stream.isatty()):
-            return _NullSplash()
-        if not force and not _wants_splash(sys.argv):
-            return _NullSplash()
+        if not force:
+            if not (hasattr(stream, "isatty") and stream.isatty()):
+                return _NullSplash()
+            if not _wants_splash(sys.argv):
+                return _NullSplash()
         if not _enable_windows_vt(stream):
             return _NullSplash()
-        return _Splash(stream)
+        return _Splash(stream, min_seconds=min_seconds)
     except Exception:
         return _NullSplash()

--- a/code_puppy/splash.py
+++ b/code_puppy/splash.py
@@ -1,0 +1,197 @@
+"""Import-time neon splash: a shimmering Pydantic pyramid while imports load.
+
+Code Puppy's cold start is dominated by heavy imports (pydantic-ai,
+prompt_toolkit, rich, ...). This module is deliberately **stdlib-only** so
+``code_puppy/main.py`` can start the animation *before* those imports begin
+and stop it the moment they finish. Do not import anything from
+``code_puppy`` here -- that would defeat the entire point.
+
+The animation is pure art (no text), so it stays outside the i18n seam.
+Every frame repaints its full region with line-clears, which also absorbs
+any stray import-time output (e.g. plugin warnings emitted while
+``cli_runner`` loads). Everything fails soft: a broken terminal gets a
+no-op splash, never a crashed CLI.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+
+# Pyramid raster, 20 rows x <=44 cols. Digits are glow tiers:
+# 0 = empty, 1 = outer halo, 2 = inner glow, 3 = neon core.
+_PYRAMID = (
+    "000000000000000000112333211",
+    "0000000000000000112233233221",
+    "000000000000000112332212232211",
+    "0000000000000012233211012233211",
+    "00000000000011223221100011233221",
+    "0000000000011233221000000112232211",
+    "00000000011223321100000000012233211",
+    "000000001123322110001111100011233221",
+    "00000001223321101112223222110112232211",
+    "000001122322111122333333332221112233211",
+    "0000112332211223332222322233322211233221",
+    "001122332222333222111232111223333222232211",
+    "0112332223332221100012321001112223332233211",
+    "12233233322111000000123210000001122233333221",
+    "22333322111000000000123210000000001122233322",
+    "23333222111100000000123210000000011122233332",
+    "11222333332221110000123210001111222333322211",
+    "00011122223333222211123211122233333222111",
+    "0000000011122233333222322233332222111",
+    "00000000000011112223333333222111",
+)
+_CHARS = (" ", "\u2591", "\u2592", "\u2588")
+_HEIGHT = len(_PYRAMID)
+
+_RESET = "\x1b[0m"
+_HIDE_CURSOR = "\x1b[?25l"
+_SHOW_CURSOR = "\x1b[?25h"
+
+# Neon palette: violet haze -> brand magenta -> hot pink core, with a
+# white-hot crest where the sheen band passes.
+_TRUECOLOR_BASE = (
+    "",
+    "\x1b[38;2;122;17;145m",
+    "\x1b[38;2;195;31;212m",
+    "\x1b[1;38;2;255;92;244m",
+)
+_TRUECOLOR_HOT = (
+    "",
+    "\x1b[38;2;195;31;212m",
+    "\x1b[38;2;255;92;244m",
+    "\x1b[1;38;2;255;209;251m",
+)
+_FALLBACK_BASE = ("", "\x1b[35m", "\x1b[95m", "\x1b[1;95m")
+_FALLBACK_HOT = ("", "\x1b[95m", "\x1b[1;95m", "\x1b[1;97m")
+
+_SHEEN_PERIOD = 70
+_SHEEN_WIDTH = 7
+_FRAME_SECONDS = 0.033
+
+# argv values that still mean "interactive boot" (splash-worthy).
+_INTERACTIVE_ARGS = frozenset({"-i", "--interactive"})
+
+
+def _truecolor() -> bool:
+    return os.environ.get("COLORTERM", "").lower() in ("truecolor", "24bit")
+
+
+def _build_frame(phase: int, truecolor: bool) -> str:
+    """Render one full frame; every line clears itself first (\\x1b[2K)."""
+    base = _TRUECOLOR_BASE if truecolor else _FALLBACK_BASE
+    hot = _TRUECOLOR_HOT if truecolor else _FALLBACK_HOT
+    lines = []
+    for y, row in enumerate(_PYRAMID):
+        parts = ["\x1b[2K"]
+        current = ""
+        for x, digit in enumerate(row):
+            tier = int(digit)
+            if tier == 0:
+                parts.append(" ")
+                continue
+            in_band = (x + 2 * y - phase) % _SHEEN_PERIOD < _SHEEN_WIDTH
+            style = (hot if in_band else base)[tier]
+            if style != current:
+                parts.append(style)
+                current = style
+            parts.append(_CHARS[tier])
+        parts.append(_RESET)
+        lines.append("".join(parts))
+    return "\n".join(lines) + "\n"
+
+
+class _NullSplash:
+    """Do-nothing stand-in so callers never need to branch."""
+
+    def stop(self) -> None:
+        pass
+
+
+class _Splash:
+    def __init__(self, stream) -> None:
+        self._stream = stream
+        self._stop_event = threading.Event()
+        self._truecolor = _truecolor()
+        self._thread = threading.Thread(
+            target=self._run, name="code-puppy-splash", daemon=True
+        )
+        self._stopped = False
+        self._thread.start()
+
+    def _run(self) -> None:
+        phase = 0
+        try:
+            self._stream.write(_HIDE_CURSOR)
+            self._stream.write(_build_frame(phase, self._truecolor))
+            self._stream.flush()
+            while not self._stop_event.wait(_FRAME_SECONDS):
+                phase = (phase + 2) % _SHEEN_PERIOD
+                self._stream.write(f"\x1b[{_HEIGHT}A")
+                self._stream.write(_build_frame(phase, self._truecolor))
+                self._stream.flush()
+        except Exception:
+            pass  # a dying terminal must never take the CLI down
+
+    def stop(self) -> None:
+        """Stop the animation and erase it so real output starts clean."""
+        if self._stopped:
+            return
+        self._stopped = True
+        self._stop_event.set()
+        self._thread.join(timeout=1.0)
+        try:
+            # Cursor up over the frame, erase to end of screen, restore cursor.
+            self._stream.write(f"\x1b[{_HEIGHT}A\x1b[0J{_SHOW_CURSOR}")
+            self._stream.flush()
+        except Exception:
+            pass
+
+
+def _wants_splash(argv: list[str]) -> bool:
+    """Only animate for an interactive-looking boot; fail closed otherwise."""
+    if os.environ.get("CODE_PUPPY_NO_SPLASH") or os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("TERM", "") == "dumb":
+        return False
+    # Any flag beyond plain interactive mode (headless -p, --help, acp
+    # bridges, ...) means someone else owns stdout. Stay out of the way.
+    return all(arg in _INTERACTIVE_ARGS for arg in argv[1:])
+
+
+def _enable_windows_vt(stream) -> bool:
+    if os.name != "nt":
+        return True
+    try:
+        import ctypes
+
+        kernel32 = ctypes.windll.kernel32
+        handle = kernel32.GetStdHandle(-11)  # STD_OUTPUT_HANDLE
+        mode = ctypes.c_uint32()
+        if not kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+            return False
+        # 0x0004 = ENABLE_VIRTUAL_TERMINAL_PROCESSING
+        return bool(kernel32.SetConsoleMode(handle, mode.value | 0x0004))
+    except Exception:
+        return False
+
+
+def start_splash(stream=None, force: bool = False):
+    """Start the shimmer if the terminal deserves it; else return a no-op.
+
+    ``force=True`` bypasses the argv/env gating (used by tests and demos)
+    but still requires a usable stream.
+    """
+    stream = stream if stream is not None else sys.stdout
+    try:
+        if not (hasattr(stream, "isatty") and stream.isatty()):
+            return _NullSplash()
+        if not force and not _wants_splash(sys.argv):
+            return _NullSplash()
+        if not _enable_windows_vt(stream):
+            return _NullSplash()
+        return _Splash(stream)
+    except Exception:
+        return _NullSplash()

--- a/code_puppy/splash.py
+++ b/code_puppy/splash.py
@@ -99,7 +99,7 @@ _SHEEN_WIDTH = 7
 _FRAME_SECONDS = 0.033
 # Keep the shimmer on screen at least this long, even if imports finish
 # early -- a sub-second flash reads as a glitch, not a splash.
-_MIN_SHOW_SECONDS = 2.0
+_MIN_SHOW_SECONDS = 3.0
 
 # argv values that still mean "interactive boot" (splash-worthy).
 _INTERACTIVE_ARGS = frozenset({"-i", "--interactive"})

--- a/code_puppy/splash.py
+++ b/code_puppy/splash.py
@@ -76,6 +76,11 @@ _SHADOW_TRIM = frozenset("\u2550\u2551\u2554\u2557\u255a\u255d")
 _RESET = "\x1b[0m"
 _HIDE_CURSOR = "\x1b[?25l"
 _SHOW_CURSOR = "\x1b[?25h"
+# Synchronized output (DEC 2026): terminals that support it (iTerm2, kitty,
+# WezTerm, Ghostty, Alacritty, ...) render the whole frame atomically --
+# zero flicker. Terminals that don't simply ignore the markers.
+_SYNC_START = "\x1b[?2026h"
+_SYNC_END = "\x1b[?2026l"
 
 # Neon palette: violet haze -> brand magenta -> hot pink core, with a
 # white-hot crest where the sheen band passes.
@@ -142,16 +147,19 @@ def _compose_rows(columns: int, lines: int):
 
 
 def _build_frame(phase: int, truecolor: bool, rows) -> str:
-    """Render one full frame; every line clears itself first (\\x1b[2K).
+    """Render one frame as newline-joined lines with NO trailing newline.
 
-    The sheen band is computed from absolute (column, row) so it sweeps one
+    Cells are overwritten in place (row shapes are constant across frames,
+    only colors change), so no erase codes are needed -- erase-then-redraw
+    is exactly what flickers on terminals without synchronized output. The
+    sheen band is computed from absolute (column, row) so it sweeps one
     continuous diagonal across the pyramid AND the figlet text below it.
     """
     base = _TRUECOLOR_BASE if truecolor else _FALLBACK_BASE
     hot = _TRUECOLOR_HOT if truecolor else _FALLBACK_HOT
     lines = []
     for y, (kind, content) in enumerate(rows):
-        parts = ["\x1b[2K"]
+        parts = []
         current = ""
         for x, ch in enumerate(content):
             if kind == "art":
@@ -171,7 +179,7 @@ def _build_frame(phase: int, truecolor: bool, rows) -> str:
             parts.append(glyph)
         parts.append(_RESET)
         lines.append("".join(parts))
-    return "\n".join(lines) + "\n"
+    return "\n".join(lines)
 
 
 class _NullSplash:
@@ -248,14 +256,20 @@ class _Splash:
 
     def _run(self) -> None:
         phase = 0
+        # Reposition to frame top: carriage return + cursor-up (height-1).
+        # The frame has no trailing newline, so nothing ever scrolls and the
+        # cursor parks at the end of the last row between frames.
+        reposition = f"\r\x1b[{self._height - 1}A"
         try:
-            self._stream.write(_HIDE_CURSOR)
-            self._stream.write(_build_frame(phase, self._truecolor, self._rows))
+            first = _build_frame(phase, self._truecolor, self._rows)
+            self._stream.write(f"{_HIDE_CURSOR}{_SYNC_START}{first}{_SYNC_END}")
             self._stream.flush()
             while not self._stop_event.wait(_FRAME_SECONDS):
                 phase = (phase + 2) % _SHEEN_PERIOD
-                self._stream.write(f"\x1b[{self._height}A")
-                self._stream.write(_build_frame(phase, self._truecolor, self._rows))
+                frame = _build_frame(phase, self._truecolor, self._rows)
+                # One atomic write per frame: no tearing between reposition
+                # and repaint even without DEC 2026 support.
+                self._stream.write(f"{_SYNC_START}{reposition}{frame}{_SYNC_END}")
                 self._stream.flush()
         except Exception:
             pass  # a dying terminal must never take the CLI down
@@ -275,8 +289,8 @@ class _Splash:
         self._stop_event.set()
         self._thread.join(timeout=1.0)
         try:
-            # Cursor up over the frame, erase to end of screen, restore cursor.
-            self._stream.write(f"\x1b[{self._height}A\x1b[0J{_SHOW_CURSOR}")
+            # Back to frame top, erase to end of screen, restore cursor.
+            self._stream.write(f"\r\x1b[{self._height - 1}A\x1b[0J{_SHOW_CURSOR}")
             self._stream.flush()
         except Exception:
             pass

--- a/code_puppy/splash.py
+++ b/code_puppy/splash.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import io
 import os
+import shutil
 import sys
 import threading
 import time
@@ -46,7 +47,31 @@ _PYRAMID = (
     "00000000000011112223333333222111",
 )
 _CHARS = (" ", "\u2591", "\u2592", "\u2588")
-_HEIGHT = len(_PYRAMID)
+_PYRAMID_WIDTH = 44
+
+# "Powered by" / "Pydantic" pre-rendered in pyfiglet's ansi_shadow (the same
+# font as the main CODE PUPPY banner). Baked as constants: pyfiglet is not
+# stdlib and this module must stay import-light. Solid blocks render as the
+# neon core tier; the box-drawing shadow trim renders as the mid glow tier.
+_TAGLINE_TOP = (
+    "\u2588\u2588\u2588\u2588\u2588\u2588\u2557  \u2588\u2588\u2588\u2588\u2588\u2588\u2557 \u2588\u2588\u2557    \u2588\u2588\u2557\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2557\u2588\u2588\u2588\u2588\u2588\u2588\u2557 \u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2557\u2588\u2588\u2588\u2588\u2588\u2588\u2557     \u2588\u2588\u2588\u2588\u2588\u2588\u2557 \u2588\u2588\u2557   \u2588\u2588\u2557",
+    "\u2588\u2588\u2554\u2550\u2550\u2588\u2588\u2557\u2588\u2588\u2554\u2550\u2550\u2550\u2588\u2588\u2557\u2588\u2588\u2551    \u2588\u2588\u2551\u2588\u2588\u2554\u2550\u2550\u2550\u2550\u255d\u2588\u2588\u2554\u2550\u2550\u2588\u2588\u2557\u2588\u2588\u2554\u2550\u2550\u2550\u2550\u255d\u2588\u2588\u2554\u2550\u2550\u2588\u2588\u2557    \u2588\u2588\u2554\u2550\u2550\u2588\u2588\u2557\u255a\u2588\u2588\u2557 \u2588\u2588\u2554\u255d",
+    "\u2588\u2588\u2588\u2588\u2588\u2588\u2554\u255d\u2588\u2588\u2551   \u2588\u2588\u2551\u2588\u2588\u2551 \u2588\u2557 \u2588\u2588\u2551\u2588\u2588\u2588\u2588\u2588\u2557  \u2588\u2588\u2588\u2588\u2588\u2588\u2554\u255d\u2588\u2588\u2588\u2588\u2588\u2557  \u2588\u2588\u2551  \u2588\u2588\u2551    \u2588\u2588\u2588\u2588\u2588\u2588\u2554\u255d \u255a\u2588\u2588\u2588\u2588\u2554\u255d",
+    "\u2588\u2588\u2554\u2550\u2550\u2550\u255d \u2588\u2588\u2551   \u2588\u2588\u2551\u2588\u2588\u2551\u2588\u2588\u2588\u2557\u2588\u2588\u2551\u2588\u2588\u2554\u2550\u2550\u255d  \u2588\u2588\u2554\u2550\u2550\u2588\u2588\u2557\u2588\u2588\u2554\u2550\u2550\u255d  \u2588\u2588\u2551  \u2588\u2588\u2551    \u2588\u2588\u2554\u2550\u2550\u2588\u2588\u2557  \u255a\u2588\u2588\u2554\u255d",
+    "\u2588\u2588\u2551     \u255a\u2588\u2588\u2588\u2588\u2588\u2588\u2554\u255d\u255a\u2588\u2588\u2588\u2554\u2588\u2588\u2588\u2554\u255d\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2557\u2588\u2588\u2551  \u2588\u2588\u2551\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2557\u2588\u2588\u2588\u2588\u2588\u2588\u2554\u255d    \u2588\u2588\u2588\u2588\u2588\u2588\u2554\u255d   \u2588\u2588\u2551",
+    "\u255a\u2550\u255d      \u255a\u2550\u2550\u2550\u2550\u2550\u255d  \u255a\u2550\u2550\u255d\u255a\u2550\u2550\u255d \u255a\u2550\u2550\u2550\u2550\u2550\u2550\u255d\u255a\u2550\u255d  \u255a\u2550\u255d\u255a\u2550\u2550\u2550\u2550\u2550\u2550\u255d\u255a\u2550\u2550\u2550\u2550\u2550\u255d     \u255a\u2550\u2550\u2550\u2550\u2550\u255d    \u255a\u2550\u255d",
+)
+_TAGLINE_TOP_WIDTH = 80
+_TAGLINE_BOTTOM = (
+    "\u2588\u2588\u2588\u2588\u2588\u2588\u2557 \u2588\u2588\u2557   \u2588\u2588\u2557\u2588\u2588\u2588\u2588\u2588\u2588\u2557  \u2588\u2588\u2588\u2588\u2588\u2557 \u2588\u2588\u2588\u2557   \u2588\u2588\u2557\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2557\u2588\u2588\u2557 \u2588\u2588\u2588\u2588\u2588\u2588\u2557",
+    "\u2588\u2588\u2554\u2550\u2550\u2588\u2588\u2557\u255a\u2588\u2588\u2557 \u2588\u2588\u2554\u255d\u2588\u2588\u2554\u2550\u2550\u2588\u2588\u2557\u2588\u2588\u2554\u2550\u2550\u2588\u2588\u2557\u2588\u2588\u2588\u2588\u2557  \u2588\u2588\u2551\u255a\u2550\u2550\u2588\u2588\u2554\u2550\u2550\u255d\u2588\u2588\u2551\u2588\u2588\u2554\u2550\u2550\u2550\u2550\u255d",
+    "\u2588\u2588\u2588\u2588\u2588\u2588\u2554\u255d \u255a\u2588\u2588\u2588\u2588\u2554\u255d \u2588\u2588\u2551  \u2588\u2588\u2551\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2551\u2588\u2588\u2554\u2588\u2588\u2557 \u2588\u2588\u2551   \u2588\u2588\u2551   \u2588\u2588\u2551\u2588\u2588\u2551",
+    "\u2588\u2588\u2554\u2550\u2550\u2550\u255d   \u255a\u2588\u2588\u2554\u255d  \u2588\u2588\u2551  \u2588\u2588\u2551\u2588\u2588\u2554\u2550\u2550\u2588\u2588\u2551\u2588\u2588\u2551\u255a\u2588\u2588\u2557\u2588\u2588\u2551   \u2588\u2588\u2551   \u2588\u2588\u2551\u2588\u2588\u2551",
+    "\u2588\u2588\u2551        \u2588\u2588\u2551   \u2588\u2588\u2588\u2588\u2588\u2588\u2554\u255d\u2588\u2588\u2551  \u2588\u2588\u2551\u2588\u2588\u2551 \u255a\u2588\u2588\u2588\u2588\u2551   \u2588\u2588\u2551   \u2588\u2588\u2551\u255a\u2588\u2588\u2588\u2588\u2588\u2588\u2557",
+    "\u255a\u2550\u255d        \u255a\u2550\u255d   \u255a\u2550\u2550\u2550\u2550\u2550\u255d \u255a\u2550\u255d  \u255a\u2550\u255d\u255a\u2550\u255d  \u255a\u2550\u2550\u2550\u255d   \u255a\u2550\u255d   \u255a\u2550\u255d \u255a\u2550\u2550\u2550\u2550\u2550\u255d",
+)
+_TAGLINE_BOTTOM_WIDTH = 63
+_SHADOW_TRIM = frozenset("\u2550\u2551\u2554\u2557\u255a\u255d")
 
 _RESET = "\x1b[0m"
 _HIDE_CURSOR = "\x1b[?25l"
@@ -84,16 +109,57 @@ def _truecolor() -> bool:
     return os.environ.get("COLORTERM", "").lower() in ("truecolor", "24bit")
 
 
-def _build_frame(phase: int, truecolor: bool) -> str:
-    """Render one full frame; every line clears itself first (\\x1b[2K)."""
+def _compose_rows(columns: int, lines: int):
+    """Pick the biggest lockup the terminal can hold and lay it out.
+
+    Returns a list of (kind, content) rows: ``art`` rows are pyramid tier
+    digits, ``text`` rows are literal figlet glyphs. Degrades gracefully:
+    full "Powered by / Pydantic" -> "Pydantic" only -> pyramid only.
+    """
+    top = [(line, _TAGLINE_TOP_WIDTH) for line in _TAGLINE_TOP]
+    bottom = [(line, _TAGLINE_BOTTOM_WIDTH) for line in _TAGLINE_BOTTOM]
+    variants = (
+        (top + [("", 0)] + bottom, _TAGLINE_TOP_WIDTH),
+        (bottom, _TAGLINE_BOTTOM_WIDTH),
+        ([], _PYRAMID_WIDTH),
+    )
+    for text_rows, text_width in variants:
+        width = max(_PYRAMID_WIDTH, text_width)
+        height = len(_PYRAMID) + (1 + len(text_rows) if text_rows else 0)
+        if columns >= width + 2 and lines >= height + 2:
+            break
+    rows = []
+    art_pad = "0" * ((width - _PYRAMID_WIDTH) // 2)
+    for row in _PYRAMID:
+        rows.append(("art", art_pad + row))
+    if text_rows:
+        rows.append(("text", ""))
+        for line, block_width in text_rows:
+            # Center each figlet block independently (blocks differ in width).
+            pad = " " * ((width - block_width) // 2) if line else ""
+            rows.append(("text", pad + line))
+    return rows
+
+
+def _build_frame(phase: int, truecolor: bool, rows) -> str:
+    """Render one full frame; every line clears itself first (\\x1b[2K).
+
+    The sheen band is computed from absolute (column, row) so it sweeps one
+    continuous diagonal across the pyramid AND the figlet text below it.
+    """
     base = _TRUECOLOR_BASE if truecolor else _FALLBACK_BASE
     hot = _TRUECOLOR_HOT if truecolor else _FALLBACK_HOT
     lines = []
-    for y, row in enumerate(_PYRAMID):
+    for y, (kind, content) in enumerate(rows):
         parts = ["\x1b[2K"]
         current = ""
-        for x, digit in enumerate(row):
-            tier = int(digit)
+        for x, ch in enumerate(content):
+            if kind == "art":
+                tier = int(ch)
+                glyph = _CHARS[tier]
+            else:
+                tier = 3 if ch == "\u2588" else 2 if ch in _SHADOW_TRIM else 0
+                glyph = ch
             if tier == 0:
                 parts.append(" ")
                 continue
@@ -102,7 +168,7 @@ def _build_frame(phase: int, truecolor: bool) -> str:
             if style != current:
                 parts.append(style)
                 current = style
-            parts.append(_CHARS[tier])
+            parts.append(glyph)
         parts.append(_RESET)
         lines.append("".join(parts))
     return "\n".join(lines) + "\n"
@@ -174,6 +240,9 @@ class _Splash:
         self._thread = threading.Thread(
             target=self._run, name="code-puppy-splash", daemon=True
         )
+        size = shutil.get_terminal_size(fallback=(80, 24))
+        self._rows = _compose_rows(size.columns, size.lines)
+        self._height = len(self._rows)
         self._stopped = False
         self._thread.start()
 
@@ -181,12 +250,12 @@ class _Splash:
         phase = 0
         try:
             self._stream.write(_HIDE_CURSOR)
-            self._stream.write(_build_frame(phase, self._truecolor))
+            self._stream.write(_build_frame(phase, self._truecolor, self._rows))
             self._stream.flush()
             while not self._stop_event.wait(_FRAME_SECONDS):
                 phase = (phase + 2) % _SHEEN_PERIOD
-                self._stream.write(f"\x1b[{_HEIGHT}A")
-                self._stream.write(_build_frame(phase, self._truecolor))
+                self._stream.write(f"\x1b[{self._height}A")
+                self._stream.write(_build_frame(phase, self._truecolor, self._rows))
                 self._stream.flush()
         except Exception:
             pass  # a dying terminal must never take the CLI down
@@ -207,7 +276,7 @@ class _Splash:
         self._thread.join(timeout=1.0)
         try:
             # Cursor up over the frame, erase to end of screen, restore cursor.
-            self._stream.write(f"\x1b[{_HEIGHT}A\x1b[0J{_SHOW_CURSOR}")
+            self._stream.write(f"\x1b[{self._height}A\x1b[0J{_SHOW_CURSOR}")
             self._stream.flush()
         except Exception:
             pass

--- a/code_puppy/splash.py
+++ b/code_puppy/splash.py
@@ -15,6 +15,7 @@ no-op splash, never a crashed CLI.
 
 from __future__ import annotations
 
+import io
 import os
 import sys
 import threading
@@ -114,12 +115,61 @@ class _NullSplash:
         pass
 
 
+class _StreamCapture(io.TextIOBase):
+    """Buffers writes made while the splash owns the screen.
+
+    Import-time code (plugin loading, theme setup, warnings) can print mid-
+    animation; a single stray newline shifts the cursor and derails the
+    relative-cursor redraws. So while the splash runs, sys.stdout/stderr
+    point here, and everything is replayed verbatim after the splash erases
+    itself -- output is deferred, never dropped.
+    """
+
+    def __init__(self, real, buffer: io.StringIO, lock: threading.Lock) -> None:
+        self._real = real
+        self._buffer = buffer
+        self._lock = lock
+
+    def write(self, s: str) -> int:
+        with self._lock:
+            self._buffer.write(s)
+        return len(s)
+
+    def flush(self) -> None:
+        pass
+
+    def isatty(self) -> bool:
+        # Mirror the real stream so import-time color/TTY sniffing behaves
+        # exactly as it would without a splash.
+        try:
+            return self._real.isatty()
+        except Exception:
+            return False
+
+    def fileno(self) -> int:
+        return self._real.fileno()
+
+    @property
+    def encoding(self):
+        return getattr(self._real, "encoding", "utf-8")
+
+
 class _Splash:
     def __init__(self, stream, min_seconds: float = _MIN_SHOW_SECONDS) -> None:
         self._stream = stream
         self._min_seconds = min_seconds
         self._started = time.monotonic()
         self._stop_event = threading.Event()
+        # Divert stdout/stderr into buffers for the splash's lifetime so
+        # import-time output can't move the cursor mid-frame. Replayed in
+        # stop(). Per-stream buffers keep each message on its real stream.
+        lock = threading.Lock()
+        self._out_buffer = io.StringIO()
+        self._err_buffer = io.StringIO()
+        self._orig_out, self._orig_err = sys.stdout, sys.stderr
+        self._cap_out = _StreamCapture(self._orig_out, self._out_buffer, lock)
+        self._cap_err = _StreamCapture(self._orig_err, self._err_buffer, lock)
+        sys.stdout, sys.stderr = self._cap_out, self._cap_err
         self._truecolor = _truecolor()
         self._thread = threading.Thread(
             target=self._run, name="code-puppy-splash", daemon=True
@@ -161,6 +211,23 @@ class _Splash:
             self._stream.flush()
         except Exception:
             pass
+        # Hand the streams back (only if nobody else swapped them since),
+        # then replay everything that printed during the show.
+        if sys.stdout is self._cap_out:
+            sys.stdout = self._orig_out
+        if sys.stderr is self._cap_err:
+            sys.stderr = self._orig_err
+        for buffer, real in (
+            (self._out_buffer, self._orig_out),
+            (self._err_buffer, self._orig_err),
+        ):
+            pending = buffer.getvalue()
+            if pending:
+                try:
+                    real.write(pending)
+                    real.flush()
+                except Exception:
+                    pass
 
 
 def _wants_splash(argv: list[str]) -> bool:

--- a/tests/test_splash.py
+++ b/tests/test_splash.py
@@ -70,7 +70,7 @@ class TestFrame:
 class TestLifecycle:
     def test_start_animate_stop(self):
         stream = FakeTty()
-        handle = splash.start_splash(stream=stream, force=True)
+        handle = splash.start_splash(stream=stream, force=True, min_seconds=0)
         assert isinstance(handle, splash._Splash)
         time.sleep(0.15)  # let a few frames render
         handle.stop()
@@ -82,7 +82,7 @@ class TestLifecycle:
 
     def test_stop_is_idempotent(self):
         stream = FakeTty()
-        handle = splash.start_splash(stream=stream, force=True)
+        handle = splash.start_splash(stream=stream, force=True, min_seconds=0)
         handle.stop()
         before = stream.getvalue()
         handle.stop()
@@ -96,6 +96,20 @@ class TestLifecycle:
             def write(self, *_a, **_k):
                 raise OSError("terminal went for a walk")
 
-        handle = splash.start_splash(stream=BrokenTty(), force=True)
+        handle = splash.start_splash(stream=BrokenTty(), force=True, min_seconds=0)
         time.sleep(0.05)
         handle.stop()  # must not raise
+
+    def test_stop_honors_minimum_showtime(self):
+        stream = FakeTty()
+        handle = splash.start_splash(stream=stream, force=True, min_seconds=0.3)
+        t0 = time.monotonic()
+        handle.stop()  # called "instantly" -- must block out the remainder
+        elapsed = time.monotonic() - t0
+        assert elapsed >= 0.25  # slack for scheduler jitter
+        assert not handle._thread.is_alive()
+        # the extra showtime produced extra frames, not a frozen screen
+        assert stream.getvalue().count("\x1b[2K") > splash._HEIGHT
+
+    def test_default_minimum_is_two_seconds(self):
+        assert splash._MIN_SHOW_SECONDS == 2.0

--- a/tests/test_splash.py
+++ b/tests/test_splash.py
@@ -113,3 +113,53 @@ class TestLifecycle:
 
     def test_default_minimum_is_two_seconds(self):
         assert splash._MIN_SHOW_SECONDS == 2.0
+
+
+class TestStreamCapture:
+    def test_output_during_splash_is_deferred_then_replayed(self, capsys):
+        import sys
+
+        stream = FakeTty()
+        handle = splash.start_splash(stream=stream, force=True, min_seconds=0)
+        try:
+            assert sys.stdout is handle._cap_out
+            assert sys.stderr is handle._cap_err
+            print("import-time chatter")
+            sys.stderr.write("plugin warning\n")
+            # nothing leaks to the animation stream mid-show
+            assert "import-time chatter" not in stream.getvalue()
+        finally:
+            handle.stop()
+        assert sys.stdout is not handle._cap_out  # restored
+        captured = capsys.readouterr()
+        assert "import-time chatter" in captured.out
+        assert "plugin warning" in captured.err
+
+    def test_streams_restored_even_if_swapped_by_someone_else(self, capsys):
+        import sys
+
+        stream = FakeTty()
+        handle = splash.start_splash(stream=stream, force=True, min_seconds=0)
+        foreign = FakeTty()
+        sys.stdout = foreign  # someone else grabbed stdout mid-import
+        try:
+            handle.stop()
+            assert sys.stdout is foreign  # we must not clobber their swap
+        finally:
+            sys.stdout = handle._orig_out  # restore for pytest's sanity
+
+    def test_capture_mirrors_isatty(self):
+        stream = FakeTty()
+        handle = splash.start_splash(stream=stream, force=True, min_seconds=0)
+        try:
+            assert handle._cap_out.isatty() is handle._orig_out.isatty()
+        finally:
+            handle.stop()
+
+    def test_null_splash_leaves_streams_alone(self):
+        import sys
+
+        out, err = sys.stdout, sys.stderr
+        handle = splash.start_splash(stream=io.StringIO())  # not a tty -> null
+        handle.stop()
+        assert sys.stdout is out and sys.stderr is err

--- a/tests/test_splash.py
+++ b/tests/test_splash.py
@@ -165,8 +165,8 @@ class TestLifecycle:
         # the extra showtime produced extra frames, not a frozen screen
         assert stream.getvalue().count("\x1b[2K") > handle._height
 
-    def test_default_minimum_is_two_seconds(self):
-        assert splash._MIN_SHOW_SECONDS == 2.0
+    def test_default_minimum_is_three_seconds(self):
+        assert splash._MIN_SHOW_SECONDS == 3.0
 
 
 class TestStreamCapture:

--- a/tests/test_splash.py
+++ b/tests/test_splash.py
@@ -1,0 +1,101 @@
+"""Tests for the import-time neon splash (code_puppy/splash.py)."""
+
+import io
+import re
+import time
+
+from code_puppy import splash
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+
+class FakeTty(io.StringIO):
+    def isatty(self):
+        return True
+
+
+class TestGating:
+    def test_non_tty_gets_null_splash(self):
+        result = splash.start_splash(stream=io.StringIO())
+        assert isinstance(result, splash._NullSplash)
+
+    def test_headless_argv_gets_null_splash(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["code-puppy", "-p", "do the thing"])
+        result = splash.start_splash(stream=FakeTty())
+        assert isinstance(result, splash._NullSplash)
+        result.stop()  # must be a harmless no-op
+
+    def test_interactive_argv_wants_splash(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["code-puppy", "-i"])
+        monkeypatch.delenv("CODE_PUPPY_NO_SPLASH", raising=False)
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        assert splash._wants_splash(["code-puppy", "-i"]) is True
+
+    def test_env_kill_switch(self, monkeypatch):
+        monkeypatch.setenv("CODE_PUPPY_NO_SPLASH", "1")
+        assert splash._wants_splash(["code-puppy"]) is False
+
+    def test_no_color_respected(self, monkeypatch):
+        monkeypatch.delenv("CODE_PUPPY_NO_SPLASH", raising=False)
+        monkeypatch.setenv("NO_COLOR", "1")
+        assert splash._wants_splash(["code-puppy"]) is False
+
+    def test_dumb_term_skipped(self, monkeypatch):
+        monkeypatch.delenv("CODE_PUPPY_NO_SPLASH", raising=False)
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv("TERM", "dumb")
+        assert splash._wants_splash(["code-puppy"]) is False
+
+
+class TestFrame:
+    def test_frame_dimensions(self):
+        frame = splash._build_frame(0, truecolor=True)
+        lines = frame.splitlines()
+        assert len(lines) == splash._HEIGHT
+        for line in lines:
+            visible = ANSI_RE.sub("", line)
+            assert len(visible) <= 44
+            assert set(visible) <= set(" \u2591\u2592\u2588")
+
+    def test_sheen_moves_between_phases(self):
+        assert splash._build_frame(0, truecolor=True) != splash._build_frame(
+            20, truecolor=True
+        )
+
+    def test_fallback_palette_has_no_truecolor_codes(self):
+        frame = splash._build_frame(0, truecolor=False)
+        assert "38;2;" not in frame
+
+
+class TestLifecycle:
+    def test_start_animate_stop(self):
+        stream = FakeTty()
+        handle = splash.start_splash(stream=stream, force=True)
+        assert isinstance(handle, splash._Splash)
+        time.sleep(0.15)  # let a few frames render
+        handle.stop()
+        output = stream.getvalue()
+        assert splash._HIDE_CURSOR in output
+        assert splash._SHOW_CURSOR in output
+        assert "\u2588" in output  # some pyramid actually got drawn
+        assert not handle._thread.is_alive()
+
+    def test_stop_is_idempotent(self):
+        stream = FakeTty()
+        handle = splash.start_splash(stream=stream, force=True)
+        handle.stop()
+        before = stream.getvalue()
+        handle.stop()
+        assert stream.getvalue() == before
+
+    def test_broken_stream_fails_soft(self):
+        class BrokenTty(io.StringIO):
+            def isatty(self):
+                return True
+
+            def write(self, *_a, **_k):
+                raise OSError("terminal went for a walk")
+
+        handle = splash.start_splash(stream=BrokenTty(), force=True)
+        time.sleep(0.05)
+        handle.stop()  # must not raise

--- a/tests/test_splash.py
+++ b/tests/test_splash.py
@@ -68,6 +68,21 @@ class TestFrame:
         frame = splash._build_frame(0, False, FULL)
         assert "38;2;" not in frame
 
+    def test_frame_has_no_erase_codes_or_trailing_newline(self):
+        # Erase-then-redraw flickers; frames overwrite in place instead,
+        # and a trailing newline would scroll at the bottom of the screen.
+        frame = splash._build_frame(0, True, FULL)
+        assert "\x1b[2K" not in frame
+        assert not frame.endswith("\n")
+
+    def test_frames_are_wrapped_in_synchronized_output(self):
+        stream = FakeTty()
+        handle = splash.start_splash(stream=stream, force=True, min_seconds=0.1)
+        handle.stop()
+        output = stream.getvalue()
+        assert output.count(splash._SYNC_START) == output.count(splash._SYNC_END)
+        assert output.count(splash._SYNC_START) >= 1
+
     def test_baked_figlet_matches_pyfiglet(self):
         import pyfiglet
 
@@ -163,7 +178,7 @@ class TestLifecycle:
         assert elapsed >= 0.25  # slack for scheduler jitter
         assert not handle._thread.is_alive()
         # the extra showtime produced extra frames, not a frozen screen
-        assert stream.getvalue().count("\x1b[2K") > handle._height
+        assert stream.getvalue().count(splash._SYNC_START) > 1
 
     def test_default_minimum_is_three_seconds(self):
         assert splash._MIN_SHOW_SECONDS == 3.0

--- a/tests/test_splash.py
+++ b/tests/test_splash.py
@@ -47,24 +47,77 @@ class TestGating:
         assert splash._wants_splash(["code-puppy"]) is False
 
 
+FULL = splash._compose_rows(120, 50)
+
+
 class TestFrame:
-    def test_frame_dimensions(self):
-        frame = splash._build_frame(0, truecolor=True)
+    def test_full_lockup_dimensions(self):
+        frame = splash._build_frame(0, True, FULL)
         lines = frame.splitlines()
-        assert len(lines) == splash._HEIGHT
+        assert len(lines) == len(FULL)
+        allowed = set(" \u2591\u2592\u2588") | splash._SHADOW_TRIM
         for line in lines:
             visible = ANSI_RE.sub("", line)
-            assert len(visible) <= 44
-            assert set(visible) <= set(" \u2591\u2592\u2588")
+            assert len(visible) <= splash._TAGLINE_TOP_WIDTH + 8
+            assert set(visible) <= allowed
 
     def test_sheen_moves_between_phases(self):
-        assert splash._build_frame(0, truecolor=True) != splash._build_frame(
-            20, truecolor=True
-        )
+        assert splash._build_frame(0, True, FULL) != splash._build_frame(20, True, FULL)
 
     def test_fallback_palette_has_no_truecolor_codes(self):
-        frame = splash._build_frame(0, truecolor=False)
+        frame = splash._build_frame(0, False, FULL)
         assert "38;2;" not in frame
+
+    def test_baked_figlet_matches_pyfiglet(self):
+        import pyfiglet
+
+        for text, baked in (
+            ("Powered by", splash._TAGLINE_TOP),
+            ("Pydantic", splash._TAGLINE_BOTTOM),
+        ):
+            rendered = pyfiglet.figlet_format(text, font="ansi_shadow", width=300)
+            lines = [ln.rstrip() for ln in rendered.splitlines()]
+            while lines and not lines[-1]:
+                lines.pop()
+            assert tuple(lines) == baked, f"baked figlet drifted for {text!r}"
+
+
+class TestComposeRows:
+    def test_wide_terminal_gets_full_lockup(self):
+        kinds = [k for k, _ in splash._compose_rows(120, 50)]
+        assert kinds.count("art") == len(splash._PYRAMID)
+        assert kinds.count("text") == 1 + len(splash._TAGLINE_TOP) + 1 + len(
+            splash._TAGLINE_BOTTOM
+        )
+
+    def test_medium_terminal_gets_pydantic_only(self):
+        rows = splash._compose_rows(70, 50)
+        text_rows = [c for k, c in rows if k == "text" and c]
+        assert len(text_rows) == len(splash._TAGLINE_BOTTOM)
+
+    def test_narrow_terminal_gets_pyramid_only(self):
+        rows = splash._compose_rows(50, 50)
+        assert all(k == "art" for k, _ in rows)
+
+    def test_short_terminal_drops_text(self):
+        rows = splash._compose_rows(120, 22)
+        assert all(k == "art" for k, _ in rows)
+
+    def test_pyramid_centered_over_text(self):
+        rows = splash._compose_rows(120, 50)
+        # Compare a row against its unpadded source: the pad is the diff.
+        idx = max(range(len(splash._PYRAMID)), key=lambda i: len(splash._PYRAMID[i]))
+        pad = len(rows[idx][1]) - len(splash._PYRAMID[idx])
+        assert pad == (splash._TAGLINE_TOP_WIDTH - splash._PYRAMID_WIDTH) // 2
+
+    def test_pydantic_block_centered_under_powered_by(self):
+        rows = splash._compose_rows(120, 50)
+        text_lines = [c for k, c in rows if k == "text" and c]
+        bottom = text_lines[-len(splash._TAGLINE_BOTTOM) :]
+        expected_pad = (splash._TAGLINE_TOP_WIDTH - splash._TAGLINE_BOTTOM_WIDTH) // 2
+        for line in bottom:
+            assert line.startswith(" " * expected_pad)
+            assert not line.startswith(" " * (expected_pad + 1))
 
 
 class TestLifecycle:
@@ -79,6 +132,7 @@ class TestLifecycle:
         assert splash._SHOW_CURSOR in output
         assert "\u2588" in output  # some pyramid actually got drawn
         assert not handle._thread.is_alive()
+        assert handle._height == len(handle._rows)
 
     def test_stop_is_idempotent(self):
         stream = FakeTty()
@@ -109,7 +163,7 @@ class TestLifecycle:
         assert elapsed >= 0.25  # slack for scheduler jitter
         assert not handle._thread.is_alive()
         # the extra showtime produced extra frames, not a frozen screen
-        assert stream.getvalue().count("\x1b[2K") > splash._HEIGHT
+        assert stream.getvalue().count("\x1b[2K") > handle._height
 
     def test_default_minimum_is_two_seconds(self):
         assert splash._MIN_SHOW_SECONDS == 2.0


### PR DESCRIPTION
## What

Cold start is ~2s of heavy imports before anything appears. This PR fills that dead air with a shimmering neon Pydantic pyramid (violet halo -> brand magenta -> hot-pink core, with a traveling white-hot sheen band), which erases itself the instant imports finish and hands the screen to the normal banner.

## How

- **`code_puppy/splash.py` — stdlib-only, zero `code_puppy` imports.** That's the entire trick: it must be importable before the heavy world loads. Comment at the top warns future paws off adding imports.
- **`main.py` starts it before `from code_puppy.cli_runner import main_entry`** and stops it in a `finally`. (That `E402` per-file ignore in pyproject finally earns its keep.)
- Pyramid is a pre-rendered 20x44 tier raster baked as digit-string constants — no rasterizer ships in the runtime (YAGNI).
- Full-frame repaints with `\x1b[2K` line-clears absorb stray import-time output (plugin warnings, theme OSC codes).
- **Gating fails closed:** animates only for interactive-looking boots (bare invocation, `-i`). No TTY, `-p`, `--help`, ACP bridges, `NO_COLOR`, `CODE_PUPPY_NO_SPLASH=1`, `TERM=dumb`, or Windows consoles without VT support all get a no-op `_NullSplash`. Broken streams never raise.
- Truecolor palette with 16-color magenta fallback (COLORTERM sniff).
- Art only, deliberately no text -> outside the i18n seam (PUP-473 scope note).

## Testing
- 12 new tests: gating matrix, frame geometry (20 rows, <=44 visible cols, legal glyphs only), sheen phase movement, palette fallback, start/stop lifecycle, idempotent stop, broken-stream soft-fail
- ruff check + format clean
- Manual: splash runs over the real cli_runner import and erases cleanly before first real output