### PR TITLE
feat: add outbound model message transform callback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ approval. With `fail_closed=True` its exception is reported as a block instead. 
 | `load_model_descriptions` | Inject description overlays | `() -> dict[str, str]` |
 | `get_model_system_prompt` | Per-model prompt | `(model_name, default_prompt, user_prompt) -> dict \| None` |
 | `stream_event` | Response streaming | `(event_type, event_data, agent_session_id=None) -> None` |
+| `transform_model_messages` | Before each model request, after history processing | `(agent_name, messages) -> None` — mutate the final `list[ModelMessage]` in place |
 | `pre_mcp_autostart` | Before bound MCP servers auto-start | `(agent_name, server_names) -> None` (refresh tokens / mint creds here) |
 
 Full list + rarely-used hooks: see `code_puppy/callbacks.py` source.
@@ -175,4 +176,3 @@ quickstart). Rules for new user-facing output (PUP-473):
 5. **Return `None` from commands you don't own**
 6. **Always run linters - `ruff check --fix`, `ruff format .`
 7. **NEVER ALLOW A CLAUDE CO-AUTHOR COMMIT**
-

--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -19,6 +19,7 @@ from pydantic_ai import Agent as PydanticAgent
 from pydantic_ai.capabilities import ProcessHistory
 
 from code_puppy.agents._compaction import make_history_processor
