### PR TITLE
fix: name pydantic-ai agents so Logfire spans show logical agent names

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -637,10 +637,15 @@ def build_pydantic_agent(
     model_settings = make_model_settings(resolved_model_name)
     history_processor = make_history_processor(agent)
     steer_processor = make_steer_history_processor(agent)
+    logical_agent_name = getattr(agent, "name", None) or agent.__class__.__name__
 
     def _new_pydantic_agent(toolsets: List[Any]) -> PydanticAgent:
         return PydanticAgent(
             model=model,
+            # Explicit name: without it pydantic-ai infers one from the
+            # caller's frame variables, so observability spans read
+            # "invoke_agent pydantic_agent" instead of the logical agent name.
+            name=logical_agent_name,
             instructions=instructions,
             output_type=output_type,
             retries=3,
@@ -667,7 +672,6 @@ def build_pydantic_agent(
     # tool registry actually produced, and filter MCP to avoid name clashes.
     probe_agent = _new_pydantic_agent(toolsets=[])
     agent_tools = agent.get_available_tools()
-    logical_agent_name = getattr(agent, "name", None) or agent.__class__.__name__
     register_tools_for_agent(
         probe_agent,
         agent_tools,

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -406,6 +406,11 @@ async def _invoke_agent_impl(
             # (e.g. DBOS) may swap them via the agent_run_context hook.
             temp_agent = Agent(
                 model=model,
+                # Explicit name: without it pydantic-ai infers one from the
+                # caller's frame variables, so every sub-agent's observability
+                # span reads "invoke_agent temp_agent" instead of the logical
+                # agent name (e.g. "invoke_agent web-retriever").
+                name=agent_name,
                 instructions=instructions,
                 output_type=str,
                 retries=3,

--- a/tests/test_agent_span_naming.py
+++ b/tests/test_agent_span_naming.py
@@ -1,0 +1,116 @@
+"""Observability span-naming contract for pydantic-ai agents.
+
+pydantic-ai names the per-run OTel span ``invoke_agent {agent.name}`` (and the
+Logfire message ``{agent.name} run``). When ``name=`` is omitted, pydantic-ai
+*infers* a name from the caller's frame variables, which produced traces like
+``invoke_agent temp_agent`` (every sub-agent!) and ``invoke_agent
+pydantic_agent`` (the main agent). These tests pin the fix: both construction
+paths must pass the *logical* agent name explicitly.
+
+No Logfire/OTel wiring is needed here -- asserting ``.name`` on the built
+pydantic-ai agent is exactly what instrumentation consumes
+(``ctx.agent.name``), so it locks the span name without global tracer state.
+"""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from pydantic_ai.models.test import TestModel
+
+
+class _FakeAgentConfig:
+    """Minimal BaseAgent-shaped config for driving the real build paths."""
+
+    name = "web-retriever"
+    display_name = "Web Retriever"
+
+    def __init__(self):
+        self._message_history = []
+        self._compacted_message_hashes = set()
+        self._puppy_rules = None
+
+    @contextmanager
+    def temporary_model_name_override(self, _model_name):
+        yield
+
+    def get_model_name(self):
+        return "test-model"
+
+    def get_full_system_prompt(self):
+        return "You are a test agent."
+
+    def get_available_tools(self):
+        return []
+
+    def get_message_history(self):
+        return self._message_history
+
+    def set_message_history(self, history):
+        self._message_history = history
+
+    def __getattr__(self, item):
+        # Misc numeric config probes used by history processors.
+        if item.startswith("__"):
+            raise AttributeError(item)
+        return lambda *a, **k: 0
+
+
+def _fake_load_model_with_fallback(*_args, **_kwargs):
+    return TestModel(custom_output_text="woof"), "test-model"
+
+
+def test_build_pydantic_agent_sets_logical_agent_name():
+    """Main agent path: spans must read 'invoke_agent code-puppy', not
+    'invoke_agent pydantic_agent' (the inferred frame-variable name)."""
+    from code_puppy.agents import _builder
+
+    cfg = _FakeAgentConfig()
+    cfg.name = "code-puppy"
+
+    with (
+        patch.object(
+            _builder, "load_model_with_fallback", _fake_load_model_with_fallback
+        ),
+        patch.object(_builder.ModelFactory, "load_config", staticmethod(dict)),
+        patch.object(_builder, "load_mcp_servers", lambda **k: []),
+        patch.object(_builder, "make_model_settings", lambda *a, **k: None),
+        patch("code_puppy.tools.register_tools_for_agent", lambda *a, **k: None),
+    ):
+        built = _builder.build_pydantic_agent(cfg)
+
+    assert built.name == "code-puppy"
+
+
+@pytest.mark.asyncio
+async def test_invoke_agent_impl_sets_subagent_name():
+    """Sub-agent path: every delegate must carry its own logical name so
+    parallel invocations don't all render as 'invoke_agent temp_agent'."""
+    from code_puppy.tools import subagent_invocation as si
+
+    cfg = _FakeAgentConfig()
+    captured = {}
+
+    def capture_wrap(_agent_config, pydantic_agent, **_kwargs):
+        captured["agent"] = pydantic_agent
+        return pydantic_agent
+
+    with (
+        patch("code_puppy.agents.agent_manager.load_agent", return_value=cfg),
+        patch(
+            "code_puppy.agents._builder.load_model_with_fallback",
+            _fake_load_model_with_fallback,
+        ),
+        patch("code_puppy.model_factory.make_model_settings", lambda *a, **k: None),
+        patch("code_puppy.config.get_value", return_value="true"),  # no MCP
+        patch.object(si, "on_wrap_pydantic_agent", capture_wrap),
+    ):
+        out = await si._invoke_agent_impl(
+            context=SimpleNamespace(),
+            agent_name="web-retriever",
+            prompt="fetch me a stick",
+        )
+
+    assert out.error is None
+    assert captured["agent"].name == "web-retriever"


### PR DESCRIPTION
## Problem

With the Logfire plugin enabled, sub-agent traces look goofy: every parallel sub-agent renders as `invoke_agent temp_agent` and the main agent as `invoke_agent pydantic_agent`.

Confirmed against live trace data:

| span_name | message | count |
|---|---|---|
| `invoke_agent temp_agent` | `temp_agent run` | 10 |
| `invoke_agent pydantic_agent` | `pydantic_agent run` | 9 |

## Root cause

pydantic-ai names the run span `invoke_agent {agent.name}` (Logfire message `{agent.name} run`). When `Agent(name=...)` is omitted, pydantic-ai **infers the name from the caller's stack-frame variables** (`AbstractAgent._infer_name`). Code Puppy never passed `name=` in either construction path, so the local variable names `temp_agent` / `pydantic_agent` leaked into every trace — all ten parallel sub-agents indistinguishable.

## Fix

Pass the logical agent name explicitly:

- `agents/_builder.py`: `name=logical_agent_name` → `invoke_agent code-puppy`
- `tools/subagent_invocation.py`: `name=agent_name` → `invoke_agent web-retriever`, `invoke_agent qa-kitten`, …

Child `chat`/`execute_tool` spans also inherit the correct `gen_ai.agent.name` via OTel baggage, so per-agent token rollups in Logfire become meaningful.

## Verification

Drove the real `build_pydantic_agent` and `_invoke_agent_impl` code paths with `TestModel` + `InMemorySpanExporter`:

**Before**
```
invoke_agent pydantic_agent   msg='pydantic_agent run'
invoke_agent temp_agent       msg='temp_agent run'
```

**After**
```
invoke_agent code-puppy       msg='code-puppy run'    gen_ai.agent.name='code-puppy'
invoke_agent web-retriever    msg='web-retriever run' gen_ai.agent.name='web-retriever'
```

- New regression test: `tests/test_agent_span_naming.py` (locks both paths)
- Full suite: 7535 passed, 28 skipped
- `ruff check` / `ruff format` clean