### PR TITLE
Prefer environment ripgrep over broken PATH shims

### DIFF
--- a/code_puppy/tools/file_operations.py
+++ b/code_puppy/tools/file_operations.py
@@ -4,6 +4,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 from typing import List
 
@@ -21,8 +22,8 @@ from code_puppy.messaging import (  # New structured messaging types
     GrepResultMessage,
     get_message_bus,
 )
-from code_puppy.tools.common import resolve_path
 from code_puppy.tools import fs_access
+from code_puppy.tools.common import resolve_path
 
 
 # Pydantic models for tool return types
@@ -64,6 +65,21 @@ class GrepOutput(BaseModel):
 # Context never evicts a real match: once this budget is full we keep scanning
 # for matches and simply stop collecting further context.
 _MAX_GREP_CONTEXT_ROWS = 200
+
+
+def _find_ripgrep() -> str | None:
+    """Prefer ripgrep installed beside the active Python, then search PATH.
+
+    Environment managers such as pyenv can expose a broken ``rg`` shim on
+    ``PATH`` even when the active Code Puppy environment contains a working
+    executable. Checking the interpreter directory first avoids that trap.
+    """
+    python_dir = os.path.dirname(sys.executable)
+    for name in ("rg", "rg.exe"):
+        candidate = os.path.join(python_dir, name)
+        if os.path.isfile(candidate):
+            return candidate
+    return shutil.which("rg")
 
 
 def is_likely_home_directory(directory):
@@ -216,8 +232,6 @@ def _list_entries_via_backend(directory: str, recursive: bool) -> List["ListedFi
 def _list_files(
     context: RunContext, directory: str = ".", recursive: bool = True
 ) -> ListFileOutput:
-    import sys
-
     results = []
     # Synthesized parent directories already added to ``results``. Membership is
     # checked once per path component of every file, so this has to be O(1);
@@ -262,18 +276,7 @@ def _list_files(
     # Create a temporary ignore file with our ignore patterns (local rg path)
     ignore_file = None
     try:
-        # Find ripgrep executable - first check system PATH, then virtual environment
-        rg_path = shutil.which("rg")
-        if not rg_path:
-            # Try to find it in the virtual environment
-            # Use sys.executable to determine the Python environment path
-            python_dir = os.path.dirname(sys.executable)
-            # python_dir is already bin/ (Unix) or Scripts/ (Windows)
-            for name in ["rg", "rg.exe"]:
-                candidate = os.path.join(python_dir, name)
-                if os.path.exists(candidate):
-                    rg_path = candidate
-                    break
+        rg_path = _find_ripgrep()
 
         if not rg_path and recursive and not _use_backend:
             # Only need ripgrep for recursive listings
@@ -1179,9 +1182,7 @@ def _carries_type_filter(rg_args: list[str]) -> bool:
 def _grep(context: RunContext, search_string: str, directory: str = ".") -> GrepOutput:
     import json
     import os
-    import shutil
     import subprocess
-    import sys
 
     # Sanitize search string to handle any surrogates from copy-paste
     search_string = _sanitize_string(search_string)
@@ -1204,18 +1205,7 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
         # ripgrep: absolute path, --json output, --max-count 50, --max-filesize 5M,
         # --type=all, --ignore-file for our ignore list.
 
-        # Find ripgrep executable - first check system PATH, then virtual environment
-        rg_path = shutil.which("rg")
-        if not rg_path:
-            # Try to find it in the virtual environment
-            # Use sys.executable to determine the Python environment path
-            python_dir = os.path.dirname(sys.executable)
-            # python_dir is already bin/ (Unix) or Scripts/ (Windows)
-            for name in ["rg", "rg.exe"]:
-                candidate = os.path.join(python_dir, name)
-                if os.path.exists(candidate):
-                    rg_path = candidate
-                    break
+        rg_path = _find_ripgrep()
 
         if not rg_path:
             error_message = (

--- a/tests/tools/test_ripgrep_discovery.py
+++ b/tests/tools/test_ripgrep_discovery.py
@@ -1,0 +1,60 @@
+"""Regression tests for ripgrep discovery under environment managers."""
+
+import subprocess
+
+from code_puppy.tools import file_operations
+
+
+def test_find_ripgrep_prefers_active_python_environment(monkeypatch):
+    """A broken pyenv PATH shim must not hide the environment's executable."""
+    environment_rg = "/active-environment/bin/rg"
+    monkeypatch.setattr(
+        file_operations.sys, "executable", "/active-environment/bin/python"
+    )
+    monkeypatch.setattr(
+        file_operations.os.path,
+        "isfile",
+        lambda path: path == environment_rg,
+    )
+    monkeypatch.setattr(
+        file_operations.shutil,
+        "which",
+        lambda _name: "/pyenv/shims/rg",
+    )
+
+    assert file_operations._find_ripgrep() == environment_rg
+
+
+def test_recursive_listing_bypasses_broken_path_shim(monkeypatch, tmp_path):
+    environment_bin = tmp_path / "environment" / "bin"
+    environment_bin.mkdir(parents=True)
+    environment_python = environment_bin / "python"
+    environment_rg = environment_bin / "rg"
+    environment_rg.touch()
+    listed_file = tmp_path / "listed.txt"
+    listed_file.write_text("hello")
+
+    monkeypatch.setattr(file_operations.sys, "executable", str(environment_python))
+    monkeypatch.setattr(
+        file_operations.shutil, "which", lambda _name: "/pyenv/shims/rg"
+    )
+
+    def run(command, **_kwargs):
+        assert command[0] == str(environment_rg)
+        return subprocess.CompletedProcess(command, 0, f"{listed_file}\n", "")
+
+    monkeypatch.setattr(file_operations.subprocess, "run", run)
+
+    result = file_operations._list_files(None, str(tmp_path), recursive=True)
+
+    assert result.error is None
+    assert "listed.txt" in result.content
+
+
+def test_find_ripgrep_falls_back_to_path(monkeypatch):
+    monkeypatch.setattr(file_operations.os.path, "isfile", lambda _path: False)
+    monkeypatch.setattr(
+        file_operations.shutil, "which", lambda _name: "/usr/local/bin/rg"
+    )
+
+    assert file_operations._find_ripgrep() == "/usr/local/bin/rg"


### PR DESCRIPTION
## Summary

Fixes recursive file listing and grep when an environment manager such as pyenv exposes a broken `rg` shim on `PATH`, while the active Code Puppy Python environment contains a working ripgrep executable.

## Root cause

The existing lookup checked `shutil.which("rg")` first. A pyenv shim is a real file, so `which()` succeeds even when that shim later reports that `rg` is unavailable for the selected environment. Code Puppy therefore never tried the executable installed beside `sys.executable`.

## Change

- centralize the duplicated list/grep executable lookup in `_find_ripgrep()`
- prefer `rg` or `rg.exe` beside the active Python interpreter
- retain normal `PATH` lookup as the fallback
- add focused resolver and recursive-listing regression coverage

No recursive-walk fallback, packaging change, or general file-tool behavior is included.

## Validation

- new regression tests: **3 passed**
- adjacent file-operation coverage tests: **78 passed**, with two pre-existing Android live-ripgrep cases deselected
- Ruff `E4,E7,E9,F,I` checks passed
- Ruff formatting passed
- `git diff --check` passed

Separate baseline check: `tests/tools/test_grep_live_behavior.py` reports 2 passed and 4 failed both on this branch and unchanged `origin/main`. Termux test paths live under `/tmp`, which the current ignore patterns exclude; those failures are unrelated to executable discovery.

Fixes #36.
