### PR TITLE
refactor: promote system-prompt delivery to an AssembledInstructions capability

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -19,6 +19,7 @@ from pydantic_ai import Agent as PydanticAgent
 from pydantic_ai.capabilities import ProcessHistory
 
 from code_puppy.agents._compaction import make_history_processor
+from code_puppy.agents._instructions import AssembledInstructions
 from code_puppy.agents._model_message_transform import build_model_message_transform
 from code_puppy.agents._output_limits import (
     build_response_clamp,
@@ -633,7 +634,13 @@ def build_pydantic_agent(
         message_group,
         agent_name=getattr(agent, "name", None),
     )
-    instructions = _assemble_instructions(agent, resolved_model_name)
+    # One shared capability across both construction passes, mirroring the
+    # single _assemble_instructions call: assembly happens once per build,
+    # and the capability's default for_agent/for_run return self, so sharing
+    # the instance between probe and final agents is side-effect-free.
+    assembled_instructions = AssembledInstructions(
+        _assemble_instructions(agent, resolved_model_name)
+    )
     mcp_servers = load_mcp_servers(agent_name=getattr(agent, "name", None))
     model_settings = make_model_settings(resolved_model_name)
     history_processor = make_history_processor(agent)
@@ -647,7 +654,6 @@ def build_pydantic_agent(
             # caller's frame variables, so observability spans read
             # "invoke_agent pydantic_agent" instead of the logical agent name.
             name=logical_agent_name,
-            instructions=instructions,
             output_type=output_type,
             retries=3,
             toolsets=toolsets,
@@ -660,7 +666,11 @@ def build_pydantic_agent(
             # hook (after_tool_execute), so its position is inert; the
             # response clamp runs before_model_request after both history
             # processors. The plugin transform wraps the final model request.
+            # AssembledInstructions replaces the `instructions=` constructor
+            # kwarg (same wire bytes -- see _instructions.py); its position
+            # is inert because no other capability contributes instructions.
             capabilities=[
+                assembled_instructions,
                 *build_tool_output_limits(),
                 ProcessHistory(history_processor),
                 ProcessHistory(steer_processor),

--- a/code_puppy/agents/_instructions.py
+++ b/code_puppy/agents/_instructions.py
@@ -1,0 +1,56 @@
+"""System-prompt delivery as a first-class pydantic-ai capability.
+
+Both agent construction paths (``agents/_builder.py`` and
+``tools/subagent_invocation.py``) used to hand their fully assembled system
+prompt to pydantic-ai via the ``Agent(instructions=...)`` constructor kwarg.
+:class:`AssembledInstructions` moves that delivery onto the dedicated
+``get_instructions()`` capability seam instead, so the prompt travels with
+the rest of the agent's capabilities.
+
+The *assembly* logic is deliberately untouched: ``_builder`` still composes
+the main agent's prompt (full system prompt + AGENTS.md puppy rules +
+extended-thinking note + GPT-5.6 guards) and ``subagent_invocation`` still
+composes the sub-agent variant (identity prompt, no AGENTS.md), both funnelled
+through ``prepare_prompt_for_model``. This capability only owns the last
+mile: handing the finished string to pydantic-ai.
+
+Parity notes (pydantic-ai 2.31.0):
+
+* **Wire content is byte-identical.** Agent-level instructions and capability
+  contributions land in the same literal pool, are joined with ``"\\n"`` and
+  stripped (``Agent._get_instructions``). With the constructor kwarg unset and
+  exactly one capability contributing one string, the resulting
+  ``ModelRequest.instructions`` is exactly what the kwarg produced. An empty
+  assembled string collapses to ``None`` on the wire on both paths.
+* **Build-time freeze is preserved.** Capability instructions are re-extracted
+  per run (``for_run`` re-resolution), but the default ``for_run`` returns
+  ``self`` and the snapshot here is a plain string field -- config or file
+  edits keep applying on agent *rebuild* only, exactly as before.
+* **``Agent.override(instructions=...)`` behaves identically.** The override
+  replaces *all* instructions, capability contributions included, so unlike
+  the model-settings conversion there is no precedence divergence to document.
+* **Spec-constructible.** The only field is a plain string, so the inherited
+  ``get_serialization_name()`` / ``from_spec`` defaults are kept.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic_ai.capabilities import AbstractCapability
+
+
+@dataclass
+class AssembledInstructions(AbstractCapability[Any]):
+    """Deliver a pre-assembled system prompt through ``get_instructions()``.
+
+    ``instructions`` is the final, model-ready prompt text -- callers finish
+    all composition (puppy rules, model-specific prep, sub-agent identity)
+    before constructing this capability.
+    """
+
+    instructions: str
+
+    def get_instructions(self) -> str:
+        return self.instructions

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -401,6 +401,7 @@ async def _invoke_agent_impl(
                 mcp_servers = manager.get_servers_for_agent(agent_name=bound_agent_name)
 
             from code_puppy.agents._compaction import make_history_processor
+            from code_puppy.agents._instructions import AssembledInstructions
             from code_puppy.agents._model_message_transform import (
                 build_model_message_transform,
             )
@@ -414,13 +415,15 @@ async def _invoke_agent_impl(
                 # span reads "invoke_agent temp_agent" instead of the logical
                 # agent name (e.g. "invoke_agent web-retriever").
                 name=agent_name,
-                instructions=instructions,
                 output_type=str,
                 retries=3,
                 toolsets=mcp_servers,
                 # ProcessHistory capability replaces the deprecated
                 # `history_processors=` kwarg (removed in pydantic-ai v2).
+                # AssembledInstructions replaces the `instructions=` kwarg
+                # (same wire bytes -- see agents/_instructions.py).
                 capabilities=[
+                    AssembledInstructions(instructions),
                     ProcessHistory(make_history_processor(agent_config)),
                     build_model_message_transform(agent_name),
                 ],

--- a/tests/agents/test_assembled_instructions_capability.py
+++ b/tests/agents/test_assembled_instructions_capability.py
@@ -1,0 +1,152 @@
+"""Contract tests for the ``AssembledInstructions`` capability.
+
+Pins the parity claims made in ``code_puppy/agents/_instructions.py``: the
+capability must deliver the same ``ModelRequest.instructions`` bytes the old
+``Agent(instructions=...)`` constructor kwarg produced, collapse an empty
+prompt to ``None`` identically, lose to ``Agent.override(instructions=...)``
+identically, and stay spec-constructible via the inherited defaults.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart
+from pydantic_ai.models.function import FunctionModel
+from pydantic_ai.models.test import TestModel
+
+from code_puppy.agents._instructions import AssembledInstructions
+
+PROMPT_TEXT = "You are a helpful puppy.\n\nAlways fetch."
+
+
+def _capture_model(captured: list):
+    """FunctionModel that records each request's wire instructions."""
+
+    def model_function(messages, info):
+        requests = [m for m in messages if isinstance(m, ModelRequest)]
+        captured.append(requests[-1].instructions if requests else None)
+        return ModelResponse(parts=[TextPart("woof")])
+
+    return FunctionModel(model_function)
+
+
+def _run_and_capture(agent: Agent) -> str | None:
+    captured: list = []
+    agent.run_sync("hi", model=_capture_model(captured))
+    assert len(captured) == 1
+    return captured[0]
+
+
+def test_get_instructions_returns_assembled_text():
+    cap = AssembledInstructions(PROMPT_TEXT)
+    assert cap.get_instructions() == PROMPT_TEXT
+
+
+def test_wire_parity_with_constructor_kwarg():
+    """Capability delivery must be byte-identical to the old kwarg path."""
+    via_kwarg = Agent(model=TestModel(), instructions=PROMPT_TEXT)
+    via_capability = Agent(
+        model=TestModel(), capabilities=[AssembledInstructions(PROMPT_TEXT)]
+    )
+
+    kwarg_wire = _run_and_capture(via_kwarg)
+    capability_wire = _run_and_capture(via_capability)
+
+    assert kwarg_wire == PROMPT_TEXT
+    assert capability_wire == kwarg_wire
+
+
+def test_empty_instructions_collapse_to_none_on_wire():
+    """Both paths strip an empty prompt down to ``instructions=None``."""
+    via_kwarg = Agent(model=TestModel(), instructions="")
+    via_capability = Agent(model=TestModel(), capabilities=[AssembledInstructions("")])
+
+    assert _run_and_capture(via_kwarg) is None
+    assert _run_and_capture(via_capability) is None
+
+
+def test_override_replaces_capability_instructions():
+    """``Agent.override(instructions=...)`` replaces capability contributions,
+    exactly as it replaced the constructor kwarg -- no precedence divergence."""
+    agent = Agent(model=TestModel(), capabilities=[AssembledInstructions(PROMPT_TEXT)])
+    with agent.override(instructions="override wins"):
+        assert _run_and_capture(agent) == "override wins"
+    # Outside the override the snapshot is back in force.
+    assert _run_and_capture(agent) == PROMPT_TEXT
+
+
+def test_from_spec_constructs_capability():
+    """The plain-string field keeps the inherited spec defaults working."""
+    agent = Agent.from_spec(
+        {"capabilities": [{"AssembledInstructions": {"instructions": PROMPT_TEXT}}]},
+        custom_capability_types=[AssembledInstructions],
+        model=TestModel(),
+    )
+    assert _run_and_capture(agent) == PROMPT_TEXT
+
+
+class _FakeAgentConfig:
+    """Minimal BaseAgent-shaped config for driving the real build path."""
+
+    name = "code-puppy"
+    display_name = "Code Puppy"
+
+    def __init__(self):
+        self._message_history = []
+        self._compacted_message_hashes = set()
+        self._puppy_rules = None
+
+    @contextmanager
+    def temporary_model_name_override(self, _model_name):
+        yield
+
+    def get_model_name(self):
+        return "test-model"
+
+    def get_full_system_prompt(self):
+        return "You are a test agent."
+
+    def get_available_tools(self):
+        return []
+
+    def get_message_history(self):
+        return self._message_history
+
+    def set_message_history(self, history):
+        self._message_history = history
+
+    def __getattr__(self, item):
+        # Misc numeric config probes used by history processors.
+        if item.startswith("__"):
+            raise AttributeError(item)
+        return lambda *a, **k: 0
+
+
+def test_build_pydantic_agent_delivers_assembled_prompt():
+    """End-to-end: the built agent's wire instructions are the assembled
+    prompt, now travelling via the capability instead of the kwarg."""
+    from code_puppy.agents import _builder
+
+    cfg = _FakeAgentConfig()
+    captured: list = []
+
+    def _fake_load_model_with_fallback(*_args, **_kwargs):
+        return _capture_model(captured), "test-model"
+
+    with (
+        patch.object(
+            _builder, "load_model_with_fallback", _fake_load_model_with_fallback
+        ),
+        patch.object(_builder.ModelFactory, "load_config", staticmethod(dict)),
+        patch.object(_builder, "load_mcp_servers", lambda **k: []),
+        patch.object(_builder, "load_puppy_rules", lambda: None),
+        patch.object(_builder, "make_model_settings", lambda *a, **k: None),
+        patch("code_puppy.tools.register_tools_for_agent", lambda *a, **k: None),
+    ):
+        built = _builder.build_pydantic_agent(cfg)
+        built.run_sync("hi")
+
+    assert len(captured) == 1
+    assert captured[0] is not None
+    assert captured[0].startswith("You are a test agent.")

--- a/tests/agents/test_assembled_instructions_capability.py
+++ b/tests/agents/test_assembled_instructions_capability.py
@@ -144,9 +144,12 @@ def test_build_pydantic_agent_delivers_assembled_prompt():
         patch.object(_builder, "make_model_settings", lambda *a, **k: None),
         patch("code_puppy.tools.register_tools_for_agent", lambda *a, **k: None),
     ):
+        # Computed under the same patches, so ambient plugin prompt
+        # fragments can't skew the exact-equality assertion below.
+        expected = _builder._assemble_instructions(cfg, "test-model")
         built = _builder.build_pydantic_agent(cfg)
         built.run_sync("hi")
 
     assert len(captured) == 1
-    assert captured[0] is not None
-    assert captured[0].startswith("You are a test agent.")
+    assert "You are a test agent." in expected
+    assert captured[0] == expected


### PR DESCRIPTION
## What

Fifth entry in the capability series (#828 SteerInjection, #829 HistoryCompaction, #830 PluginMessageTransform, #831 PerModelSettings): the fully assembled system prompt used to ride in on the `Agent(instructions=...)` constructor kwarg at both construction call sites. It now travels through pydantic-ai's dedicated `get_instructions()` capability seam via a new `AssembledInstructions` capability in `code_puppy/agents/_instructions.py`.

**Assembly logic is deliberately untouched** — `_assemble_instructions` (full system prompt + AGENTS.md puppy rules + extended-thinking note + GPT-5.6 guards) and the sub-agent composition (identity prompt, no AGENTS.md) still run exactly as before, both funnelled through `prepare_prompt_for_model`. The capability only owns the last mile: handing the finished string to pydantic-ai. Same precedent as #831 leaving `make_model_settings` untouched.

## Parity analysis (pydantic-ai 2.31.0)

- **Wire bytes identical.** `Agent._get_instructions` pools agent-level and capability instructions into one literal list, joins with `"\n"`, and strips. With the kwarg unset and exactly one capability contributing one string, `ModelRequest.instructions` is unchanged.
- **Empty prompt** collapses to `instructions=None` on the wire on both paths.
- **No override divergence this time.** Unlike #831 (where `Agent.override(model_settings=...)` flipped precedence), `Agent.override(instructions=...)` *replaces all instructions, capability contributions included* — identical behaviour to the kwarg. Pinned by a test.
- **Build-time freeze preserved.** Capability instructions are re-extracted per run via `for_run` re-resolution, but the snapshot is a plain string field and the default `for_run` returns `self` — config/file edits keep applying on agent rebuild only.
- **Spec-constructible.** Only field is a plain string, so the inherited `get_serialization_name()` / `from_spec` defaults are kept (same reasoning as #830).

## Call sites

- `_builder.py` hoists **one shared instance** across both construction passes, mirroring the old single `_assemble_instructions` call (safe: default `for_agent`/`for_run` return `self`; `bind_capabilities_tier` doesn't mutate — same pattern #831 established).
- `subagent_invocation.py` constructs inline; the claude-code *user-prompt* transformation stays where it is (it is prompt prep, not instructions delivery).
- The capability sits first in both `capabilities=[...]` lists; position is inert since no other capability contributes instructions (comment in code).

## Tests

Six contract tests in `tests/agents/test_assembled_instructions_capability.py`:
1. direct `get_instructions()` seam
2. kwarg-vs-capability wire parity via `FunctionModel`
3. empty-string → `None` collapse parity
4. `Agent.override(instructions=...)` replacement parity (in and out of the override scope)
5. `from_spec` end-to-end with `custom_capability_types`
6. real `build_pydantic_agent` drive: assembled prompt arrives on the wire via the capability

Full suite: identical results to main — the only reds (`test_invoke_agent_impl_sets_subagent_name`, `test_subagent_construction_installs_transform` in full-run order, `test_render_version_check_current`) reproduce on a clean main checkout. Ruff clean.

## Heads-up

Same participation-trophy rebase caveat as the rest of the series: this grazes both shared `capabilities=[...]` blocks, so whichever of the five lands last eats a trivial rebase.

**Do not merge yet** — awaiting review.