### PR TITLE
feat: double Ctrl+C at the idle prompt quits like Ctrl+D

### DIFF
--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -10,6 +10,7 @@ apply_all_patches()
 
 import argparse
 import asyncio
+import time
 import json
 import os
 import signal
@@ -703,20 +704,22 @@ def _interactive_sigint_guard(_sig, _frame):
         ensure_ctrl_c_disabled()
     except Exception:
         pass
-    # Persistent prompt: Ctrl+C clears the buffer (readline feel; Ctrl+D quits).
-    # Only out-of-band SIGINTs land here — raw \x03 goes to the key listener, which
-    # also owns mid-run cancel (remapped key -> buffer-first clearing).
+    # Persistent prompt: Ctrl+C clears the buffer (readline feel; Ctrl+D
+    # quits), and a second idle Ctrl+C within DOUBLE_CTRL_C_WINDOW_S quits
+    # like Ctrl+D. Only out-of-band SIGINTs land here — raw \x03 goes to the
+    # key listener, which also owns mid-run cancel (remapped key ->
+    # buffer-first clearing).
     try:
         from code_puppy.messaging.run_ui import (
             absorb_ctrl_c_if_composing,
-            clear_idle_buffer,
             is_run_active,
+            note_idle_ctrl_c,
         )
 
         if is_run_active():
             absorb_ctrl_c_if_composing()
         else:
-            clear_idle_buffer()
+            note_idle_ctrl_c()
     except Exception:
         pass
     return
@@ -843,6 +846,9 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
     record_terminal_session(get_current_session_name(), overwrite=False)
     # Track the current agent task for cancellation on quit
     current_agent_task = None
+    # Classic prompt: timestamp of the last idle Ctrl+C, for the
+    # double-tap-to-quit gesture (persistent mode tracks its own in run_ui).
+    last_idle_ctrl_c = 0.0
 
     # Baseline SIGINT guard for the REPL's whole life: Ctrl+C = cancel (Ctrl+D
     # quits); without it, a fast double-tap in the handler gap raises
@@ -935,12 +941,36 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
                     # Fall back to basic input if prompt_toolkit is not available
                     task = input(">>> ")
 
-        except (KeyboardInterrupt, asyncio.CancelledError):
+        except (KeyboardInterrupt, asyncio.CancelledError) as cancel_exc:
             # Ctrl+C: cancel input and continue. Reset terminal state on Windows
             # so it doesn't become unresponsive.
             reset_windows_terminal_full()
             from code_puppy.callbacks import on_interactive_turn_cancel
-            from code_puppy.messaging import emit_warning
+            from code_puppy.command_line.prompt_toolkit_completion import (
+                pop_non_ctrl_c_cancel,
+            )
+            from code_puppy.messaging import emit_success, emit_warning
+            from code_puppy.messaging.run_ui import DOUBLE_CTRL_C_WINDOW_S
+
+            # Double Ctrl+C at the idle prompt quits like Ctrl+D. Escape and
+            # Ctrl+X raise the same KeyboardInterrupt but mark themselves, so
+            # mashing Escape can never exit; CancelledError never counts.
+            was_plain_ctrl_c = (
+                isinstance(cancel_exc, KeyboardInterrupt)
+                and not pop_non_ctrl_c_cancel()
+            )
+            now = time.monotonic()
+            if was_plain_ctrl_c and now - last_idle_ctrl_c <= DOUBLE_CTRL_C_WINDOW_S:
+                emit_success("\n" + t("cli.goodbye_ctrld"))
+                if current_agent_task and not current_agent_task.done():
+                    emit_info(t("cli.agent.cancelling"))
+                    current_agent_task.cancel()
+                    try:
+                        await current_agent_task
+                    except asyncio.CancelledError:
+                        pass  # Expected when cancelling
+                break
+            last_idle_ctrl_c = now if was_plain_ctrl_c else 0.0
 
             await on_interactive_turn_cancel("", reason="Ctrl+C")
             emit_warning("\n" + t("cli.input.cancelled"))

--- a/code_puppy/command_line/prompt_toolkit_completion.py
+++ b/code_puppy/command_line/prompt_toolkit_completion.py
@@ -694,6 +694,27 @@ def _complete_or_cycle(buffer) -> None:
         buffer.complete_next()
 
 
