### PR TITLE
Add plugin hook for curating agent tool surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ approval. With `fail_closed=True` its exception is reported as a block instead. 
 | `custom_command_help` | `/help` menu | `() -> list[tuple[str, str]]` |
 | `register_tools` | Tool registration | `() -> list[dict]` with `{"name": str, "register_func": callable}` |
 | `register_agent_tools` | Advertise tools to an agent's available list | `(agent_name: str \| None) -> list[str]` — tool names from `TOOL_REGISTRY` to merge into the agent's hardcoded `get_available_tools()` |
+| `filter_agent_tools` | Curate an agent's merged tool list | `(agent_name: str \| None, tool_names: list[str]) -> list[str] \| None` — filters compose in registration order and fail open |
 | `register_agents` | Agent catalogue | `() -> list[dict]` with `{"name": str, "class": type}` |
 | `register_model_type` | Custom model type | `() -> list[dict]` with `{"type": str, "handler": callable}` |
 | `register_skills` | Skill catalogue | `() -> list[dict]` with `{"name": str, "skill_md" \| "skill_md_path" \| "frontmatter"+"body"}` |

--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -35,6 +35,7 @@ PhaseType = Literal[
     "prompt_text_color",
     "register_tools",
     "register_agent_tools",
+    "filter_agent_tools",
     "register_agents",
     "register_model_type",
     "register_skills",
@@ -121,6 +122,7 @@ _callbacks: Dict[PhaseType, List[CallbackFunc]] = {
     "prompt_text_color": [],
     "register_tools": [],
     "register_agent_tools": [],
+    "filter_agent_tools": [],
     "register_agents": [],
     "register_model_type": [],
     "register_skills": [],
@@ -926,6 +928,41 @@ def on_register_agent_tools(agent_name: Optional[str] = None) -> List[str]:
                 seen.add(item)
                 flat.append(item)
     return flat
+
+
+def on_filter_agent_tools(
+    agent_name: Optional[str], tool_names: List[str]
+) -> List[str]:
+    """Apply plugin-owned policy filters to an agent's merged tool list.
+
+    Filters run in registration order and receive the previous filter's output.
+    Returning ``None`` leaves the list unchanged. Invalid results and exceptions
+    fail open so an optional policy plugin cannot disable core tooling.
+    """
+    filtered = list(tool_names)
+    for callback in get_callbacks("filter_agent_tools"):
+        try:
+            result = callback(agent_name, list(filtered))
+        except Exception as exc:
+            logger.error(
+                "Callback %s failed in phase 'filter_agent_tools': %s\n%s",
+                callback.__name__,
+                exc,
+                traceback.format_exc(),
+            )
+            continue
+        if result is None:
+            continue
+        if not isinstance(result, list) or not all(
+            isinstance(name, str) and name for name in result
+        ):
+            logger.warning(
+                "Ignoring invalid filter_agent_tools result from %s",
+                callback.__name__,
+            )
+            continue
+        filtered = result
+    return filtered
 
 
 def on_register_agents() -> List[Dict[str, Any]]:

--- a/code_puppy/tools/__init__.py
+++ b/code_puppy/tools/__init__.py
@@ -1,15 +1,14 @@
 import os
 import sys
 
-from code_puppy.callbacks import on_register_agent_tools, on_register_tools
+from code_puppy.callbacks import (
+    on_filter_agent_tools,
+    on_register_agent_tools,
+    on_register_tools,
+)
 from code_puppy.messaging import emit_warning
 from code_puppy.tools.agent_tools import register_list_agents
-from code_puppy.tools.subagent_invocation import (
-    register_invoke_agent,
-    register_invoke_agent_with_model,
-)
 from code_puppy.tools.ask_user_question import register_ask_user_question
-
 from code_puppy.tools.command_runner import (
     register_agent_run_shell_command,
     register_agent_share_your_reasoning,
@@ -31,6 +30,10 @@ from code_puppy.tools.file_operations import (
 )
 from code_puppy.tools.image_tools import register_load_image
 from code_puppy.tools.model_tools import register_list_available_models
+from code_puppy.tools.subagent_invocation import (
+    register_invoke_agent,
+    register_invoke_agent_with_model,
+)
 
 # Map of tool names to their individual registration functions
 TOOL_REGISTRY = {
@@ -193,8 +196,8 @@ def register_tools_for_agent(
             (like agent_share_your_reasoning) should be skipped. If None,
             falls back to the current global model.
         agent_name: Optional logical agent name (e.g. ``"code-puppy"``).
-            Passed to the ``register_agent_tools`` callback so plugins can
-            advertise tools per-agent if they want.
+            Passed to the ``register_agent_tools`` and ``filter_agent_tools``
+            callbacks so plugins can advertise and curate tools per agent.
     """
     from code_puppy.config import get_universal_constructor_enabled
 
@@ -216,6 +219,10 @@ def register_tools_for_agent(
                 merged.append(extra)
                 seen.add(extra)
         tool_names = merged
+
+    # Let policy plugins curate the complete merged surface without changing
+    # registration. Specialized tools remain available to other agents.
+    tool_names = on_filter_agent_tools(agent_name, tool_names)
 
     if os.environ.get("CODE_PUPPY_DISABLE_ASK_USER_QUESTION", "").lower() in {
         "1",

--- a/tests/test_tool_filter_callbacks.py
+++ b/tests/test_tool_filter_callbacks.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from code_puppy import callbacks
+
+
+def test_agent_tool_filters_compose_in_registration_order():
+    callbacks.clear_callbacks("filter_agent_tools")
+    try:
+        callbacks.register_callback(
+            "filter_agent_tools",
+            lambda _agent, tools: tools + ["added"],
+        )
+        callbacks.register_callback(
+            "filter_agent_tools",
+            lambda _agent, tools: [name for name in tools if name != "removed"],
+        )
+
+        assert callbacks.on_filter_agent_tools("code-puppy", ["kept", "removed"]) == [
+            "kept",
+            "added",
+        ]
+    finally:
+        callbacks.clear_callbacks("filter_agent_tools")
+
+
+def test_agent_tool_filter_failure_leaves_previous_result_usable():
+    callbacks.clear_callbacks("filter_agent_tools")
+
+    def explode(_agent, _tools):
+        raise RuntimeError("boom")
+
+    try:
+        callbacks.register_callback("filter_agent_tools", explode)
+        assert callbacks.on_filter_agent_tools("code-puppy", ["kept"]) == ["kept"]
+    finally:
+        callbacks.clear_callbacks("filter_agent_tools")
+
+
+def test_invalid_agent_tool_filter_result_is_ignored():
+    callbacks.clear_callbacks("filter_agent_tools")
+    try:
+        callbacks.register_callback(
+            "filter_agent_tools", lambda _agent, _tools: "not-a-list"
+        )
+        assert callbacks.on_filter_agent_tools("code-puppy", ["kept"]) == ["kept"]
+    finally:
+        callbacks.clear_callbacks("filter_agent_tools")

--- a/tests/test_tools_registration.py
+++ b/tests/test_tools_registration.py
@@ -66,6 +66,35 @@ class TestToolRegistration:
         # nothing raised.
         assert True  # If we get here, no exception was raised
 
+    @patch("code_puppy.tools._load_plugin_tools")
+    @patch("code_puppy.tools.on_filter_agent_tools")
+    @patch("code_puppy.tools.on_register_agent_tools")
+    def test_filter_receives_complete_merged_tool_surface(
+        self, mock_plugin_tools, mock_filter, _mock_load_plugin_tools
+    ):
+        """Policy filters run after plugin tools join the agent's base tools."""
+        base_register = MagicMock()
+        plugin_register = MagicMock()
+        mock_plugin_tools.return_value = ["__plugin_tool"]
+        mock_filter.return_value = ["__base_tool"]
+
+        with patch.dict(
+            TOOL_REGISTRY,
+            {
+                "__base_tool": base_register,
+                "__plugin_tool": plugin_register,
+            },
+        ):
+            register_tools_for_agent(
+                MagicMock(), ["__base_tool"], agent_name="code-puppy"
+            )
+
+        mock_filter.assert_called_once_with(
+            "code-puppy", ["__base_tool", "__plugin_tool"]
+        )
+        base_register.assert_called_once()
+        plugin_register.assert_not_called()
+
     def test_register_tools_invalid_tool(self):
         """Test that registering an invalid tool prints warning and continues."""
         mock_agent = MagicMock()


### PR DESCRIPTION
## Summary

Add a general `filter_agent_tools` callback phase that lets plugins curate an agent's final merged tool surface without unregistering tools globally.

The callback runs after the agent's built-in tools and `register_agent_tools` contributions are merged. This gives optional tool bundles and policy plugins a narrow seam to remove or reorder tools for one agent while keeping those tools registered and available to specialized agents.

## Behavior

- filters compose in callback registration order
- each filter receives the previous filter's result as a defensive list copy
- `None` preserves the last valid tool list
- exceptions and malformed return values fail open and are logged
- the existing `CODE_PUPPY_DISABLE_ASK_USER_QUESTION` override remains authoritative

## Motivation

Large optional plugin bundles can otherwise advertise every registered tool to the primary agent, increasing schema size and exposing tools intended only for specialized agents. This hook keeps registration and per-agent exposure as separate responsibilities.

The mechanism is intentionally generic. It does not add Android-specific policy or tools to core; an existing DroidPuppy tool curator was used only as a compatibility proof.

## Validation

- `46 passed` across callback fail-closed regressions, dedicated filter tests, and tool-registration tests
- Ruff `E4,E7,E9,F,I` checks passed for all changed Python files
- Ruff formatting check passed
- `git diff --check` passed
- compatibility smoke with the existing DroidPuppy curator produced the expected filtered tool list
