### PR TITLE
fix(sessions): leave migrated .pkl files in place, don't archive them away

### DIFF
--- a/code_puppy/session_format_migration.py
+++ b/code_puppy/session_format_migration.py
@@ -12,8 +12,10 @@ caller/validation layer: it round-trips the normalized messages through
 declaring a migration successful.
 
 Startup entry point is :func:`sweep_legacy_pickle_sessions`, idempotent via a
-marker file in the config dir. Originals are never deleted: migrated pickles
-move to ``<dir>/pre_v2_backup/``, failures to ``<dir>/pre_v2_backup/failed/``.
+marker file in the config dir. Originals are never deleted or moved on a
+successful migration -- the ``.pkl`` stays next to its new ``.json`` twin so
+an older code_puppy version can still find it after a downgrade. Only
+unmigratable pickles are relocated, to ``<dir>/pre_v2_backup/failed/``.
 """
 
 from __future__ import annotations
@@ -127,12 +129,16 @@ def _move_to(pkl_path: pathlib.Path, dest_dir: pathlib.Path) -> None:
 
 
 def archive_legacy_pickle(pkl_path: pathlib.Path) -> None:
-    """Move a migrated pickle into its directory's ``pre_v2_backup/``."""
-    try:
-        _move_to(pkl_path, pkl_path.parent / _BACKUP_DIRNAME)
-    except OSError:
-        # Leaving the pickle behind is harmless: loads prefer the JSON twin.
-        pass
+    """No-op: a successfully migrated pickle is left at ``pkl_path``.
+
+    Moving it out of the session directory (the old behavior) hid it from
+    any older code_puppy version's loader -- which only ever looks for
+    ``<name>.pkl`` next to the session, never in a backup subfolder -- so a
+    downgrade after migration looked like data loss even though nothing was
+    deleted. Leaving the original in place keeps downgrades working; the
+    current version already prefers the JSON twin (see ``load_session``), so
+    the leftover ``.pkl`` is otherwise inert.
+    """
 
 
 def quarantine_failed_pickle(pkl_path: pathlib.Path) -> None:
@@ -264,8 +270,9 @@ def sweep_legacy_pickle_sessions() -> None:
             )
         if migrated or failed:
             _emit_info_safely(
-                f"Session format migration: {migrated} migrated to JSON, "
-                f"{failed} failed (originals kept under {_BACKUP_DIRNAME}/)."
+                f"Session format migration: {migrated} migrated to JSON "
+                f"(original .pkl left in place), {failed} failed "
+                f"(quarantined under {_BACKUP_DIRNAME}/failed/)."
             )
         if rescued:
             _emit_info_safely(

--- a/tests/test_session_format_migration.py
+++ b/tests/test_session_format_migration.py
@@ -104,9 +104,10 @@ class TestGoldenFixtureMigration:
 
         _assert_golden_history(history)
         assert (tmp_path / "mysess.json").exists()
-        # Original pickle archived, never deleted.
-        assert not (tmp_path / "mysess.pkl").exists()
-        assert (tmp_path / "pre_v2_backup" / "mysess.pkl").exists()
+        # Original pickle stays put -- never deleted, never moved -- so an
+        # older code_puppy version can still find it after a downgrade.
+        assert (tmp_path / "mysess.pkl").exists()
+        assert not (tmp_path / "pre_v2_backup").exists()
 
     def test_migration_repoints_meta_sidecar(self, tmp_path):
         pkl_path = tmp_path / "named.pkl"
@@ -269,11 +270,11 @@ class TestStartupSweep:
 
         sfm.sweep_legacy_pickle_sessions()
 
-        # Good file migrated + archived; bad file quarantined; both kept.
+        # Good file migrated, original left in place; bad file quarantined.
         assert (autosaves / "good.json").exists()
-        assert (autosaves / "pre_v2_backup" / "good.pkl").exists()
+        assert (autosaves / "good.pkl").exists()
+        assert not (autosaves / "pre_v2_backup" / "good.pkl").exists()
         assert (autosaves / "pre_v2_backup" / "failed" / "bad.pkl").exists()
-        assert not (autosaves / "good.pkl").exists()
         assert not (autosaves / "bad.pkl").exists()
         assert (config / ".session_format_v2_migrated").exists()
 
@@ -444,14 +445,16 @@ class TestJsonRoundTrip:
         _assert_golden_history(history)
         assert (tmp_path / "legacy-session.json").exists()
 
-        # Save-back writes the shared JSON envelope, no pickle.
+        # Save-back writes the shared JSON envelope. The legacy pickle from
+        # the lazy migration above is intentionally left in place (never
+        # moved/deleted) so an older code_puppy version can still read it.
         agent_tools._save_session_history(
             session_id="legacy-session",
             message_history=history,
             agent_name="tester",
             initial_prompt="hello",
         )
-        assert not (tmp_path / "legacy-session.pkl").exists()
+        assert (tmp_path / "legacy-session.pkl").exists()
         assert agent_tools._load_session_history("legacy-session") == history
 
 


### PR DESCRIPTION
## What

Stop the pickle→JSON session migration from *moving* successfully-migrated
legacy `.pkl` session files into `pre_v2_backup/`. `archive_legacy_pickle()`
is now a no-op: the original pickle simply stays exactly where it always was,
right next to its new `.json` twin.

## Why

The migration never deleted pickles, but it did relocate them into a backup
subfolder — and that's just as bad in practice. Any older code_puppy version
(and even the current version's own `load_session` fallback) only ever looks
for `<name>.pkl` directly next to the session file; none of them know
`pre_v2_backup/` exists. So downgrading after a migration *looked and felt*
exactly like losing every session, even though the bytes were technically
still on disk somewhere you'd never think to check.

## How

- `archive_legacy_pickle()` in `code_puppy/session_format_migration.py` is now
  a no-op with an explanatory docstring — callers still invoke it (from
  `session_storage.load_session`'s lazy-migration path and the startup sweep),
  but it no longer touches the filesystem.
- Updated the module docstring and the startup-sweep summary log line to
  describe the new (correct) behavior.
- New sessions were already JSON-only — `save_session` never wrote a `.pkl`
  in the first place — so this change only affects **pre-existing** legacy
  pickles that get lazily migrated; nothing changes for anything created on
  the current version.
- Left the separate quarantine-for-unmigratable-pickles path
  (`pre_v2_backup/failed/`) untouched. That's a distinct, already-tested
  self-healing retry subsystem for genuinely corrupt pickles — out of scope
  for this fix.

## Testing

- `uv run --frozen pytest tests/test_session_format_migration.py` — 24/24 passed
  (updated 3 assertions that encoded the old move-to-backup behavior)
- `uv run --frozen pytest tests/test_session_migration.py tests/test_session_pickle_loading_safety.py tests/test_session_scoping.py tests/test_session_storage_coverage.py tests/test_agent_tools.py` — all passing
- `uv run --frozen ruff check` / `ruff format --check` on changed files — clean

## Scope

Two files: `code_puppy/session_format_migration.py` (production fix) and
`tests/test_session_format_migration.py` (updated assertions). No dependency,
lockfile, tooling, or CI/config changes.
