### PR TITLE
Promote plugin message transform to a first-class capability

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -19,7 +19,7 @@ from pydantic_ai import Agent as PydanticAgent
 from pydantic_ai.capabilities import ProcessHistory
 
 from code_puppy.agents._compaction import make_history_processor
-from code_puppy.agents._model_message_transform import build_model_message_transform
+from code_puppy.agents._model_message_transform import PluginMessageTransform
 from code_puppy.agents._output_limits import (
     build_response_clamp,
     build_tool_output_limits,
@@ -665,7 +665,7 @@ def build_pydantic_agent(
                 ProcessHistory(history_processor),
                 ProcessHistory(steer_processor),
                 build_response_clamp(),
-                build_model_message_transform(logical_agent_name),
+                PluginMessageTransform(logical_agent_name),
             ],
             model_settings=model_settings,
         )

--- a/code_puppy/agents/_model_message_transform.py
+++ b/code_puppy/agents/_model_message_transform.py
@@ -31,9 +31,12 @@ class PluginMessageTransform(AbstractCapability[Any]):
     the final wire request.
 
     **Request-only by construction.** The request context is shallow-copied
-    and its message list materialized fresh, so plugin mutations reach the
-    model for exactly one request without leaking into the durable history
-    (``result.all_messages()`` never shows them). Callback failures are
+    and its message list materialized fresh, so plugin *list* mutations
+    (append/insert/remove/replace) reach the model for exactly one request
+    without leaking into the durable history (``result.all_messages()``
+    never shows them). The contained message objects are still shared --
+    mutating an existing message in place would leak, exactly as it did
+    under the previous ``Hooks`` adapter. Callback failures are
     already isolated inside the ``on_transform_model_messages`` fan-out --
     a crashing plugin never takes down the request.
     """

--- a/code_puppy/agents/_model_message_transform.py
+++ b/code_puppy/agents/_model_message_transform.py
@@ -1,28 +1,55 @@
-"""Plugin transforms for final outbound model messages."""
+"""Plugin transforms for final outbound model messages.
+
+``PluginMessageTransform`` is the capability behind the
+``transform_model_messages`` plugin hook: it hands plugins the final
+outbound message list -- after compaction, steering, and clamping have
+run -- immediately before the model call.
+"""
+
+from __future__ import annotations
 
 from copy import copy
+from dataclasses import dataclass
 from typing import Any
 
 from pydantic_ai import RunContext
-from pydantic_ai.capabilities import Hooks, WrapModelRequestHandler
+from pydantic_ai.capabilities import AbstractCapability, WrapModelRequestHandler
 from pydantic_ai.messages import ModelResponse
 from pydantic_ai.models import ModelRequestContext
 
 from code_puppy.callbacks import on_transform_model_messages
 
 
-def build_model_message_transform(agent_name: str | None) -> Hooks:
-    """Build the request-only plugin transform for an agent."""
+@dataclass
+class PluginMessageTransform(AbstractCapability[Any]):
+    """Run ``transform_model_messages`` plugin callbacks on each model request.
 
