### PR TITLE
feat: deliver Logfire tracing as an explicit Instrumentation capability

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -19,6 +19,7 @@ from pydantic_ai import Agent as PydanticAgent
 from pydantic_ai.capabilities import ProcessHistory
 
 from code_puppy.agents._compaction import make_history_processor
+from code_puppy.agents._instrumentation import build_instrumentation
 from code_puppy.agents._model_message_transform import build_model_message_transform
 from code_puppy.agents._output_limits import (
     build_response_clamp,
@@ -660,7 +661,12 @@ def build_pydantic_agent(
             # hook (after_tool_execute), so its position is inert; the
             # response clamp runs before_model_request after both history
             # processors. The plugin transform wraps the final model request.
+            # Instrumentation declares its own 'outermost' ordering, so its
+            # list position is inert too — empty unless logfire is live (see
+            # _instrumentation.py; the run-layer fallback covers agents built
+            # before configure_logfire ran).
             capabilities=[
+                *build_instrumentation(),
                 *build_tool_output_limits(),
                 ProcessHistory(history_processor),
                 ProcessHistory(steer_processor),

--- a/code_puppy/agents/_instrumentation.py
+++ b/code_puppy/agents/_instrumentation.py
@@ -1,0 +1,85 @@
+"""OpenTelemetry/Logfire tracing as a first-class pydantic-ai capability.
+
+Historically, opting into observability (``observability.configure_logfire``)
+called ``logfire.instrument_pydantic_ai()``, which sets the *process-global*
+``Agent.instrument_all(settings)`` default. Every agent run then received an
+``Instrumentation`` capability injected by pydantic-ai's run layer.
+
+This module promotes that implicit delivery to an explicit one for the agents
+code_puppy itself constructs: :func:`build_instrumentation` snapshots the
+effective global settings at build time and returns a stock
+:class:`pydantic_ai.capabilities.Instrumentation` capability carrying the
+*same* ``InstrumentationSettings`` object logfire installed. The run layer
+skips its own injection when an explicit ``Instrumentation`` capability is
+present ("explicit-capability-wins"), so spans are identical — same settings,
+same tracer provider, same ``outermost`` ordering (``Instrumentation.
+get_ordering()`` sorts it outermost regardless of list position).
+
+**The global default is deliberately NOT removed.** Two reasons:
+
+1. Out-of-tree agents. Plugins construct their own raw pydantic-ai agents
+   (e.g. wiggum's judge, btw's side-query) and get spans purely from
+   ``Agent.instrument_all``. Dropping the global would silently kill their
+   telemetry.
+2. ``ctx.tracer`` consistency. pydantic-ai resolves the run context's tracer
+   from the *global/instance* settings, independent of explicit capabilities.
+   Keeping both in sync means capabilities and toolsets observing
+   ``ctx.tracer`` see the real tracer, never a ``NoOpTracer``.
+
+Observable divergence (documented + pinned by tests): the capability is a
+build-time snapshot, while the global default is read per run. If something
+called ``Agent.instrument_all(False)`` *after* an agent was built, that agent
+would keep tracing until rebuilt (previously it would go quiet on the next
+run). Nothing in code_puppy or its plugins flips the default after startup —
+``configure_logfire`` runs once, before the first agent build. The inverse
+direction degrades to exact old behaviour: an agent built *before* logfire
+configuration carries no capability, so the run-layer fallback instruments it
+from the global default just like before.
+
+``Agent._instrument_default`` is private, but it is the only source of the
+exact settings object logfire installed — re-deriving settings here would
+duplicate logfire's shim and drift. pydantic-ai's own ``direct.py`` reads the
+same attribute. A contract test pins the attribute name so a pydantic-ai bump
+that renames it fails loudly; at runtime a missing attribute degrades to "no
+explicit capability", which the run-layer fallback covers.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from pydantic_ai import Agent as PydanticAgent
+from pydantic_ai.capabilities import Instrumentation
+
+
+def _effective_default_settings():
+    """Resolve the effective global instrumentation settings, or ``None``.
+
+    Mirrors ``Agent._resolve_instrumentation_settings`` for the class-level
+    default: ``False``/unset → ``None``; ``True`` → default-constructed
+    ``InstrumentationSettings``; otherwise the installed settings object
+    itself (what ``logfire.instrument_pydantic_ai()`` put there).
+    """
+    instrument = getattr(PydanticAgent, "_instrument_default", False)
+    if not instrument:
+        return None
+    if instrument is True:
+        from pydantic_ai.models.instrumented import InstrumentationSettings
+
+        return InstrumentationSettings()
+    return instrument
+
+
+def build_instrumentation() -> List[Instrumentation]:
+    """Return the explicit tracing capability for one agent construction.
+
+    Returns a single-element list when the process has been instrumented
+    (``configure_logfire`` opted in), else an empty list — splat it into the
+    ``capabilities=[...]`` block. List position is inert: the capability
+    declares ``position='outermost'`` ordering, exactly where the run layer
+    would have injected it.
+    """
+    settings = _effective_default_settings()
+    if settings is None:
+        return []
+    return [Instrumentation(settings=settings)]

--- a/code_puppy/agents/_instrumentation.py
+++ b/code_puppy/agents/_instrumentation.py
@@ -21,10 +21,12 @@ get_ordering()`` sorts it outermost regardless of list position).
    (e.g. wiggum's judge, btw's side-query) and get spans purely from
    ``Agent.instrument_all``. Dropping the global would silently kill their
    telemetry.
-2. ``ctx.tracer`` consistency. pydantic-ai resolves the run context's tracer
-   from the *global/instance* settings, independent of explicit capabilities.
-   Keeping both in sync means capabilities and toolsets observing
-   ``ctx.tracer`` see the real tracer, never a ``NoOpTracer``.
+2. ``ctx.tracer`` consistency. In the classic ``run``/``iter`` path,
+   pydantic-ai resolves the run context's tracer from the *global/instance*
+   settings before explicit capabilities are considered (realtime sessions
+   additionally consult an explicit capability's settings — same object
+   here either way). Keeping both in sync means capabilities and toolsets
+   observing ``ctx.tracer`` see the real tracer, never a ``NoOpTracer``.
 
 Observable divergence (documented + pinned by tests): the capability is a
 build-time snapshot, while the global default is read per run. If something

--- a/code_puppy/observability.py
+++ b/code_puppy/observability.py
@@ -41,6 +41,13 @@ def configure_logfire() -> bool:
     Returns True when instrumentation is live. A missing package or a
     misconfiguration must never break the CLI, so every failure path
     emits a warning and returns False instead of raising.
+
+    ``logfire.instrument_pydantic_ai()`` installs the process-global
+    ``Agent.instrument_all`` default. Agents code_puppy builds afterwards
+    additionally declare tracing as an explicit ``Instrumentation``
+    capability carrying the same settings (see
+    ``code_puppy.agents._instrumentation``); the global default remains the
+    fallback for out-of-tree agents (e.g. plugin-built ones).
     """
     global _logfire_active
     _logfire_active = False

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -401,6 +401,7 @@ async def _invoke_agent_impl(
                 mcp_servers = manager.get_servers_for_agent(agent_name=bound_agent_name)
 
             from code_puppy.agents._compaction import make_history_processor
+            from code_puppy.agents._instrumentation import build_instrumentation
             from code_puppy.agents._model_message_transform import (
                 build_model_message_transform,
             )
@@ -420,7 +421,10 @@ async def _invoke_agent_impl(
                 toolsets=mcp_servers,
                 # ProcessHistory capability replaces the deprecated
                 # `history_processors=` kwarg (removed in pydantic-ai v2).
+                # Instrumentation is empty unless logfire is live and sorts
+                # itself outermost regardless of position (_instrumentation.py).
                 capabilities=[
+                    *build_instrumentation(),
                     ProcessHistory(make_history_processor(agent_config)),
                     build_model_message_transform(agent_name),
                 ],

--- a/tests/agents/test_instrumentation_capability.py
+++ b/tests/agents/test_instrumentation_capability.py
@@ -27,7 +27,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
 from pydantic_ai import Agent as PydanticAgent
-from pydantic_ai.capabilities import Instrumentation
+from pydantic_ai.capabilities import AbstractCapability, Instrumentation
 
 # Private helper, but it is exactly what pydantic-ai's run layer uses for its
 # explicit-capability-wins check -- introspecting with the same traversal
@@ -92,12 +92,32 @@ def test_instrument_all_true_normalizes_to_default_settings():
 
 
 def test_each_call_builds_a_fresh_capability():
-    """Probe and final construction passes must not share per-run state."""
+    """Each construction pass (probe/final) gets its own capability object.
+
+    Per-run isolation itself is upstream's job (``Instrumentation.for_run``
+    returns a ``dataclasses.replace`` copy — pinned below); this only pins
+    that build passes don't share one instance.
+    """
     settings, _ = _memory_settings()
     PydanticAgent.instrument_all(settings)
     (first,) = build_instrumentation()
     (second,) = build_instrumentation()
     assert first is not second
+
+
+@pytest.mark.asyncio
+async def test_for_run_returns_isolated_copies():
+    """Upstream per-run isolation contract: ``for_run`` copies never share."""
+    settings, _ = _memory_settings()
+    PydanticAgent.instrument_all(settings)
+    (cap,) = build_instrumentation()
+    ctx = SimpleNamespace(agent=None, messages=[])
+    run_a = await cap.for_run(ctx)
+    run_b = await cap.for_run(ctx)
+    assert run_a is not cap
+    assert run_b is not cap
+    assert run_a is not run_b
+    assert run_a.settings is settings
 
 
 # ---------------------------------------------------------------------------
@@ -136,6 +156,50 @@ def _text_model():
     return FunctionModel(reply)
 
 
+# Attribute values that are stable across two identical runs. Everything else
+# (run ids, conversation ids, serialized messages with timestamps, durations)
+# is inherently per-run; for those we still compare the *key sets* so a
+# structural change in either delivery path can't hide.
+_STABLE_ATTR_KEYS = frozenset(
+    {
+        "gen_ai.operation.name",
+        "gen_ai.agent.name",
+        "agent_name",
+        "model_name",
+        "gen_ai.request.model",
+        "logfire.msg",
+        "gen_ai.system",
+    }
+)
+
+
+def _normalized_spans(exporter):
+    """Project finished spans onto their run-stable identity.
+
+    Captures name, status code, parent topology (by span name), the full
+    attribute key set, and the values of stable attributes — excluding only
+    fields that legitimately differ between two runs (ids, timestamps,
+    serialized message payloads).
+    """
+    spans = exporter.get_finished_spans()
+    by_id = {s.context.span_id: s.name for s in spans}
+    normalized = []
+    for s in spans:
+        attrs = dict(s.attributes or {})
+        normalized.append(
+            (
+                s.name,
+                s.status.status_code,
+                by_id.get(s.parent.span_id) if s.parent else None,
+                tuple(sorted(attrs)),
+                tuple(
+                    sorted((k, v) for k, v in attrs.items() if k in _STABLE_ATTR_KEYS)
+                ),
+            )
+        )
+    return normalized
+
+
 @pytest.mark.asyncio
 async def test_explicit_capability_matches_global_default_spans():
     """Same settings, same spans -- whether delivered globally or explicitly."""
@@ -143,10 +207,7 @@ async def test_explicit_capability_matches_global_default_spans():
     PydanticAgent.instrument_all(settings_a)
     old_path = PydanticAgent(model=_text_model(), name="parity-agent")
     await old_path.run("hello")
-    old_spans = [
-        (s.name, dict(s.attributes or {}).get("gen_ai.operation.name"))
-        for s in exporter_a.get_finished_spans()
-    ]
+    old_spans = _normalized_spans(exporter_a)
 
     settings_b, exporter_b = _memory_settings()
     PydanticAgent.instrument_all(settings_b)
@@ -156,12 +217,13 @@ async def test_explicit_capability_matches_global_default_spans():
         capabilities=[Instrumentation(settings=settings_b)],
     )
     await new_path.run("hello")
-    new_spans = [
-        (s.name, dict(s.attributes or {}).get("gen_ai.operation.name"))
-        for s in exporter_b.get_finished_spans()
-    ]
+    new_spans = _normalized_spans(exporter_b)
 
+    # Full normalized comparison: same span sequence, same statuses, same
+    # parent topology, same attribute key sets, same stable attribute values.
+    # Equality here also rules out duplicated request/tool spans wholesale.
     assert old_spans == new_spans
+    assert len(old_spans) > 0
 
 
 @pytest.mark.asyncio
@@ -181,6 +243,34 @@ async def test_no_double_instrumentation_with_global_default_set():
         if dict(s.attributes or {}).get("gen_ai.operation.name") == "invoke_agent"
     ]
     assert len(run_spans) == 1
+
+
+@pytest.mark.asyncio
+async def test_ctx_tracer_is_real_with_global_default_retained():
+    """The module's rationale for keeping the global default, pinned.
+
+    Classic ``run``/``iter`` resolves ``ctx.tracer`` from the global/instance
+    settings *before* explicit capabilities are considered. Because the
+    explicit capability and the global default carry the same settings
+    object, capabilities observing ``ctx.tracer`` must see the real tracer
+    (identity with ``settings.tracer``), never a ``NoOpTracer``.
+    """
+    settings, _ = _memory_settings()
+    PydanticAgent.instrument_all(settings)
+    seen = {}
+
+    class _TracerProbe(AbstractCapability):
+        async def for_run(self, ctx):
+            seen["tracer"] = ctx.tracer
+            return self
+
+    agent = PydanticAgent(
+        model=_text_model(),
+        name="tracer-probe-agent",
+        capabilities=[Instrumentation(settings=settings), _TracerProbe()],
+    )
+    await agent.run("hello")
+    assert seen["tracer"] is settings.tracer
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agents/test_instrumentation_capability.py
+++ b/tests/agents/test_instrumentation_capability.py
@@ -1,0 +1,313 @@
+"""Contract tests for the explicit ``Instrumentation`` capability delivery.
+
+Logfire tracing used to reach code_puppy's agents only through the
+process-global ``Agent.instrument_all`` default installed by
+``logfire.instrument_pydantic_ai()``. ``code_puppy/agents/_instrumentation.py``
+promotes that to an explicit ``Instrumentation`` capability on the agents
+code_puppy builds, carrying the *same* settings object. These tests pin:
+
+* the builder contract (empty when uninstrumented, verbatim settings when
+  instrumented, ``True`` normalisation);
+* the private-attribute seam (``Agent._instrument_default``) so a pydantic-ai
+  rename fails loudly here instead of silently degrading;
+* span parity between the old (global-only) and new (explicit-capability)
+  delivery, including the no-double-instrumentation guarantee;
+* both real construction paths (main builder + sub-agent invoker);
+* the documented build-time-snapshot divergence.
+"""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from pydantic_ai import Agent as PydanticAgent
+from pydantic_ai.capabilities import Instrumentation
+
+# Private helper, but it is exactly what pydantic-ai's run layer uses for its
+# explicit-capability-wins check -- introspecting with the same traversal
+# keeps these assertions honest.
+from pydantic_ai.capabilities._ordering import collect_leaves
+from pydantic_ai.messages import ModelResponse, TextPart
+from pydantic_ai.models.function import FunctionModel
+from pydantic_ai.models.instrumented import InstrumentationSettings
+from pydantic_ai.models.test import TestModel
+
+from code_puppy.agents._instrumentation import build_instrumentation
+
+
+@pytest.fixture(autouse=True)
+def _restore_global_instrument_default():
+    """Never leak instrumentation state into the rest of the suite."""
+    original = PydanticAgent._instrument_default
+    yield
+    PydanticAgent.instrument_all(original)
+
+
+def _memory_settings():
+    """InstrumentationSettings wired to an in-memory exporter."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return InstrumentationSettings(tracer_provider=provider), exporter
+
+
+def _instrumentation_leaves(agent):
+    return [
+        leaf
+        for leaf in collect_leaves(agent.root_capability)
+        if isinstance(leaf, Instrumentation)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# build_instrumentation contract
+# ---------------------------------------------------------------------------
+
+
+def test_uninstrumented_process_builds_no_capability():
+    PydanticAgent.instrument_all(False)
+    assert build_instrumentation() == []
+
+
+def test_instrument_all_settings_delivered_verbatim():
+    settings, _ = _memory_settings()
+    PydanticAgent.instrument_all(settings)
+    (cap,) = build_instrumentation()
+    assert isinstance(cap, Instrumentation)
+    # Identity, not equality: the capability must deliver the exact object
+    # logfire installed, or provider wiring could silently drift.
+    assert cap.settings is settings
+
+
+def test_instrument_all_true_normalizes_to_default_settings():
+    PydanticAgent.instrument_all(True)
+    (cap,) = build_instrumentation()
+    assert isinstance(cap.settings, InstrumentationSettings)
+
+
+def test_each_call_builds_a_fresh_capability():
+    """Probe and final construction passes must not share per-run state."""
+    settings, _ = _memory_settings()
+    PydanticAgent.instrument_all(settings)
+    (first,) = build_instrumentation()
+    (second,) = build_instrumentation()
+    assert first is not second
+
+
+# ---------------------------------------------------------------------------
+# pydantic-ai seam pins
+# ---------------------------------------------------------------------------
+
+
+def test_private_default_attribute_is_pinned():
+    """``_instrument_default`` is the only source of logfire's exact settings.
+
+    If a pydantic-ai bump renames it, ``build_instrumentation`` degrades to
+    "no explicit capability" (covered by the run-layer fallback) -- this test
+    makes that bump loud instead of silent.
+    """
+    assert hasattr(PydanticAgent, "_instrument_default")
+    settings, _ = _memory_settings()
+    PydanticAgent.instrument_all(settings)
+    assert PydanticAgent._instrument_default is settings
+
+
+def test_capability_orders_itself_outermost():
+    """List position in ``capabilities=[...]`` is inert -- pinned here."""
+    (ordering,) = [Instrumentation().get_ordering()]
+    assert ordering.position == "outermost"
+
+
+# ---------------------------------------------------------------------------
+# span parity: old global-only path vs explicit capability path
+# ---------------------------------------------------------------------------
+
+
+def _text_model():
+    def reply(_messages, _info):
+        return ModelResponse(parts=[TextPart("woof")])
+
+    return FunctionModel(reply)
+
+
+@pytest.mark.asyncio
+async def test_explicit_capability_matches_global_default_spans():
+    """Same settings, same spans -- whether delivered globally or explicitly."""
+    settings_a, exporter_a = _memory_settings()
+    PydanticAgent.instrument_all(settings_a)
+    old_path = PydanticAgent(model=_text_model(), name="parity-agent")
+    await old_path.run("hello")
+    old_spans = [
+        (s.name, dict(s.attributes or {}).get("gen_ai.operation.name"))
+        for s in exporter_a.get_finished_spans()
+    ]
+
+    settings_b, exporter_b = _memory_settings()
+    PydanticAgent.instrument_all(settings_b)
+    new_path = PydanticAgent(
+        model=_text_model(),
+        name="parity-agent",
+        capabilities=[Instrumentation(settings=settings_b)],
+    )
+    await new_path.run("hello")
+    new_spans = [
+        (s.name, dict(s.attributes or {}).get("gen_ai.operation.name"))
+        for s in exporter_b.get_finished_spans()
+    ]
+
+    assert old_spans == new_spans
+
+
+@pytest.mark.asyncio
+async def test_no_double_instrumentation_with_global_default_set():
+    """Explicit capability + live global default must not duplicate spans."""
+    settings, exporter = _memory_settings()
+    PydanticAgent.instrument_all(settings)
+    agent = PydanticAgent(
+        model=_text_model(),
+        name="dedupe-agent",
+        capabilities=[Instrumentation(settings=settings)],
+    )
+    await agent.run("hello")
+    run_spans = [
+        s
+        for s in exporter.get_finished_spans()
+        if dict(s.attributes or {}).get("gen_ai.operation.name") == "invoke_agent"
+    ]
+    assert len(run_spans) == 1
+
+
+# ---------------------------------------------------------------------------
+# real construction paths
+# ---------------------------------------------------------------------------
+
+
+class _FakeAgentConfig:
+    """Minimal BaseAgent-shaped config for driving the real build paths."""
+
+    name = "code-puppy"
+    display_name = "Code Puppy"
+
+    def __init__(self):
+        self._message_history = []
+        self._compacted_message_hashes = set()
+        self._puppy_rules = None
+
+    @contextmanager
+    def temporary_model_name_override(self, _model_name):
+        yield
+
+    def get_model_name(self):
+        return "test-model"
+
+    def get_full_system_prompt(self):
+        return "You are a test agent."
+
+    def get_available_tools(self):
+        return []
+
+    def get_message_history(self):
+        return self._message_history
+
+    def set_message_history(self, history):
+        self._message_history = history
+
+    def __getattr__(self, item):
+        if item.startswith("__"):
+            raise AttributeError(item)
+        return lambda *a, **k: 0
+
+
+def _fake_load_model_with_fallback(*_args, **_kwargs):
+    return TestModel(custom_output_text="woof"), "test-model"
+
+
+@contextmanager
+def _builder_patches():
+    from code_puppy.agents import _builder
+
+    with (
+        patch.object(
+            _builder, "load_model_with_fallback", _fake_load_model_with_fallback
+        ),
+        patch.object(_builder.ModelFactory, "load_config", staticmethod(dict)),
+        patch.object(_builder, "load_mcp_servers", lambda **k: []),
+        patch.object(_builder, "make_model_settings", lambda *a, **k: None),
+        patch("code_puppy.tools.register_tools_for_agent", lambda *a, **k: None),
+    ):
+        yield _builder
+
+
+def test_main_builder_declares_capability_when_instrumented():
+    settings, _ = _memory_settings()
+    PydanticAgent.instrument_all(settings)
+    with _builder_patches() as _builder:
+        built = _builder.build_pydantic_agent(_FakeAgentConfig())
+    (leaf,) = _instrumentation_leaves(built)
+    assert leaf.settings is settings
+
+
+def test_main_builder_omits_capability_when_uninstrumented():
+    PydanticAgent.instrument_all(False)
+    with _builder_patches() as _builder:
+        built = _builder.build_pydantic_agent(_FakeAgentConfig())
+    assert _instrumentation_leaves(built) == []
+
+
+@pytest.mark.asyncio
+async def test_subagent_path_declares_capability_when_instrumented():
+    from code_puppy.tools import subagent_invocation as si
+
+    settings, _ = _memory_settings()
+    PydanticAgent.instrument_all(settings)
+
+    cfg = _FakeAgentConfig()
+    cfg.name = "web-retriever"
+    captured = {}
+
+    def capture_wrap(_agent_config, pydantic_agent, **_kwargs):
+        captured["agent"] = pydantic_agent
+        return pydantic_agent
+
+    with (
+        patch("code_puppy.agents.agent_manager.load_agent", return_value=cfg),
+        patch(
+            "code_puppy.agents._builder.load_model_with_fallback",
+            _fake_load_model_with_fallback,
+        ),
+        patch("code_puppy.model_factory.make_model_settings", lambda *a, **k: None),
+        patch("code_puppy.config.get_value", return_value="true"),  # no MCP
+        patch.object(si, "on_wrap_pydantic_agent", capture_wrap),
+    ):
+        out = await si._invoke_agent_impl(
+            context=SimpleNamespace(),
+            agent_name="web-retriever",
+            prompt="fetch me a stick",
+        )
+
+    assert out.error is None
+    (leaf,) = _instrumentation_leaves(captured["agent"])
+    assert leaf.settings is settings
+
+
+# ---------------------------------------------------------------------------
+# documented divergence: build-time snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_survives_later_global_disable():
+    """Divergence pin (see _instrumentation.py docstring): an agent built
+    while instrumented keeps its capability even if the global default is
+    later cleared. Nothing in code_puppy flips the default after startup."""
+    settings, _ = _memory_settings()
+    PydanticAgent.instrument_all(settings)
+    with _builder_patches() as _builder:
+        built = _builder.build_pydantic_agent(_FakeAgentConfig())
+    PydanticAgent.instrument_all(False)
+    assert len(_instrumentation_leaves(built)) == 1


### PR DESCRIPTION
## What

Tenth in the capability-conversion series (#828–#836). Promotes OpenTelemetry/Logfire tracing from the **process-global mutable default** (`logfire.instrument_pydantic_ai()` → `Agent.instrument_all(settings)`) to a first-class, explicitly-declared `Instrumentation` capability on the agents code_puppy constructs.

pydantic-ai 2.31.0 itself treats the capability as the canonical form — `instrument_all`'s own docstring reads *"for all agents that don't explicitly add an `Instrumentation` capability"*, and the run layer skips its internal injection whenever an explicit one is present ("explicit-capability-wins").

## How

- **New `code_puppy/agents/_instrumentation.py`** — `build_instrumentation()` resolves the effective global default at build time (mirroring `Agent._resolve_instrumentation_settings`) and returns a stock `Instrumentation` capability carrying the **exact settings object** logfire installed (`True` → default-constructed settings; unset/`False` → empty list).
- **Both construction sites converted** — main builder (`_builder.py`) and sub-agent invoker (`subagent_invocation.py`) splat `*build_instrumentation()` into their `capabilities=[...]` blocks. List position is inert: the capability declares `position='outermost'` ordering — the same slot the run layer's internal prepend targets.
- **`observability.configure_logfire()` unchanged** in behaviour; docstring now documents the two delivery paths.

## Why the global default is deliberately retained

1. **Out-of-tree agents.** Core plugins construct their own raw pydantic-ai agents (wiggum's judge, btw's side-query) and receive spans purely from `Agent.instrument_all`. Removing it would silently kill their telemetry — a parity break.
2. **`ctx.tracer` consistency.** pydantic-ai resolves the run context's tracer from global/instance settings independently of explicit capabilities; keeping both in sync means capabilities/toolsets observing `ctx.tracer` never see a `NoOpTracer` while spans exist.
3. **Ordering robustness.** An agent built *before* `configure_logfire` runs carries no capability and degrades to exactly the old behaviour via the run-layer fallback.

Explicit-when-ours, fallback-for-guests.

## Divergence (documented + pinned)

The capability is a **build-time snapshot**; the global default is read per run. If `Agent.instrument_all(False)` were called after a build, that agent would keep tracing until rebuilt (previously it would go quiet on the next run). Nothing in code_puppy or its plugins flips the default after startup. Pinned by `test_snapshot_survives_later_global_disable`.

## Tests

12 contract tests in `tests/agents/test_instrumentation_capability.py`:
- builder contract (empty/verbatim/`True`-normalisation/fresh-per-call)
- private-seam pin on `Agent._instrument_default` (a pydantic-ai rename fails loudly here; runtime degrades soft to the fallback)
- `position='outermost'` ordering pin
- **span parity**: identical span name + `gen_ai.operation.name` sequences between the old global-only path and the new explicit path (in-memory OTel exporter)
- **no double instrumentation** with both the explicit capability and the global default live
- both real construction paths (main builder + `_invoke_agent_impl`) deliver the verbatim settings object

Full suite: **7609 passed, 28 skipped, 1 xpassed, 0 failed** — including the previously-eternal `test_render_version_check_current`, healed on main by #837.