### PR TITLE
test: align version check regression test with quiet renderer

### DIFF
--- a/tests/messaging/test_rich_renderer.py
+++ b/tests/messaging/test_rich_renderer.py
@@ -670,7 +670,7 @@ def test_render_version_check_current(renderer, console):
     )
     renderer._render_version_check(msg)
     out = output(console)
-    assert "latest" in out
+    assert out == ""
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary

The renderer intentionally stopped printing a message when the installed version is current, but the corresponding test still expected the old `latest` text. Update the test to assert that the current-version path emits no output.

## Validation

- `pytest --no-cov -q tests/messaging/test_rich_renderer.py` — 91 passed
- `ruff check tests/messaging/test_rich_renderer.py` — passed

This fixes the failure in the post-merge publish CI run: https://github.com/mpfaffenberger/code_puppy/actions/runs/32527980980