+from code_puppy.agents._model_message_transform import build_model_message_transform
 from code_puppy.agents._output_limits import (
     build_response_clamp,
     build_tool_output_limits,
@@ -657,13 +658,14 @@ def build_pydantic_agent(
             # `history_processors=` kwarg, removed in pydantic-ai v2).
             # ToolOutputLimits reduces oversized tool returns on a different
             # hook (after_tool_execute), so its position is inert; the
-            # response clamp runs before_model_request and sits LAST so it
-            # sees the final, steer-injected history.
+            # response clamp runs before_model_request after both history
+            # processors. The plugin transform wraps the final model request.
             capabilities=[
                 *build_tool_output_limits(),
                 ProcessHistory(history_processor),
                 ProcessHistory(steer_processor),
                 build_response_clamp(),
+                build_model_message_transform(logical_agent_name),
             ],
             model_settings=model_settings,
         )

--- a/code_puppy/agents/_model_message_transform.py
+++ b/code_puppy/agents/_model_message_transform.py
@@ -1,0 +1,28 @@
+"""Plugin transforms for final outbound model messages."""
+
+from copy import copy
+from typing import Any
+
+from pydantic_ai import RunContext
+from pydantic_ai.capabilities import Hooks, WrapModelRequestHandler
+from pydantic_ai.messages import ModelResponse
+from pydantic_ai.models import ModelRequestContext
+
+from code_puppy.callbacks import on_transform_model_messages
+
+
+def build_model_message_transform(agent_name: str | None) -> Hooks:
+    """Build the request-only plugin transform for an agent."""
+
+    async def transform(
+        _ctx: RunContext[Any],
+        *,
+        request_context: ModelRequestContext,
+        handler: WrapModelRequestHandler,
+    ) -> ModelResponse:
+        transformed_context = copy(request_context)
+        transformed_context.messages = list(request_context.messages)
+        await on_transform_model_messages(agent_name, transformed_context.messages)
+        return await handler(transformed_context)
+
+    return Hooks(model_request=transform)

--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -3,6 +3,8 @@ import logging
 import traceback
 from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple
 
+from pydantic_ai.messages import ModelMessage
+
 PhaseType = Literal[
     "startup",
     "shutdown",
@@ -73,6 +75,7 @@ PhaseType = Literal[
     "awaiting_user_input",
     "git_branch_provider",
     "feature_capability",
+    "transform_model_messages",
 ]
 CallbackFunc = Callable[..., Any]
 
@@ -160,6 +163,7 @@ _callbacks: Dict[PhaseType, List[CallbackFunc]] = {
     "awaiting_user_input": [],
     "git_branch_provider": [],
     "feature_capability": [],
+    "transform_model_messages": [],
 }
 
 logger = logging.getLogger(__name__)
@@ -884,6 +888,13 @@ async def on_stream_event(
     return await _trigger_callbacks(
         "stream_event", event_type, event_data, agent_session_id
     )
+
+
+async def on_transform_model_messages(
+    agent_name: str | None, messages: List[ModelMessage]
+) -> List[Any]:
+    """Let plugins mutate the final outbound model messages in place."""
+    return await _trigger_callbacks("transform_model_messages", agent_name, messages)
 
 
 def on_register_tools() -> List[Dict[str, Any]]:

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -401,6 +401,9 @@ async def _invoke_agent_impl(
                 mcp_servers = manager.get_servers_for_agent(agent_name=bound_agent_name)
 
             from code_puppy.agents._compaction import make_history_processor
+            from code_puppy.agents._model_message_transform import (
+                build_model_message_transform,
+            )
 
             # Build the pydantic-ai agent. MCP servers always included; plugins
             # (e.g. DBOS) may swap them via the agent_run_context hook.
@@ -417,7 +420,10 @@ async def _invoke_agent_impl(
                 toolsets=mcp_servers,
                 # ProcessHistory capability replaces the deprecated
                 # `history_processors=` kwarg (removed in pydantic-ai v2).
-                capabilities=[ProcessHistory(make_history_processor(agent_config))],
+                capabilities=[
+                    ProcessHistory(make_history_processor(agent_config)),
+                    build_model_message_transform(agent_name),
+                ],
                 model_settings=model_settings,
             )
 

--- a/tests/test_transform_model_messages.py
+++ b/tests/test_transform_model_messages.py
@@ -1,0 +1,240 @@
+"""Plugin transforms at the final model-message boundary."""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import ProcessHistory
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    UserPromptPart,
+)
+from pydantic_ai.models.function import FunctionModel
+from pydantic_ai.models.test import TestModel
+
+from code_puppy import callbacks
+from code_puppy.agents._model_message_transform import build_model_message_transform
+
+
+@pytest.fixture(autouse=True)
+def isolate_callbacks():
+    callbacks.clear_callbacks("transform_model_messages")
+    yield
+    callbacks.clear_callbacks("transform_model_messages")
+
+
+def _message(content: str) -> ModelRequest:
+    return ModelRequest(parts=[UserPromptPart(content=content)])
+
+
+def _contents(messages: list[ModelMessage]) -> list[str]:
+    return [
+        part.content
+        for message in messages
+        for part in message.parts
+        if isinstance(part, UserPromptPart) and isinstance(part.content, str)
+    ]
+
+
+async def test_callbacks_compose_in_order_and_isolate_failures():
+    observed: list[list[str]] = []
+
+    def first(_agent_name, messages):
+        messages.append(_message("first"))
+
+    async def broken(_agent_name, _messages):
+        raise RuntimeError("broken plugin")
+
+    async def third(_agent_name, messages):
+        observed.append(_contents(messages))
+        messages.append(_message("third"))
+
+    callbacks.register_callback("transform_model_messages", first)
+    callbacks.register_callback("transform_model_messages", broken)
+    callbacks.register_callback("transform_model_messages", third)
+    messages: list[ModelMessage] = []
+
+    await callbacks.on_transform_model_messages("code-puppy", messages)
+
+    assert observed == [["first"]]
+    assert _contents(messages) == ["first", "third"]
+
+
+async def test_disabled_plugin_callback_is_filtered(monkeypatch):
+    callbacks.set_loading_context("disabled-transform")
+
+    def callback(_agent_name, messages):
+        messages.append(_message("disabled"))
+
+    callbacks.register_callback("transform_model_messages", callback)
+    callbacks.clear_loading_context()
+    monkeypatch.setattr(
+        callbacks, "_get_disabled_plugins", lambda: {"disabled-transform"}
+    )
+    messages: list[ModelMessage] = []
+
+    await callbacks.on_transform_model_messages(None, messages)
+
+    assert messages == []
+
+
+async def test_transform_is_after_history_processing_and_request_only():
+    model_requests: list[list[str]] = []
+    transformed_agents: list[str | None] = []
+
+    def model(messages, _info):
+        model_requests.append(_contents(messages))
+        if len(model_requests) == 1:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(tool_name="continue_run", args={}, tool_call_id="1")
+                ]
+            )
+        return ModelResponse(parts=[TextPart(content="done")])
+
+    def process_history(messages):
+        return [_message("history-processed"), *messages]
+
+    async def transform(agent_name, messages):
+        transformed_agents.append(agent_name)
+        assert "history-processed" in _contents(messages)
+        messages.insert(0, _message("transformed"))
+
+    callbacks.register_callback("transform_model_messages", transform)
+    agent = Agent(
+        FunctionModel(model),
+        capabilities=[
+            ProcessHistory(process_history),
+            build_model_message_transform("code-puppy"),
+        ],
+    )
+
+    @agent.tool_plain
+    def continue_run() -> str:
+        return "continue"
+
+    result = await agent.run("start")
+
+    assert transformed_agents == ["code-puppy", "code-puppy"]
+    assert all(messages[0] == "transformed" for messages in model_requests)
+    assert "transformed" not in _contents(result.all_messages())
+
+
+async def test_streaming_uses_the_same_request_only_transform():
+    called: list[str | None] = []
+
+    def transform(agent_name, messages):
+        called.append(agent_name)
+        messages.insert(0, _message("transformed"))
+
+    async def handle_events(_ctx, stream):
+        async for _event in stream:
+            pass
+
+    callbacks.register_callback("transform_model_messages", transform)
+    agent = Agent(
+        TestModel(custom_output_text="done"),
+        capabilities=[build_model_message_transform("code-puppy")],
+    )
+
+    result = await agent.run("start", event_stream_handler=handle_events)
+
+    assert called
+    assert set(called) == {"code-puppy"}
+    assert "transformed" not in _contents(result.all_messages())
+
+
+class _AgentConfig:
+    name = "test-agent"
+
+    def __init__(self):
+        self._message_history = []
+        self._compacted_message_hashes = set()
+        self._puppy_rules = None
+
+    @contextmanager
+    def temporary_model_name_override(self, _model_name):
+        yield
+
+    def get_model_name(self):
+        return "test-model"
+
+    def get_full_system_prompt(self):
+        return "Test instructions"
+
+    def get_available_tools(self):
+        return []
+
+    def get_message_history(self):
+        return self._message_history
+
+    def set_message_history(self, history):
+        self._message_history = history
+
+    def __getattr__(self, item):
+        if item.startswith("__"):
+            raise AttributeError(item)
+        return lambda *_args, **_kwargs: 0
+
+
+def _load_test_model(*_args, **_kwargs):
+    return TestModel(custom_output_text="done"), "test-model"
+
+
+async def test_main_agent_construction_installs_transform():
+    from code_puppy.agents import _builder
+
+    called: list[str | None] = []
+    callbacks.register_callback(
+        "transform_model_messages",
+        lambda agent_name, _messages: called.append(agent_name),
+    )
+    config = _AgentConfig()
+    config.name = "code-puppy"
+    with (
+        patch.object(_builder, "load_model_with_fallback", _load_test_model),
+        patch.object(_builder.ModelFactory, "load_config", staticmethod(dict)),
+        patch.object(_builder, "load_mcp_servers", lambda **_kwargs: []),
+        patch.object(_builder, "make_model_settings", lambda *_args, **_kwargs: None),
+        patch(
+            "code_puppy.tools.register_tools_for_agent", lambda *_args, **_kwargs: None
+        ),
+    ):
+        agent = _builder.build_pydantic_agent(config)
+        await agent.run("start")
+
+    assert called
+    assert set(called) == {"code-puppy"}
+
+
+async def test_subagent_construction_installs_transform():
+    from code_puppy.tools import subagent_invocation
+
+    called: list[str | None] = []
+    callbacks.register_callback(
+        "transform_model_messages",
+        lambda agent_name, _messages: called.append(agent_name),
+    )
+    config = _AgentConfig()
+    with (
+        patch("code_puppy.agents.agent_manager.load_agent", return_value=config),
+        patch("code_puppy.agents._builder.load_model_with_fallback", _load_test_model),
+        patch(
+            "code_puppy.model_factory.make_model_settings",
+            lambda *_args, **_kwargs: None,
+        ),
+        patch("code_puppy.config.get_value", return_value="true"),
+    ):
+        result = await subagent_invocation._invoke_agent_impl(
+            context=SimpleNamespace(), agent_name="test-agent", prompt="start"
+        )
+
+    assert result.error is None
+    assert called
+    assert set(called) == {"test-agent"}


### PR DESCRIPTION
## What

Add a narrow plugin extension point for transforming the final message list before it is sent to a model.

## Why

This enables plugins to contribute request-scoped context after Code Puppy has finished assembling, processing, and compacting history. Example uses include:

- Injecting consistent project or user context into every model request that must survive compaction.
- Applying outbound policy, redaction, or annotation immediately before provider submission.
- Enabling advanced context-management techniques such as cache-aware tool-call trimming, message dropping, and message merging.
- Building model-independent integrations without replacing Code Puppy's agent or model.

This is an established extension boundary in other agent harnesses. OpenCode, for example, exposes `experimental.chat.messages.transform` so plugins can modify final outbound messages without changing persisted session history.

Code Puppy already provides rich plugin callbacks around prompts, agents, and tools, but it does not currently expose this final request boundary. Earlier prompt hooks run before history processing and do not cover every request within an agent run.

I need this for [Operator Memory](https://github.com/aerovato/operator-memory), which provides agents with durable project and user context. Operator renders an immutable context preamble once per conversation and must attach it to every outbound request, including subagent requests and requests between tool calls. The preamble must be added after compaction so it cannot be discarded, while remaining outside persisted conversation history.

Operator currently accomplishes this by temporarily overriding Code Puppy's model. That works through public Pydantic AI APIs, but it is not a supported Code Puppy plugin pattern and is superseded when DBOS installs its own model override. A message-transform callback provides the narrow integration boundary needed without exposing model replacement or arbitrary Pydantic AI capabilities.

## Example

```python
from code_puppy.callbacks import register_callback
from pydantic_ai.messages import ModelMessage, ModelRequest, UserPromptPart


async def transform_model_messages(
    agent_name: str | None,
    messages: list[ModelMessage],
) -> None:
    context = await load_request_context(agent_name)

    messages.insert(
        0,
        ModelRequest(
            parts=[UserPromptPart(content=context)],
        ),
    )


register_callback("transform_model_messages", transform_model_messages)
```

Callbacks mutate the shared message list in place and run sequentially in plugin registration order. Both synchronous and asynchronous callbacks are supported.

## Implementation

- Add `transform_model_messages` to the existing callback registry.
- Dispatch it through one internal Pydantic AI model-request hook.
- Install the hook after built-in history processing for main agents and subagents.
- Copy the request context and message list before transformation so changes affect only the current model request.
- Reuse existing callback ordering, failure isolation, ownership tracking, and disabled-plugin filtering.
- Use the same request path for streaming, non-streaming, tool-loop, and DBOS-wrapped model requests.
