### PR TITLE
Deliver stream rendering via a StreamRendering capability

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -25,7 +25,7 @@ from code_puppy.agents._output_limits import (
     build_tool_output_limits,
 )
 from code_puppy.agents._steer_processor import make_steer_history_processor
-from code_puppy.agents.event_stream_handler import event_stream_handler
+from code_puppy.agents._stream_rendering import StreamRendering
 from code_puppy.callbacks import (
     on_pre_mcp_autostart,
     on_pre_mcp_autostart_sync,
@@ -660,12 +660,17 @@ def build_pydantic_agent(
             # hook (after_tool_execute), so its position is inert; the
             # response clamp runs before_model_request after both history
             # processors. The plugin transform wraps the final model request.
+            # StreamRendering delivers the streaming render pipeline on the
+            # wrap_run_event_stream seam (its own hook — position inert); it
+            # only activates for runs that install a StreamObservation, so
+            # the streaming gate keeps working (see _stream_rendering.py).
             capabilities=[
                 *build_tool_output_limits(),
                 ProcessHistory(history_processor),
                 ProcessHistory(steer_processor),
                 build_response_clamp(),
                 build_model_message_transform(logical_agent_name),
+                StreamRendering(),
             ],
             model_settings=model_settings,
         )
@@ -700,10 +705,15 @@ def build_pydantic_agent(
     agent._last_model_name = resolved_model_name
     agent._mcp_servers = filtered_mcp_servers
 
+    # ``event_stream_handler=None``: streaming render now rides the
+    # StreamRendering capability on the agent itself, so wrappers (e.g. the
+    # DBOS plugin's DBOSAgent) no longer need a constructor-level fallback
+    # handler — the capability fires for their runs too. Mirrors the
+    # sub-agent invocation site, which has always passed ``None``.
     wrapped = on_wrap_pydantic_agent(
         agent,
         final_pydantic,
-        event_stream_handler=event_stream_handler,
+        event_stream_handler=None,
         message_group=message_group,
         kind="main",
     )

--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -72,7 +72,6 @@ from code_puppy.agents import _history, _key_listeners
 from code_puppy.agents._builder import build_pydantic_agent
 from code_puppy.agents._diagnostics import emit_exception_diagnostics
 from code_puppy.agents._non_streaming_render import (
-    StreamingTextDetector,
     render_result_without_streaming,
     should_render_fallback,
 )
@@ -84,6 +83,7 @@ from code_puppy.agents._run_signals import (
     reset_pause_state_at_run_start,
     sigint_should_cancel,
 )
+from code_puppy.agents._stream_rendering import stream_observation
 from code_puppy.agents.event_stream_handler import event_stream_handler
 from code_puppy.callbacks import (
     on_agent_exception,
@@ -721,23 +721,11 @@ async def _run_with_mcp_impl(
         """Run the agent once, then honour any plugin ``retry`` requests."""
         usage_limits = UsageLimits(request_limit=get_message_limit())
 
-        # Streaming gate (issue #295): off → no handler, render final result;
-        # on → wrap handler in a detector, fall back to one-shot render only
-        # if no text actually streamed.
+        # Streaming gate (issue #295): off → no streaming, render the final
+        # result one-shot; on → the agent's StreamRendering capability streams
+        # the run (observability capture + text detection included), and we
+        # fall back to the one-shot render only if no text actually streamed.
         use_streaming = get_enable_streaming()
-
-        async def _observed_event_stream_handler(ctx: Any, events: Any) -> Any:
-            from code_puppy.observability import capture_agent_context
-
-            capture_agent_context(group_id)
-            return await event_stream_handler(ctx, events)
-
-        detector: Optional[StreamingTextDetector] = (
-            StreamingTextDetector(_observed_event_stream_handler)
-            if use_streaming
-            else None
-        )
-        stream_handler = detector if detector is not None else None
         # Plugins (e.g. DBOS) can render their own output and skip the fallback.
         skip_fallback_render = on_should_skip_fallback_render(agent)
 
@@ -759,7 +747,6 @@ async def _run_with_mcp_impl(
                 prompt_to_use,
                 message_history=agent._message_history,
                 usage_limits=usage_limits,
-                event_stream_handler=stream_handler,
                 **kwargs,
             )
 
@@ -786,8 +773,6 @@ async def _run_with_mcp_impl(
                     await asyncio.sleep(retry_delay)
                 return await _call()
 
-        result = await _call_with_exception_recovery()
-
         # ``now``-mode steers are injected by make_steer_history_processor
         # (before every model call); ``queue``-mode ones drain between runs
         # below — additive, won't interrupt in-progress work.
@@ -798,52 +783,67 @@ async def _run_with_mcp_impl(
                     follow_up_prompt,
                     message_history=agent._message_history,
                     usage_limits=usage_limits,
-                    event_stream_handler=stream_handler,
                     **kwargs,
                 )
 
             return await _call_follow_up()
 
-        hook_retries_used = 0
-        queued_steers_used = 0
-        max_hook_retries = get_max_hook_retries()
-        max_queued_steers = 50  # safety cap to prevent runaway loops
+        # One observation spans the initial run and every follow-up, so
+        # ``streamed_text`` accumulates across the sequence exactly as the
+        # old shared StreamingTextDetector did. ``enabled`` keeps the
+        # streaming gate, with one deliberate carve-out: a plugin that
+        # renders its own output (skip_fallback_render, e.g. DBOS) used to
+        # stream regardless of the gate via its wrapper's constructor-level
+        # handler — the capability preserves that by enabling the stream for
+        # it here.
+        with stream_observation(
+            event_stream_handler,
+            group_id=group_id,
+            enabled=use_streaming or skip_fallback_render,
+        ) as observation:
+            result = await _call_with_exception_recovery()
 
-        while True:
-            # 1) Drain queue-mode steers FIRST (user-priority over hook retries).
-            if queued_steers_used < max_queued_steers:
-                steer_text = prepare_queued_steer_injection(agent, result)
-                if steer_text is not None:
-                    queued_steers_used += 1
-                    result = await _follow_up_run(steer_text)
-                    continue
+            hook_retries_used = 0
+            queued_steers_used = 0
+            max_hook_retries = get_max_hook_retries()
+            max_queued_steers = 50  # safety cap to prevent runaway loops
 
-            # 2) Plugin-requested hook retry (cap matches original loop).
-            if hook_retries_used >= max_hook_retries:
-                break
-            hook_results = await on_agent_run_result(
-                result,
-                agent_name=agent.name,
-                model_name=agent.get_model_name(),
-            )
-            retry_req = next(
-                (r for r in hook_results if isinstance(r, dict) and r.get("retry")),
-                None,
-            )
-            if not retry_req:
-                break
+            while True:
+                # 1) Drain queue-mode steers FIRST (user-priority over hook retries).
+                if queued_steers_used < max_queued_steers:
+                    steer_text = prepare_queued_steer_injection(agent, result)
+                    if steer_text is not None:
+                        queued_steers_used += 1
+                        result = await _follow_up_run(steer_text)
+                        continue
 
-            retry_prompt = retry_req.get("prompt", "Please continue.")
-            retry_delay = retry_req.get("delay", 1.0)
-            if hasattr(result, "all_messages"):
-                agent._message_history = list(result.all_messages())
-            await asyncio.sleep(retry_delay)
-            result = await _follow_up_run(retry_prompt)
-            hook_retries_used += 1
+                # 2) Plugin-requested hook retry (cap matches original loop).
+                if hook_retries_used >= max_hook_retries:
+                    break
+                hook_results = await on_agent_run_result(
+                    result,
+                    agent_name=agent.name,
+                    model_name=agent.get_model_name(),
+                )
+                retry_req = next(
+                    (r for r in hook_results if isinstance(r, dict) and r.get("retry")),
+                    None,
+                )
+                if not retry_req:
+                    break
+
+                retry_prompt = retry_req.get("prompt", "Please continue.")
+                retry_delay = retry_req.get("delay", 1.0)
+                if hasattr(result, "all_messages"):
+                    agent._message_history = list(result.all_messages())
+                await asyncio.sleep(retry_delay)
+                result = await _follow_up_run(retry_prompt)
+                hook_retries_used += 1
 
         # Fallback render when streaming didn't surface any text to the user.
         if result is not None and should_render_fallback(
-            detector, skip=skip_fallback_render
+            observation.detector if use_streaming else None,
+            skip=skip_fallback_render,
         ):
             render_result_without_streaming(result)
 

--- a/code_puppy/agents/_stream_rendering.py
+++ b/code_puppy/agents/_stream_rendering.py
@@ -1,0 +1,161 @@
+"""Streaming render delivery via the pydantic-ai capability seam.
+
+Historically the streaming pipeline reached pydantic-ai as a per-run
+``event_stream_handler=`` kwarg: ``_runtime._do_run`` (main agent) and
+``subagent_invocation`` (invoke_agent tool) each picked a handler, wrapped it
+in a ``StreamingTextDetector``, and passed it to every ``run()`` call. This
+module promotes that delivery to a first-class capability,
+:class:`StreamRendering`, using pydantic-ai's ``wrap_run_event_stream`` seam
+(via the stock ``ProcessEventStream`` observer, which tees events to the
+handler while passing them through unchanged).
+
+The seam is static but the state is per-run, so the two meet through a
+context-local :class:`StreamObservation`:
+
+* The **caller** (``_do_run`` / ``_invoke_agent``) installs an observation
+  with :func:`stream_observation` around its ``run()`` calls. The observation
+  carries the handler to drive, the observability ``group_id`` to capture,
+  and whether streaming is enabled for this run sequence.
+* The **capability** resolves the observation once per run in ``for_run``.
+  With no observation (or streaming disabled) it resolves to an inert
+  capability that does *not* override ``wrap_run_event_stream`` — pydantic-ai
+  then keeps the run non-streamed, exactly as passing no handler did.
+* ``streamed_text`` accumulates across every run under one observation
+  (initial run + steer/hook follow-ups share the detector, as the old shared
+  ``StreamingTextDetector`` instance did), so the caller's fallback-render
+  decision after the loop is unchanged.
+
+The observation rides a ``ContextVar``: ``asyncio.create_task`` snapshots the
+context, so a sub-agent run launched as a task sees the observation installed
+by its invoker, and a nested invocation's own observation shadows the outer
+one only within that task.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterator, Optional
+
+from pydantic_ai import RunContext
+from pydantic_ai.capabilities import AbstractCapability, ProcessEventStream
+
+from code_puppy.agents._non_streaming_render import StreamingTextDetector
+
+
+@dataclass
+class StreamObservation:
+    """Run-scoped streaming state shared between a caller and the capability.
+
+    ``handler`` is the event-stream consumer to drive (the main renderer, the
+    sub-agent silencer, ...). ``group_id``, when set, is captured into the
+    observability context before the handler runs — mirroring the old
+    ``_observed_event_stream_handler`` wrapper. ``enabled=False`` records the
+    streaming gate: the capability resolves inert and the run stays
+    non-streamed.
+    """
+
+    handler: Callable[..., Any]
+    group_id: Optional[str] = None
+    enabled: bool = True
+    _detector: StreamingTextDetector = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        async def _observed(ctx: Any, events: Any) -> Any:
+            if self.group_id is not None:
+                from code_puppy.observability import capture_agent_context
+
+                capture_agent_context(self.group_id)
+            return await self.handler(ctx, events)
+
+        self._detector = StreamingTextDetector(_observed)
+
+    @property
+    def streamed_text(self) -> bool:
+        """Whether any run under this observation streamed visible text."""
+        return self._detector.streamed_text
+
+    @property
+    def detector(self) -> StreamingTextDetector:
+        """The detector-wrapped handler the capability delivers per run.
+
+        Doubles as the ``should_render_fallback`` detector argument — the
+        detector is both the event-stream consumer and the streamed-text
+        flag-holder, exactly as it was under the per-run kwarg.
+        """
+        return self._detector
+
+
+_current_observation: ContextVar[Optional[StreamObservation]] = ContextVar(
+    "code_puppy_stream_observation", default=None
+)
+
+
+def current_stream_observation() -> Optional[StreamObservation]:
+    """Return the observation installed for the current context, if any."""
+    return _current_observation.get()
+
+
+@contextmanager
+def stream_observation(
+    handler: Callable[..., Any],
+    *,
+    group_id: Optional[str] = None,
+    enabled: bool = True,
+) -> Iterator[StreamObservation]:
+    """Install a fresh :class:`StreamObservation` for the enclosed run(s).
+
+    Yields the observation so the caller can read ``streamed_text`` after the
+    runs complete (the object stays valid past the ``with`` block; only the
+    context-local registration is reverted).
+    """
+    observation = StreamObservation(handler=handler, group_id=group_id, enabled=enabled)
+    token = _current_observation.set(observation)
+    try:
+        yield observation
+    finally:
+        _current_observation.reset(token)
+
+
+# Shared inert resolution for gated-off runs. A plain ``AbstractCapability``
+# does not override ``wrap_run_event_stream``, so pydantic-ai keeps the run
+# non-streamed — byte-for-byte the old "no event_stream_handler" behaviour.
+# Stateless, so one instance is safe to share across concurrent runs.
+_INERT = AbstractCapability()
+
+
+@dataclass
+class StreamRendering(AbstractCapability[Any]):
+    """Deliver the run's event-stream handler through the capability seam.
+
+    Stateless at rest: everything per-run lives on the
+    :class:`StreamObservation` resolved in :meth:`for_run`. Attaching this
+    capability to an agent therefore does NOT force streaming on its own —
+    only runs whose caller installed an enabled observation stream (pydantic-ai
+    checks ``has_wrap_run_event_stream`` on the *resolved* run capability).
+    """
+
+    async def for_run(self, ctx: RunContext[Any]) -> AbstractCapability[Any]:
+        observation = current_stream_observation()
+        if observation is None or not observation.enabled:
+            return _INERT
+        # ``ProcessEventStream`` (observer form) tees each node's events to
+        # the handler while passing them through unchanged — the same view the
+        # old per-run ``event_stream_handler`` kwarg consumed, with delivery
+        # back-pressure preserved (a paused handler stalls the stream).
+        return ProcessEventStream(observation.detector)
+
+    @classmethod
+    def get_serialization_name(cls) -> Optional[str]:
+        # Resolution depends on ambient context-local state; a spec cannot
+        # meaningfully reconstruct it.
+        return None
+
+
+__all__ = [
+    "StreamObservation",
+    "StreamRendering",
+    "current_stream_observation",
+    "stream_observation",
+]

--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -1527,6 +1527,12 @@ def on_wrap_pydantic_agent(
     interface) or ``None`` to leave the agent unchanged. The last non-``None``
     result wins.
 
+    ``event_stream_handler`` is kept for signature compatibility but core now
+    passes ``None`` for both kinds: streaming render is delivered by the
+    ``StreamRendering`` capability on the pydantic agent itself (see
+    ``code_puppy/agents/_stream_rendering.py``), so it fires for wrapped
+    agents' runs too — wrappers no longer need a constructor-level handler.
+
     Returns the (possibly wrapped) agent. Always returns something — falls
     back to the input ``pydantic_agent`` if no plugin handled it.
     """

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -404,6 +404,10 @@ async def _invoke_agent_impl(
             from code_puppy.agents._model_message_transform import (
                 build_model_message_transform,
             )
+            from code_puppy.agents._stream_rendering import (
+                StreamRendering,
+                stream_observation,
+            )
 
             # Build the pydantic-ai agent. MCP servers always included; plugins
             # (e.g. DBOS) may swap them via the agent_run_context hook.
@@ -420,9 +424,13 @@ async def _invoke_agent_impl(
                 toolsets=mcp_servers,
                 # ProcessHistory capability replaces the deprecated
                 # `history_processors=` kwarg (removed in pydantic-ai v2).
+                # StreamRendering delivers the sub-agent's stream handler
+                # (silencer or inline renderer) via the observation installed
+                # around the run below.
                 capabilities=[
                     ProcessHistory(make_history_processor(agent_config)),
                     build_model_message_transform(agent_name),
+                    StreamRendering(),
                 ],
                 model_settings=model_settings,
             )
@@ -445,29 +453,29 @@ async def _invoke_agent_impl(
             )
 
             # subagent_stream_handler silences sub-agent output (aggregated
-            # dashboard); high mode streams it inline via a StreamingTextDetector,
+            # dashboard); high mode streams it inline via the main renderer,
             # falling back to one-shot render if no text tokens were emitted.
+            # Either way the handler reaches the run through the temp agent's
+            # StreamRendering capability, which resolves the observation
+            # installed below (asyncio.create_task snapshots the context, so
+            # the run task sees it).
             from code_puppy.config import get_output_level
 
             is_high_mode = get_output_level() == "high"
-            streaming_detector = None
 
             if is_high_mode:
-                from code_puppy.agents._non_streaming_render import (
-                    StreamingTextDetector,
-                )
                 from code_puppy.agents.event_stream_handler import (
                     event_stream_handler as _main_stream_handler,
                 )
 
-                streaming_detector = StreamingTextDetector(_main_stream_handler)
-                stream_handler = streaming_detector
+                stream_handler = _main_stream_handler
             else:
                 stream_handler = partial(subagent_stream_handler, session_id=session_id)
 
             with (
                 subagent_context(agent_name, effective_model_name),
                 executing_agent_context(agent_config),
+                stream_observation(stream_handler) as observation,
             ):
                 run_ctxs = on_agent_run_context(
                     agent_config, temp_agent, group_id, mcp_servers
@@ -498,7 +506,6 @@ async def _invoke_agent_impl(
                             prompt,
                             message_history=agent_config.get_message_history(),
                             usage_limits=UsageLimits(request_limit=get_message_limit()),
-                            event_stream_handler=stream_handler,
                         )
 
                     # Time the full run (incl. retries) so duration_ms reflects real
@@ -534,10 +541,7 @@ async def _invoke_agent_impl(
                 # Still inside subagent_context: if high mode and streaming
                 # didn't produce any text, fall back to the one-shot renderer
                 # so the user always sees the response.
-                streamed_text = (
-                    streaming_detector is not None and streaming_detector.streamed_text
-                )
-                if is_high_mode and not streamed_text:
+                if is_high_mode and not observation.streamed_text:
                     from code_puppy.agents._non_streaming_render import (
                         render_result_without_streaming,
                     )
@@ -560,8 +564,12 @@ async def _invoke_agent_impl(
             )
 
             # Emit via MessageBus; skip in high mode when streaming already
-            # rendered the response (avoids future double-render).
-            if emit_response_message and not (is_high_mode and streamed_text):
+            # rendered the response (avoids future double-render). The
+            # observation object outlives its with-block; only the
+            # context-local registration was reverted.
+            if emit_response_message and not (
+                is_high_mode and observation.streamed_text
+            ):
                 bus.emit(
                     SubAgentResponseMessage(
                         agent_name=agent_name,

--- a/tests/agents/test_stream_rendering_capability.py
+++ b/tests/agents/test_stream_rendering_capability.py
@@ -55,6 +55,16 @@ def _stream_only_model(text: str = "woof woof") -> FunctionModel:
     return FunctionModel(stream_function=stream_fn)
 
 
+def _chunked_stream_model(*chunks: str) -> FunctionModel:
+    """A stream-only model that emits each chunk as its own delta."""
+
+    async def stream_fn(_messages, _info: AgentInfo):
+        for chunk in chunks:
+            yield chunk
+
+    return FunctionModel(stream_function=stream_fn)
+
+
 def _request_only_model(text: str = "plain") -> FunctionModel:
     """A model that can ONLY answer non-streamed requests."""
 
@@ -242,6 +252,120 @@ async def test_observation_propagates_into_created_task():
     result = await task
     assert result.output == "woof woof"
     assert observation.streamed_text is True
+
+
+async def test_handler_sees_deltas_in_stream_order():
+    # ProcessEventStream must not reorder the observed view — the renderer
+    # depends on deltas arriving exactly as the model produced them.
+    seen: list = []
+
+    async def handler(_ctx, events):
+        async for event in events:
+            if isinstance(event, PartDeltaEvent):
+                seen.append(event.delta.content_delta)
+            elif isinstance(event, PartStartEvent):
+                seen.append(event.part.content)
+
+    agent = Agent(
+        model=_chunked_stream_model("al", "pha ", "bra", "vo"),
+        output_type=str,
+        capabilities=[StreamRendering()],
+    )
+    with stream_observation(handler):
+        result = await agent.run("hi")
+
+    assert result.output == "alpha bravo"
+    assert "".join(seen) == "alpha bravo"
+
+
+async def test_early_returning_handler_does_not_stall_the_run():
+    # An observer that bails after one event must not block the node stream
+    # (pydantic-ai keeps forwarding; the old direct-consumption path drained
+    # leftovers the same way).
+    received: list = []
+
+    async def one_and_done(_ctx, events):
+        async for event in events:
+            received.append(event)
+            return
+
+    agent = Agent(
+        model=_chunked_stream_model("never", " gonna", " give"),
+        output_type=str,
+        capabilities=[StreamRendering()],
+    )
+    with stream_observation(one_and_done):
+        result = await agent.run("hi")
+
+    assert result.output == "never gonna give"
+    assert len(received) == 1
+
+
+async def test_raising_handler_propagates_to_the_run():
+    # Parity with the per-run kwarg: a handler crash must surface, not be
+    # swallowed into a silent render-less run.
+    class HandlerBoom(Exception):
+        pass
+
+    async def explode(_ctx, events):
+        async for _event in events:
+            raise HandlerBoom("boom")
+
+    agent = Agent(
+        model=_stream_only_model(),
+        output_type=str,
+        capabilities=[StreamRendering()],
+    )
+    with stream_observation(explode):
+        try:
+            await agent.run("hi")
+        except* HandlerBoom:
+            propagated = True
+        else:
+            propagated = False
+    assert propagated
+
+
+async def test_nested_subagent_observation_shadows_and_restores():
+    # The sub-agent topology: an outer (main-run) observation, an inner one
+    # installed for the delegate, the delegate run launched via create_task,
+    # and the outer observation restored — with each handler seeing only its
+    # own run's events.
+    outer_seen: list = []
+    inner_seen: list = []
+
+    async def outer_handler(_ctx, events):
+        async for event in events:
+            outer_seen.append(event)
+
+    async def inner_handler(_ctx, events):
+        async for event in events:
+            inner_seen.append(event)
+
+    outer_agent = Agent(
+        model=_stream_only_model("outer text"),
+        output_type=str,
+        capabilities=[StreamRendering()],
+    )
+    inner_agent = Agent(
+        model=_stream_only_model("inner text"),
+        output_type=str,
+        capabilities=[StreamRendering()],
+    )
+
+    with stream_observation(outer_handler) as outer_observation:
+        with stream_observation(inner_handler) as inner_observation:
+            task = asyncio.create_task(inner_agent.run("delegate"))
+        assert current_stream_observation() is outer_observation
+        inner_result = await task
+        outer_result = await outer_agent.run("main")
+
+    assert inner_result.output == "inner text"
+    assert outer_result.output == "outer text"
+    assert inner_observation.streamed_text is True
+    assert outer_observation.streamed_text is True
+    assert inner_seen and outer_seen
+    assert not (set(map(id, inner_seen)) & set(map(id, outer_seen)))
 
 
 async def test_detector_ignores_non_text_events():

--- a/tests/agents/test_stream_rendering_capability.py
+++ b/tests/agents/test_stream_rendering_capability.py
@@ -1,0 +1,399 @@
+"""Contract tests for the ``StreamRendering`` capability.
+
+The streaming render pipeline used to reach pydantic-ai as a per-run
+``event_stream_handler=`` kwarg; it now rides the ``wrap_run_event_stream``
+capability seam, resolved per run against a context-local
+``StreamObservation``. These tests pin the contract:
+
+* no observation (or a disabled one) resolves inert, so the run stays
+  non-streamed — the streaming gate's old "no handler" behaviour;
+* an enabled observation streams the run, drives the handler with the run's
+  events, records ``streamed_text``, and captures the observability group;
+* state accumulates across sequential runs under one observation (the
+  steer/hook follow-up loop shares one detector);
+* the observation propagates into ``asyncio.create_task`` (the sub-agent
+  invocation pattern);
+* both construction sites attach the capability, and the main build no
+  longer hands the raw handler to the ``wrap_pydantic_agent`` hook.
+"""
+
+import asyncio
+from contextlib import ExitStack, contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from pydantic_ai import Agent, PartDeltaEvent, PartStartEvent, RunContext
+from pydantic_ai.capabilities import ProcessEventStream
+from pydantic_ai.messages import (
+    ModelResponse,
+    TextPart,
+    ThinkingPart,
+    ThinkingPartDelta,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.test import TestModel
+
+from code_puppy.agents._stream_rendering import (
+    StreamObservation,
+    StreamRendering,
+    current_stream_observation,
+    stream_observation,
+)
+
+
+async def _consume(_ctx, events):
+    async for _event in events:
+        pass
+
+
+def _stream_only_model(text: str = "woof woof") -> FunctionModel:
+    """A model that can ONLY stream — a non-streamed request would raise."""
+
+    async def stream_fn(_messages, _info: AgentInfo):
+        yield text
+
+    return FunctionModel(stream_function=stream_fn)
+
+
+def _request_only_model(text: str = "plain") -> FunctionModel:
+    """A model that can ONLY answer non-streamed requests."""
+
+    def fn(_messages, _info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[TextPart(content=text)])
+
+    return FunctionModel(fn)
+
+
+# ---------------------------------------------------------------------------
+# StreamObservation context plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_stream_observation_installs_and_restores():
+    assert current_stream_observation() is None
+    with stream_observation(_consume) as outer:
+        assert current_stream_observation() is outer
+        with stream_observation(_consume) as inner:
+            assert current_stream_observation() is inner
+        assert current_stream_observation() is outer
+    assert current_stream_observation() is None
+
+
+def test_stream_observation_restores_on_error():
+    try:
+        with stream_observation(_consume):
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    assert current_stream_observation() is None
+
+
+def test_observation_outlives_its_context_block():
+    with stream_observation(_consume) as observation:
+        pass
+    # streamed_text stays readable after the registration is reverted — the
+    # runtime reads it for the fallback-render decision after the run loop.
+    assert observation.streamed_text is False
+
+
+# ---------------------------------------------------------------------------
+# for_run resolution
+# ---------------------------------------------------------------------------
+
+
+async def test_for_run_resolves_inert_without_observation():
+    resolved = await StreamRendering().for_run(None)
+    assert not resolved.has_wrap_run_event_stream
+
+
+async def test_for_run_resolves_inert_when_disabled():
+    with stream_observation(_consume, enabled=False):
+        resolved = await StreamRendering().for_run(None)
+    assert not resolved.has_wrap_run_event_stream
+
+
+async def test_for_run_delivers_the_observation_detector():
+    with stream_observation(_consume) as observation:
+        resolved = await StreamRendering().for_run(None)
+    assert isinstance(resolved, ProcessEventStream)
+    assert resolved.handler is observation.detector
+    assert resolved.has_wrap_run_event_stream
+
+
+def test_stream_rendering_is_not_spec_constructible():
+    assert StreamRendering.get_serialization_name() is None
+
+
+def test_stream_rendering_alone_does_not_force_streaming():
+    # The static capability must not trip pydantic-ai's "streaming needed"
+    # check — only the per-run resolution may.
+    assert not StreamRendering().has_wrap_run_event_stream
+
+
+# ---------------------------------------------------------------------------
+# Run behaviour through a real pydantic-ai agent
+# ---------------------------------------------------------------------------
+
+
+async def test_run_stays_non_streamed_without_observation():
+    # A request-only model would raise UserError if the capability forced
+    # streaming mode; a clean run proves the inert path.
+    agent = Agent(
+        model=_request_only_model(),
+        output_type=str,
+        capabilities=[StreamRendering()],
+    )
+    result = await agent.run("hi")
+    assert result.output == "plain"
+
+
+async def test_run_stays_non_streamed_when_observation_disabled():
+    agent = Agent(
+        model=_request_only_model(),
+        output_type=str,
+        capabilities=[StreamRendering()],
+    )
+    with stream_observation(_consume, enabled=False) as observation:
+        result = await agent.run("hi")
+    assert result.output == "plain"
+    assert observation.streamed_text is False
+
+
+async def test_enabled_observation_streams_and_drives_handler():
+    seen: list = []
+    contexts: list = []
+
+    async def handler(ctx, events):
+        contexts.append(ctx)
+        async for event in events:
+            seen.append(event)
+
+    # A stream-only model proves the run actually streamed: a non-streamed
+    # request against it would raise.
+    agent = Agent(
+        model=_stream_only_model("woof woof"),
+        output_type=str,
+        capabilities=[StreamRendering()],
+    )
+    with stream_observation(handler) as observation:
+        result = await agent.run("hi")
+
+    assert result.output == "woof woof"
+    assert seen, "handler should observe the run's stream events"
+    assert all(isinstance(ctx, RunContext) for ctx in contexts)
+    assert observation.streamed_text is True
+
+
+async def test_group_id_is_captured_into_observability_context(monkeypatch):
+    captured: list = []
+    monkeypatch.setattr(
+        "code_puppy.observability.capture_agent_context", captured.append
+    )
+    agent = Agent(
+        model=_stream_only_model(),
+        output_type=str,
+        capabilities=[StreamRendering()],
+    )
+    with stream_observation(_consume, group_id="grp-42"):
+        await agent.run("hi")
+    assert captured
+    assert set(captured) == {"grp-42"}
+
+
+async def test_no_group_id_skips_observability_capture(monkeypatch):
+    captured: list = []
+    monkeypatch.setattr(
+        "code_puppy.observability.capture_agent_context", captured.append
+    )
+    agent = Agent(
+        model=_stream_only_model(),
+        output_type=str,
+        capabilities=[StreamRendering()],
+    )
+    with stream_observation(_consume):
+        await agent.run("hi")
+    assert captured == []
+
+
+async def test_streamed_text_accumulates_across_sequential_runs():
+    agent = Agent(
+        model=_stream_only_model(),
+        output_type=str,
+        capabilities=[StreamRendering()],
+    )
+    with stream_observation(_consume) as observation:
+        await agent.run("one")
+        assert observation.streamed_text is True
+        await agent.run("two")
+        assert observation.streamed_text is True
+
+
+async def test_observation_propagates_into_created_task():
+    # subagent_invocation launches the run via asyncio.create_task; the task's
+    # context snapshot must carry the observation even though the with-block
+    # exits before the await completes.
+    agent = Agent(
+        model=_stream_only_model(),
+        output_type=str,
+        capabilities=[StreamRendering()],
+    )
+    with stream_observation(_consume) as observation:
+        task = asyncio.create_task(agent.run("hi"))
+    result = await task
+    assert result.output == "woof woof"
+    assert observation.streamed_text is True
+
+
+async def test_detector_ignores_non_text_events():
+    observation = StreamObservation(handler=_consume)
+
+    async def thinking_only():
+        yield PartStartEvent(index=0, part=ThinkingPart(content="pondering"))
+        yield PartDeltaEvent(index=0, delta=ThinkingPartDelta(content_delta="..."))
+
+    await observation.detector(None, thinking_only())
+    assert observation.streamed_text is False
+
+
+# ---------------------------------------------------------------------------
+# Construction sites
+# ---------------------------------------------------------------------------
+
+
+class _AgentConfig:
+    """Duck-typed BaseAgent stand-in (pattern shared with builder tests)."""
+
+    def __init__(self):
+        self._message_history = []
+        self._compacted_message_hashes = set()
+        self._puppy_rules = None
+        self.name = "code-puppy"
+
+    @contextmanager
+    def temporary_model_name_override(self, _model_name):
+        yield
+
+    def get_model_name(self):
+        return "test-model"
+
+    def get_full_system_prompt(self):
+        return "Test instructions"
+
+    def get_available_tools(self):
+        return []
+
+    def get_message_history(self):
+        return self._message_history
+
+    def set_message_history(self, history):
+        self._message_history = history
+
+    def __getattr__(self, item):
+        if item.startswith("__"):
+            raise AttributeError(item)
+        return lambda *_args, **_kwargs: 0
+
+
+def _load_test_model(*_args, **_kwargs):
+    return TestModel(custom_output_text="woof"), "test-model"
+
+
+def _builder_patches(_builder):
+    return (
+        patch.object(_builder, "load_model_with_fallback", _load_test_model),
+        patch.object(_builder.ModelFactory, "load_config", staticmethod(dict)),
+        patch.object(_builder, "load_mcp_servers", lambda **_kwargs: []),
+        patch.object(_builder, "make_model_settings", lambda *_args, **_kwargs: None),
+        patch(
+            "code_puppy.tools.register_tools_for_agent", lambda *_args, **_kwargs: None
+        ),
+    )
+
+
+async def test_main_agent_build_attaches_stream_rendering():
+    from code_puppy.agents import _builder
+
+    config = _AgentConfig()
+    seen: list = []
+
+    async def handler(_ctx, events):
+        async for event in events:
+            seen.append(event)
+
+    with ExitStack() as stack:
+        for patcher in _builder_patches(_builder):
+            stack.enter_context(patcher)
+        built = _builder.build_pydantic_agent(config)
+
+        # Without an observation the built agent must not stream...
+        await built.run("start")
+        assert seen == []
+
+        # ...and with one, the capability delivers the handler.
+        with stream_observation(handler) as observation:
+            await built.run("again")
+
+    assert seen
+    assert observation.streamed_text is True
+
+
+async def test_main_build_wrap_hook_no_longer_receives_the_handler():
+    from code_puppy.agents import _builder
+
+    captured: dict = {}
+
+    def capture_wrap(_agent, pydantic_agent, **kwargs):
+        captured.update(kwargs)
+        return pydantic_agent
+
+    with ExitStack() as stack:
+        for patcher in _builder_patches(_builder):
+            stack.enter_context(patcher)
+        stack.enter_context(
+            patch.object(_builder, "on_wrap_pydantic_agent", capture_wrap)
+        )
+        _builder.build_pydantic_agent(_AgentConfig())
+
+    assert captured["kind"] == "main"
+    assert captured["event_stream_handler"] is None
+
+
+def _leaves(capability):
+    children = getattr(capability, "capabilities", None)
+    if children is None:
+        yield capability
+        return
+    for child in children:
+        yield from _leaves(child)
+
+
+async def test_subagent_build_attaches_stream_rendering():
+    from code_puppy.tools import subagent_invocation as si
+
+    cfg = _AgentConfig()
+    cfg.name = "web-retriever"
+    captured: dict = {}
+
+    def capture_wrap(_agent_config, pydantic_agent, **_kwargs):
+        captured["agent"] = pydantic_agent
+        return pydantic_agent
+
+    with (
+        patch("code_puppy.agents.agent_manager.load_agent", return_value=cfg),
+        patch(
+            "code_puppy.agents._builder.load_model_with_fallback",
+            _load_test_model,
+        ),
+        patch("code_puppy.model_factory.make_model_settings", lambda *a, **k: None),
+        patch("code_puppy.config.get_value", return_value="true"),  # no MCP
+        patch.object(si, "on_wrap_pydantic_agent", capture_wrap),
+    ):
+        out = await si._invoke_agent_impl(
+            context=SimpleNamespace(),
+            agent_name="web-retriever",
+            prompt="fetch me a stick",
+        )
+
+    assert out.error is None
+    leaves = list(_leaves(captured["agent"]._root_capability))
+    assert any(isinstance(leaf, StreamRendering) for leaf in leaves)

--- a/tests/messaging/test_high_mode_audit.py
+++ b/tests/messaging/test_high_mode_audit.py
@@ -458,13 +458,19 @@ class TestChecklist4_SubagentInline:
     """In high mode, subagent_invocation uses the main event_stream_handler."""
 
     def test_high_mode_selects_main_handler(self):
-        """Code path verified: high mode wraps main handler in StreamingTextDetector."""
+        """Code path verified: high mode hands the main handler to the run.
+
+        Text detection moved into the ``StreamObservation`` installed around
+        the run; the handler reaches pydantic-ai via the ``StreamRendering``
+        capability instead of a per-run kwarg.
+        """
         import inspect
 
         from code_puppy.tools import subagent_invocation
 
         source = inspect.getsource(subagent_invocation)
-        assert "StreamingTextDetector" in source
+        assert "stream_observation" in source
+        assert "StreamRendering" in source
         assert 'is_high_mode = get_output_level() == "high"' in source
         assert "event_stream_handler as _main_stream_handler" in source
 


### PR DESCRIPTION
## What

Eighth in the capability series (#828 `SteerInjection`, #829 `HistoryCompaction`, #830 `PluginMessageTransform`, #831 `PerModelSettings`, #832 `AssembledInstructions`, #833 `ResolvedModel`, #834 `McpToolsets`): the **streaming render pipeline** no longer reaches pydantic-ai as a per-run `event_stream_handler=` kwarg. It is now a first-class capability, `StreamRendering`, on the `wrap_run_event_stream` seam.

## The problem this seam poses

Unlike the previous seven, this seam is **static-vs-per-run**: overriding `wrap_run_event_stream` makes pydantic-ai force streaming mode for *every* run, while code_puppy's streaming state is inherently per-run — the gate (`get_enable_streaming()`), the observability `group_id`, and the `StreamingTextDetector` whose `streamed_text` flag the runtime reads *after* the run to decide on the one-shot fallback render.

The two meet through a context-local **`StreamObservation`** (`code_puppy/agents/_stream_rendering.py`):

- The caller (`_do_run` / `_invoke_agent_impl`) installs an observation around its run(s): handler, `group_id`, `enabled`.
- `StreamRendering.for_run` resolves it once per run. No observation, or a disabled one → an **inert** capability that does *not* override the seam, so pydantic-ai keeps the run non-streamed (`has_wrap_run_event_stream` is checked on the *resolved* run capability — verified against installed 2.31.0 source). The static class never trips the streaming check (pinned by test).
- Enabled → the stock **`ProcessEventStream`** observer delivers the detector-wrapped handler: tee semantics, synchronous delivery, so the pause gate's back-pressure and handler-exception propagation match the old direct-consumption behaviour.
- One observation spans the initial run **and** every steer/hook follow-up, so `streamed_text` accumulates across the sequence exactly as the old shared detector did.
- `asyncio.create_task` snapshots the context, so the sub-agent run task sees the observation installed by its invoker (pinned by test).

## Feature-parity checklist

-  Streaming gate off → non-streamed model requests + one-shot fallback render (a request-only `FunctionModel` proves no streaming is forced)
-  Gate on → same handler, same per-node invocation, same observability capture (`capture_agent_context(group_id)`), same text detection
-  Sub-agent path: silencer (low/medium) vs inline main renderer (high), fallback render + `SubAgentResponseMessage` double-render guard unchanged
-  DBOS: `DBOSAgent` runs get rendering from the capability (durable base explicitly applies `wrap_run_event_stream` workflow-side — same replayed-model-events semantics as the per-run kwarg it replaces)
-  ACP / plugins driving `run_with_mcp`: observation installed inside `_do_run`, nothing to change

## Two honest divergences, both deliberate

1. **`on_wrap_pydantic_agent` now receives `event_stream_handler=None` for `kind="main"`** (the sub-agent site always passed `None`). The hook signature is unchanged; the docstring documents it. Sole known reader is the DBOS plugin, which used the handler as a constructor-level fallback on `DBOSAgent` — redundant now that the capability fires for wrapped agents' runs (and previously it could double-render if kept).
2. **The DBOS gate carve-out is now explicit.** Today, with streaming *off* under DBOS, runs still streamed — an emergent effect of the constructor-level fallback handler winning via `self.event_stream_handler`. That behaviour is preserved on purpose: `_do_run` enables the observation when `use_streaming or skip_fallback_render` (a plugin that skips the fallback render *is* declaring the stream its output path). Without this, DBOS + gate-off would render nothing.

`get_serialization_name() → None` (resolution depends on ambient context-local state; series precedent for non-spec-constructible capabilities).

## Tests

23 contract tests in `tests/agents/test_stream_rendering_capability.py`: context install/restore (incl. error paths and post-block reads), `for_run` resolution (inert/no-observation, inert/disabled, `ProcessEventStream` bound to the observation's detector), non-streamed-run preservation, handler delivery + `RunContext`, observability capture (and its absence without a `group_id`), `streamed_text` accumulation across sequential runs, create_task context propagation, non-text event detection, both construction sites, and the hook-contract change.

One existing test updated: the high-mode audit checklist pinned the old `StreamingTextDetector` wiring in `subagent_invocation` — now pins the capability delivery.

Full suite: **7597 passed**; the single red (`test_render_version_check_current`) fails identically with this branch's changes stashed — pre-existing on main.

## Heads-up

Eighth PR touching the shared `capabilities=[...]` blocks in `_builder.py` + `subagent_invocation.py` — whichever of #828–#835 lands last inherits trivial rebases.

**Do not merge yet** — awaiting review.

