### PR TITLE
feat: promote native tool delivery to a NativeTools capability

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -650,7 +650,11 @@ def build_pydantic_agent(
     # filtering no longer needs a throwaway probe build. (The old two-pass
     # probe introspected ``probe_agent._tools`` -- an attribute pydantic-ai
     # v2 removed -- so the filter had silently become a no-op; sourcing
-    # names from the toolset repairs it.)
+    # names from the toolset repairs it.) Scope: NATIVE tool names only.
+    # Tools contributed by other capabilities (e.g. ToolOutputLimits'
+    # ``read_tool_result``) are not in the set -- an MCP tool shadowing one
+    # of those still collides at run time, exactly as it would have under
+    # the original probe's intent.
     existing_tool_names: Set[str] = set(native_toolset.tools)
     filtered_mcp_servers = filter_conflicting_mcp_tools(
         mcp_servers, existing_tool_names

--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -20,6 +20,7 @@ from pydantic_ai.capabilities import ProcessHistory
 
 from code_puppy.agents._compaction import make_history_processor
 from code_puppy.agents._model_message_transform import build_model_message_transform
+from code_puppy.agents._native_tools import NativeTools, build_native_toolset
 from code_puppy.agents._output_limits import (
     build_response_clamp,
     build_tool_output_limits,
@@ -615,14 +616,13 @@ def build_pydantic_agent(
     - ``agent._code_generation_agent`` ← same as ``pydantic_agent``
     - ``agent._mcp_servers``          ← MCP toolsets (post-filter)
 
-    The build happens in two passes: we construct once with ``toolsets=[]`` so
-    we can introspect registered tool names, then rebuild with MCP servers
-    filtered against those names to prevent collisions. Plugins may wrap the
-    final pydantic agent via the ``wrap_pydantic_agent`` hook (e.g. to swap
-    in a durable-exec wrapper).
+    Native tools are delivered via the ``NativeTools`` capability
+    (``get_toolset()`` seam) rather than post-construction ``@agent.tool``
+    registration, so the toolset's tool names are known up front and MCP
+    servers can be collision-filtered without a throwaway probe build.
+    Plugins may wrap the final pydantic agent via the ``wrap_pydantic_agent``
+    hook (e.g. to swap in a durable-exec wrapper).
     """
-    from code_puppy.tools import register_tools_for_agent
-
     agent._puppy_rules = None
     message_group = message_group or str(uuid.uuid4())
 
@@ -640,60 +640,54 @@ def build_pydantic_agent(
     steer_processor = make_steer_history_processor(agent)
     logical_agent_name = getattr(agent, "name", None) or agent.__class__.__name__
 
-    def _new_pydantic_agent(toolsets: List[Any]) -> PydanticAgent:
-        return PydanticAgent(
-            model=model,
-            # Explicit name: without it pydantic-ai infers one from the
-            # caller's frame variables, so observability spans read
-            # "invoke_agent pydantic_agent" instead of the logical agent name.
-            name=logical_agent_name,
-            instructions=instructions,
-            output_type=output_type,
-            retries=3,
-            toolsets=toolsets,
-            # Order matters: compaction first (may trim history to fit
-            # context), THEN steer injection (a fresh steer must not be
-            # compacted away). ProcessHistory capabilities apply in
-            # registration order (replaces the deprecated
-            # `history_processors=` kwarg, removed in pydantic-ai v2).
-            # ToolOutputLimits reduces oversized tool returns on a different
-            # hook (after_tool_execute), so its position is inert; the
-            # response clamp runs before_model_request after both history
-            # processors. The plugin transform wraps the final model request.
-            capabilities=[
-                *build_tool_output_limits(),
-                ProcessHistory(history_processor),
-                ProcessHistory(steer_processor),
-                build_response_clamp(),
-                build_model_message_transform(logical_agent_name),
-            ],
-            model_settings=model_settings,
-        )
-
-    # Pass 1: build with empty toolsets so we can see what pydantic-ai + our
-    # tool registry actually produced, and filter MCP to avoid name clashes.
-    probe_agent = _new_pydantic_agent(toolsets=[])
-    agent_tools = agent.get_available_tools()
-    register_tools_for_agent(
-        probe_agent,
-        agent_tools,
+    native_toolset = build_native_toolset(
+        agent.get_available_tools(),
         model_name=resolved_model_name,
         agent_name=logical_agent_name,
     )
 
-    existing_tool_names: Set[str] = set(getattr(probe_agent, "_tools", {}) or {})
+    # The native toolset knows its own tool names up front, so MCP collision
+    # filtering no longer needs a throwaway probe build. (The old two-pass
+    # probe introspected ``probe_agent._tools`` -- an attribute pydantic-ai
+    # v2 removed -- so the filter had silently become a no-op; sourcing
+    # names from the toolset repairs it.)
+    existing_tool_names: Set[str] = set(native_toolset.tools)
     filtered_mcp_servers = filter_conflicting_mcp_tools(
         mcp_servers, existing_tool_names
     )
 
-    # Pass 2: real build. MCP servers always go in the constructor; plugins
-    # (e.g. DBOS) may swap them at run time via ``agent_run_context``.
-    final_pydantic = _new_pydantic_agent(toolsets=filtered_mcp_servers)
-    register_tools_for_agent(
-        final_pydantic,
-        agent_tools,
-        model_name=resolved_model_name,
-        agent_name=logical_agent_name,
+    # MCP servers always go in the constructor; plugins (e.g. DBOS) may swap
+    # them at run time via ``agent_run_context``.
+    final_pydantic = PydanticAgent(
+        model=model,
+        # Explicit name: without it pydantic-ai infers one from the
+        # caller's frame variables, so observability spans read
+        # "invoke_agent pydantic_agent" instead of the logical agent name.
+        name=logical_agent_name,
+        instructions=instructions,
+        output_type=output_type,
+        retries=3,
+        toolsets=filtered_mcp_servers,
+        # Order matters: compaction first (may trim history to fit
+        # context), THEN steer injection (a fresh steer must not be
+        # compacted away). ProcessHistory capabilities apply in
+        # registration order (replaces the deprecated
+        # `history_processors=` kwarg, removed in pydantic-ai v2).
+        # ToolOutputLimits reduces oversized tool returns on a different
+        # hook (after_tool_execute), so its position is inert; the
+        # response clamp runs before_model_request after both history
+        # processors. The plugin transform wraps the final model request.
+        # NativeTools is a pure configuration seam (get_toolset), so its
+        # position is inert too.
+        capabilities=[
+            NativeTools(native_toolset),
+            *build_tool_output_limits(),
+            ProcessHistory(history_processor),
+            ProcessHistory(steer_processor),
+            build_response_clamp(),
+            build_model_message_transform(logical_agent_name),
+        ],
+        model_settings=model_settings,
     )
 
     agent.cur_model = model
@@ -724,8 +718,6 @@ def build_tool_probe_for_agent(agent: Any) -> Optional[Any]:
     caching the result; this is a non-trivial construction even with the
     shortcuts.
     """
-    from code_puppy.tools import register_tools_for_agent
-
     try:
         models_config = ModelFactory.load_config()
         model, resolved_model_name = load_model_with_fallback(
@@ -738,15 +730,20 @@ def build_tool_probe_for_agent(agent: Any) -> Optional[Any]:
         return None
 
     try:
+        # Same delivery mechanics as the real build: tools ride a
+        # FunctionToolset. Passed straight through ``toolsets=`` here (the
+        # probe is deliberately capability-free) -- schema counting only
+        # needs the toolset's tool dict, which is identical either way.
         probe = PydanticAgent(
             model=model,
             instructions="",
             output_type=str,
             retries=1,
-            toolsets=[],
-        )
-        register_tools_for_agent(
-            probe, agent.get_available_tools(), model_name=resolved_model_name
+            toolsets=[
+                build_native_toolset(
+                    agent.get_available_tools(), model_name=resolved_model_name
+                )
+            ],
         )
     except Exception:
         return None

--- a/code_puppy/agents/_native_tools.py
+++ b/code_puppy/agents/_native_tools.py
@@ -1,0 +1,82 @@
+"""Native tool delivery as a first-class pydantic-ai capability.
+
+Code Puppy's own tools (file ops, shell, sub-agent invocation, browser,
+plugin-contributed extras, ...) were historically bolted onto the constructed
+``pydantic_ai.Agent`` *after* the fact, via ``@agent.tool`` registration in
+``code_puppy.tools.register_tools_for_agent``. pydantic-ai's capability
+system has a dedicated seam for exactly this contribution --
+``AbstractCapability.get_toolset()`` -- so the tool suite now arrives as a
+:class:`NativeTools` capability instead of post-construction surgery.
+
+Registration mechanics are deliberately unchanged: every ``register_*``
+function in ``code_puppy.tools`` only ever uses the ``.tool`` decorator on
+the object it is handed, and ``pydantic_ai.toolsets.FunctionToolset.tool``
+is signature-identical to ``Agent.tool``. :func:`build_native_toolset`
+therefore just points the existing registry at a ``FunctionToolset`` -- all
+registry semantics (plugin tool merging, ``edit_file`` expansion,
+kill-switches, per-model filtering, UC wrappers) live in
+``register_tools_for_agent``, untouched.
+
+Per-tool retry budgets are also unchanged: both registration paths leave
+``max_retries=None`` on each tool, which pydantic-ai resolves to the
+agent-level ``retries`` at ``get_tools`` time (``FunctionToolset.get_tools``
+falls back to ``ctx.max_retries``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional, Sequence
+
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.toolsets import FunctionToolset
+
+
+def build_native_toolset(
+    tool_names: Sequence[str],
+    model_name: Optional[str] = None,
+    agent_name: Optional[str] = None,
+) -> FunctionToolset:
+    """Register ``tool_names`` from the tool registry onto a fresh toolset.
+
+    Delegates to ``register_tools_for_agent`` -- imported at call time so
+    test patches on ``code_puppy.tools`` still apply -- which only ever uses
+    the ``.tool`` decorator on what it is given: historically an ``Agent``,
+    here a ``FunctionToolset``. When tools are globally disabled
+    (``--no-tools``) or every registration is filtered out, the returned
+    toolset is simply empty.
+    """
+    from code_puppy.tools import register_tools_for_agent
+
+    toolset: FunctionToolset = FunctionToolset()
+    register_tools_for_agent(
+        toolset,
+        list(tool_names),
+        model_name=model_name,
+        agent_name=agent_name,
+    )
+    return toolset
+
+
+@dataclass
+class NativeTools(AbstractCapability[Any]):
+    """Deliver code_puppy's registered tool suite via ``get_toolset()``.
+
+    A pure configuration-seam capability: its position in the agent's
+    ``capabilities=[...]`` list is inert, and it carries no per-run state.
+    """
+
+    toolset: FunctionToolset
+
+    def get_toolset(self) -> Optional[FunctionToolset]:
+        # An agent with nothing registered (``--no-tools``, or a test that
+        # stubbed registration out) contributes no toolset at all, keeping
+        # the run's toolset chain identical to the old post-construction
+        # registration path (which likewise added nothing).
+        return self.toolset if self.toolset.tools else None
+
+    @classmethod
+    def get_serialization_name(cls) -> Optional[str]:
+        # Built from the live tool registry (plugins included) -- not
+        # spec-constructible. Same opt-out as SteerInjection & friends.
+        return None

--- a/code_puppy/agents/_native_tools.py
+++ b/code_puppy/agents/_native_tools.py
@@ -11,11 +11,13 @@ system has a dedicated seam for exactly this contribution --
 Registration mechanics are deliberately unchanged: every ``register_*``
 function in ``code_puppy.tools`` only ever uses the ``.tool`` decorator on
 the object it is handed, and ``pydantic_ai.toolsets.FunctionToolset.tool``
-is signature-identical to ``Agent.tool``. :func:`build_native_toolset`
-therefore just points the existing registry at a ``FunctionToolset`` -- all
-registry semantics (plugin tool merging, ``edit_file`` expansion,
-kill-switches, per-model filtering, UC wrappers) live in
-``register_tools_for_agent``, untouched.
+accepts the same arguments as ``Agent.tool`` (their default *spellings*
+differ -- ``None`` vs concrete values like ``"auto"`` -- but resolve to
+equivalent model-visible tool definitions; pinned by the wire-parity
+contract test). :func:`build_native_toolset` therefore just points the
+existing registry at a ``FunctionToolset`` -- all registry semantics
+(plugin tool merging, ``edit_file`` expansion, kill-switches, per-model
+filtering, UC wrappers) live in ``register_tools_for_agent``, untouched.
 
 Per-tool retry budgets are also unchanged: both registration paths leave
 ``max_retries=None`` on each tool, which pydantic-ai resolves to the

--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -72,6 +72,12 @@ def _extract_pydantic_agent_tools(pyd_agent: Any) -> Optional[Dict[str, Any]]:
     back to the direct ``agent._function_toolset`` read, then the legacy
     ``agent._tools`` attribute, so older pydantic-ai versions (and mocked
     agents in tests) still work. Returns ``None`` when nothing is populated.
+
+    Deliberately broad: any ``FunctionToolset``-shaped constructor toolset
+    is included too, which could in principle double-count with the
+    separate ``mcp_servers=`` estimator input -- acceptable slack for a
+    best-effort context-overhead estimate (real MCP servers are not
+    ``FunctionToolset``s).
     """
     if pyd_agent is None:
         return None

--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -43,20 +43,53 @@ should_retry_streaming_exception = should_retry_streaming
 __all__ = ["BaseAgent", "should_retry_streaming_exception"]
 
 
+def _iter_function_toolsets(node: Any):
+    """Yield every ``FunctionToolset`` reachable from a toolset ``node``.
+
+    Capability-delivered toolsets (``NativeTools`` via ``get_toolset()``)
+    surface on the agent's public ``toolsets`` property wrapped in
+    ``CombinedToolset``/``CapabilityOwnedToolset`` chains; combined nodes
+    expose ``.toolsets`` and wrapper nodes expose ``.wrapped``. Recurse
+    through both.
+    """
+    from pydantic_ai.toolsets import FunctionToolset
+
+    if isinstance(node, FunctionToolset):
+        yield node
+    for child in getattr(node, "toolsets", None) or []:
+        yield from _iter_function_toolsets(child)
+    wrapped = getattr(node, "wrapped", None)
+    if wrapped is not None:
+        yield from _iter_function_toolsets(wrapped)
+
+
 def _extract_pydantic_agent_tools(pyd_agent: Any) -> Optional[Dict[str, Any]]:
     """Return the registered tool dict for a pydantic-ai agent, or None.
 
-    Handles the modern shape (``agent._function_toolset.tools``) and falls
-    back to the legacy ``agent._tools`` attribute so older pydantic-ai
-    versions still work. Returns ``None`` when neither is populated.
+    Walks the agent's public ``toolsets`` property, which covers both the
+    internal function toolset (legacy ``@agent.tool`` registration) and the
+    ``NativeTools`` capability toolset (``get_toolset()`` delivery). Falls
+    back to the direct ``agent._function_toolset`` read, then the legacy
+    ``agent._tools`` attribute, so older pydantic-ai versions (and mocked
+    agents in tests) still work. Returns ``None`` when nothing is populated.
     """
     if pyd_agent is None:
         return None
+    tools: Dict[str, Any] = {}
+    try:
+        for node in getattr(pyd_agent, "toolsets", None) or []:
+            for fts in _iter_function_toolsets(node):
+                tools.update(getattr(fts, "tools", None) or {})
+    except Exception:
+        # Best-effort estimator input -- fall through to the direct reads.
+        tools = {}
+    if tools:
+        return tools
     fts = getattr(pyd_agent, "_function_toolset", None)
     if fts is not None:
-        tools = getattr(fts, "tools", None)
-        if tools:
-            return tools
+        direct = getattr(fts, "tools", None)
+        if direct:
+            return direct
     legacy = getattr(pyd_agent, "_tools", None)
     return legacy or None
 

--- a/code_puppy/tools/__init__.py
+++ b/code_puppy/tools/__init__.py
@@ -187,7 +187,11 @@ def register_tools_for_agent(
     """Register specific tools for an agent based on tool names.
 
     Args:
-        agent: The agent to register tools to.
+        agent: The registration target. Anything exposing a pydantic-ai
+            ``.tool`` decorator works: historically a ``pydantic_ai.Agent``,
+            now typically a ``pydantic_ai.toolsets.FunctionToolset`` (see
+            ``code_puppy.agents._native_tools.build_native_toolset``, which
+            delivers the result via the ``NativeTools`` capability).
         tool_names: List of tool names to register. UC tools are prefixed with "uc:".
         model_name: Optional model name. Used to determine if certain tools
             (like agent_share_your_reasoning) should be skipped. If None,

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -404,6 +404,10 @@ async def _invoke_agent_impl(
             from code_puppy.agents._model_message_transform import (
                 build_model_message_transform,
             )
+            from code_puppy.agents._native_tools import (
+                NativeTools,
+                build_native_toolset,
+            )
 
             # Build the pydantic-ai agent. MCP servers always included; plugins
             # (e.g. DBOS) may swap them via the agent_run_context hook.
@@ -420,19 +424,20 @@ async def _invoke_agent_impl(
                 toolsets=mcp_servers,
                 # ProcessHistory capability replaces the deprecated
                 # `history_processors=` kwarg (removed in pydantic-ai v2).
+                # NativeTools delivers the sub-agent's tool suite via the
+                # get_toolset() capability seam (replaces post-construction
+                # @agent.tool registration; position in this list is inert).
                 capabilities=[
+                    NativeTools(
+                        build_native_toolset(
+                            agent_config.get_available_tools(),
+                            model_name=effective_model_name,
+                        )
+                    ),
                     ProcessHistory(make_history_processor(agent_config)),
                     build_model_message_transform(agent_name),
                 ],
                 model_settings=model_settings,
-            )
-
-            # Register the tools that the agent needs
-            from code_puppy.tools import register_tools_for_agent
-
-            agent_tools = agent_config.get_available_tools()
-            register_tools_for_agent(
-                temp_agent, agent_tools, model_name=effective_model_name
             )
 
             # Allow plugins to wrap the agent (e.g. DBOS durable-exec wrapper).

--- a/tests/agents/test_native_tools_capability.py
+++ b/tests/agents/test_native_tools_capability.py
@@ -141,8 +141,12 @@ def test_serialization_name_opt_out():
 
 
 def test_tool_metadata_parity_with_agent_tool_registration():
-    """``Agent.tool`` and ``FunctionToolset.tool`` must produce identical
-    per-tool metadata for the same register function."""
+    """``Agent.tool`` and ``FunctionToolset.tool`` produce equivalent
+    per-tool metadata for the same register function.
+
+    (The two decorators' default *spellings* differ -- ``None`` vs concrete
+    values -- but resolve identically; the wire-parity test below pins the
+    model-visible result.)"""
     from code_puppy.tools.file_operations import register_read_file
 
     legacy_agent = Agent(model=None, retries=3)
@@ -159,6 +163,43 @@ def test_tool_metadata_parity_with_agent_tool_registration():
     # ``retries`` at get_tools time -- the retry-parity linchpin.
     assert legacy_tool.max_retries is None
     assert cap_tool.max_retries is None
+
+
+@pytest.mark.asyncio
+async def test_wire_parity_with_agent_tool_registration():
+    """The model-visible ToolDefinition is identical whichever path
+    registered the tool -- the strongest possible parity claim.
+
+    Provenance bookkeeping (``toolset_id``/``capability_id``) legitimately
+    differs -- the tool now honestly reports it arrived via the capability
+    -- and is never serialized into the model request, so it is normalized
+    out before comparing."""
+    import dataclasses
+
+    from code_puppy.tools.file_operations import register_read_file
+
+    def _visible_tool_def(model):
+        tool_def = next(
+            t
+            for t in model.last_model_request_parameters.function_tools
+            if t.name == "read_file"
+        )
+        return dataclasses.replace(tool_def, toolset_id=None, capability_id=None)
+
+    legacy_model = TestModel(custom_output_text="woof", call_tools=[])
+    legacy_agent = Agent(model=legacy_model, retries=3)
+    register_read_file(legacy_agent)
+    await legacy_agent.run("hi")
+
+    cap_model = TestModel(custom_output_text="woof", call_tools=[])
+    cap_agent = Agent(
+        model=cap_model,
+        retries=3,
+        capabilities=[NativeTools(build_native_toolset(["read_file"]))],
+    )
+    await cap_agent.run("hi")
+
+    assert _visible_tool_def(legacy_model) == _visible_tool_def(cap_model)
 
 
 @pytest.mark.asyncio

--- a/tests/agents/test_native_tools_capability.py
+++ b/tests/agents/test_native_tools_capability.py
@@ -1,0 +1,318 @@
+"""Contract tests for the ``NativeTools`` capability.
+
+Pins the promotion of native tool delivery from post-construction
+``@agent.tool`` registration (``register_tools_for_agent(pydantic_agent, ...)``)
+to a first-class pydantic-ai capability riding the ``get_toolset()`` seam.
+
+Feature-parity checklist covered here:
+
+- registry semantics (expansion, unknown-tool skip) flow through unchanged,
+  because ``build_native_toolset`` delegates to ``register_tools_for_agent``;
+- per-tool schema/retry metadata is identical between the old and new
+  registration targets (``Agent.tool`` vs ``FunctionToolset.tool``);
+- capability-delivered tools genuinely dispatch through ``Agent.run()``;
+- the builder delivers tools ONLY via the capability (the agent's internal
+  function toolset stays empty -- the one observable divergence);
+- MCP collision filtering now works off the native toolset's names (the old
+  probe introspected ``probe_agent._tools``, removed in pydantic-ai v2, so
+  the filter had silently become a no-op);
+- ``_extract_pydantic_agent_tools`` (context-overhead estimators) finds
+  tools in both the capability shape and the legacy shape.
+"""
+
+from contextlib import ExitStack, contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.toolsets import FunctionToolset
+
+from code_puppy.agents._native_tools import NativeTools, build_native_toolset
+from code_puppy.agents.base_agent import _extract_pydantic_agent_tools
+
+
+class _FakeAgentConfig:
+    """Minimal BaseAgent-shaped config for driving the real build paths."""
+
+    name = "test-puppy"
+    display_name = "Test Puppy"
+
+    def __init__(self, tools=None):
+        self._message_history = []
+        self._compacted_message_hashes = set()
+        self._puppy_rules = None
+        self._tools = list(tools or [])
+
+    @contextmanager
+    def temporary_model_name_override(self, _model_name):
+        yield
+
+    def get_model_name(self):
+        return "test-model"
+
+    def get_full_system_prompt(self):
+        return "You are a test agent."
+
+    def get_available_tools(self):
+        return list(self._tools)
+
+    def get_message_history(self):
+        return self._message_history
+
+    def set_message_history(self, history):
+        self._message_history = history
+
+    def __getattr__(self, item):
+        # Misc numeric config probes used by history processors.
+        if item.startswith("__"):
+            raise AttributeError(item)
+        return lambda *a, **k: 0
+
+
+def _fake_load_model_with_fallback(*_args, **_kwargs):
+    return TestModel(custom_output_text="woof", call_tools=[]), "test-model"
+
+
+@contextmanager
+def _builder_patches(*extra):
+    from code_puppy.agents import _builder
+
+    patches = (
+        patch.object(
+            _builder, "load_model_with_fallback", _fake_load_model_with_fallback
+        ),
+        patch.object(_builder.ModelFactory, "load_config", staticmethod(dict)),
+        patch.object(_builder, "make_model_settings", lambda *a, **k: None),
+        *extra,
+    )
+    with ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        yield
+
+
+# ---------------------------------------------------------------------------
+# build_native_toolset: registry semantics ride through unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_build_native_toolset_registers_requested_tools():
+    toolset = build_native_toolset(["read_file", "list_files"])
+    assert "read_file" in toolset.tools
+    assert "list_files" in toolset.tools
+
+
+def test_edit_file_expansion_preserved():
+    """The deprecated compound tool expands; the original is not registered."""
+    toolset = build_native_toolset(["edit_file"])
+    assert "edit_file" not in toolset.tools
+    for expanded in ("create_file", "replace_in_file", "delete_snippet"):
+        assert expanded in toolset.tools
+
+
+def test_unknown_tool_skipped_not_raised():
+    toolset = build_native_toolset(["__no_such_tool__", "read_file"])
+    assert "read_file" in toolset.tools
+    assert "__no_such_tool__" not in toolset.tools
+
+
+# ---------------------------------------------------------------------------
+# NativeTools contract
+# ---------------------------------------------------------------------------
+
+
+def test_get_toolset_returns_toolset_when_populated():
+    toolset = build_native_toolset(["read_file"])
+    cap = NativeTools(toolset)
+    assert cap.get_toolset() is toolset
+
+
+def test_get_toolset_inert_when_empty():
+    """A tool-less agent contributes no toolset at all -- same chain as the
+    old registration path, which likewise added nothing."""
+    cap = NativeTools(FunctionToolset())
+    assert cap.get_toolset() is None
+
+
+def test_serialization_name_opt_out():
+    assert NativeTools.get_serialization_name() is None
+
+
+def test_tool_metadata_parity_with_agent_tool_registration():
+    """``Agent.tool`` and ``FunctionToolset.tool`` must produce identical
+    per-tool metadata for the same register function."""
+    from code_puppy.tools.file_operations import register_read_file
+
+    legacy_agent = Agent(model=None, retries=3)
+    register_read_file(legacy_agent)
+    toolset = build_native_toolset(["read_file"])
+
+    legacy_tool = legacy_agent._function_toolset.tools["read_file"]
+    cap_tool = toolset.tools["read_file"]
+
+    assert legacy_tool.name == cap_tool.name
+    assert legacy_tool.description == cap_tool.description
+    assert legacy_tool.takes_ctx == cap_tool.takes_ctx
+    # Both leave the per-tool budget unset, deferring to the agent-level
+    # ``retries`` at get_tools time -- the retry-parity linchpin.
+    assert legacy_tool.max_retries is None
+    assert cap_tool.max_retries is None
+
+
+@pytest.mark.asyncio
+async def test_capability_tool_dispatches_through_agent_run():
+    """Real framework dispatch: a capability-delivered tool executes."""
+    calls = []
+    toolset = FunctionToolset()
+
+    @toolset.tool
+    def fetch_stick(ctx: RunContext, length: int) -> str:
+        """Fetch a stick of the given length."""
+        calls.append(length)
+        return f"stick[{length}]"
+
+    agent = Agent(
+        model=TestModel(),
+        retries=3,
+        capabilities=[NativeTools(toolset)],
+    )
+    result = await agent.run("fetch!")
+    assert calls, "capability-delivered tool was never executed"
+    assert "stick[" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Builder integration: main-agent path
+# ---------------------------------------------------------------------------
+
+
+def test_builder_delivers_tools_via_capability_only():
+    from code_puppy.agents import _builder
+
+    cfg = _FakeAgentConfig(tools=["read_file"])
+    with _builder_patches(patch.object(_builder, "load_mcp_servers", lambda **k: [])):
+        built = _builder.build_pydantic_agent(cfg)
+
+    # The one observable divergence, pinned: the agent's internal function
+    # toolset stays empty; tools live in the capability toolset.
+    assert built._function_toolset.tools == {}
+    extracted = _extract_pydantic_agent_tools(built)
+    assert extracted is not None and "read_file" in extracted
+
+
+@pytest.mark.asyncio
+async def test_builder_collision_filter_hides_mcp_duplicate():
+    """MCP tools shadowing native names are filtered; unique ones survive.
+
+    On main the filter was inert (``probe_agent._tools`` no longer exists in
+    pydantic-ai v2), so a genuine collision would have raised a conflict
+    error at run time. Sourcing names from the native toolset restores the
+    documented behaviour.
+    """
+    from code_puppy.agents import _builder
+
+    mcp_like = FunctionToolset()
+
+    @mcp_like.tool
+    def read_file(ctx: RunContext, path: str) -> str:
+        """Colliding MCP tool -- must be hidden."""
+        return "mcp"
+
+    @mcp_like.tool
+    def unique_mcp_tool(ctx: RunContext) -> str:
+        """Non-colliding MCP tool -- must stay visible."""
+        return "mcp"
+
+    cfg = _FakeAgentConfig(tools=["read_file"])
+    with _builder_patches(
+        patch.object(_builder, "load_mcp_servers", lambda **k: [mcp_like])
+    ):
+        built = _builder.build_pydantic_agent(cfg)
+
+    model = TestModel(custom_output_text="woof", call_tools=[])
+    result = await built.run("hi", model=model)
+    assert result.output == "woof"
+
+    visible = [t.name for t in model.last_model_request_parameters.function_tools]
+    # Membership (not equality): harness capabilities contribute their own
+    # tools (e.g. ToolOutputLimits' read_tool_result).
+    assert "unique_mcp_tool" in visible
+    # Exactly one read_file: the native one; the MCP shadow was filtered
+    # (a surviving duplicate would have raised before we got here).
+    assert visible.count("read_file") == 1
+
+
+def test_probe_builder_tools_countable():
+    """The stripped probe used by context estimators still exposes tools."""
+    from code_puppy.agents import _builder
+
+    cfg = _FakeAgentConfig(tools=["read_file", "list_files"])
+    with _builder_patches():
+        probe = _builder.build_tool_probe_for_agent(cfg)
+
+    assert probe is not None
+    extracted = _extract_pydantic_agent_tools(probe)
+    assert extracted is not None
+    assert {"read_file", "list_files"} <= set(extracted)
+
+
+# ---------------------------------------------------------------------------
+# Builder integration: sub-agent path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_subagent_path_delivers_tools_via_capability():
+    from code_puppy.tools import subagent_invocation as si
+
+    cfg = _FakeAgentConfig(tools=["read_file"])
+    captured = {}
+
+    def capture_wrap(_agent_config, pydantic_agent, **_kwargs):
+        captured["agent"] = pydantic_agent
+        return pydantic_agent
+
+    with (
+        patch("code_puppy.agents.agent_manager.load_agent", return_value=cfg),
+        patch(
+            "code_puppy.agents._builder.load_model_with_fallback",
+            _fake_load_model_with_fallback,
+        ),
+        patch("code_puppy.model_factory.make_model_settings", lambda *a, **k: None),
+        patch("code_puppy.config.get_value", return_value="true"),  # no MCP
+        patch.object(si, "on_wrap_pydantic_agent", capture_wrap),
+    ):
+        out = await si._invoke_agent_impl(
+            context=SimpleNamespace(),
+            agent_name="test-puppy",
+            prompt="fetch me a stick",
+        )
+
+    assert out.error is None
+    built = captured["agent"]
+    assert built._function_toolset.tools == {}
+    extracted = _extract_pydantic_agent_tools(built)
+    assert extracted is not None and "read_file" in extracted
+
+
+# ---------------------------------------------------------------------------
+# _extract_pydantic_agent_tools: both shapes
+# ---------------------------------------------------------------------------
+
+
+def test_extractor_still_handles_legacy_agent_tool_registration():
+    agent = Agent(model=None, retries=3)
+
+    @agent.tool
+    def legacy_tool(ctx: RunContext, x: int) -> str:
+        """A tool registered the old way."""
+        return str(x)
+
+    extracted = _extract_pydantic_agent_tools(agent)
+    assert extracted is not None and "legacy_tool" in extracted
+
+
+def test_extractor_none_for_none_agent():
+    assert _extract_pydantic_agent_tools(None) is None


### PR DESCRIPTION
## What

Ninth in the capability series (#828–#835). Promotes **native tool delivery** — Code Puppy's own tool suite (file ops, shell, sub-agent invocation, browser, plugin extras, UC wrappers) — from post-construction `@agent.tool` registration onto the constructed `pydantic_ai.Agent`, to a first-class **`NativeTools`** capability on the `get_toolset()` seam.

New module: `code_puppy/agents/_native_tools.py`
- `build_native_toolset(tool_names, model_name, agent_name)` — points the *existing* registry at a `FunctionToolset`. Zero changes to `register_tools_for_agent`: every `register_*` function only ever uses the `.tool` decorator, and `FunctionToolset.tool` is **argument-compatible** with `Agent.tool` (default spellings differ; resolved model-visible tool definitions are equivalent — pinned by a wire-parity test). All registry semantics (plugin tool merging, `edit_file` expansion, kill-switches, per-model filtering) live where they always did.
- `@dataclass NativeTools(AbstractCapability[Any])` — delivers the toolset via `get_toolset()`; returns `None` when empty (tool-less agents contribute nothing, same chain as before); `get_serialization_name() -> None` (built from the live registry — not spec-constructible, series precedent).

Both construction sites converted: `_builder.build_pydantic_agent` (+ the stripped tool probe) and `tools/subagent_invocation.py`.

## Feature-parity notes

- **Retry budgets unchanged:** both registration paths leave per-tool `max_retries=None`, which pydantic-ai resolves to the agent-level `retries=3` at `get_tools` time. Pinned by test.
- **Two-pass probe build deleted — and it was hiding a bug.** Pass 1 existed solely to introspect `probe_agent._tools` for MCP collision filtering; pydantic-ai v2 removed that attribute, so `existing_tool_names` was always `∅` and `filter_conflicting_mcp_tools` had silently become a no-op (a real collision would have raised a toolset-conflict error at run time). The native toolset knows its names up front, so filtering now works as documented again. Pinned by an end-to-end test (MCP shadow of `read_file` hidden; unique MCP tool survives).
- **One observable divergence:** the built agent's internal `_function_toolset` is now empty — tools ride the capability toolset (`CombinedToolset`/`CapabilityOwnedToolset` chain on the public `toolsets` property, the exact traversal #834 verified DBOS-transparent). The only readers were the context-overhead estimators via `_extract_pydantic_agent_tools`, which now walks the public `toolsets` property (covers both shapes) before falling back to the legacy reads. No core-plugin reads the old location (audited).
- Sub-agent site keeps its exact old call shape (`agent_name` not passed → plugin per-agent extras unchanged).

## Tests

14 contract tests in `tests/agents/test_native_tools_capability.py`: registry semantics ride-through (expansion, unknown-tool skip), capability contract (populated/empty/serialization), tool-metadata parity between `Agent.tool` and `FunctionToolset.tool`, real dispatch through `Agent.run()`, builder + sub-agent integration (divergence pins), repaired collision filter end-to-end, probe countability, extractor on both shapes.

Full suite: **7592 passed**; the single red (`test_render_version_check_current`) is pre-existing on main — verified failing with these changes stashed. `ruff check` + `ruff format` clean.

## Not merged on purpose

Per series protocol — awaiting human review. Note this PR grazes the same two `capabilities=[...]` blocks as #828–#835; whoever lands last inherits the (trivial) rebases.

---
**Review round 1** (code-puppy clone): APPROVE with 2 non-blocking findings + 1 nit — all addressed in `13e4d24b` (claim precision + wire-parity test; collision-set scope + extractor breadth documented).
