### PR TITLE
Refresh catalog-declared model setting choices

### DIFF
--- a/code_puppy/command_line/model_settings_menu.py
+++ b/code_puppy/command_line/model_settings_menu.py
@@ -343,8 +343,7 @@ def _get_setting_choices(
 ) -> List[str]:
     """Get the available choices for a setting, filtered by model capabilities.
 
-    Reasoning effort is capability-gated: xhigh is available to codex and
-    GPT-5.4+ models, while max is reserved for GPT-5.6+ variants.
+    Catalog-declared choices take precedence over legacy reasoning flags.
 
     Args:
         setting_key: The setting name (e.g., 'reasoning_effort', 'verbosity')
@@ -359,16 +358,25 @@ def _get_setting_choices(
 
     base_choices = setting_def.get("choices", [])
 
-    if setting_key == "reasoning_effort" and model_name:
+    if model_name:
         if models_config is None:
             models_config = ModelFactory.load_config()
         model_config = models_config.get(model_name, {})
-        unsupported_choices = set()
-        if not model_config.get("supports_xhigh_reasoning", False):
-            unsupported_choices.add("xhigh")
-        if not model_config.get("supports_max_reasoning", False):
-            unsupported_choices.add("max")
-        return [choice for choice in base_choices if choice not in unsupported_choices]
+        advertised = model_config.get("setting_choices", {}).get(setting_key)
+        if isinstance(advertised, list):
+            recognized = [choice for choice in base_choices if choice in advertised]
+            if recognized:
+                return recognized
+
+        if setting_key == "reasoning_effort":
+            unsupported_choices = set()
+            if not model_config.get("supports_xhigh_reasoning", False):
+                unsupported_choices.add("xhigh")
+            if not model_config.get("supports_max_reasoning", False):
+                unsupported_choices.add("max")
+            return [
+                choice for choice in base_choices if choice not in unsupported_choices
+            ]
 
     return base_choices
 

--- a/tests/command_line/test_model_settings_menu_coverage.py
+++ b/tests/command_line/test_model_settings_menu_coverage.py
@@ -186,6 +186,19 @@ class TestGetSettingChoices:
         assert "xhigh" not in choices
         assert "high" in choices
 
+    def test_catalog_can_advertise_exact_reasoning_effort_choices(self):
+        models_config = {
+            "remote-gpt": {
+                "setting_choices": {
+                    "reasoning_effort": ["low", "medium", "high", "xhigh"]
+                }
+            }
+        }
+
+        assert _get_setting_choices(
+            "reasoning_effort", "remote-gpt", models_config
+        ) == ["low", "medium", "high", "xhigh"]
+
 
 class TestLoadAllModelNames:
     @patch("code_puppy.command_line.model_settings_menu.ModelFactory")


### PR DESCRIPTION
## Summary

Conflict-only companion refresh for approved PR #709.

This replays breedx's original feature commit on current `main`, preserving original authorship. The conflict resolution keeps the newer optional `models_config` parameter, so menu rendering still reuses its loaded catalog rather than adding repeated config reads.

Behavior remains the same as #709:

- prefer catalog `setting_choices` for choice settings
- intersect advertised values with client-supported choices
- retain legacy reasoning capability flags as fallback

No additional model IDs, settings, or menu behavior are included.

## Validation

- model-settings coverage and latency suites: **42 passed**
- conservative Ruff correctness checks passed for both touched files
- Ruff formatting check passed
- `git diff --check` passed

The old #709 `quality` failure was repository-wide formatting in `agent_creator_agent.py` and its tests, neither of which #709 touched. Those stale-base files are not part of this refresh.

Supersedes #709 after preserving its contributor commit.
