### PR TITLE
Refresh approved CodePuppy prompt cleanup

### DIFF
--- a/code_puppy/agents/agent_code_puppy.py
+++ b/code_puppy/agents/agent_code_puppy.py
@@ -48,7 +48,7 @@ class CodePuppyAgent(BaseAgent):
             ),
             "loop_rule": (
                 "- You're encouraged to loop between reasoning, file "
-                "tools, and run_shell_command to test output in order "
+                "tools, and agent_run_shell_command to test output in order "
                 "to write programs"
             ),
         }

--- a/code_puppy/agents/agent_code_puppy.py
+++ b/code_puppy/agents/agent_code_puppy.py
@@ -59,34 +59,44 @@ class CodePuppyAgent(BaseAgent):
         owner_name = get_owner_name()
         r = self._get_reasoning_prompt_sections()
 
-        result = f"""
+        result = f"""\
+# Identity
+
 You are {puppy_name}, the most loyal digital puppy, helping your owner {owner_name} get coding stuff done!
 You are a code-agent assistant with the ability to use tools to help users complete coding tasks.
 You MUST use the provided tools to write, modify, and execute code rather than just describing what to do.
 
+# Personality & Tone
+
 Be super informal - we're here to have fun. Don't be scared of being a little bit sarcastic too.
-Be very pedantic about code principles like DRY, YAGNI, and SOLID.
 Be fun and playful. Don't be too serious.
 
+# Code Standards
+
+Be very pedantic about code principles like DRY, YAGNI, and SOLID.
 Keep files under 600 lines. If a file grows beyond that, consider splitting into smaller subcomponents—but don't split purely to hit a line count if it hurts cohesion.
 Always obey the Zen of Python, even if you are not writing Python code.
 
-If asked about your origins: 'I am {puppy_name}, authored on a rainy weekend in May 2025.
-If asked 'what is code puppy': 'I am {puppy_name}! 🐶 A sassy, open-source AI code agent—no bloated IDEs, or closed-source vendor traps needed.'
+# About You
+
+If asked about your origins: 'I am {puppy_name}, authored on a rainy weekend in May 2025.'
+If asked about what Code Puppy is: 'I am {puppy_name}! A sassy, open-source AI code agent—no bloated IDEs, or closed-source vendor traps needed.'
+
+# Workflow
 
 When given a coding task:
 1. Analyze the requirements carefully
 2. Execute the plan by using appropriate tools
 3. Continue autonomously whenever possible
 
-Important rules:
+# Rules
+
 - You MUST use tools — DO NOT just output code or descriptions
 {r["pre_tool_rule"]}
 - Explore directories before reading/modifying files
 - Read existing files before modifying them
 - Prefer replace_in_file over create_file. Keep diffs small (100-300 lines).
 {r["loop_rule"]}
-- Continue autonomously unless user input is definitively required
 """
         # NOTE: runtime ``load_prompt`` fragments (env context, permission
         # rules, memory recall) are intentionally NOT appended here — injected

--- a/tests/test_coverage_agents_gaps.py
+++ b/tests/test_coverage_agents_gaps.py
@@ -62,6 +62,8 @@ class TestCodePuppyAgentTools:
         assert "replace_in_file" in tools
         assert "delete_snippet" in tools
         assert "invoke_agent" in tools
+        assert "agent_run_shell_command" in tools
+        assert "agent_run_shell_command" in agent.get_system_prompt()
 
     def test_default_code_puppy_does_not_get_model_override_tools(self):
         from code_puppy.agents.agent_code_puppy import CodePuppyAgent


### PR DESCRIPTION
## Summary

Companion refresh for #226 on current `main`.

This preserves Jan Feddersen's original prompt-structure commit, including its original authorship, and adds only the explicit unresolved inline-review correction: the prompt now names `agent_run_shell_command`, matching `CodePuppyAgent.get_available_tools()`.

## Commits

1. `Refine CodePuppyAgent system prompt structure` — original #226 commit by Jan Feddersen
2. `Align prompt with shell tool name` — narrow review correction and regression assertion

## Validation

- `tests/test_coverage_agents_gaps.py` plus `tests/agents`: **414 passed**
- Ruff check/format passed for both touched files
- `git diff --check` passed

The repository-wide Ruff command with the newly pinned Ruff 0.15 could not be reproduced on Termux because `uvx` had to compile Ruff from source and timed out; hosted CI remains authoritative for that check.

Supersedes #226 after preserving its contributor commit.
