### PR TITLE
Promote model delivery to a ResolvedModel capability

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -24,6 +24,7 @@ from code_puppy.agents._output_limits import (
     build_response_clamp,
     build_tool_output_limits,
 )
+from code_puppy.agents._resolved_model import ResolvedModel
 from code_puppy.agents._steer_processor import make_steer_history_processor
 from code_puppy.agents.event_stream_handler import event_stream_handler
 from code_puppy.callbacks import (
@@ -639,10 +640,14 @@ def build_pydantic_agent(
     history_processor = make_history_processor(agent)
     steer_processor = make_steer_history_processor(agent)
     logical_agent_name = getattr(agent, "name", None) or agent.__class__.__name__
+    # One shared instance across the probe and final construction passes:
+    # the capability is a static snapshot (default ``for_run`` returns
+    # ``self``) and carries no id, so sharing is safe and mirrors the single
+    # model resolution above.
+    resolved_model = ResolvedModel(model)
 
     def _new_pydantic_agent(toolsets: List[Any]) -> PydanticAgent:
         return PydanticAgent(
-            model=model,
             # Explicit name: without it pydantic-ai infers one from the
             # caller's frame variables, so observability spans read
             # "invoke_agent pydantic_agent" instead of the logical agent name.
@@ -660,7 +665,11 @@ def build_pydantic_agent(
             # hook (after_tool_execute), so its position is inert; the
             # response clamp runs before_model_request after both history
             # processors. The plugin transform wraps the final model request.
+            # ResolvedModel is a configuration seam (get_model), not a
+            # request hook, so its position is inert too; it replaces the
+            # former ``model=`` constructor kwarg.
             capabilities=[
+                resolved_model,
                 *build_tool_output_limits(),
                 ProcessHistory(history_processor),
                 ProcessHistory(steer_processor),

--- a/code_puppy/agents/_resolved_model.py
+++ b/code_puppy/agents/_resolved_model.py
@@ -1,0 +1,73 @@
+"""Model delivery as a first-class pydantic-ai capability.
+
+Both agent construction paths (``agents/_builder.py`` and
+``tools/subagent_invocation.py``) used to hand their fully resolved
+pydantic-ai model to the ``Agent(model=...)`` constructor kwarg.
+:class:`ResolvedModel` moves that delivery onto the dedicated ``get_model()``
+capability seam instead, so the model travels with the rest of the agent's
+capabilities.
+
+The *resolution* logic is deliberately untouched:
+``_builder.load_model_with_fallback`` still owns requested-model loading, the
+global-model/any-configured-model fallback chain, and the per-conversation
+warning dedup, and ``subagent_invocation`` still resolves pins and explicit
+overrides before calling it. This capability only owns the last mile: handing
+the resolved ``Model`` instance to pydantic-ai.
+
+Parity notes (pydantic-ai 2.31.0):
+
+* **Static contribution, resolved once per run.** A non-callable
+  ``get_model()`` return is used directly as the run's model
+  (``Agent._evaluate_model_contribution``), exactly as the agent-slot model
+  was. No selector semantics are introduced; ``_check_dynamic_model_resume``
+  is a no-op for static contributions.
+* **``run(model=...)`` and ``Agent.override(model=...)`` stay
+  authoritative.** Both set ``model_is_explicit``, which short-circuits
+  capability contribution evaluation entirely -- the same precedence the
+  old constructor kwarg had. Pinned by tests.
+* **Enter/exit lifecycle is preserved.** ``Agent.__aenter__`` enters a
+  static capability model's context exactly as it entered the agent-slot
+  model, so provider HTTP clients are opened and closed identically.
+* **One observable divergence:** the built agent's ``.model`` property now
+  reads ``None`` -- the model no longer occupies the agent slot. No
+  code_puppy call site reads it (everything goes through
+  ``BaseAgent.cur_model``, which ``build_pydantic_agent`` still sets).
+  One *plugin* reader exists: wiggum's ``_resolve_judges`` probes
+  ``get_pydantic_agent().model.model_name`` for its default-judge fallback
+  and now takes its own next fallback, ``BaseAgent.get_model_name()`` --
+  the configured model name, which is what judge configs resolve against
+  anyway. Pinned by a regression test so the trade-off stays visible.
+
+``get_serialization_name()`` returns ``None``: the capability holds a live,
+provider-configured ``Model`` instance (HTTP clients and all), so it is
+deliberately not spec-constructible -- the same precedent as
+``SteerInjection`` and ``HistoryCompaction``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.models import Model
+
+
+@dataclass
+class ResolvedModel(AbstractCapability[Any]):
+    """Deliver an already-resolved pydantic-ai ``Model`` via ``get_model()``.
+
+    ``model`` is the final ``Model`` instance -- callers finish all
+    resolution (fallback chain, pins, explicit overrides) before
+    constructing this capability.
+    """
+
+    model: Model
+
+    def get_model(self) -> Model:
+        return self.model
+
+    @classmethod
+    def get_serialization_name(cls) -> Optional[str]:
+        # Holds a live Model instance; opt out of spec-based construction.
+        return None

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -404,11 +404,11 @@ async def _invoke_agent_impl(
             from code_puppy.agents._model_message_transform import (
                 build_model_message_transform,
             )
+            from code_puppy.agents._resolved_model import ResolvedModel
 
             # Build the pydantic-ai agent. MCP servers always included; plugins
             # (e.g. DBOS) may swap them via the agent_run_context hook.
             temp_agent = Agent(
-                model=model,
                 # Explicit name: without it pydantic-ai infers one from the
                 # caller's frame variables, so every sub-agent's observability
                 # span reads "invoke_agent temp_agent" instead of the logical
@@ -420,7 +420,10 @@ async def _invoke_agent_impl(
                 toolsets=mcp_servers,
                 # ProcessHistory capability replaces the deprecated
                 # `history_processors=` kwarg (removed in pydantic-ai v2).
+                # ResolvedModel replaces the former ``model=`` constructor
+                # kwarg; it is a configuration seam so its position is inert.
                 capabilities=[
+                    ResolvedModel(model),
                     ProcessHistory(make_history_processor(agent_config)),
                     build_model_message_transform(agent_name),
                 ],

--- a/tests/agents/test_resolved_model_capability.py
+++ b/tests/agents/test_resolved_model_capability.py
@@ -8,10 +8,17 @@ run/override models staying authoritative, and the one observable divergence
 (the built agent's ``.model`` slot reads ``None``).
 """
 
+from contextlib import contextmanager
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from pydantic_ai import Agent
-from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+)
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 
 from code_puppy.agents._resolved_model import ResolvedModel
@@ -115,6 +122,61 @@ async def test_override_model_stays_authoritative_in_scope_only():
     assert cap_seen
 
 
+async def test_agent_enter_manages_capability_model_lifecycle():
+    """``Agent.__aenter__`` enters (and ``__aexit__`` exits) a static
+    capability model's context exactly as it did the agent-slot model, so
+    provider HTTP clients keep their open/close lifecycle."""
+
+    class _TrackedModel(FunctionModel):
+        entered = 0
+        exited = 0
+
+        async def __aenter__(self):
+            type(self).entered += 1
+            return await super().__aenter__()
+
+        async def __aexit__(self, *exc_info):
+            type(self).exited += 1
+            return await super().__aexit__(*exc_info)
+
+    def respond(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[TextPart("entered")])
+
+    agent = Agent(capabilities=[ResolvedModel(_TrackedModel(respond))])
+    async with agent:
+        assert _TrackedModel.entered == 1
+        assert _TrackedModel.exited == 0
+        result = await agent.run("fetch")
+    assert result.output == "entered"
+    assert _TrackedModel.exited == 1
+
+
+async def test_static_model_serves_every_step_of_a_multi_step_run():
+    """A static contribution is resolved once per run: the same instance
+    serves every request step (tool-call round trip included), with no
+    dynamic re-selection between steps."""
+    seen: list[list[ModelMessage]] = []
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        seen.append(messages)
+        if len(seen) == 1:
+            return ModelResponse(
+                parts=[ToolCallPart(tool_name="bark", args={})],
+            )
+        return ModelResponse(parts=[TextPart("done")])
+
+    agent = Agent(capabilities=[ResolvedModel(FunctionModel(respond))])
+
+    @agent.tool_plain
+    def bark() -> str:
+        return "woof"
+
+    result = await agent.run("fetch")
+
+    assert result.output == "done"
+    assert len(seen) == 2, "both request steps must hit the one static model"
+
+
 def test_agent_model_slot_reads_none():
     """Pinned divergence: the model no longer occupies the agent slot, so the
     built agent's ``.model`` property reads ``None``. No code_puppy call site
@@ -148,6 +210,10 @@ class _AgentConfig:
 
     def set_message_history(self, history):
         self._message_history = history
+
+    @contextmanager
+    def temporary_model_name_override(self, _model_name):
+        yield
 
     def __getattr__(self, item):
         if item.startswith("__"):
@@ -185,3 +251,41 @@ async def test_build_pydantic_agent_delivers_capability_model():
     assert seen, "the resolved model never received the request"
     assert config.cur_model is model
     assert built.model is None
+
+
+async def test_subagent_construction_delivers_capability_model():
+    """End-to-end on the second construction site: the sub-agent's temporary
+    pydantic agent runs on the model delivered via ``ResolvedModel``."""
+    from code_puppy.tools import subagent_invocation
+
+    seen: list[list[ModelMessage]] = []
+
+    # The sub-agent path drives the model through an event_stream_handler,
+    # so the capture model must support streamed requests.
+    async def stream_respond(messages: list[ModelMessage], _info: AgentInfo):
+        seen.append(messages)
+        yield "subagent-built"
+
+    model = FunctionModel(stream_function=stream_respond)
+    config = _AgentConfig()
+
+    with (
+        patch("code_puppy.agents.agent_manager.load_agent", return_value=config),
+        patch(
+            "code_puppy.agents._builder.load_model_with_fallback",
+            lambda *_args, **_kwargs: (model, "test-model"),
+        ),
+        patch(
+            "code_puppy.model_factory.make_model_settings",
+            lambda *_args, **_kwargs: None,
+        ),
+        # "true" disables MCP servers for the invocation.
+        patch("code_puppy.config.get_value", return_value="true"),
+    ):
+        result = await subagent_invocation._invoke_agent_impl(
+            context=SimpleNamespace(), agent_name="test-agent", prompt="fetch"
+        )
+
+    assert result.error is None
+    assert result.response == "subagent-built"
+    assert seen, "the resolved model never received the sub-agent request"

--- a/tests/agents/test_resolved_model_capability.py
+++ b/tests/agents/test_resolved_model_capability.py
@@ -1,0 +1,187 @@
+"""Contract tests for :class:`code_puppy.agents._resolved_model.ResolvedModel`.
+
+The capability replaces the ``Agent(model=...)`` constructor kwarg at both
+construction sites (``_builder.build_pydantic_agent`` and
+``subagent_invocation``). These tests pin the parity contract documented in
+the module docstring: identical wire behavior on the standard path, explicit
+run/override models staying authoritative, and the one observable divergence
+(the built agent's ``.model`` slot reads ``None``).
+"""
+
+from unittest.mock import patch
+
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from code_puppy.agents._resolved_model import ResolvedModel
+
+
+def _wire_shape(messages: list[ModelMessage]) -> list[tuple]:
+    """Project wire messages onto their model-visible content.
+
+    Timestamps and request ids legitimately differ between two separate
+    runs, so equality is asserted on everything the model actually sees:
+    message type, instructions, and each part's type + content.
+    """
+    return [
+        (
+            type(message).__name__,
+            getattr(message, "instructions", None),
+            [
+                (type(part).__name__, getattr(part, "content", None))
+                for part in message.parts
+            ],
+        )
+        for message in messages
+    ]
+
+
+def _capture_model(reply: str, seen: list[list[ModelMessage]]) -> FunctionModel:
+    """A FunctionModel that records the wire messages of every request."""
+
+    def respond(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        seen.append(messages)
+        return ModelResponse(parts=[TextPart(reply)])
+
+    return FunctionModel(respond)
+
+
+def test_get_model_returns_exact_instance():
+    seen: list[list[ModelMessage]] = []
+    model = _capture_model("woof", seen)
+    capability = ResolvedModel(model)
+    assert capability.get_model() is model
+
+
+def test_not_spec_constructible():
+    # Holds a live Model instance -- deliberately opted out of spec-based
+    # construction, like SteerInjection/HistoryCompaction.
+    assert ResolvedModel.get_serialization_name() is None
+
+
+async def test_kwarg_vs_capability_wire_parity():
+    """Same prompt, same instructions: both delivery paths produce identical
+    wire messages and identical output."""
+    kwarg_seen: list[list[ModelMessage]] = []
+    cap_seen: list[list[ModelMessage]] = []
+
+    kwarg_agent = Agent(
+        model=_capture_model("done", kwarg_seen),
+        instructions="Be a good dog.",
+    )
+    cap_agent = Agent(
+        instructions="Be a good dog.",
+        capabilities=[ResolvedModel(_capture_model("done", cap_seen))],
+    )
+
+    kwarg_result = await kwarg_agent.run("fetch")
+    cap_result = await cap_agent.run("fetch")
+
+    assert kwarg_result.output == cap_result.output == "done"
+    assert len(kwarg_seen) == len(cap_seen) == 1
+    assert _wire_shape(kwarg_seen[0]) == _wire_shape(cap_seen[0])
+    assert _wire_shape(kwarg_seen[0])[0][1] == "Be a good dog."
+
+
+async def test_run_model_argument_stays_authoritative():
+    """``run(model=...)`` short-circuits the capability contribution, exactly
+    as it overrode the old constructor kwarg."""
+    cap_seen: list[list[ModelMessage]] = []
+    run_seen: list[list[ModelMessage]] = []
+
+    agent = Agent(capabilities=[ResolvedModel(_capture_model("cap", cap_seen))])
+    result = await agent.run("fetch", model=_capture_model("run", run_seen))
+
+    assert result.output == "run"
+    assert run_seen and not cap_seen
+
+
+async def test_override_model_stays_authoritative_in_scope_only():
+    """``Agent.override(model=...)`` wins inside the scope; the capability
+    model is back in charge outside it -- same precedence as the old kwarg."""
+    cap_seen: list[list[ModelMessage]] = []
+    override_seen: list[list[ModelMessage]] = []
+
+    agent = Agent(capabilities=[ResolvedModel(_capture_model("cap", cap_seen))])
+
+    with agent.override(model=_capture_model("override", override_seen)):
+        overridden = await agent.run("fetch")
+    assert overridden.output == "override"
+    assert override_seen and not cap_seen
+
+    restored = await agent.run("fetch")
+    assert restored.output == "cap"
+    assert cap_seen
+
+
+def test_agent_model_slot_reads_none():
+    """Pinned divergence: the model no longer occupies the agent slot, so the
+    built agent's ``.model`` property reads ``None``. No code_puppy call site
+    reads it -- everything goes through ``BaseAgent.cur_model``."""
+    seen: list[list[ModelMessage]] = []
+    agent = Agent(capabilities=[ResolvedModel(_capture_model("woof", seen))])
+    assert agent.model is None
+
+
+class _AgentConfig:
+    """Minimal BaseAgent stand-in for driving ``build_pydantic_agent``."""
+
+    name = "test-agent"
+
+    def __init__(self):
+        self._message_history = []
+        self._compacted_message_hashes = set()
+        self._puppy_rules = None
+
+    def get_model_name(self):
+        return "test-model"
+
+    def get_full_system_prompt(self):
+        return "Test instructions"
+
+    def get_available_tools(self):
+        return []
+
+    def get_message_history(self):
+        return self._message_history
+
+    def set_message_history(self, history):
+        self._message_history = history
+
+    def __getattr__(self, item):
+        if item.startswith("__"):
+            raise AttributeError(item)
+        return lambda *_args, **_kwargs: 0
+
+
+async def test_build_pydantic_agent_delivers_capability_model():
+    """End-to-end: the built agent runs on the resolved model delivered via
+    the capability, ``cur_model`` still tracks it, and the agent slot is
+    empty."""
+    from code_puppy.agents import _builder
+
+    seen: list[list[ModelMessage]] = []
+    model = _capture_model("built", seen)
+    config = _AgentConfig()
+
+    with (
+        patch.object(
+            _builder,
+            "load_model_with_fallback",
+            lambda *_args, **_kwargs: (model, "test-model"),
+        ),
+        patch.object(_builder.ModelFactory, "load_config", staticmethod(dict)),
+        patch.object(_builder, "load_mcp_servers", lambda **_kwargs: []),
+        patch.object(_builder, "make_model_settings", lambda *_args, **_kwargs: None),
+        patch(
+            "code_puppy.tools.register_tools_for_agent", lambda *_args, **_kwargs: None
+        ),
+    ):
+        built = _builder.build_pydantic_agent(config)
+        result = await built.run("fetch")
+
+    assert result.output == "built"
+    assert seen, "the resolved model never received the request"
+    assert config.cur_model is model
+    assert built.model is None


### PR DESCRIPTION
## Summary

Sixth in the capability series (#828 SteerInjection, #829 HistoryCompaction, #830 PluginMessageTransform, #831 PerModelSettings, #832 AssembledInstructions): promotes **model delivery** from the `Agent(model=...)` constructor kwarg to a first-class pydantic-ai capability, `ResolvedModel`, on the dedicated `get_model()` seam.

Both construction sites (`agents/_builder.py` and `tools/subagent_invocation.py`) previously handed their fully resolved `Model` instance to the constructor kwarg while everything else about the agent's behavior already composes through `capabilities=[...]`.

## What changed

- New `code_puppy/agents/_resolved_model.py` — `@dataclass ResolvedModel(AbstractCapability[Any])` with a single `model: Model` field, delivering via `get_model()`.
- `_builder.build_pydantic_agent` drops `model=` and hoists **one shared `ResolvedModel` instance** across the probe + final construction passes (mirrors the single `load_model_with_fallback` call; safe because the capability is a static snapshot, default `for_run` returns `self`, and it carries no id).
- `subagent_invocation` drops `model=` and constructs `ResolvedModel(model)` inline.
- **Resolution logic untouched** (same restraint as #831/#832): `load_model_with_fallback` still owns the fallback chain + per-conversation warning dedup; sub-agent pin/explicit-override resolution unchanged; `BaseAgent.cur_model` still set. `build_tool_probe_for_agent` keeps its `model=` kwarg deliberately (stripped probe, per the #832 precedent for `instructions=""`).

## Parity (verified against pydantic-ai 2.31.0 source)

- **Static contribution, resolved once per run.** A non-callable `get_model()` return is used directly as the run's model (`Agent._evaluate_model_contribution`), exactly like the agent-slot model. `_check_dynamic_model_resume` is a no-op for static contributions — no selector semantics introduced.
- **`run(model=...)` and `Agent.override(model=...)` stay authoritative.** Both set `model_is_explicit`, which short-circuits capability contribution evaluation entirely — same precedence as the old kwarg. Pinned by tests.
- **Enter/exit lifecycle preserved.** `Agent.__aenter__` enters a static capability model's context identically (line ~3736: `static_selection = capability_model`), so provider HTTP clients open/close the same.
- **One observable divergence:** the built agent's `.model` property now reads `None` (the model no longer occupies the agent slot). Verified: **zero** code_puppy readers — everything goes through `BaseAgent.cur_model`. One plugin reader exists: wiggum's `_resolve_judges` probes `get_pydantic_agent().model.model_name` for its **default-judge fallback** and now takes its own next fallback, `BaseAgent.get_model_name()` — the configured model name, which is what judge configs resolve against anyway (arguably more correct than the provider model id it used to get). Degrades gracefully by design (`getattr(None, "model_name", None)`); documented in the module docstring and pinned by `test_agent_model_slot_reads_none`.
- **Not spec-constructible by design:** `get_serialization_name() -> None` because the capability holds a live, provider-configured `Model` instance (HTTP clients and all) — same precedent as SteerInjection/HistoryCompaction.
- **List position inert:** `get_model` is a configuration seam, not a request hook; placed first in both blocks for readability.

## Tests

7 contract tests in `tests/agents/test_resolved_model_capability.py`:
1. direct seam identity (`get_model() is model`)
2. spec-construction opt-out
3. kwarg-vs-capability **wire parity** via `FunctionModel` (model-visible content compared; timestamps excluded)
4. `run(model=...)` authoritative over the capability
5. `override(model=...)` authoritative in scope, capability restored outside
6. pinned `.model is None` divergence
7. end-to-end `build_pydantic_agent` drive: built agent runs on the capability-delivered model, `cur_model` tracks it, agent slot empty

Full suite: **7583 passed**; the 3 reds are the documented pre-existing main failures (`test_render_version_check_current`, plus the two full-run-order `FieldInfo has no attribute 'strip'` flakes noted in #832) — both `subagent_invocation`-adjacent ones pass in isolation on this branch.

## Merge-order note

Like its five siblings, this touches the shared `capabilities=[...]` blocks in `_builder.py` + `subagent_invocation.py`. Whichever PRs land last eat trivial rebases. 
