### PR TITLE
feat: deliver MCP toolsets via a pydantic-ai capability (McpToolsets)

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -19,6 +19,7 @@ from pydantic_ai import Agent as PydanticAgent
 from pydantic_ai.capabilities import ProcessHistory
 
 from code_puppy.agents._compaction import make_history_processor
+from code_puppy.agents._mcp_toolsets import McpToolsets
 from code_puppy.agents._model_message_transform import build_model_message_transform
 from code_puppy.agents._output_limits import (
     build_response_clamp,
@@ -615,8 +616,8 @@ def build_pydantic_agent(
     - ``agent._code_generation_agent`` ← same as ``pydantic_agent``
     - ``agent._mcp_servers``          ← MCP toolsets (post-filter)
 
-    The build happens in two passes: we construct once with ``toolsets=[]`` so
-    we can introspect registered tool names, then rebuild with MCP servers
+    The build happens in two passes: we construct once with no MCP toolsets
+    so we can introspect registered tool names, then rebuild with MCP servers
     filtered against those names to prevent collisions. Plugins may wrap the
     final pydantic agent via the ``wrap_pydantic_agent`` hook (e.g. to swap
     in a durable-exec wrapper).
@@ -640,7 +641,7 @@ def build_pydantic_agent(
     steer_processor = make_steer_history_processor(agent)
     logical_agent_name = getattr(agent, "name", None) or agent.__class__.__name__
 
-    def _new_pydantic_agent(toolsets: List[Any]) -> PydanticAgent:
+    def _new_pydantic_agent(mcp_toolsets: List[Any]) -> PydanticAgent:
         return PydanticAgent(
             model=model,
             # Explicit name: without it pydantic-ai infers one from the
@@ -650,10 +651,12 @@ def build_pydantic_agent(
             instructions=instructions,
             output_type=output_type,
             retries=3,
-            toolsets=toolsets,
-            # Order matters: compaction first (may trim history to fit
-            # context), THEN steer injection (a fresh steer must not be
-            # compacted away). ProcessHistory capabilities apply in
+            # McpToolsets delivers the MCP servers via the get_toolset()
+            # capability seam (replaces the `toolsets=` kwarg); it is a
+            # configuration seam, so its position in this list is inert.
+            # Order matters for the rest: compaction first (may trim history
+            # to fit context), THEN steer injection (a fresh steer must not
+            # be compacted away). ProcessHistory capabilities apply in
             # registration order (replaces the deprecated
             # `history_processors=` kwarg, removed in pydantic-ai v2).
             # ToolOutputLimits reduces oversized tool returns on a different
@@ -661,6 +664,7 @@ def build_pydantic_agent(
             # response clamp runs before_model_request after both history
             # processors. The plugin transform wraps the final model request.
             capabilities=[
+                McpToolsets(mcp_toolsets),
                 *build_tool_output_limits(),
                 ProcessHistory(history_processor),
                 ProcessHistory(steer_processor),
@@ -670,9 +674,9 @@ def build_pydantic_agent(
             model_settings=model_settings,
         )
 
-    # Pass 1: build with empty toolsets so we can see what pydantic-ai + our
+    # Pass 1: build with no MCP toolsets so we can see what pydantic-ai + our
     # tool registry actually produced, and filter MCP to avoid name clashes.
-    probe_agent = _new_pydantic_agent(toolsets=[])
+    probe_agent = _new_pydantic_agent(mcp_toolsets=[])
     agent_tools = agent.get_available_tools()
     register_tools_for_agent(
         probe_agent,
@@ -686,9 +690,9 @@ def build_pydantic_agent(
         mcp_servers, existing_tool_names
     )
 
-    # Pass 2: real build. MCP servers always go in the constructor; plugins
-    # (e.g. DBOS) may swap them at run time via ``agent_run_context``.
-    final_pydantic = _new_pydantic_agent(toolsets=filtered_mcp_servers)
+    # Pass 2: real build. MCP servers always ride the McpToolsets capability;
+    # plugins (e.g. DBOS) may swap them at run time via ``agent_run_context``.
+    final_pydantic = _new_pydantic_agent(mcp_toolsets=filtered_mcp_servers)
     register_tools_for_agent(
         final_pydantic,
         agent_tools,

--- a/code_puppy/agents/_mcp_toolsets.py
+++ b/code_puppy/agents/_mcp_toolsets.py
@@ -1,0 +1,93 @@
+"""MCP toolset delivery as a pydantic-ai capability.
+
+Seventh in the capability series: promotes MCP server delivery from the
+``Agent(toolsets=...)`` constructor kwarg to the first-class ``get_toolset()``
+capability seam. Only *delivery* moves — server discovery
+(``load_mcp_servers``), bound-server autostart, and collision filtering
+(``filter_conflicting_mcp_tools``) are untouched and still run before this
+capability is constructed.
+
+Parity notes (verified against pydantic-ai 2.31.0 source):
+
+* ``Agent.__aenter__`` enters ``_get_toolset()``, which includes
+  capability-contributed toolsets — MCP server lifecycle is identical.
+* ``Agent.override(toolsets=...)`` skips ``_cap_toolsets`` exactly as it
+  skips constructor ``_user_toolsets`` — same replace semantics. This is
+  what keeps the DBOS durable wrapper working: ``DBOSAgent`` reads the
+  public ``agent.toolsets`` property (which includes capability toolsets),
+  dbosifies them, and overrides them in per run.
+* The ``toolsets=`` kwarg splits its input: ``AbstractToolset`` instances
+  become ``_user_toolsets`` (in order), everything else is wrapped in
+  ``DynamicToolset(toolset_func=...)`` and appended after. ``get_toolset()``
+  returns a single toolset, so this capability replicates that split-then-
+  wrap normalization itself before combining.
+* Ordering divergence (inert): capability toolsets append *after*
+  constructor/dynamic toolsets in ``_build_toolset_list``. MCP servers are
+  the only toolsets code_puppy delivers, so the combined run toolset is
+  identical; name conflicts raise either way.
+
+Not spec-constructible (``get_serialization_name() -> None``): the servers
+are live toolsets backed by subprocesses/HTTP clients owned by the MCP
+manager — same precedent as the other live-object capabilities in the
+series.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.toolsets import AbstractToolset, CombinedToolset, DynamicToolset
+
+
+@dataclass
+class McpToolsets(AbstractCapability[Any]):
+    """Deliver pre-filtered MCP server toolsets via ``get_toolset()``.
+
+    ``servers`` is the exact list previously passed to
+    ``Agent(toolsets=...)`` — post collision-filter on the main path,
+    unfiltered on the sub-agent path (parity with what each call site did
+    before).
+    """
+
+    servers: List[Any] = field(default_factory=list)
+
+    # Built once so repeated ``get_toolset()`` calls (init-time snapshot,
+    # any per-run re-extraction) hand pydantic-ai the same object identity —
+    # matching the constructor, which stores its toolsets exactly once.
+    _toolset: Optional[AbstractToolset[Any]] = field(
+        init=False, repr=False, compare=False, default=None
+    )
+
+    def __post_init__(self) -> None:
+        self._toolset = _combine(self.servers)
+
+    @classmethod
+    def get_serialization_name(cls) -> Optional[str]:
+        return None  # Live MCP toolsets — not spec-constructible.
+
+    def get_toolset(self) -> Optional[AbstractToolset[Any]]:
+        return self._toolset
+
+
+def _combine(servers: List[Any]) -> Optional[AbstractToolset[Any]]:
+    """Normalize ``servers`` the way ``Agent(toolsets=...)`` did, as one toolset.
+
+    The constructor keeps ``AbstractToolset`` instances (in order) and wraps
+    anything else in ``DynamicToolset(toolset_func=...)`` appended after —
+    ``filter_conflicting_mcp_tools`` deliberately passes non-toolset objects
+    through, so we preserve that defensive tolerance here too.
+    """
+    static = [s for s in servers if isinstance(s, AbstractToolset)]
+    dynamic = [
+        DynamicToolset(toolset_func=s)
+        for s in servers
+        if not isinstance(s, AbstractToolset)
+    ]
+    toolsets: List[AbstractToolset[Any]] = [*static, *dynamic]
+    if not toolsets:
+        return None
+    if len(toolsets) == 1:
+        return toolsets[0]
+    return CombinedToolset(toolsets)

--- a/code_puppy/mcp_/managed_server.py
+++ b/code_puppy/mcp_/managed_server.py
@@ -242,8 +242,8 @@ class ManagedMCPServer:
         Get the pydantic-ai toolset for this server.
 
         Returns the ``MCPToolset`` wrapped in a ``PrefixedToolset`` (the
-        public replacement for the old ``tool_prefix=`` kwarg), ready to be
-        passed to ``Agent(toolsets=...)``.
+        public replacement for the old ``tool_prefix=`` kwarg), ready for
+        delivery via the ``McpToolsets`` capability.
 
         Raises:
             RuntimeError: If server creation failed or server is not available

--- a/code_puppy/mcp_/manager.py
+++ b/code_puppy/mcp_/manager.py
@@ -316,7 +316,8 @@ class MCPManager:
                 used by status / listing code paths).
 
         Returns:
-            List of pydantic-ai toolsets ready for ``Agent(toolsets=...)``
+            List of pydantic-ai toolsets, delivered to agents via the
+            ``McpToolsets`` capability (``get_toolset()`` seam).
         """
         bound_names: Optional[set] = None
         if agent_name is not None:

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -401,12 +401,14 @@ async def _invoke_agent_impl(
                 mcp_servers = manager.get_servers_for_agent(agent_name=bound_agent_name)
 
             from code_puppy.agents._compaction import make_history_processor
+            from code_puppy.agents._mcp_toolsets import McpToolsets
             from code_puppy.agents._model_message_transform import (
                 build_model_message_transform,
             )
 
-            # Build the pydantic-ai agent. MCP servers always included; plugins
-            # (e.g. DBOS) may swap them via the agent_run_context hook.
+            # Build the pydantic-ai agent. MCP servers always included (via
+            # the McpToolsets capability — replaces the `toolsets=` kwarg);
+            # plugins (e.g. DBOS) may swap them via the agent_run_context hook.
             temp_agent = Agent(
                 model=model,
                 # Explicit name: without it pydantic-ai infers one from the
@@ -417,10 +419,10 @@ async def _invoke_agent_impl(
                 instructions=instructions,
                 output_type=str,
                 retries=3,
-                toolsets=mcp_servers,
                 # ProcessHistory capability replaces the deprecated
                 # `history_processors=` kwarg (removed in pydantic-ai v2).
                 capabilities=[
+                    McpToolsets(mcp_servers),
                     ProcessHistory(make_history_processor(agent_config)),
                     build_model_message_transform(agent_name),
                 ],

--- a/tests/agents/test_mcp_toolsets_capability.py
+++ b/tests/agents/test_mcp_toolsets_capability.py
@@ -278,23 +278,41 @@ def test_builder_delivers_mcp_servers_via_capability():
     assert cfg._mcp_servers == [server]
 
 
-def test_builder_collision_filter_still_applies():
-    """A server tool colliding with a registered tool is hidden, exactly as
-    the pre-capability two-pass filter guaranteed."""
+async def test_builder_collision_filter_still_applies():
+    """A server tool colliding with a registered tool is hidden from the
+    model, exactly as the pre-capability two-pass filter guaranteed — while
+    non-colliding tools from the same server stay visible."""
     from code_puppy.agents import _builder
 
-    server = _echo_toolset("read_file")
+    server = FunctionToolset()
+
+    def read_file(path: str) -> str:
+        """Colliding MCP tool."""
+        return path
+
+    def mcp_echo(text: str) -> str:
+        """Non-colliding MCP tool."""
+        return text
+
+    server.add_function(read_file, takes_ctx=False)
+    server.add_function(mcp_echo, takes_ctx=False)
 
     def fake_register(agent, *_a, **_k):
         # Simulate the registry contributing a colliding native tool name.
         agent._tools = {"read_file": SimpleNamespace()}
+
+    seen_tool_names: list[set] = []
+
+    def model_function(_messages, info: AgentInfo) -> ModelResponse:
+        seen_tool_names.append({t.name for t in info.function_tools})
+        return ModelResponse(parts=[TextPart("woof")])
 
     cfg = _FakeAgentConfig()
     with (
         patch.object(
             _builder,
             "load_model_with_fallback",
-            lambda *a, **k: (TestModel(custom_output_text="woof"), "test-model"),
+            lambda *a, **k: (FunctionModel(model_function), "test-model"),
         ),
         patch.object(_builder.ModelFactory, "load_config", staticmethod(dict)),
         patch.object(_builder, "load_mcp_servers", lambda **k: [server]),
@@ -306,3 +324,11 @@ def test_builder_collision_filter_still_applies():
     delivered = built.root_capability.get_toolset()
     assert delivered is not None
     assert delivered is not server  # the FilteredToolset wrapper rode along
+
+    # The model must see the surviving MCP tool but not the colliding one.
+    # (Other capabilities may contribute their own tools — e.g. the
+    # ToolOutputLimits spill reader — so assert membership, not the full set.)
+    await built.run("hi")
+    assert len(seen_tool_names) == 1
+    assert "mcp_echo" in seen_tool_names[0]
+    assert "read_file" not in seen_tool_names[0]

--- a/tests/agents/test_mcp_toolsets_capability.py
+++ b/tests/agents/test_mcp_toolsets_capability.py
@@ -1,0 +1,308 @@
+"""Contract tests for the ``McpToolsets`` capability.
+
+Pins the parity story for moving MCP server delivery off the
+``Agent(toolsets=...)`` constructor kwarg and onto the ``get_toolset()``
+capability seam:
+
+* normalization matches the kwarg byte-for-byte (AbstractToolsets kept in
+  order, non-toolsets wrapped in ``DynamicToolset`` and appended after);
+* the delivered toolsets surface through the public ``agent.toolsets``
+  property (what the DBOS durable wrapper reads);
+* ``Agent.override(toolsets=...)`` replaces capability toolsets exactly as
+  it replaced constructor toolsets (what DBOS relies on per run);
+* ``Agent.__aenter__`` enters the delivered toolset (MCP lifecycle);
+* tools delivered via the capability are actually callable end-to-end.
+"""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.toolsets import CombinedToolset, DynamicToolset, FunctionToolset
+
+from code_puppy.agents._mcp_toolsets import McpToolsets
+
+
+class _EnterCountingToolset(FunctionToolset):
+    """FunctionToolset that counts async-context enters/exits."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.enter_count = 0
+        self.exit_count = 0
+
+    async def __aenter__(self):
+        self.enter_count += 1
+        return await super().__aenter__()
+
+    async def __aexit__(self, *exc_info):
+        self.exit_count += 1
+        return await super().__aexit__(*exc_info)
+
+
+def _echo_toolset(tool_name: str = "mcp_echo") -> FunctionToolset:
+    toolset = FunctionToolset()
+
+    def echo(text: str) -> str:
+        """Echo text back."""
+        return f"echo: {text}"
+
+    toolset.add_function(echo, takes_ctx=False, name=tool_name)
+    return toolset
+
+
+# ---------------------------------------------------------------------------
+# Pure capability contract
+# ---------------------------------------------------------------------------
+
+
+def test_empty_servers_deliver_no_toolset():
+    assert McpToolsets([]).get_toolset() is None
+    assert McpToolsets().get_toolset() is None
+
+
+def test_single_server_delivered_by_identity():
+    server = _echo_toolset()
+    assert McpToolsets([server]).get_toolset() is server
+
+
+def test_multiple_servers_combined_in_order():
+    first, second = _echo_toolset("one"), _echo_toolset("two")
+    delivered = McpToolsets([first, second]).get_toolset()
+    assert isinstance(delivered, CombinedToolset)
+    assert list(delivered.toolsets) == [first, second]
+
+
+def test_non_toolset_entries_wrapped_dynamic_and_appended_after():
+    """Parity with ``Agent(toolsets=...)``: AbstractToolsets first (in
+    order), everything else wrapped in DynamicToolset after them."""
+
+    def factory(_ctx):  # a ToolsetFunc, as the kwarg accepted
+        return None
+
+    static = _echo_toolset()
+    delivered = McpToolsets([factory, static]).get_toolset()
+    assert isinstance(delivered, CombinedToolset)
+    inner = list(delivered.toolsets)
+    assert inner[0] is static
+    assert isinstance(inner[1], DynamicToolset)
+
+
+def test_get_toolset_is_stable_across_calls():
+    capability = McpToolsets([_echo_toolset("one"), _echo_toolset("two")])
+    assert capability.get_toolset() is capability.get_toolset()
+
+
+def test_not_spec_constructible():
+    assert McpToolsets.get_serialization_name() is None
+
+
+# ---------------------------------------------------------------------------
+# pydantic-ai integration parity
+# ---------------------------------------------------------------------------
+
+
+def _toolset_leaves(agent: Agent) -> list:
+    """Collect leaf toolsets reachable from ``agent.toolsets``.
+
+    Walks the same wrapper chain DBOS's ``visit_and_replace`` recurses
+    through (``CombinedToolset.toolsets`` / ``WrapperToolset.wrapped``), so
+    membership here proves the durable wrapper can find and dbosify the
+    delivered MCP toolsets.
+    """
+    leaves = []
+
+    def walk(toolset):
+        children = getattr(toolset, "toolsets", None)
+        if children is not None:
+            for child in children:
+                walk(child)
+        elif (wrapped := getattr(toolset, "wrapped", None)) is not None:
+            walk(wrapped)
+        else:
+            leaves.append(toolset)
+
+    for toolset in agent.toolsets:
+        walk(toolset)
+    return leaves
+
+
+def _build_agent(servers, **kwargs) -> Agent:
+    return Agent(
+        model=TestModel(custom_output_text="woof"),
+        name="cap-test",
+        capabilities=[McpToolsets(servers)],
+        **kwargs,
+    )
+
+
+def test_delivered_toolsets_surface_on_public_property():
+    """DBOSAgent reads ``wrapped.toolsets`` and dbosifies via
+    ``visit_and_replace`` — the capability-delivered server must be a
+    reachable leaf of that public property."""
+    server = _echo_toolset()
+    agent = _build_agent([server])
+    assert any(leaf is server for leaf in _toolset_leaves(agent))
+
+
+def test_delivered_toolsets_visit_and_replaceable():
+    """The exact traversal DBOSAgent performs reaches the MCP leaf."""
+    server = _echo_toolset()
+    agent = _build_agent([server])
+    visited = []
+
+    def visitor(leaf):
+        visited.append(leaf)
+        return leaf
+
+    for toolset in agent.toolsets:
+        toolset.visit_and_replace(visitor)
+    assert any(leaf is server for leaf in visited)
+
+
+def test_override_toolsets_replaces_capability_toolsets():
+    """Same replace semantics the kwarg had — DBOS overrides per run."""
+    server = _echo_toolset()
+    replacement = _echo_toolset("replacement_tool")
+    agent = _build_agent([server])
+    with agent.override(toolsets=[replacement]):
+        toolsets = agent.toolsets
+        assert all(ts is not server for ts in toolsets)
+        assert any(ts is replacement for ts in toolsets)
+
+
+async def test_aenter_enters_delivered_toolset():
+    server = _EnterCountingToolset()
+    agent = _build_agent([server])
+    async with agent:
+        assert server.enter_count == 1
+    assert server.exit_count == 1
+    # Re-entrancy stays a no-op inside one entered context, as before.
+    async with agent:
+        async with agent:
+            pass
+    assert server.enter_count == 2
+    assert server.exit_count == 2
+
+
+async def test_capability_delivered_tool_is_callable_end_to_end():
+    """The model can call a tool that only exists via McpToolsets."""
+
+    def model_function(messages, info: AgentInfo) -> ModelResponse:
+        assert any(t.name == "mcp_echo" for t in info.function_tools)
+        if len(messages) == 1:
+            return ModelResponse(
+                parts=[ToolCallPart(tool_name="mcp_echo", args={"text": "woof"})]
+            )
+        tool_return = messages[-1].parts[0]
+        return ModelResponse(parts=[TextPart(f"got {tool_return.content}")])
+
+    agent = Agent(
+        model=FunctionModel(model_function),
+        name="cap-test",
+        capabilities=[McpToolsets([_echo_toolset()])],
+    )
+    result = await agent.run("hi")
+    assert result.output == "got echo: woof"
+
+
+# ---------------------------------------------------------------------------
+# Builder integration: the real construction path delivers via the capability
+# ---------------------------------------------------------------------------
+
+
+class _FakeAgentConfig:
+    """Minimal BaseAgent-shaped config (pattern from test_agent_span_naming)."""
+
+    name = "code-puppy"
+    display_name = "Code Puppy"
+
+    def __init__(self):
+        self._message_history = []
+        self._compacted_message_hashes = set()
+        self._puppy_rules = None
+
+    @contextmanager
+    def temporary_model_name_override(self, _model_name):
+        yield
+
+    def get_model_name(self):
+        return "test-model"
+
+    def get_full_system_prompt(self):
+        return "You are a test agent."
+
+    def get_available_tools(self):
+        return []
+
+    def get_message_history(self):
+        return self._message_history
+
+    def set_message_history(self, history):
+        self._message_history = history
+
+    def __getattr__(self, item):
+        if item.startswith("__"):
+            raise AttributeError(item)
+        return lambda *a, **k: 0
+
+
+def _build_with_servers(servers):
+    from code_puppy.agents import _builder
+
+    cfg = _FakeAgentConfig()
+    with (
+        patch.object(
+            _builder,
+            "load_model_with_fallback",
+            lambda *a, **k: (TestModel(custom_output_text="woof"), "test-model"),
+        ),
+        patch.object(_builder.ModelFactory, "load_config", staticmethod(dict)),
+        patch.object(_builder, "load_mcp_servers", lambda **k: servers),
+        patch.object(_builder, "make_model_settings", lambda *a, **k: None),
+        patch("code_puppy.tools.register_tools_for_agent", lambda *a, **k: None),
+    ):
+        return _builder.build_pydantic_agent(cfg), cfg
+
+
+def test_builder_delivers_mcp_servers_via_capability():
+    server = _echo_toolset()
+    built, cfg = _build_with_servers([server])
+    assert not built._user_toolsets  # nothing rides the kwarg any more
+    assert any(leaf is server for leaf in _toolset_leaves(built))
+    # The plugin-facing attribute contract is unchanged.
+    assert cfg._mcp_servers == [server]
+
+
+def test_builder_collision_filter_still_applies():
+    """A server tool colliding with a registered tool is hidden, exactly as
+    the pre-capability two-pass filter guaranteed."""
+    from code_puppy.agents import _builder
+
+    server = _echo_toolset("read_file")
+
+    def fake_register(agent, *_a, **_k):
+        # Simulate the registry contributing a colliding native tool name.
+        agent._tools = {"read_file": SimpleNamespace()}
+
+    cfg = _FakeAgentConfig()
+    with (
+        patch.object(
+            _builder,
+            "load_model_with_fallback",
+            lambda *a, **k: (TestModel(custom_output_text="woof"), "test-model"),
+        ),
+        patch.object(_builder.ModelFactory, "load_config", staticmethod(dict)),
+        patch.object(_builder, "load_mcp_servers", lambda **k: [server]),
+        patch.object(_builder, "make_model_settings", lambda *a, **k: None),
+        patch("code_puppy.tools.register_tools_for_agent", fake_register),
+    ):
+        built = _builder.build_pydantic_agent(cfg)
+
+    delivered = built.root_capability.get_toolset()
+    assert delivered is not None
+    assert delivered is not server  # the FilteredToolset wrapper rode along


### PR DESCRIPTION
## What

Seventh in the capability series (#828 SteerInjection, #829 HistoryCompaction, #830 PluginMessageTransform, #831 PerModelSettings, #832 AssembledInstructions, #833 ResolvedModel): promotes **MCP server delivery** from the `Agent(toolsets=...)` constructor kwarg to the first-class **`get_toolset()`** capability seam, via a new `McpToolsets` capability in `code_puppy/agents/_mcp_toolsets.py`.

Both construction sites converted:
- `_builder.build_pydantic_agent` — probe pass gets `McpToolsets([])`, final pass gets `McpToolsets(filtered_mcp_servers)`
- `subagent_invocation` — `McpToolsets(mcp_servers)` (unfiltered, exactly as the kwarg was there)

## What deliberately did NOT move

- Server discovery (`load_mcp_servers`), bound-server autostart, and the **two-pass collision filter** (`filter_conflicting_mcp_tools`) still run before the capability is constructed — same restraint as the rest of the series: only *delivery* changes.
- `agent._mcp_servers` keeps its plugin-facing contract (`agent_run_context` hook, `token_usage`, the acp plugin's mutation) — all unaffected.
- `build_tool_probe_for_agent`'s stripped probe keeps `toolsets=[]` (#832/#833 precedent).

## Parity (verified against pydantic-ai 2.31.0 source)

- **Lifecycle:** `Agent.__aenter__` enters `_get_toolset()`, which includes capability toolsets — MCP servers get entered/exited identically.
- **DBOS durable wrapper (the scary one):** `DBOSAgent` reads the *public* `agent.toolsets` property (which includes capability toolsets), dbosifies leaves via `visit_and_replace`, and applies them per run with `override(toolsets=...)` — and `override` skips `_cap_toolsets` exactly as it skipped constructor `_user_toolsets`. Same replace semantics; pinned by tests that perform the exact traversal DBOS does.
- **Normalization:** the kwarg kept `AbstractToolset`s (in order) and wrapped anything else in `DynamicToolset(toolset_func=...)` appended after; `get_toolset()` returns a single toolset, so the capability replicates that split-then-wrap itself, then combines (`0 → None`, `1 → identity`, `n → CombinedToolset`). Memoized so repeated `get_toolset()` calls deliver stable identity, matching the constructor storing its list once.
- **One inert divergence:** capability toolsets append *after* dynamic toolsets in `_build_toolset_list`, and ride wrapped in `CapabilityOwnedToolset`/`CombinedToolset` inside `agent.toolsets`. MCP servers are the only toolsets code_puppy delivers and name conflicts raise either way, so the combined run toolset is behaviorally identical; the wrapper chain is transparent to `visit_and_replace` (pinned by test).

Not spec-constructible (`get_serialization_name() -> None`): live MCP toolsets backed by subprocesses/HTTP clients owned by the MCP manager — same precedent as the other live-object capabilities in the series.

## Tests

13 contract tests in `tests/agents/test_mcp_toolsets_capability.py`: pure normalization contract, pydantic-ai integration (public property surfacing, `visit_and_replace` reachability, `override` replacement, `__aenter__` lifecycle counters, end-to-end `FunctionModel` tool call through a capability-delivered toolset), and real-builder integration (delivery + collision filter still applied, `_user_toolsets` empty, `agent._mcp_servers` contract pinned).

Full suite: **7589 passed**; the 3 reds are the exact documented pre-existing main failures (`test_render_version_check_current` + the two full-run-order subagent-adjacent flakes, which pass in isolation on this branch).

## Merge-order note

Like the previous six, this PR grazes the shared `capabilities=[...]` blocks in `_builder.py` + `subagent_invocation.py`. Whichever of the seven lands last eats trivial rebases. Musical chairs continues.
