### PR TITLE
Emit Logfire event when agent run is cancelled

### DIFF
--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -725,8 +725,17 @@ async def _run_with_mcp_impl(
         # on → wrap handler in a detector, fall back to one-shot render only
         # if no text actually streamed.
         use_streaming = get_enable_streaming()
+
+        async def _observed_event_stream_handler(ctx: Any, events: Any) -> Any:
+            from code_puppy.observability import capture_agent_context
+
+            capture_agent_context(group_id)
+            return await event_stream_handler(ctx, events)
+
         detector: Optional[StreamingTextDetector] = (
-            StreamingTextDetector(event_stream_handler) if use_streaming else None
+            StreamingTextDetector(_observed_event_stream_handler)
+            if use_streaming
+            else None
         )
         stream_handler = detector if detector is not None else None
         # Plugins (e.g. DBOS) can render their own output and skip the fallback.
@@ -920,6 +929,9 @@ async def _run_with_mcp_impl(
             if unexpected:
                 raise unexpected[0] from other
         finally:
+            from code_puppy.observability import clear_agent_context
+
+            clear_agent_context(group_id)
             agent._message_history = _history.prune_interrupted_tool_calls(
                 agent._message_history
             )

--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -1564,6 +1564,9 @@ async def on_agent_run_cancel(group_id: str) -> List[Any]:
 
     Plugins use this to cancel any external workflow tracking the run.
     """
+    from code_puppy.observability import emit_cancellation
+
+    emit_cancellation(group_id)
     return await _trigger_callbacks("agent_run_cancel", group_id)
 
 

--- a/code_puppy/observability.py
+++ b/code_puppy/observability.py
@@ -80,7 +80,7 @@ def emit_cancellation(group_id: str) -> None:
     try:
         import logfire
 
-        logfire.info("Agent run cancelled", group_id=group_id)
+        logfire.warning("Agent run cancelled", group_id=group_id)
     except Exception:
         # Observability must never interfere with cancelling an agent run.
         return

--- a/code_puppy/observability.py
+++ b/code_puppy/observability.py
@@ -18,6 +18,7 @@ import os
 from code_puppy.config import get_enable_logfire
 
 _TRUTHY = ("1", "true", "yes", "on")
+_logfire_active = False
 
 
 def logfire_opted_in() -> bool:
@@ -40,6 +41,9 @@ def configure_logfire() -> bool:
     misconfiguration must never break the CLI, so every failure path
     emits a warning and returns False instead of raising.
     """
+    global _logfire_active
+    _logfire_active = False
+
     if not logfire_opted_in():
         return False
 
@@ -63,5 +67,20 @@ def configure_logfire() -> bool:
         emit_warning(t("logfire.configure_failed", error=str(exc)))
         return False
 
+    _logfire_active = True
     emit_system_message(t("logfire.enabled"))
     return True
+
+
+def emit_cancellation(group_id: str) -> None:
+    """Emit an agent cancellation event when Logfire is active."""
+    if not _logfire_active:
+        return
+
+    try:
+        import logfire
+
+        logfire.info("Agent run cancelled", group_id=group_id)
+    except Exception:
+        # Observability must never interfere with cancelling an agent run.
+        return

--- a/code_puppy/observability.py
+++ b/code_puppy/observability.py
@@ -19,6 +19,7 @@ from code_puppy.config import get_enable_logfire
 
 _TRUTHY = ("1", "true", "yes", "on")
 _logfire_active = False
+_agent_contexts: dict[str, dict[str, str]] = {}
 
 
 def logfire_opted_in() -> bool:
@@ -72,15 +73,40 @@ def configure_logfire() -> bool:
     return True
 
 
-def emit_cancellation(group_id: str) -> None:
-    """Emit an agent cancellation event when Logfire is active."""
+def capture_agent_context(group_id: str) -> None:
+    """Capture the active agentic span context for later cancellation logging."""
     if not _logfire_active:
         return
 
     try:
         import logfire
 
-        logfire.warning("Agent run cancelled", group_id=group_id)
+        _agent_contexts[group_id] = logfire.get_context()
+    except Exception:
+        # Observability must never interfere with an agent run.
+        return
+
+
+def clear_agent_context(group_id: str) -> None:
+    """Discard trace context retained for a completed agent run."""
+    _agent_contexts.pop(group_id, None)
+
+
+def emit_cancellation(group_id: str) -> None:
+    """Emit a cancellation as a child of its instrumented agentic call."""
+    if not _logfire_active:
+        return
+
+    context = _agent_contexts.pop(group_id, None)
+    try:
+        import logfire
+
+        if context is None:
+            logfire.warning("Agent run cancelled", group_id=group_id)
+            return
+
+        with logfire.attach_context(context):
+            logfire.warning("Agent run cancelled", group_id=group_id)
     except Exception:
         # Observability must never interfere with cancelling an agent run.
         return

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -2,6 +2,7 @@
 
 import sys
 import types
+from contextlib import nullcontext
 from unittest.mock import patch
 
 from code_puppy import observability
@@ -106,6 +107,37 @@ class TestEmitCancellation:
             observability.emit_cancellation("group-1")
 
         warning.assert_called_once_with("Agent run cancelled", group_id="group-1")
+
+    def test_emits_as_child_of_captured_agent_context(self, monkeypatch):
+        context = {"traceparent": "00-trace-span-01"}
+        fake = types.SimpleNamespace(
+            get_context=lambda: context,
+            attach_context=lambda carrier: nullcontext(carrier),
+            warning=lambda *_args, **_kwargs: None,
+        )
+        monkeypatch.setitem(sys.modules, "logfire", fake)
+        monkeypatch.setattr(observability, "_logfire_active", True)
+        monkeypatch.setattr(observability, "_agent_contexts", {})
+
+        observability.capture_agent_context("group-1")
+        with (
+            patch.object(fake, "attach_context", wraps=fake.attach_context) as attach,
+            patch.object(fake, "warning") as warning,
+        ):
+            observability.emit_cancellation("group-1")
+
+        attach.assert_called_once_with(context)
+        warning.assert_called_once_with("Agent run cancelled", group_id="group-1")
+        assert "group-1" not in observability._agent_contexts
+
+    def test_clear_agent_context(self, monkeypatch):
+        monkeypatch.setattr(
+            observability, "_agent_contexts", {"group-1": {"traceparent": "value"}}
+        )
+
+        observability.clear_agent_context("group-1")
+
+        assert observability._agent_contexts == {}
 
     def test_logfire_error_fails_soft(self, monkeypatch):
         def boom(*_args, **_kwargs):

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -88,30 +88,30 @@ class TestConfigureLogfire:
 
 class TestEmitCancellation:
     def test_noop_when_logfire_is_inactive(self, monkeypatch):
-        fake = types.SimpleNamespace(info=lambda *_args, **_kwargs: None)
+        fake = types.SimpleNamespace(warning=lambda *_args, **_kwargs: None)
         monkeypatch.setitem(sys.modules, "logfire", fake)
         monkeypatch.setattr(observability, "_logfire_active", False)
 
-        with patch.object(fake, "info") as info:
+        with patch.object(fake, "warning") as warning:
             observability.emit_cancellation("group-1")
 
-        info.assert_not_called()
+        warning.assert_not_called()
 
     def test_emits_event_when_logfire_is_active(self, monkeypatch):
-        fake = types.SimpleNamespace(info=lambda *_args, **_kwargs: None)
+        fake = types.SimpleNamespace(warning=lambda *_args, **_kwargs: None)
         monkeypatch.setitem(sys.modules, "logfire", fake)
         monkeypatch.setattr(observability, "_logfire_active", True)
 
-        with patch.object(fake, "info") as info:
+        with patch.object(fake, "warning") as warning:
             observability.emit_cancellation("group-1")
 
-        info.assert_called_once_with("Agent run cancelled", group_id="group-1")
+        warning.assert_called_once_with("Agent run cancelled", group_id="group-1")
 
     def test_logfire_error_fails_soft(self, monkeypatch):
         def boom(*_args, **_kwargs):
             raise RuntimeError("collector exploded")
 
-        monkeypatch.setitem(sys.modules, "logfire", types.SimpleNamespace(info=boom))
+        monkeypatch.setitem(sys.modules, "logfire", types.SimpleNamespace(warning=boom))
         monkeypatch.setattr(observability, "_logfire_active", True)
 
         observability.emit_cancellation("group-1")

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -84,3 +84,34 @@ class TestConfigureLogfire:
         ):
             assert observability.configure_logfire() is False
         warn.assert_called_once()
+
+
+class TestEmitCancellation:
+    def test_noop_when_logfire_is_inactive(self, monkeypatch):
+        fake = types.SimpleNamespace(info=lambda *_args, **_kwargs: None)
+        monkeypatch.setitem(sys.modules, "logfire", fake)
+        monkeypatch.setattr(observability, "_logfire_active", False)
+
+        with patch.object(fake, "info") as info:
+            observability.emit_cancellation("group-1")
+
+        info.assert_not_called()
+
+    def test_emits_event_when_logfire_is_active(self, monkeypatch):
+        fake = types.SimpleNamespace(info=lambda *_args, **_kwargs: None)
+        monkeypatch.setitem(sys.modules, "logfire", fake)
+        monkeypatch.setattr(observability, "_logfire_active", True)
+
+        with patch.object(fake, "info") as info:
+            observability.emit_cancellation("group-1")
+
+        info.assert_called_once_with("Agent run cancelled", group_id="group-1")
+
+    def test_logfire_error_fails_soft(self, monkeypatch):
+        def boom(*_args, **_kwargs):
+            raise RuntimeError("collector exploded")
+
+        monkeypatch.setitem(sys.modules, "logfire", types.SimpleNamespace(info=boom))
+        monkeypatch.setattr(observability, "_logfire_active", True)
+
+        observability.emit_cancellation("group-1")


### PR DESCRIPTION
## Summary
- track whether Logfire was configured successfully
- capture the active Pydantic AI trace context while the instrumented agentic call is running
- reattach that context so `Agent run cancelled` is emitted as a child of its parent agentic call
- retain the run group ID as event metadata and clean up captured context after every run
- keep cancellation reporting fail-soft when Logfire is inactive or errors

## Testing
- `uv run pytest tests/test_observability.py tests/test_agent_span_naming.py tests/test_transform_model_messages.py -q` — 23 passed
- `uv run ruff check code_puppy/observability.py code_puppy/callbacks.py code_puppy/agents/_runtime.py tests/test_observability.py`
- `uv run ruff format --check code_puppy/observability.py code_puppy/callbacks.py code_puppy/agents/_runtime.py tests/test_observability.py`
- `uv run pytest -q` — 7563 passed; two existing order-dependent failures passed in the targeted run above