-    async def transform(
-        _ctx: RunContext[Any],
+    Overrides :meth:`wrap_model_request` -- the same seam the previous
+    ``Hooks(model_request=...)`` adapter registered on -- so its position in
+    the ``capabilities=[...]`` list keeps the established ordering: history
+    processors and the response clamp run first, then this transform wraps
+    the final wire request.
+
+    **Request-only by construction.** The request context is shallow-copied
+    and its message list materialized fresh, so plugin mutations reach the
+    model for exactly one request without leaking into the durable history
+    (``result.all_messages()`` never shows them). Callback failures are
+    already isolated inside the ``on_transform_model_messages`` fan-out --
+    a crashing plugin never takes down the request.
+    """
+
+    agent_name: str | None
+    """Logical agent name forwarded to each callback (``None`` when unknown)."""
+
+    async def wrap_model_request(
+        self,
+        ctx: RunContext[Any],
         *,
         request_context: ModelRequestContext,
         handler: WrapModelRequestHandler,
     ) -> ModelResponse:
+        """Copy the context, let plugins mutate the copy, call the model."""
         transformed_context = copy(request_context)
         transformed_context.messages = list(request_context.messages)
-        await on_transform_model_messages(agent_name, transformed_context.messages)
+        await on_transform_model_messages(self.agent_name, transformed_context.messages)
         return await handler(transformed_context)
-
-    return Hooks(model_request=transform)

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -402,7 +402,7 @@ async def _invoke_agent_impl(
 
             from code_puppy.agents._compaction import make_history_processor
             from code_puppy.agents._model_message_transform import (
-                build_model_message_transform,
+                PluginMessageTransform,
             )
 
             # Build the pydantic-ai agent. MCP servers always included; plugins
@@ -422,7 +422,7 @@ async def _invoke_agent_impl(
                 # `history_processors=` kwarg (removed in pydantic-ai v2).
                 capabilities=[
                     ProcessHistory(make_history_processor(agent_config)),
-                    build_model_message_transform(agent_name),
+                    PluginMessageTransform(agent_name),
                 ],
                 model_settings=model_settings,
             )

--- a/tests/test_transform_model_messages.py
+++ b/tests/test_transform_model_messages.py
@@ -115,11 +115,15 @@ async def test_wrap_model_request_copies_context_and_isolates_mutations():
 
 async def test_wrap_model_request_without_callbacks_is_a_passthrough():
     capability = PluginMessageTransform(None)
-    request_context = SimpleNamespace(messages=[_message("only")])
+    original_messages = [_message("only")]
+    request_context = SimpleNamespace(messages=original_messages)
     sentinel = ModelResponse(parts=[TextPart(content="done")])
 
     async def handler(ctx):
         assert _contents(ctx.messages) == ["only"]
+        # Copy semantics hold even with zero callbacks registered.
+        assert ctx is not request_context
+        assert ctx.messages is not original_messages
         return sentinel
 
     response = await capability.wrap_model_request(

--- a/tests/test_transform_model_messages.py
+++ b/tests/test_transform_model_messages.py
@@ -19,7 +19,7 @@ from pydantic_ai.models.function import FunctionModel
 from pydantic_ai.models.test import TestModel
 
 from code_puppy import callbacks
-from code_puppy.agents._model_message_transform import build_model_message_transform
+from code_puppy.agents._model_message_transform import PluginMessageTransform
 
 
 @pytest.fixture(autouse=True)
@@ -84,6 +84,51 @@ async def test_disabled_plugin_callback_is_filtered(monkeypatch):
     assert messages == []
 
 
+async def test_wrap_model_request_copies_context_and_isolates_mutations():
+    """Contract: plugins mutate a fresh copy; the caller's context stays pristine."""
+
+    def transform(_agent_name, messages):
+        messages.append(_message("injected"))
+
+    callbacks.register_callback("transform_model_messages", transform)
+    capability = PluginMessageTransform("code-puppy")
+    original_messages: list[ModelMessage] = [_message("original")]
+    request_context = SimpleNamespace(messages=original_messages)
+    sentinel = ModelResponse(parts=[TextPart(content="done")])
+    seen: list[list[ModelMessage]] = []
+
+    async def handler(ctx):
+        seen.append(ctx.messages)
+        return sentinel
+
+    response = await capability.wrap_model_request(
+        None, request_context=request_context, handler=handler
+    )
+
+    assert response is sentinel
+    assert _contents(seen[0]) == ["original", "injected"]
+    # The caller's context and list object are untouched.
+    assert request_context.messages is original_messages
+    assert _contents(original_messages) == ["original"]
+    assert seen[0] is not original_messages
+
+
+async def test_wrap_model_request_without_callbacks_is_a_passthrough():
+    capability = PluginMessageTransform(None)
+    request_context = SimpleNamespace(messages=[_message("only")])
+    sentinel = ModelResponse(parts=[TextPart(content="done")])
+
+    async def handler(ctx):
+        assert _contents(ctx.messages) == ["only"]
+        return sentinel
+
+    response = await capability.wrap_model_request(
+        None, request_context=request_context, handler=handler
+    )
+
+    assert response is sentinel
+
+
 async def test_transform_is_after_history_processing_and_request_only():
     model_requests: list[list[str]] = []
     transformed_agents: list[str | None] = []
@@ -111,7 +156,7 @@ async def test_transform_is_after_history_processing_and_request_only():
         FunctionModel(model),
         capabilities=[
             ProcessHistory(process_history),
-            build_model_message_transform("code-puppy"),
+            PluginMessageTransform("code-puppy"),
         ],
     )
 
@@ -140,7 +185,7 @@ async def test_streaming_uses_the_same_request_only_transform():
     callbacks.register_callback("transform_model_messages", transform)
     agent = Agent(
         TestModel(custom_output_text="done"),
-        capabilities=[build_model_message_transform("code-puppy")],
+        capabilities=[PluginMessageTransform("code-puppy")],
     )
 
     result = await agent.run("start", event_stream_handler=handle_events)


### PR DESCRIPTION
## What

Third entry in the capability-ification series (after #828 SteerInjection and #829 HistoryCompaction): the `transform_model_messages` plugin hook was a closure stuffed into the generic `Hooks(model_request=...)` adapter — at **two** call sites. It's now `PluginMessageTransform`, a `@dataclass` `AbstractCapability` subclass in `code_puppy/agents/_model_message_transform.py`.

## Why

- `Hooks(model_request=...)` registers on the `wrap_model_request` seam (verified in `pydantic_ai/capabilities/hooks.py` — the `model_request` kwarg maps straight to `'wrap_model_request'`). Overriding that method on a subclass is the same seam at the same list position, so ordering vs. history processors and the response clamp is **byte-identical**.
- Both call sites (`agents/_builder.py` and `tools/subagent_invocation.py`) now wire `PluginMessageTransform(agent_name)` directly — no factory closure, no adapter indirection. The `build_model_message_transform` factory is gone (YAGNI: it added nothing once the capability holds only a plain `agent_name` field).

## Feature parity checklist

-  Shallow-copy of `ModelRequestContext` + fresh `list(...)` of messages — plugin mutations are request-only and never leak into durable history (`result.all_messages()` stays clean)
-  Async fan-out via `on_transform_model_messages(agent_name, messages)` — callback failure isolation unchanged (lives in the fan-out, not here)
-  Runs after compaction/steering/clamp — same position in `capabilities=[...]` at both call sites
-  Streaming path covered (existing `TestModel` streaming test still green)
-  Serialization: unlike #828/#829, this capability holds no live agent reference — just a `str | None` — so it keeps the inherited `get_serialization_name()` default (spec-constructible)

## Tests

- 2 new contract tests drive `wrap_model_request` directly: copy isolation (caller's context **and list object** untouched, handler receives the mutated fresh copy, sentinel response passes through) and bare passthrough with zero callbacks registered
- Existing suite updated to construct the capability directly; the `FunctionModel`-backed run test still proves post-history-processing ordering and request-only semantics on the real wire
- Full suite: 7490 passed; the one red (`test_render_version_check_current`) is pre-existing on main and unrelated

## Notes

- Do **not** merge yet (per instructions).
- Independent of #828/#829 — this touches a different line of the shared `capabilities=[...]` block, so expect at most a trivial rebase whichever lands last.