+# Classic-prompt cancel-source discrimination: Escape and Ctrl+X exit the
+# prompt with the same KeyboardInterrupt as a real Ctrl+C. They mark this
+# flag so the REPL's double-Ctrl+C-to-quit detection never counts them
+# (double-Escape must NOT exit the app).
+_non_ctrl_c_cancel = False
+
+
+def mark_non_ctrl_c_cancel() -> None:
+    """Record that the imminent prompt KeyboardInterrupt is not a Ctrl+C."""
+    global _non_ctrl_c_cancel
+    _non_ctrl_c_cancel = True
+
+
+def pop_non_ctrl_c_cancel() -> bool:
+    """Consume the marker; True when the last cancel came from Escape/Ctrl+X."""
+    global _non_ctrl_c_cancel
+    was = _non_ctrl_c_cancel
+    _non_ctrl_c_cancel = False
+    return was
+
+
 async def get_input_with_combined_completion(
     prompt_str=">>> ", history_file: Optional[str] = None
 ) -> str:
@@ -733,6 +754,7 @@ async def get_input_with_combined_completion(
     # Ctrl+X keybinding - exit with KeyboardInterrupt for shell command cancellation
     @bindings.add(Keys.ControlX)
     def _(event):
+        mark_non_ctrl_c_cancel()
         try:
             event.app.exit(exception=KeyboardInterrupt)
         except Exception:
@@ -743,6 +765,7 @@ async def get_input_with_combined_completion(
     # Escape keybinding - exit with KeyboardInterrupt
     @bindings.add(Keys.Escape)
     def _(event):
+        mark_non_ctrl_c_cancel()
         try:
             event.app.exit(exception=KeyboardInterrupt)
         except Exception:

--- a/code_puppy/messaging/line_editor.py
+++ b/code_puppy/messaging/line_editor.py
@@ -112,6 +112,7 @@ class RunningLineEditor:
         # Optional overrides installed by run_ui.
         self._router: Optional[SubmitRouter] = None
         self._eof_handler: Optional[Callable[[], None]] = None
+        self._ctrl_c_handler: Optional[Callable[[], None]] = None
         self._clipboard_handler: Optional[Callable[[], None]] = None
         self._ctrl_x_pending = False  # Ctrl+X chord prefix armed (see chords)
         # Phase B feature state.
@@ -157,6 +158,10 @@ class RunningLineEditor:
     def set_eof_handler(self, handler: Optional[Callable[[], None]]) -> None:
         with self._lock:  # Ctrl+D-on-empty-buffer handler (run_ui)
             self._eof_handler = handler
+
+    def set_ctrl_c_handler(self, handler: Optional[Callable[[], None]]) -> None:
+        with self._lock:  # raw-\x03 handler (run_ui double-tap policy)
+            self._ctrl_c_handler = handler
 
     def set_clipboard_handler(self, handler: Optional[Callable[[], None]]) -> None:
         with self._lock:  # async Ctrl+V clipboard handler (run_ui)
@@ -352,7 +357,12 @@ class RunningLineEditor:
             # Raw ^C reaches the editor only when the console can't turn it into
             # SIGINT (Windows clamp); mirror the SIGINT path — discard input,
             # never submit/kill (cancel stays with the hotkey/signal layers).
-            self.clear_buffer()
+            # run_ui installs a handler that adds the idle double-tap-to-quit
+            # policy; without one, fall back to the plain buffer wipe.
+            if self._ctrl_c_handler is not None:
+                self._call_handler(self._ctrl_c_handler, "ctrl-c")
+            else:
+                self.clear_buffer()
             return None
 
         if self._rsearch.active:

--- a/code_puppy/messaging/run_ui.py
+++ b/code_puppy/messaging/run_ui.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
+import time
 from contextlib import contextmanager
 from typing import Dict, Iterator, Optional
 
@@ -74,6 +75,12 @@ def _get_loop() -> Optional[asyncio.AbstractEventLoop]:
 
 _listener_handle = None  # KeyListenerHandle owned by the persistent UI
 _EOF = object()  # idle-queue sentinel: Ctrl+D on an empty buffer
+
+#: Double-tap window for idle Ctrl+C -> quit (mirrors Ctrl+D). Two idle
+#: Ctrl+C presses within this many seconds exit the REPL; a lone press
+#: keeps the readline feel (clear the buffer, stay alive).
+DOUBLE_CTRL_C_WINDOW_S = 0.5
+_last_idle_ctrl_c: float = 0.0
 
 #: How long the consumer waits for the agent to actually park at its
 #: pause boundary before running commands anyway (best-effort).
@@ -264,6 +271,7 @@ def start_persistent_ui(
         editor.set_prompt_prefix(prompt_prefix, prefix_sgrs)
     editor.set_submit_router(_persistent_router)
     editor.set_eof_handler(_handle_eof)
+    editor.set_ctrl_c_handler(_handle_raw_ctrl_c)
     _spawn_persistent_listener()
     return True
 
@@ -283,6 +291,7 @@ def stop_persistent_ui() -> None:
         if editor is not None:
             editor.set_submit_router(None)
             editor.set_eof_handler(None)
+            editor.set_ctrl_c_handler(None)
         stop_run_ui()  # persistent flag is off -> full teardown
     if handle is not None:
         try:
@@ -349,6 +358,35 @@ def clear_idle_buffer() -> None:
         editor.clear_buffer()
 
 
+def note_idle_ctrl_c(now: Optional[float] = None) -> bool:
+    """One idle Ctrl+C press: clear the buffer, arm the quit double-tap.
+
+    A second press within ``DOUBLE_CTRL_C_WINDOW_S`` exits the REPL by
+    pushing the same ``_EOF`` sentinel Ctrl+D uses, so the interactive
+    loop's existing quit branch handles teardown. Returns True when the
+    press triggered the quit. No-op (False) while a run is active — mid-run
+    Ctrl+C belongs to the cancel/absorb layers, never to quit.
+
+    ``now`` is injectable for tests; production callers pass nothing.
+    """
+    global _last_idle_ctrl_c
+    if not is_persistent() or is_run_active():
+        return False
+    if now is None:
+        now = time.monotonic()
+    if now - _last_idle_ctrl_c <= DOUBLE_CTRL_C_WINDOW_S:
+        _last_idle_ctrl_c = 0.0
+        _push_idle(_EOF)
+        return True
+    _last_idle_ctrl_c = now
+    clear_idle_buffer()
+    try:
+        get_bottom_bar().set_status("press ctrl+c again quickly to exit")
+    except Exception:
+        logger.debug("double-ctrl+c hint paint failed", exc_info=True)
+    return False
+
+
 def absorb_ctrl_c_if_composing() -> bool:
     """Buffer-first Ctrl+C mid-run (Claude Code / Gemini CLI convention).
 
@@ -410,6 +448,21 @@ def _handle_eof() -> None:
     if is_run_active():
         return
     _push_idle(_EOF)
+
+
+def _handle_raw_ctrl_c() -> None:
+    """Raw \\x03 from the key listener (Windows clamp path).
+
+    Mid-run: keep the historical buffer wipe (cancel stays with the
+    hotkey/signal layers). Idle: same double-tap-to-quit policy as the
+    SIGINT path.
+    """
+    if is_run_active():
+        editor = get_run_editor()
+        if editor is not None:
+            editor.clear_buffer()
+        return
+    note_idle_ctrl_c()
 
 
 def _push_idle(item) -> None:
@@ -680,6 +733,7 @@ def _suspended_key_listener():
 __all__ = [
     "MID_RUN_DENYLIST",
     "clear_idle_buffer",
+    "note_idle_ctrl_c",
     "get_run_editor",
     "is_draining",
     "is_persistent",

--- a/tests/test_double_ctrl_c_exit.py
+++ b/tests/test_double_ctrl_c_exit.py
@@ -1,0 +1,270 @@
+"""Double-Ctrl+C-to-quit at the idle prompt (mirrors Ctrl+D).
+
+Covers all three arrival paths:
+
+- persistent mode via SIGINT   -> run_ui.note_idle_ctrl_c
+- persistent mode via raw \\x03 -> line_editor ctrl_c handler -> run_ui
+- classic prompt_toolkit mode  -> cli_runner's KeyboardInterrupt branch
+
+Escape / Ctrl+X raise the same KeyboardInterrupt as a real Ctrl+C on the
+classic path but must never trigger the quit (they mark themselves via
+mark_non_ctrl_c_cancel).
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import code_puppy.cli_runner as cli_runner
+import code_puppy.messaging.run_ui as run_ui
+from code_puppy.command_line.prompt_toolkit_completion import (
+    mark_non_ctrl_c_cancel,
+    pop_non_ctrl_c_cancel,
+)
+from code_puppy.messaging.line_editor import RunningLineEditor
+
+
+# ---------------------------------------------------------------------------
+# run_ui.note_idle_ctrl_c (persistent mode, SIGINT + raw paths converge here)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def idle_persistent(monkeypatch):
+    """Force idle persistent-mode state with the side effects spied."""
+    monkeypatch.setattr(run_ui, "_persistent", True)
+    monkeypatch.setattr(run_ui, "_run_active", False)
+    monkeypatch.setattr(run_ui, "_last_idle_ctrl_c", 0.0)
+    cleared = []
+    pushed = []
+    monkeypatch.setattr(run_ui, "clear_idle_buffer", lambda: cleared.append(True))
+    monkeypatch.setattr(run_ui, "_push_idle", lambda item: pushed.append(item))
+    monkeypatch.setattr(run_ui, "get_bottom_bar", MagicMock())
+    return cleared, pushed
+
+
+def test_single_ctrl_c_clears_and_arms(idle_persistent):
+    cleared, pushed = idle_persistent
+    assert run_ui.note_idle_ctrl_c(now=100.0) is False
+    assert cleared and not pushed
+
+
+def test_double_ctrl_c_within_window_quits(idle_persistent):
+    _, pushed = idle_persistent
+    assert run_ui.note_idle_ctrl_c(now=100.0) is False
+    assert run_ui.note_idle_ctrl_c(now=100.4) is True
+    assert pushed == [run_ui._EOF]
+
+
+def test_double_ctrl_c_after_window_does_not_quit(idle_persistent):
+    _, pushed = idle_persistent
+    assert run_ui.note_idle_ctrl_c(now=100.0) is False
+    assert run_ui.note_idle_ctrl_c(now=100.6) is False
+    assert not pushed
+
+
+def test_quit_resets_the_arm(idle_persistent):
+    """The press that quits must not leave a live timestamp behind."""
+    _, pushed = idle_persistent
+    run_ui.note_idle_ctrl_c(now=100.0)
+    assert run_ui.note_idle_ctrl_c(now=100.4) is True
+    # A hypothetical third press right after must re-arm, not double-quit.
+    assert run_ui.note_idle_ctrl_c(now=100.5) is False
+    assert pushed == [run_ui._EOF]
+
+
+def test_ctrl_c_ignored_while_run_active(idle_persistent, monkeypatch):
+    cleared, pushed = idle_persistent
+    monkeypatch.setattr(run_ui, "_run_active", True)
+    assert run_ui.note_idle_ctrl_c(now=100.0) is False
+    assert run_ui.note_idle_ctrl_c(now=100.1) is False
+    assert not cleared and not pushed
+
+
+def test_ctrl_c_ignored_in_classic_mode(idle_persistent, monkeypatch):
+    cleared, pushed = idle_persistent
+    monkeypatch.setattr(run_ui, "_persistent", False)
+    assert run_ui.note_idle_ctrl_c(now=100.0) is False
+    assert not cleared and not pushed
+
+
+# ---------------------------------------------------------------------------
+# Raw-\x03 path (Windows clamp): editor delegates to the installed handler
+# ---------------------------------------------------------------------------
+
+
+def test_editor_raw_ctrl_c_uses_installed_handler():
+    editor = RunningLineEditor(bar=MagicMock())
+    calls = []
+    editor.set_ctrl_c_handler(lambda: calls.append(True))
+    editor._buffer = "half-typed"
+    editor._feed_one("\x03")
+    assert calls == [True]
+    # Policy moved to the handler; the editor must not also wipe the buffer.
+    assert editor._buffer == "half-typed"
+
+
+def test_editor_raw_ctrl_c_without_handler_clears_buffer():
+    editor = RunningLineEditor(bar=MagicMock())
+    editor._buffer = "half-typed"
+    editor._feed_one("\x03")
+    assert editor._buffer == ""
+
+
+def test_handle_raw_ctrl_c_idle_delegates_to_note(monkeypatch):
+    noted = []
+    monkeypatch.setattr(run_ui, "_persistent", True)
+    monkeypatch.setattr(run_ui, "_run_active", False)
+    monkeypatch.setattr(run_ui, "note_idle_ctrl_c", lambda: noted.append(True))
+    run_ui._handle_raw_ctrl_c()
+    assert noted == [True]
+
+
+def test_handle_raw_ctrl_c_mid_run_only_clears(monkeypatch):
+    editor = MagicMock()
+    monkeypatch.setattr(run_ui, "_persistent", True)
+    monkeypatch.setattr(run_ui, "_run_active", True)
+    monkeypatch.setattr(run_ui, "get_run_editor", lambda: editor)
+    noted = []
+    monkeypatch.setattr(run_ui, "note_idle_ctrl_c", lambda: noted.append(True))
+    run_ui._handle_raw_ctrl_c()
+    editor.clear_buffer.assert_called_once()
+    assert not noted
+
+
+# ---------------------------------------------------------------------------
+# Classic prompt_toolkit mode: the REPL's KeyboardInterrupt branch
+# ---------------------------------------------------------------------------
+
+
+class _FakeTime:
+    """Deterministic stand-in for cli_runner's ``time`` module."""
+
+    def __init__(self, values):
+        self._values = list(values)
+
+    def monotonic(self):
+        return self._values.pop(0) if self._values else 1e9
+
+
+@pytest.fixture
+def renderer():
+    r = MagicMock()
+    r.console = MagicMock()
+    return r
+
+
+def _force_classic(monkeypatch):
+    monkeypatch.setattr(cli_runner, "_use_persistent_prompt", lambda: True)
+    monkeypatch.setattr(
+        "code_puppy.messaging.run_ui.start_persistent_ui",
+        lambda prompt_prefix=None, prefix_sgrs=None: False,
+    )
+    monkeypatch.setattr(cli_runner, "print_truecolor_warning", lambda console: None)
+    monkeypatch.setattr(cli_runner, "record_terminal_session", lambda *a, **k: None)
+
+
+@pytest.mark.asyncio
+async def test_classic_double_ctrl_c_quits(monkeypatch, renderer):
+    _force_classic(monkeypatch)
+    pop_non_ctrl_c_cancel()  # hygiene: never inherit a stale marker
+    monkeypatch.setattr(cli_runner, "time", _FakeTime([100.0, 100.3]))
+
+    async def fake_classic_input(*a, **k):
+        raise KeyboardInterrupt
+
+    successes = []
+    with (
+        patch(
+            "code_puppy.command_line.prompt_toolkit_completion.get_input_with_combined_completion",
+            fake_classic_input,
+        ),
+        patch("code_puppy.messaging.emit_info", lambda msg, **k: None),
+        patch("code_puppy.messaging.emit_warning", lambda msg, **k: None),
+        patch(
+            "code_puppy.messaging.emit_success",
+            lambda msg, **k: successes.append(str(msg)),
+        ),
+    ):
+        await asyncio.wait_for(
+            cli_runner.interactive_mode(renderer, initial_command=None), 10.0
+        )
+
+    assert any("Ctrl+D" in s for s in successes)  # exited via the quit path
+
+
+@pytest.mark.asyncio
+async def test_classic_slow_ctrl_c_taps_do_not_quit(monkeypatch, renderer):
+    _force_classic(monkeypatch)
+    pop_non_ctrl_c_cancel()
+    # Two taps 0.6 s apart, then /exit ends the loop normally.
+    monkeypatch.setattr(cli_runner, "time", _FakeTime([100.0, 100.6]))
+    events = iter([KeyboardInterrupt, KeyboardInterrupt, "/exit"])
+
+    async def fake_classic_input(*a, **k):
+        item = next(events)
+        if item is KeyboardInterrupt:
+            raise KeyboardInterrupt
+        return item
+
+    successes = []
+    with (
+        patch(
+            "code_puppy.command_line.prompt_toolkit_completion.get_input_with_combined_completion",
+            fake_classic_input,
+        ),
+        patch("code_puppy.messaging.emit_info", lambda msg, **k: None),
+        patch("code_puppy.messaging.emit_warning", lambda msg, **k: None),
+        patch(
+            "code_puppy.messaging.emit_success",
+            lambda msg, **k: successes.append(str(msg)),
+        ),
+    ):
+        await asyncio.wait_for(
+            cli_runner.interactive_mode(renderer, initial_command=None), 10.0
+        )
+
+    assert not any("Ctrl+D" in s for s in successes)  # quit came from /exit
+
+
+@pytest.mark.asyncio
+async def test_classic_double_escape_never_quits(monkeypatch, renderer):
+    """Escape marks itself non-Ctrl+C; two fast Escapes must not exit."""
+    _force_classic(monkeypatch)
+    pop_non_ctrl_c_cancel()
+    monkeypatch.setattr(cli_runner, "time", _FakeTime([100.0, 100.1]))
+    events = iter(["esc", "esc", "/exit"])
+
+    async def fake_classic_input(*a, **k):
+        item = next(events)
+        if item == "esc":
+            mark_non_ctrl_c_cancel()  # what the Escape keybinding does
+            raise KeyboardInterrupt
+        return item
+
+    successes = []
+    with (
+        patch(
+            "code_puppy.command_line.prompt_toolkit_completion.get_input_with_combined_completion",
+            fake_classic_input,
+        ),
+        patch("code_puppy.messaging.emit_info", lambda msg, **k: None),
+        patch("code_puppy.messaging.emit_warning", lambda msg, **k: None),
+        patch(
+            "code_puppy.messaging.emit_success",
+            lambda msg, **k: successes.append(str(msg)),
+        ),
+    ):
+        await asyncio.wait_for(
+            cli_runner.interactive_mode(renderer, initial_command=None), 10.0
+        )
+
+    assert not any("Ctrl+D" in s for s in successes)
+
+
+def test_cancel_source_marker_round_trip():
+    assert pop_non_ctrl_c_cancel() is False
+    mark_non_ctrl_c_cancel()
+    assert pop_non_ctrl_c_cancel() is True
+    assert pop_non_ctrl_c_cancel() is False


### PR DESCRIPTION
## What

Pressing Ctrl+C twice within 0.5s at the **idle** prompt (no agent running) now exits Code Puppy through the exact same quit path as Ctrl+D. A lone Ctrl+C keeps its readline feel — clear the buffer / cancel input — and shows a bottom-bar hint (`press ctrl+c again quickly to exit`).

## Why

Ctrl+C is a cancel gesture and Ctrl+D is the quit gesture, but the double-tap-to-exit convention (Claude Code, Gemini CLI, etc.) is muscle memory for most terminal users. This adds it without touching mid-run semantics: while an agent is running, Ctrl+C still belongs to the cancel/absorb layers and can never quit.

## How

Ctrl+C reaches the REPL by three different roads; all are covered:

1. **Persistent mode, Unix (SIGINT)** — `_interactive_sigint_guard`'s idle branch now calls the new `run_ui.note_idle_ctrl_c()`, which clears the buffer + arms a 0.5s window (`DOUBLE_CTRL_C_WINDOW_S`) on the first press and pushes the existing `_EOF` idle-queue sentinel (the Ctrl+D pathway) on a double-tap.
2. **Persistent mode, Windows raw `\x03`** — new `set_ctrl_c_handler()` hook on `RunningLineEditor` (mirrors `set_eof_handler`), installed/cleared by `start_persistent_ui`/`stop_persistent_ui`. Without a handler the editor falls back to the historical plain buffer wipe.
3. **Classic prompt_toolkit mode** — the REPL's `KeyboardInterrupt` branch tracks the double-tap and reuses the EOF quit body. Escape and Ctrl+X raise the *same* `KeyboardInterrupt`, so they now mark themselves via `mark_non_ctrl_c_cancel()` — **mashing Escape can never exit the app**, and `asyncio.CancelledError` never counts either.

The quit-triggering press resets the arm, so a stray third press re-arms instead of double-firing. `note_idle_ctrl_c()` is a no-op while a run is active or in classic mode.

## Verification

- 14 new tests in `tests/test_double_ctrl_c_exit.py` covering all three arrival paths, window expiry, re-arm after quit, mid-run no-op, classic-mode no-op, the Escape/Ctrl+X marker, and both editor fallback behaviors (deterministic via injectable `now`/fake time — no sleeps)
- `ruff check` + `ruff format --check` clean
- Full suite: **7579 passed**, 16 skipped; the only errors are pre-existing env-gated integration tests (`CEREBRAS_API_KEY`) that fail identically on untouched main
- Rebased onto current `origin/main` (e88d6551) before pushing