### PR TITLE
Promote per-model settings to a PerModelSettings capability

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -20,6 +20,7 @@ from pydantic_ai.capabilities import ProcessHistory
 
 from code_puppy.agents._compaction import make_history_processor
 from code_puppy.agents._model_message_transform import build_model_message_transform
+from code_puppy.agents._model_settings import PerModelSettings
 from code_puppy.agents._output_limits import (
     build_response_clamp,
     build_tool_output_limits,
@@ -40,7 +41,7 @@ from code_puppy.config import (
 )
 from code_puppy.mcp_ import get_mcp_manager
 from code_puppy.messaging import emit_error, emit_info, emit_warning
-from code_puppy.model_factory import ModelFactory, make_model_settings
+from code_puppy.model_factory import ModelFactory
 
 _AGENT_RULE_FILES = ("AGENTS.md", "AGENT.md", "agents.md", "agent.md")
 _CODE_PUPPY_DIR = ".code_puppy"
@@ -635,7 +636,9 @@ def build_pydantic_agent(
     )
     instructions = _assemble_instructions(agent, resolved_model_name)
     mcp_servers = load_mcp_servers(agent_name=getattr(agent, "name", None))
-    model_settings = make_model_settings(resolved_model_name)
+    # Built once and shared by both construction passes, mirroring the old
+    # single make_model_settings() call (the snapshot lives in the instance).
+    model_settings_cap = PerModelSettings(resolved_model_name)
     history_processor = make_history_processor(agent)
     steer_processor = make_steer_history_processor(agent)
     logical_agent_name = getattr(agent, "name", None) or agent.__class__.__name__
@@ -660,14 +663,17 @@ def build_pydantic_agent(
             # hook (after_tool_execute), so its position is inert; the
             # response clamp runs before_model_request after both history
             # processors. The plugin transform wraps the final model request.
+            # PerModelSettings feeds the get_model_settings configuration
+            # seam (formerly the model_settings= kwarg), so its position is
+            # inert too.
             capabilities=[
                 *build_tool_output_limits(),
                 ProcessHistory(history_processor),
                 ProcessHistory(steer_processor),
                 build_response_clamp(),
                 build_model_message_transform(logical_agent_name),
+                model_settings_cap,
             ],
-            model_settings=model_settings,
         )
 
     # Pass 1: build with empty toolsets so we can see what pydantic-ai + our

--- a/code_puppy/agents/_model_settings.py
+++ b/code_puppy/agents/_model_settings.py
@@ -1,0 +1,68 @@
+"""Code Puppy's per-model tuning as a first-class pydantic-ai capability.
+
+:func:`code_puppy.model_factory.make_model_settings` assembles the per-model
+``ModelSettings`` payload: the auto-derived ``max_tokens`` budget, GPT-5
+reasoning effort/verbosity, Anthropic extended-thinking, GLM ``extra_body``
+riders, Copilot API translation, and the yolo-mode ``parallel_tool_calls``
+gate. Historically that payload rode in on the ``Agent(model_settings=...)``
+constructor kwarg; :class:`PerModelSettings` promotes it to the
+``get_model_settings`` capability seam so it lives in the same
+``capabilities=[...]`` block as the rest of the agent's behavior.
+
+Feature-parity notes:
+
+* **Identical merged payload.** pydantic-ai layers settings agent ->
+  capability -> run on top of the model's own base settings
+  (``_layer_model_settings``). Nothing else contributes capability-level
+  settings, so moving ours from the agent slot to the capability slot
+  produces a byte-identical merge result on the wire.
+* **Identical snapshot timing.** The constructor kwarg froze settings at
+  agent-build time. A capability's ``get_model_settings`` is re-extracted on
+  every run (``for_run`` re-resolution), which would silently pick up config
+  edits mid-session. ``__post_init__`` therefore computes the payload once,
+  and the seam returns that snapshot -- config changes keep applying on
+  agent rebuild, exactly as before.
+* **List position is inert.** ``get_model_settings`` is a configuration
+  seam, not a request hook, so ordering relative to the history processors
+  and clamps in the capabilities block does not matter.
+
+The inherited :meth:`~pydantic_ai.capabilities.AbstractCapability.get_serialization_name`
+default is deliberately kept: the only fields are plain data
+(``model_name``/``max_tokens``), so the capability stays spec-constructible;
+a spec-built instance recomputes its snapshot from the same config the
+constructor path reads.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.settings import ModelSettings
+
+from code_puppy.model_factory import make_model_settings
+
+
+@dataclass
+class PerModelSettings(AbstractCapability[Any]):
+    """Supply Code Puppy's per-model ``ModelSettings`` via the capability seam.
+
+    Wraps :func:`code_puppy.model_factory.make_model_settings`; see the module
+    docstring for the parity contract.
+    """
+
+    model_name: str
+    max_tokens: int | None = None
+
+    def __post_init__(self) -> None:
+        # Snapshot at construction: parity with the old constructor-kwarg
+        # path, where settings were computed once per agent build. Stored as
+        # a plain attribute (not a dataclass field) so __init__/repr/eq keep
+        # describing the capability by its inputs, not its derived payload.
+        self._settings: ModelSettings = make_model_settings(
+            self.model_name, self.max_tokens
+        )
+
+    def get_model_settings(self) -> ModelSettings:
+        return self._settings

--- a/code_puppy/agents/_model_settings.py
+++ b/code_puppy/agents/_model_settings.py
@@ -11,11 +11,20 @@ constructor kwarg; :class:`PerModelSettings` promotes it to the
 
 Feature-parity notes:
 
-* **Identical merged payload.** pydantic-ai layers settings agent ->
-  capability -> run on top of the model's own base settings
-  (``_layer_model_settings``). Nothing else contributes capability-level
-  settings, so moving ours from the agent slot to the capability slot
-  produces a byte-identical merge result on the wire.
+* **Identical merged payload on the standard path.** pydantic-ai layers
+  settings agent -> capability -> run on top of the model's own base
+  settings (``_layer_model_settings``). Nothing else contributes
+  capability-level settings and per-run settings
+  (``agent.run(model_settings=...)``) still merge last, so the payload the
+  model receives is unchanged everywhere code_puppy builds agents.
+* **One deliberate divergence:** ``Agent.override(model_settings=...)``
+  replaces the *agent-slot* settings, which is where ours used to live.
+  The override now merges *before* this capability, so the snapshot wins
+  conflicting keys, and the built agent's ``model_settings`` attribute
+  reads ``None``. No code_puppy call site uses either seam (verified: no
+  ``.override(`` callers, no readers of the built agent's
+  ``model_settings``), and per-run overrides keep their old precedence.
+  Pinned by regression tests so the trade-off stays visible.
 * **Identical snapshot timing.** The constructor kwarg froze settings at
   agent-build time. A capability's ``get_model_settings`` is re-extracted on
   every run (``for_run`` re-resolution), which would silently pick up config

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -296,7 +296,7 @@ async def _invoke_agent_impl(
 
     try:
         # Lazy import to break circular dependency with messaging module
-        from code_puppy.model_factory import ModelFactory, make_model_settings
+        from code_puppy.model_factory import ModelFactory
 
         # Load the specified agent config
         agent_config = load_agent(agent_name)
@@ -379,8 +379,6 @@ async def _invoke_agent_impl(
             instructions = prepared.instructions
             prompt = prepared.user_prompt
 
-            model_settings = make_model_settings(effective_model_name)
-
             # Warm up bound MCP servers with the ASYNC autostart variant: the run
             # is wrapped in create_task, and the sync variant races pydantic-ai's
             # cancel-scope entry ("Attempted to exit a cancel scope..."). Awaiting
@@ -404,6 +402,7 @@ async def _invoke_agent_impl(
             from code_puppy.agents._model_message_transform import (
                 build_model_message_transform,
             )
+            from code_puppy.agents._model_settings import PerModelSettings
 
             # Build the pydantic-ai agent. MCP servers always included; plugins
             # (e.g. DBOS) may swap them via the agent_run_context hook.
@@ -420,11 +419,13 @@ async def _invoke_agent_impl(
                 toolsets=mcp_servers,
                 # ProcessHistory capability replaces the deprecated
                 # `history_processors=` kwarg (removed in pydantic-ai v2).
+                # PerModelSettings replaces the model_settings= kwarg via the
+                # get_model_settings seam; position in this list is inert.
                 capabilities=[
                     ProcessHistory(make_history_processor(agent_config)),
                     build_model_message_transform(agent_name),
+                    PerModelSettings(effective_model_name),
                 ],
-                model_settings=model_settings,
             )
 
             # Register the tools that the agent needs

--- a/tests/agents/test_model_settings_capability.py
+++ b/tests/agents/test_model_settings_capability.py
@@ -1,0 +1,77 @@
+"""PerModelSettings: the ``model_settings=`` constructor kwarg as a capability."""
+
+from unittest.mock import patch
+
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelResponse, TextPart
+from pydantic_ai.models.function import FunctionModel
+from pydantic_ai.settings import ModelSettings
+
+from code_puppy.agents import _model_settings
+from code_puppy.agents._model_settings import PerModelSettings
+from code_puppy.model_factory import make_model_settings
+
+_MODEL_NAME = "capability-parity-model"
+
+
+def test_snapshot_is_taken_at_construction_and_frozen():
+    """Settings are computed once, at build time -- never re-read per run.
+
+    The old kwarg path froze the payload when the agent was built; a config
+    edit only landed on rebuild. ``get_model_settings`` re-extraction per run
+    must observe the same freeze.
+    """
+    payloads = [ModelSettings(max_tokens=111), ModelSettings(max_tokens=222)]
+    with patch.object(
+        _model_settings, "make_model_settings", side_effect=payloads
+    ) as factory:
+        cap = PerModelSettings(_MODEL_NAME, max_tokens=111)
+
+        first = cap.get_model_settings()
+        second = cap.get_model_settings()
+
+    factory.assert_called_once_with(_MODEL_NAME, 111)
+    assert first is second
+    assert first == ModelSettings(max_tokens=111)
+
+
+def test_capability_matches_make_model_settings():
+    """The capability is a pure carrier: same inputs, same payload."""
+    cap = PerModelSettings(_MODEL_NAME)
+
+    assert cap.get_model_settings() == make_model_settings(_MODEL_NAME)
+
+
+async def test_wire_parity_with_model_settings_kwarg():
+    """The model receives identical settings from the capability and the kwarg.
+
+    Runs the same FunctionModel twice -- once with the historical
+    ``Agent(model_settings=...)`` wiring, once with ``PerModelSettings`` in
+    ``capabilities=[...]`` -- and asserts the merged settings that reach the
+    model request are equal.
+    """
+    captured: list[ModelSettings | None] = []
+
+    def model_fn(messages, info):
+        captured.append(info.model_settings)
+        return ModelResponse(parts=[TextPart(content="ok")])
+
+    settings = make_model_settings(_MODEL_NAME)
+
+    kwarg_agent = Agent(FunctionModel(model_fn), model_settings=settings)
+    await kwarg_agent.run("hello")
+
+    capability_agent = Agent(
+        FunctionModel(model_fn),
+        capabilities=[PerModelSettings(_MODEL_NAME)],
+    )
+    await capability_agent.run("hello")
+
+    kwarg_settings, capability_settings = captured
+    assert kwarg_settings is not None
+    assert capability_settings == kwarg_settings
+
+
+def test_stays_spec_constructible():
+    """Only plain-data fields -- keep the default spec serialization name."""
+    assert PerModelSettings.get_serialization_name() == "PerModelSettings"

--- a/tests/agents/test_model_settings_capability.py
+++ b/tests/agents/test_model_settings_capability.py
@@ -93,7 +93,13 @@ async def test_full_layering_base_then_capability_then_run():
         cap = PerModelSettings(_MODEL_NAME)
 
     agent = Agent(
-        FunctionModel(model_fn, settings=ModelSettings(max_tokens=1, seed=42)),
+        FunctionModel(
+            model_fn,
+            # temperature overlaps with the capability layer so the
+            # capability-over-base assertion below is unmasked: a base<->cap
+            # ordering regression would surface as 0.9 winning.
+            settings=ModelSettings(max_tokens=1, temperature=0.9, seed=42),
+        ),
         capabilities=[cap],
     )
     await agent.run("hello", model_settings=ModelSettings(max_tokens=7))

--- a/tests/agents/test_model_settings_capability.py
+++ b/tests/agents/test_model_settings_capability.py
@@ -72,6 +72,82 @@ async def test_wire_parity_with_model_settings_kwarg():
     assert capability_settings == kwarg_settings
 
 
+async def test_full_layering_base_then_capability_then_run():
+    """Model base settings < capability snapshot < per-run settings.
+
+    The per-run override path (``agent.run(model_settings=...)``) keeps its
+    historical precedence over code_puppy's settings -- proven with all three
+    layers populated and overlapping.
+    """
+    captured: list[ModelSettings | None] = []
+
+    def model_fn(messages, info):
+        captured.append(info.model_settings)
+        return ModelResponse(parts=[TextPart(content="ok")])
+
+    with patch.object(
+        _model_settings,
+        "make_model_settings",
+        return_value=ModelSettings(max_tokens=100, temperature=0.1),
+    ):
+        cap = PerModelSettings(_MODEL_NAME)
+
+    agent = Agent(
+        FunctionModel(model_fn, settings=ModelSettings(max_tokens=1, seed=42)),
+        capabilities=[cap],
+    )
+    await agent.run("hello", model_settings=ModelSettings(max_tokens=7))
+
+    (settings,) = captured
+    assert settings is not None
+    assert settings["max_tokens"] == 7  # run layer wins
+    assert settings["temperature"] == 0.1  # capability beats model base
+    assert settings["seed"] == 42  # untouched model base survives
+
+
+async def test_agent_override_merges_below_capability():
+    """Pin the one deliberate divergence from the kwarg wiring.
+
+    ``Agent.override(model_settings=...)`` replaces the agent-slot settings
+    -- previously ours, now empty -- so the capability snapshot merges after
+    it and wins conflicting keys. No code_puppy call site uses the seam;
+    this test keeps the trade-off visible rather than accidental.
+    """
+    captured: list[ModelSettings | None] = []
+
+    def model_fn(messages, info):
+        captured.append(info.model_settings)
+        return ModelResponse(parts=[TextPart(content="ok")])
+
+    with patch.object(
+        _model_settings,
+        "make_model_settings",
+        return_value=ModelSettings(max_tokens=100, temperature=0.1),
+    ):
+        cap = PerModelSettings(_MODEL_NAME)
+
+    agent = Agent(FunctionModel(model_fn), capabilities=[cap])
+    with agent.override(model_settings=ModelSettings(max_tokens=7)):
+        await agent.run("hello")
+
+    (settings,) = captured
+    assert settings is not None
+    assert settings["max_tokens"] == 100  # capability wins over override
+    assert settings["temperature"] == 0.1
+
+
 def test_stays_spec_constructible():
-    """Only plain-data fields -- keep the default spec serialization name."""
+    """``from_spec`` builds a working instance from plain-data fields."""
     assert PerModelSettings.get_serialization_name() == "PerModelSettings"
+
+    payload = ModelSettings(max_tokens=123)
+    with patch.object(
+        _model_settings, "make_model_settings", return_value=payload
+    ) as factory:
+        cap = PerModelSettings.from_spec(_MODEL_NAME, max_tokens=123)
+
+    factory.assert_called_once_with(_MODEL_NAME, 123)
+    assert isinstance(cap, PerModelSettings)
+    assert cap.model_name == _MODEL_NAME
+    assert cap.max_tokens == 123
+    assert cap.get_model_settings() is payload

--- a/tests/test_agent_span_naming.py
+++ b/tests/test_agent_span_naming.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 
 import pytest
 from pydantic_ai.models.test import TestModel
+from pydantic_ai.settings import ModelSettings
 
 
 class _FakeAgentConfig:
@@ -77,7 +78,7 @@ def test_build_pydantic_agent_sets_logical_agent_name():
         patch.object(_builder, "load_mcp_servers", lambda **k: []),
         patch(
             "code_puppy.agents._model_settings.make_model_settings",
-            lambda *a, **k: None,
+            lambda *a, **k: ModelSettings(),
         ),
         patch("code_puppy.tools.register_tools_for_agent", lambda *a, **k: None),
     ):
@@ -107,7 +108,7 @@ async def test_invoke_agent_impl_sets_subagent_name():
         ),
         patch(
             "code_puppy.agents._model_settings.make_model_settings",
-            lambda *a, **k: None,
+            lambda *a, **k: ModelSettings(),
         ),
         patch("code_puppy.config.get_value", return_value="true"),  # no MCP
         patch.object(si, "on_wrap_pydantic_agent", capture_wrap),

--- a/tests/test_agent_span_naming.py
+++ b/tests/test_agent_span_naming.py
@@ -75,7 +75,10 @@ def test_build_pydantic_agent_sets_logical_agent_name():
         ),
         patch.object(_builder.ModelFactory, "load_config", staticmethod(dict)),
         patch.object(_builder, "load_mcp_servers", lambda **k: []),
-        patch.object(_builder, "make_model_settings", lambda *a, **k: None),
+        patch(
+            "code_puppy.agents._model_settings.make_model_settings",
+            lambda *a, **k: None,
+        ),
         patch("code_puppy.tools.register_tools_for_agent", lambda *a, **k: None),
     ):
         built = _builder.build_pydantic_agent(cfg)
@@ -102,7 +105,10 @@ async def test_invoke_agent_impl_sets_subagent_name():
             "code_puppy.agents._builder.load_model_with_fallback",
             _fake_load_model_with_fallback,
         ),
-        patch("code_puppy.model_factory.make_model_settings", lambda *a, **k: None),
+        patch(
+            "code_puppy.agents._model_settings.make_model_settings",
+            lambda *a, **k: None,
+        ),
         patch("code_puppy.config.get_value", return_value="true"),  # no MCP
         patch.object(si, "on_wrap_pydantic_agent", capture_wrap),
     ):

--- a/tests/test_transform_model_messages.py
+++ b/tests/test_transform_model_messages.py
@@ -201,7 +201,10 @@ async def test_main_agent_construction_installs_transform():
         patch.object(_builder, "load_model_with_fallback", _load_test_model),
         patch.object(_builder.ModelFactory, "load_config", staticmethod(dict)),
         patch.object(_builder, "load_mcp_servers", lambda **_kwargs: []),
-        patch.object(_builder, "make_model_settings", lambda *_args, **_kwargs: None),
+        patch(
+            "code_puppy.agents._model_settings.make_model_settings",
+            lambda *_args, **_kwargs: None,
+        ),
         patch(
             "code_puppy.tools.register_tools_for_agent", lambda *_args, **_kwargs: None
         ),
@@ -226,7 +229,7 @@ async def test_subagent_construction_installs_transform():
         patch("code_puppy.agents.agent_manager.load_agent", return_value=config),
         patch("code_puppy.agents._builder.load_model_with_fallback", _load_test_model),
         patch(
-            "code_puppy.model_factory.make_model_settings",
+            "code_puppy.agents._model_settings.make_model_settings",
             lambda *_args, **_kwargs: None,
         ),
         patch("code_puppy.config.get_value", return_value="true"),

--- a/tests/test_transform_model_messages.py
+++ b/tests/test_transform_model_messages.py
@@ -17,6 +17,7 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models.function import FunctionModel
 from pydantic_ai.models.test import TestModel
+from pydantic_ai.settings import ModelSettings
 
 from code_puppy import callbacks
 from code_puppy.agents._model_message_transform import build_model_message_transform
@@ -203,7 +204,7 @@ async def test_main_agent_construction_installs_transform():
         patch.object(_builder, "load_mcp_servers", lambda **_kwargs: []),
         patch(
             "code_puppy.agents._model_settings.make_model_settings",
-            lambda *_args, **_kwargs: None,
+            lambda *_args, **_kwargs: ModelSettings(),
         ),
         patch(
             "code_puppy.tools.register_tools_for_agent", lambda *_args, **_kwargs: None
@@ -230,7 +231,7 @@ async def test_subagent_construction_installs_transform():
         patch("code_puppy.agents._builder.load_model_with_fallback", _load_test_model),
         patch(
             "code_puppy.agents._model_settings.make_model_settings",
-            lambda *_args, **_kwargs: None,
+            lambda *_args, **_kwargs: ModelSettings(),
         ),
         patch("code_puppy.config.get_value", return_value="true"),
     ):


### PR DESCRIPTION
## What

Fourth entry in the capability-conversion series (#828 `SteerInjection`, #829 `HistoryCompaction`, #830 `PluginMessageTransform`): the per-model `ModelSettings` payload — auto-derived `max_tokens` budget, GPT-5 reasoning effort/verbosity, Anthropic extended-thinking, GLM `extra_body` riders, Copilot API translation, and the yolo-mode `parallel_tool_calls` gate — previously rode in on the `Agent(model_settings=...)` constructor kwarg at both construction sites. It now travels through pydantic-ai's first-class `get_model_settings` capability seam as `PerModelSettings` in `code_puppy/agents/_model_settings.py`, joining the rest of the agent's behavior in the `capabilities=[...]` block.

Upstream precedent: pydantic-ai's own `Thinking` capability (`capabilities/thinking.py`) is exactly this shape — a `@dataclass` subclass returning a static `ModelSettings` from `get_model_settings()`.

## Feature parity

- **Identical merged payload on the standard path.** pydantic-ai layers settings agent → capability → run over the model's base settings (`_layer_model_settings`, verified in the installed 2.31.0 source). Nothing else contributes capability-level settings and per-run settings (`agent.run(model_settings=...)`) still merge last, so the payload the model receives is unchanged everywhere code_puppy builds agents. Proven by a `FunctionModel` wire-parity test against the old kwarg wiring, plus a full three-layer merge test (model base < capability < per-run).
- **One deliberate, reviewer-flagged divergence:** `Agent.override(model_settings=...)` replaces the *agent-slot* settings — previously ours, now empty — so the capability snapshot merges after it and wins conflicting keys; the built agent's `model_settings` attribute also reads `None`. No code_puppy call site uses either seam (verified: zero `.override(` callers, zero readers of the built agent's `model_settings`). The trade-off is documented in the module docstring and pinned by a dedicated regression test so it stays visible rather than accidental.
- **Identical snapshot timing.** The kwarg froze settings at agent-build time; `get_model_settings` is re-extracted on **every run** (`for_run` re-resolution), which would silently pick up config edits mid-session. `__post_init__` therefore snapshots `make_model_settings()` once — config changes keep applying on agent rebuild, exactly as before.
- **Builder still computes once.** `build_pydantic_agent` constructs a single `PerModelSettings` shared by both construction passes, mirroring the old single `make_model_settings()` call. Sub-agents construct theirs inline (single pass).
- **List position is inert** — `get_model_settings` is a configuration seam, not a request hook; documented at both call sites.
- **Spec-constructible.** Like #830 (and unlike #828/#829), the inherited `get_serialization_name()` default is kept: the only fields are plain data (`model_name`/`max_tokens`), no live agent references. The spec path is tested end-to-end via `from_spec`.

`make_model_settings` itself is untouched and stays exported from `model_factory` — plugins that import it directly are unaffected.

## Tests

- `tests/agents/test_model_settings_capability.py`: snapshot-freeze contract, `make_model_settings` equivalence, FunctionModel wire-parity vs the old kwarg, three-layer merge precedence, the pinned `Agent.override` divergence, and `from_spec` construction.
- Two existing tests stubbed `_builder.make_model_settings`; retargeted to `code_puppy.agents._model_settings.make_model_settings` and their stubs now return `ModelSettings()` instead of an annotation-invalid `None`.
- Full suite: **7494 passed**, ruff clean. The lone red (`test_render_version_check_current`) is pre-existing on main.

## Heads-up

Like #828/#829/#830, this grazes the shared `capabilities=[...]` blocks in `_builder.py` and `subagent_invocation.py` — whichever of the four lands last eats a trivial rebase.

**Do not merge** — awaiting human review.