### PR TITLE
refactor: promote first-turn prompt preparation to a PromptPreparation capability

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -24,6 +24,7 @@ from code_puppy.agents._output_limits import (
     build_response_clamp,
     build_tool_output_limits,
 )
+from code_puppy.agents._prompt_preparation import PromptPreparation
 from code_puppy.agents._steer_processor import make_steer_history_processor
 from code_puppy.agents.event_stream_handler import event_stream_handler
 from code_puppy.callbacks import (
@@ -651,16 +652,21 @@ def build_pydantic_agent(
             output_type=output_type,
             retries=3,
             toolsets=toolsets,
-            # Order matters: compaction first (may trim history to fit
-            # context), THEN steer injection (a fresh steer must not be
-            # compacted away). ProcessHistory capabilities apply in
-            # registration order (replaces the deprecated
-            # `history_processors=` kwarg, removed in pydantic-ai v2).
-            # ToolOutputLimits reduces oversized tool returns on a different
-            # hook (after_tool_execute), so its position is inert; the
-            # response clamp runs before_model_request after both history
-            # processors. The plugin transform wraps the final model request.
+            # Order matters: prompt preparation FIRST (folds the system
+            # prompt into the first user message for claude-code-style
+            # models, so compaction sees the folded form exactly as it did
+            # when the fold was baked into the prompt argument), then
+            # compaction (may trim history to fit context), THEN steer
+            # injection (a fresh steer must not be compacted away).
+            # ProcessHistory capabilities apply in registration order
+            # (replaces the deprecated `history_processors=` kwarg, removed
+            # in pydantic-ai v2). ToolOutputLimits reduces oversized tool
+            # returns on a different hook (after_tool_execute), so its
+            # position is inert; the response clamp runs before_model_request
+            # after both history processors. The plugin transform wraps the
+            # final model request.
             capabilities=[
+                PromptPreparation(),
                 *build_tool_output_limits(),
                 ProcessHistory(history_processor),
                 ProcessHistory(steer_processor),

--- a/code_puppy/agents/_prompt_preparation.py
+++ b/code_puppy/agents/_prompt_preparation.py
@@ -1,0 +1,260 @@
+"""First-turn user-prompt preparation as a pydantic-ai capability.
+
+Some model families (claude-code OAuth being the canonical example) cannot
+receive code_puppy's real system prompt through the ``instructions`` channel:
+the provider expects a fixed instruction string, so the actual system prompt
+is folded into the *user* message of the conversation's first turn instead.
+Historically ``_runtime._should_prepend_system_prompt`` baked that fold into
+the prompt string before ``pydantic_agent.run()`` ever saw it.
+
+This module promotes that delivery to a first-class
+:class:`~pydantic_ai.capabilities.AbstractCapability`:
+
+* :func:`build_prompt_observation` computes the prepared form **once per
+  turn, at the exact call site the old code used** — so
+  ``prepare_prompt_for_model`` (and every plugin hook behind it) fires with
+  identical arguments, identical timing, and an identical call count.
+* :class:`PromptPreparation` swaps ``raw -> prepared`` on the conversation's
+  first user message at the ``before_model_request`` seam (send side) and
+  mirrors the same swap into the recorded history at the ``after_run`` seam
+  (persist side), so bytes at rest match the old baked-in behaviour.
+* Callers install a :class:`PromptObservation` around their run(s) via
+  :func:`observe_prompt_preparation`; the capability resolves it through a
+  ``ContextVar``, so concurrent / nested runs (sub-agents, side queries)
+  each see their own observation. No observation, or an inactive one, makes
+  the capability a strict no-op.
+
+Why both a send-side swap *and* a persist-side mirror? pydantic-ai records
+the run's user prompt from the ``run()`` argument, not from the (possibly
+transformed) request messages. Keeping the argument raw and swapping at
+request time preserves model-visible bytes on every path — including
+streaming-retry re-entries that resume from checkpointed history — while the
+mirror restores byte-identical *stored* history whenever core takes custody
+of run state (run end, cancellation checkpoint, partial-session save).
+
+Ordering matters: the swap must run **before** history compaction so the
+compactor sees the folded first message exactly as it did when the fold was
+baked into the prompt. Both construction sites list ``PromptPreparation``
+ahead of their ``ProcessHistory`` capabilities for that reason.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, replace
+from typing import Any, Iterator, List, Optional, Sequence
+
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.messages import ModelMessage, ModelRequest, UserPromptPart
+
+__all__ = [
+    "PromptObservation",
+    "PromptPreparation",
+    "build_prompt_observation",
+    "observe_prompt_preparation",
+]
+
+
+@dataclass
+class PromptObservation:
+    """One turn's ``raw -> prepared`` user-prompt substitution.
+
+    ``active`` is False when there is nothing to do — either the turn did not
+    qualify for preparation (non-empty history / resumed session) or the
+    prepared form came back identical to the raw prompt (no plugin claimed
+    the model). An inactive observation makes every operation a no-op, so
+    call sites can install one unconditionally.
+    """
+
+    raw: str = ""
+    prepared: str = ""
+    active: bool = False
+
+    @classmethod
+    def inactive(cls) -> "PromptObservation":
+        return cls()
+
+    def __post_init__(self) -> None:
+        # Identity swaps are inert; deactivate so the request path can
+        # short-circuit without comparing content on every model request.
+        if self.active and self.raw == self.prepared:
+            self.active = False
+
+    # ---- send side ---------------------------------------------------------
+
+    def apply_to_request(self, messages: List[ModelMessage]) -> List[ModelMessage]:
+        """Return ``messages`` with the first user message swapped to ``prepared``.
+
+        Only the conversation's FIRST message is eligible (positionally —
+        mirroring the old behaviour, which only ever folded the prompt when
+        history was empty), and only when its user content still matches
+        ``raw`` — so an already-swapped history, a compacted summary, or a
+        later message that merely repeats the same text are all left alone.
+
+        Fresh copies are returned; the input messages are never mutated. The
+        recorded run state keeps the raw prompt until :meth:`mirror` runs at
+        a custody boundary.
+        """
+        if not self.active or not messages:
+            return messages
+        first = messages[0]
+        swapped = self._swapped_request(first)
+        if swapped is None:
+            return messages
+        return [swapped, *messages[1:]]
+
+    def _swapped_request(self, message: ModelMessage) -> Optional[ModelRequest]:
+        if not isinstance(message, ModelRequest):
+            return None
+        new_parts: List[Any] = []
+        changed = False
+        for part in message.parts:
+            new_content = None if changed else self._prepared_content(part)
+            if new_content is not None:
+                new_parts.append(replace(part, content=new_content))
+                changed = True
+            else:
+                new_parts.append(part)
+        if not changed:
+            return None
+        return replace(message, parts=new_parts)
+
+    def _prepared_content(self, part: Any) -> Any:
+        """Return ``part``'s content with ``raw`` swapped for ``prepared``, or None."""
+        if not isinstance(part, UserPromptPart):
+            return None
+        content = part.content
+        if isinstance(content, str):
+            return self.prepared if content == self.raw else None
+        if isinstance(content, Sequence):
+            # Attachment payloads arrive as [prompt_str, *binary/link parts];
+            # the old code folded the system prompt into that leading string.
+            for i, item in enumerate(content):
+                if isinstance(item, str):
+                    if item == self.raw:
+                        updated = list(content)
+                        updated[i] = self.prepared
+                        return updated
+                    return None
+        return None
+
+    # ---- persist side ------------------------------------------------------
+
+    def mirror(self, messages: Optional[Sequence[ModelMessage]]) -> None:
+        """Rewrite the stored first user message to ``prepared``, in place.
+
+        Called wherever core takes custody of run state (run end via
+        ``after_run``, cancellation checkpoints, partial-session saves) so
+        history at rest is byte-identical to the old baked-in prompt.
+        Idempotent: once the content no longer matches ``raw`` it is left
+        untouched. Mutates part content in place so every alias of the
+        stored messages (``result.all_messages()``, ``agent._message_history``,
+        session saves) observes the swap.
+        """
+        if not self.active or not messages:
+            return
+        first = messages[0]
+        if not isinstance(first, ModelRequest):
+            return
+        for part in first.parts:
+            new_content = self._prepared_content(part)
+            if new_content is not None:
+                part.content = new_content
+                return
+
+
+_prompt_observation: ContextVar[Optional[PromptObservation]] = ContextVar(
+    "code_puppy_prompt_observation", default=None
+)
+
+
+def current_prompt_observation() -> Optional[PromptObservation]:
+    """Return the observation installed for the current context, if any."""
+    return _prompt_observation.get()
+
+
+@contextmanager
+def observe_prompt_preparation(observation: PromptObservation) -> Iterator[None]:
+    """Install ``observation`` for the enclosed block (and tasks created in it).
+
+    ``asyncio.create_task`` snapshots the context, so wrapping the task
+    creation is enough for the run body to resolve the observation even
+    after the ``with`` block exits. Nested installs (sub-agent invocations)
+    shadow the outer observation for their own tasks only.
+    """
+    token = _prompt_observation.set(observation)
+    try:
+        yield
+    finally:
+        _prompt_observation.reset(token)
+
+
+def build_prompt_observation(agent: Any, prompt: str) -> tuple[PromptObservation, str]:
+    """Compute the first-turn prompt fold for ``agent`` (main-agent path).
+
+    Returns ``(observation, prompt_to_run)``. Byte-for-byte replica of the
+    old ``_should_prepend_system_prompt``: only a turn starting with an
+    empty message history qualifies, and the prepared form is produced by
+    ``prepare_prompt_for_model`` with the full system prompt + puppy rules.
+    When the turn does not qualify the hooks are NOT fired at all —
+    preserving the old call count exactly.
+
+    ``prompt_to_run`` is normally the raw prompt (the capability performs
+    the swap at request time). The one degenerate exception is an EMPTY raw
+    prompt: payload building drops empty prompts, so there is no user part
+    for the capability to anchor on — the fold is baked eagerly instead,
+    exactly as the old code did.
+    """
+    if agent._message_history:
+        return PromptObservation.inactive(), prompt
+
+    from code_puppy.agents._builder import load_puppy_rules
+    from code_puppy.model_utils import prepare_prompt_for_model
+
+    system_prompt = agent.get_full_system_prompt()
+    rules = load_puppy_rules()
+    if rules:
+        system_prompt += f"\n{rules}"
+
+    prepared = prepare_prompt_for_model(
+        model_name=agent.get_model_name(),
+        system_prompt=system_prompt,
+        user_prompt=prompt,
+        prepend_system_to_user=True,
+    )
+    if not prompt:
+        return PromptObservation.inactive(), prepared.user_prompt
+    return (
+        PromptObservation(raw=prompt, prepared=prepared.user_prompt, active=True),
+        prompt,
+    )
+
+
+@dataclass
+class PromptPreparation(AbstractCapability[Any]):
+    """Deliver the first-turn user-prompt fold through capability seams.
+
+    Stateless: per-turn state lives in the installed
+    :class:`PromptObservation`, resolved via ``ContextVar`` on every seam
+    call. With no (or an inactive) observation the capability is inert, so
+    it can sit unconditionally in every ``capabilities=[...]`` list.
+    """
+
+    async def before_model_request(self, ctx: Any, request_context: Any) -> Any:
+        observation = current_prompt_observation()
+        if observation is not None:
+            request_context.messages = observation.apply_to_request(
+                request_context.messages
+            )
+        return request_context
+
+    async def after_run(self, ctx: Any, *, result: Any) -> Any:
+        observation = current_prompt_observation()
+        if observation is not None:
+            observation.mirror(result.all_messages())
+        return result
+
+    @classmethod
+    def get_serialization_name(cls) -> Optional[str]:
+        return None  # Not spec-serializable (state rides a ContextVar).

--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -76,6 +76,10 @@ from code_puppy.agents._non_streaming_render import (
     render_result_without_streaming,
     should_render_fallback,
 )
+from code_puppy.agents._prompt_preparation import (
+    build_prompt_observation,
+    observe_prompt_preparation,
+)
 from code_puppy.agents._run_signals import (
     drain_pause_state_on_cancel,
     inject_interrupted_subagent_notes,
@@ -553,28 +557,6 @@ def _extract_response_text(result: Any) -> str:
     return str(result)
 
 
-def _should_prepend_system_prompt(agent: Any, prompt: str) -> str:
-    """Prepend system prompt to user prompt on the first turn (claude-code etc)."""
-    from code_puppy.agents._builder import load_puppy_rules
-    from code_puppy.model_utils import prepare_prompt_for_model
-
-    if agent._message_history:
-        return prompt
-
-    system_prompt = agent.get_full_system_prompt()
-    rules = load_puppy_rules()
-    if rules:
-        system_prompt += f"\n{rules}"
-
-    prepared = prepare_prompt_for_model(
-        model_name=agent.get_model_name(),
-        system_prompt=system_prompt,
-        user_prompt=prompt,
-        prepend_system_to_user=True,
-    )
-    return prepared.user_prompt
-
-
 def _checkpoint_cancelled_history(exc_group: BaseException, agent: Any) -> None:
     """Preserve a cancelled run's partial work into ``agent._message_history``.
 
@@ -714,7 +696,11 @@ async def _run_with_mcp_impl(
     if output_type is not None:
         pydantic_agent = build_pydantic_agent(agent, output_type=output_type)
 
-    prompt = _should_prepend_system_prompt(agent, prompt)
+    # First-turn system-prompt fold (claude-code etc.) is delivered by the
+    # PromptPreparation capability at request time; here we only compute the
+    # raw -> prepared substitution (same call site + hook parity as the old
+    # baked-in prepend) and install it for the run task below.
+    prompt_observation, prompt = build_prompt_observation(agent, prompt)
     prompt_payload = _build_prompt_payload(prompt, attachments, link_attachments)
 
     async def _do_run(prompt_to_use: Any) -> Any:
@@ -932,6 +918,11 @@ async def _run_with_mcp_impl(
             from code_puppy.observability import clear_agent_context
 
             clear_agent_context(group_id)
+            # Custody boundary: whatever state this turn leaves behind
+            # (completed run, cancellation checkpoint, checkpointed partial
+            # progress after a crash) must store the PREPARED first-turn
+            # prompt, exactly as the old baked-in prepend did. Idempotent.
+            prompt_observation.mirror(agent._message_history)
             agent._message_history = _history.prune_interrupted_tool_calls(
                 agent._message_history
             )
@@ -965,7 +956,11 @@ async def _run_with_mcp_impl(
         # MCP trouble must never block the agent run itself.
         pass
 
-    agent_task = asyncio.create_task(run_agent_task())
+    # Install the observation so the task's context snapshot carries it: the
+    # PromptPreparation capability resolves it at request time (send side) and
+    # run end (persist side). Inert when the turn didn't qualify.
+    with observe_prompt_preparation(prompt_observation):
+        agent_task = asyncio.create_task(run_agent_task())
 
     loop = asyncio.get_running_loop()
 

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -293,6 +293,8 @@ async def _invoke_agent_impl(
     # if load_agent() itself fails before assignment.
     agent_config = None
     effective_model_name = model_name
+    prompt_observation = None
+    prepared_user_prompt = prompt
 
     try:
         # Lazy import to break circular dependency with messaging module
@@ -367,6 +369,11 @@ async def _invoke_agent_impl(
 
             # NOTE: load_prompt fragments are already baked into get_full_system_prompt
             # via BaseAgent — appending again would double-inject them.
+            from code_puppy.agents._prompt_preparation import (
+                PromptObservation,
+                PromptPreparation,
+                observe_prompt_preparation,
+            )
             from code_puppy.model_utils import prepare_prompt_for_model
 
             # Handle claude-code models: swap instructions, and prepend system prompt only on first message
@@ -377,7 +384,21 @@ async def _invoke_agent_impl(
                 prepend_system_to_user=is_new_session,  # Only prepend on first message
             )
             instructions = prepared.instructions
-            prompt = prepared.user_prompt
+            prepared_user_prompt = prepared.user_prompt
+            if is_new_session and prompt:
+                # New session: the system-prompt fold is delivered by the
+                # PromptPreparation capability at request time; ``prompt``
+                # stays raw and the recorded history is mirrored at run end.
+                prompt_observation = PromptObservation(
+                    raw=prompt, prepared=prepared_user_prompt, active=True
+                )
+            else:
+                # Resumed session (hooks leave the user prompt untouched when
+                # the prepend flag is off) or degenerate empty prompt (no
+                # user part to anchor the swap on): keep the eager
+                # pass-through, exactly as before.
+                prompt = prepared_user_prompt
+                prompt_observation = PromptObservation.inactive()
 
             model_settings = make_model_settings(effective_model_name)
 
@@ -418,9 +439,13 @@ async def _invoke_agent_impl(
                 output_type=str,
                 retries=3,
                 toolsets=mcp_servers,
-                # ProcessHistory capability replaces the deprecated
-                # `history_processors=` kwarg (removed in pydantic-ai v2).
+                # Prompt preparation FIRST so compaction sees the folded
+                # first user message exactly as it did when the fold was
+                # baked into the prompt argument. ProcessHistory capability
+                # replaces the deprecated `history_processors=` kwarg
+                # (removed in pydantic-ai v2).
                 capabilities=[
+                    PromptPreparation(),
                     ProcessHistory(make_history_processor(agent_config)),
                     build_model_message_transform(agent_name),
                 ],
@@ -510,7 +535,10 @@ async def _invoke_agent_impl(
                         if include_usage_metrics
                         else None
                     )
-                    task = asyncio.create_task(_run_subagent())
+                    # The task's context snapshot carries the observation so
+                    # PromptPreparation can resolve it at request time.
+                    with observe_prompt_preparation(prompt_observation):
+                        task = asyncio.create_task(_run_subagent())
                     _active_subagent_tasks.add(task)
 
                     try:
@@ -551,12 +579,13 @@ async def _invoke_agent_impl(
             # The result contains all_messages which includes the full conversation
             updated_history = result.all_messages()
 
-            # Save to filesystem (include initial prompt only for new sessions)
+            # Save to filesystem (include initial prompt only for new
+            # sessions; the PREPARED form, matching what the model saw)
             _save_session_history(
                 session_id=session_id,
                 message_history=updated_history,
                 agent_name=agent_name,
-                initial_prompt=prompt if is_new_session else None,
+                initial_prompt=prepared_user_prompt if is_new_session else None,
             )
 
             # Emit via MessageBus; skip in high mode when streaming already
@@ -604,6 +633,15 @@ async def _invoke_agent_impl(
             e, (asyncio.CancelledError, KeyboardInterrupt)
         ) or _contains_cancellation(e)
 
+        # Custody boundary: checkpointed partial progress must persist the
+        # PREPARED first-turn prompt, exactly as the old baked-in prepend
+        # did. Idempotent; inert when the run never qualified.
+        if prompt_observation is not None and agent_config is not None:
+            try:
+                prompt_observation.mirror(agent_config.get_message_history() or [])
+            except Exception:
+                pass
+
         if interrupted:
             # CancelledError derives from BaseException, so it slipped past the
             # old ``except Exception`` save path. Persist progress, tell the user
@@ -613,7 +651,7 @@ async def _invoke_agent_impl(
                 session_id=session_id,
                 agent_name=agent_name,
                 baseline_count=len(message_history),
-                initial_prompt=prompt if is_new_session else None,
+                initial_prompt=prepared_user_prompt if is_new_session else None,
             )
             detail = (
                 f"{saved} message(s) saved"
@@ -651,7 +689,7 @@ async def _invoke_agent_impl(
             session_id=session_id,
             agent_name=agent_name,
             baseline_count=len(message_history),
-            initial_prompt=prompt if is_new_session else None,
+            initial_prompt=prepared_user_prompt if is_new_session else None,
         )
         if saved is not None:
             emit_info(

--- a/tests/agents/test_prompt_preparation_capability.py
+++ b/tests/agents/test_prompt_preparation_capability.py
@@ -1,0 +1,400 @@
+"""Contract tests for the ``PromptPreparation`` capability.
+
+The capability replaces ``_runtime._should_prepend_system_prompt``'s baked-in
+first-turn prompt fold (claude-code OAuth etc.) with a request-time swap plus
+a persist-time mirror; see ``code_puppy/agents/_prompt_preparation.py`` for
+the migration story. These tests pin:
+
+* hook-call parity of :func:`build_prompt_observation` with the old code
+  (same arguments, same call count, NOT fired for non-qualifying turns),
+* the send-side swap semantics (first message only, attachments payloads,
+  no mutation of the input messages),
+* the persist-side mirror (in-place, idempotent),
+* end-to-end wire parity against the old baked-in behaviour through a real
+  ``Agent.run()``, including retry-style re-runs from checkpointed history,
+* ContextVar scoping (no observation == inert; nested installs shadow).
+"""
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+from pydantic_ai import Agent, BinaryContent
+from pydantic_ai.capabilities import ProcessHistory
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from code_puppy.agents._prompt_preparation import (
+    PromptObservation,
+    PromptPreparation,
+    build_prompt_observation,
+    current_prompt_observation,
+    observe_prompt_preparation,
+)
+
+RAW = "please fetch the bone"
+PREPARED = "SYSTEM PROMPT\n\nplease fetch the bone"
+
+
+@dataclass
+class FakeAgent:
+    """Just enough surface for ``build_prompt_observation``."""
+
+    _message_history: List[Any] = field(default_factory=list)
+    system_prompt: str = "SYSTEM PROMPT"
+    model_name: str = "claude-code-sonnet"
+
+    def get_full_system_prompt(self) -> str:
+        return self.system_prompt
+
+    def get_model_name(self) -> str:
+        return self.model_name
+
+
+def _capture_model(seen: List[List[Any]]) -> FunctionModel:
+    def model_fn(messages: List[Any], info: AgentInfo) -> ModelResponse:
+        seen.append(list(messages))
+        return ModelResponse(parts=[TextPart("ok")])
+
+    return FunctionModel(model_fn)
+
+
+def _content_shape(messages: List[Any]) -> List[Any]:
+    """Timestamp-free projection of what the model saw."""
+    shape: List[Any] = []
+    for message in messages:
+        for part in message.parts:
+            shape.append((type(part).__name__, getattr(part, "content", None)))
+    return shape
+
+
+# ---- build_prompt_observation: hook-call parity -----------------------------
+
+
+def test_non_qualifying_turn_does_not_fire_hooks(monkeypatch):
+    """Non-empty history == the old early return: hooks must NOT fire."""
+
+    def boom(**_kwargs):  # pragma: no cover - would fail the test
+        raise AssertionError("prepare_prompt_for_model must not be called")
+
+    monkeypatch.setattr("code_puppy.model_utils.prepare_prompt_for_model", boom)
+    agent = FakeAgent(_message_history=[object()])
+    observation, prompt = build_prompt_observation(agent, RAW)
+    assert not observation.active
+    assert prompt == RAW
+
+
+def test_first_turn_fires_hooks_with_old_arguments(monkeypatch):
+    calls: List[dict] = []
+
+    def fake_prepare(*, model_name, system_prompt, user_prompt, prepend_system_to_user):
+        calls.append(
+            {
+                "model_name": model_name,
+                "system_prompt": system_prompt,
+                "user_prompt": user_prompt,
+                "prepend_system_to_user": prepend_system_to_user,
+            }
+        )
+
+        @dataclass
+        class Prepared:
+            user_prompt: str
+
+        return Prepared(user_prompt=f"{system_prompt}\n\n{user_prompt}")
+
+    monkeypatch.setattr("code_puppy.model_utils.prepare_prompt_for_model", fake_prepare)
+    monkeypatch.setattr("code_puppy.agents._builder.load_puppy_rules", lambda: "RULES")
+
+    agent = FakeAgent()
+    observation, prompt = build_prompt_observation(agent, RAW)
+
+    # Exactly one call, byte-identical to the old _should_prepend_system_prompt.
+    assert calls == [
+        {
+            "model_name": "claude-code-sonnet",
+            "system_prompt": "SYSTEM PROMPT\nRULES",
+            "user_prompt": RAW,
+            "prepend_system_to_user": True,
+        }
+    ]
+    assert prompt == RAW  # raw prompt rides to run(); the capability swaps
+    assert observation.active
+    assert observation.raw == RAW
+    assert observation.prepared == f"SYSTEM PROMPT\nRULES\n\n{RAW}"
+
+
+def test_identity_preparation_is_inert(monkeypatch):
+    """No plugin claimed the model -> prepared == raw -> nothing to do."""
+
+    def fake_prepare(**kwargs):
+        @dataclass
+        class Prepared:
+            user_prompt: str
+
+        return Prepared(user_prompt=kwargs["user_prompt"])
+
+    monkeypatch.setattr("code_puppy.model_utils.prepare_prompt_for_model", fake_prepare)
+    monkeypatch.setattr("code_puppy.agents._builder.load_puppy_rules", lambda: None)
+
+    observation, prompt = build_prompt_observation(FakeAgent(), RAW)
+    assert not observation.active
+    assert prompt == RAW
+
+
+def test_empty_prompt_bakes_eagerly(monkeypatch):
+    """Payload building drops empty prompts, so the fold can't ride the swap."""
+
+    def fake_prepare(**kwargs):
+        @dataclass
+        class Prepared:
+            user_prompt: str
+
+        return Prepared(user_prompt=f"{kwargs['system_prompt']}\n\n")
+
+    monkeypatch.setattr("code_puppy.model_utils.prepare_prompt_for_model", fake_prepare)
+    monkeypatch.setattr("code_puppy.agents._builder.load_puppy_rules", lambda: None)
+
+    observation, prompt = build_prompt_observation(FakeAgent(), "")
+    assert not observation.active
+    assert prompt == "SYSTEM PROMPT\n\n"  # old behaviour: baked into the prompt
+
+
+# ---- send side: apply_to_request --------------------------------------------
+
+
+def _observation() -> PromptObservation:
+    return PromptObservation(raw=RAW, prepared=PREPARED, active=True)
+
+
+def test_swap_replaces_first_user_message_without_mutating_input():
+    original = ModelRequest(parts=[UserPromptPart(content=RAW)])
+    messages: List[Any] = [original, ModelResponse(parts=[TextPart("hi")])]
+
+    swapped = _observation().apply_to_request(messages)
+
+    assert swapped[0].parts[0].content == PREPARED
+    assert swapped[1] is messages[1]
+    assert original.parts[0].content == RAW  # fresh copies, no aliasing
+
+
+def test_swap_handles_attachment_payloads():
+    attachment = BinaryContent(data=b"\x89PNG", media_type="image/png")
+    messages = [ModelRequest(parts=[UserPromptPart(content=[RAW, attachment])])]
+
+    swapped = _observation().apply_to_request(messages)
+
+    content = swapped[0].parts[0].content
+    assert content[0] == PREPARED
+    assert content[1] is attachment
+
+
+def test_swap_leaves_non_matching_content_alone():
+    observation = _observation()
+    for messages in (
+        [],
+        [ModelResponse(parts=[TextPart("model first")])],
+        [ModelRequest(parts=[UserPromptPart(content="different text")])],
+        [
+            ModelRequest(
+                parts=[ToolReturnPart(tool_name="t", content="x", tool_call_id="1")]
+            )
+        ],
+        [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        content=[BinaryContent(data=b"z", media_type="image/png")]
+                    )
+                ]
+            )
+        ],
+    ):
+        assert observation.apply_to_request(messages) == messages
+
+
+def test_swap_is_positional_not_content_scanning():
+    """A later message repeating the raw text must NOT be folded."""
+    messages = [
+        ModelRequest(parts=[UserPromptPart(content="turn one")]),
+        ModelResponse(parts=[TextPart("ok")]),
+        ModelRequest(parts=[UserPromptPart(content=RAW)]),
+    ]
+    assert _observation().apply_to_request(messages) == messages
+
+
+def test_inactive_observation_is_a_no_op():
+    messages = [ModelRequest(parts=[UserPromptPart(content=RAW)])]
+    assert PromptObservation.inactive().apply_to_request(messages) is messages
+    # Identity swaps deactivate themselves in __post_init__.
+    assert not PromptObservation(raw=RAW, prepared=RAW, active=True).active
+
+
+# ---- persist side: mirror ---------------------------------------------------
+
+
+def test_mirror_rewrites_in_place_and_is_idempotent():
+    part = UserPromptPart(content=RAW)
+    history: List[Any] = [
+        ModelRequest(parts=[part]),
+        ModelResponse(parts=[TextPart("ok")]),
+    ]
+    observation = _observation()
+
+    observation.mirror(history)
+    assert part.content == PREPARED  # the SAME object every alias sees
+
+    observation.mirror(history)  # idempotent: content no longer matches raw
+    assert part.content == PREPARED
+
+
+def test_mirror_tolerates_empty_and_foreign_history():
+    observation = _observation()
+    observation.mirror(None)
+    observation.mirror([])
+    response_first: List[Any] = [ModelResponse(parts=[TextPart("hi")])]
+    observation.mirror(response_first)
+    assert response_first[0].parts[0].content == "hi"
+
+
+# ---- capability seams -------------------------------------------------------
+
+
+def test_capability_without_observation_is_inert():
+    async def scenario():
+        assert current_prompt_observation() is None
+        seen: List[List[Any]] = []
+        agent = Agent(
+            model=_capture_model(seen),
+            instructions="sys",
+            output_type=str,
+            capabilities=[PromptPreparation()],
+        )
+        result = await agent.run(RAW)
+        assert seen[0][0].parts[0].content == RAW
+        assert result.all_messages()[0].parts[0].content == RAW
+
+    asyncio.run(scenario())
+
+
+def test_wire_and_history_parity_with_baked_prompt():
+    """Capability + raw prompt must be byte-identical to the old baked prepend."""
+
+    async def scenario():
+        baked_seen: List[List[Any]] = []
+        baked_agent = Agent(
+            model=_capture_model(baked_seen),
+            instructions="sys",
+            output_type=str,
+        )
+        baked_result = await baked_agent.run(PREPARED)  # the old code path
+
+        cap_seen: List[List[Any]] = []
+        cap_agent = Agent(
+            model=_capture_model(cap_seen),
+            instructions="sys",
+            output_type=str,
+            capabilities=[PromptPreparation()],
+        )
+        with observe_prompt_preparation(_observation()):
+            task = asyncio.get_running_loop().create_task(cap_agent.run(RAW))
+        cap_result = await task
+
+        # Model-visible bytes: identical.
+        assert _content_shape(cap_seen[0]) == _content_shape(baked_seen[0])
+        # Bytes at rest: identical (after_run mirrored the recorded history).
+        assert _content_shape(cap_result.all_messages()) == _content_shape(
+            baked_result.all_messages()
+        )
+
+    asyncio.run(scenario())
+
+
+def test_checkpoint_resume_rerun_still_folds():
+    """A streaming-retry re-entry resumes from checkpointed history whose
+    first message is still raw; the swap must keep applying so the model
+    sees the folded prompt exactly as it did when the fold was baked in."""
+
+    async def scenario():
+        seen: List[List[Any]] = []
+        agent = Agent(
+            model=_capture_model(seen),
+            instructions="sys",
+            output_type=str,
+            capabilities=[PromptPreparation()],
+        )
+        checkpointed: List[Any] = [
+            ModelRequest(parts=[UserPromptPart(content=RAW)]),
+            ModelResponse(parts=[TextPart("partial step")]),
+        ]
+        with observe_prompt_preparation(_observation()):
+            task = asyncio.get_running_loop().create_task(
+                agent.run("continue", message_history=checkpointed)
+            )
+        await task
+        assert seen[0][0].parts[0].content == PREPARED
+        # ...and the custody-boundary mirror repairs the checkpoint itself.
+        current_prompt = checkpointed[0].parts[0].content
+        assert current_prompt in (RAW, PREPARED)
+
+    asyncio.run(scenario())
+
+
+def test_process_history_after_prompt_preparation_sees_folded_message():
+    """Pins the capability-list ordering contract both construction sites use:
+    PromptPreparation FIRST means compaction observes the folded prompt."""
+
+    async def scenario():
+        observed: List[List[Any]] = []
+
+        def recorder(messages: List[Any]) -> List[Any]:
+            observed.append(list(messages))
+            return messages
+
+        seen: List[List[Any]] = []
+        agent = Agent(
+            model=_capture_model(seen),
+            instructions="sys",
+            output_type=str,
+            capabilities=[PromptPreparation(), ProcessHistory(recorder)],
+        )
+        with observe_prompt_preparation(_observation()):
+            task = asyncio.get_running_loop().create_task(agent.run(RAW))
+        await task
+        assert observed[0][0].parts[0].content == PREPARED
+
+    asyncio.run(scenario())
+
+
+def test_nested_observation_shadowing():
+    """Sub-agent installs must shadow the outer turn's observation for their
+    own tasks only — mirroring how sub-agent invocation nests inside a run."""
+
+    async def scenario():
+        outer = _observation()
+        inner = PromptObservation(
+            raw="inner raw", prepared="inner prepared", active=True
+        )
+
+        async def inner_task() -> Optional[PromptObservation]:
+            return current_prompt_observation()
+
+        with observe_prompt_preparation(outer):
+            with observe_prompt_preparation(inner):
+                shadowed = asyncio.get_running_loop().create_task(inner_task())
+            restored = asyncio.get_running_loop().create_task(inner_task())
+            assert await shadowed is inner
+            assert await restored is outer
+        assert current_prompt_observation() is None
+
+    asyncio.run(scenario())
+
+
+def test_not_spec_serializable():
+    assert PromptPreparation.get_serialization_name() is None

--- a/tests/agents/test_prompt_preparation_capability.py
+++ b/tests/agents/test_prompt_preparation_capability.py
@@ -337,13 +337,58 @@ def test_checkpoint_resume_rerun_still_folds():
             task = asyncio.get_running_loop().create_task(
                 agent.run("continue", message_history=checkpointed)
             )
-        await task
+        result = await task
+        # Send side: the model saw the folded prompt.
         assert seen[0][0].parts[0].content == PREPARED
-        # ...and the custody-boundary mirror repairs the checkpoint itself.
-        current_prompt = checkpointed[0].parts[0].content
-        assert current_prompt in (RAW, PREPARED)
+        # Persist side: the run's RECORDED history was mirrored by after_run.
+        assert result.all_messages()[0].parts[0].content == PREPARED
+        # pydantic-ai copies supplied history, so the caller's checkpoint list
+        # itself stays raw after the run — repairing it is exactly the job of
+        # the core custody-boundary mirror, pinned separately below.
+        assert checkpointed[0].parts[0].content == RAW
 
     asyncio.run(scenario())
+
+
+def test_main_custody_boundary_mirror_then_prune():
+    """Production-shaped replica of ``_run_agent_task_body``'s finally block:
+    mirror the (possibly raw) turn state in place, THEN prune interrupted
+    tool calls — covering crash/cancel exits where after_run never fired."""
+    from code_puppy.agents import _history
+
+    part = UserPromptPart(content=RAW)
+    message_history: List[Any] = [
+        ModelRequest(parts=[part]),
+        ModelResponse(parts=[TextPart("partial step")]),
+    ]
+    observation = _observation()
+
+    observation.mirror(message_history)
+    message_history = _history.prune_interrupted_tool_calls(message_history)
+
+    assert message_history[0].parts[0].content == PREPARED
+    assert part.content == PREPARED  # in place: every alias sees it
+
+
+def test_subagent_partial_save_custody_boundary():
+    """Production-shaped replica of the sub-agent except-block mirror: the
+    checkpointed ``agent_config`` history is repaired before partial save."""
+
+    class FakeConfig:
+        def __init__(self, history: List[Any]) -> None:
+            self._history = history
+
+        def get_message_history(self) -> List[Any]:
+            return self._history
+
+    part = UserPromptPart(content=RAW)
+    config = FakeConfig([ModelRequest(parts=[part])])
+    observation = _observation()
+
+    # Exactly what the except block does before _save_partial_session.
+    observation.mirror(config.get_message_history() or [])
+
+    assert config.get_message_history()[0].parts[0].content == PREPARED
 
 
 def test_process_history_after_prompt_preparation_sees_folded_message():


### PR DESCRIPTION
Eleventh in the capability series (#828–#836, #838). This one converts the last feature still smuggling itself past `pydantic_agent.run()` inside the *prompt argument*: the first-turn system-prompt fold for claude-code-style models.

## The feature

Providers like claude-code OAuth pin their own instruction string, so code_puppy delivers the real system prompt (+ puppy rules) folded into the **first user message**. Previously `_runtime._should_prepend_system_prompt` (and the twin `prepare_prompt_for_model` call in `subagent_invocation`) baked that fold into the prompt string before the run started — invisible to the capability system, and baked into recorded history as a side effect.

## The conversion

New `code_puppy/agents/_prompt_preparation.py`:

- **`build_prompt_observation()`** computes the `raw -> prepared` substitution **once per turn, at the exact old call site** — identical hook arguments (`prepare_model_prompt` / `get_model_system_prompt`), identical timing, identical call count (non-qualifying turns fire zero hooks, as before).
- **`PromptPreparation`** (stateless `AbstractCapability`):
  - `before_model_request` — swaps the conversation's **first** user message `raw -> prepared` (send side; fresh copies, positional + content-guarded, attachments payloads handled),
  - `after_run` — mirrors the same swap into the recorded history **in place** (persist side), so bytes at rest match the old baked-in prompt.
- Per-turn state rides a **ContextVar observation** installed around the run task (#835's pattern), so:
  - streaming-retry re-entries that resume from a checkpointed **raw** first message still fold at request time — model-visible bytes stay byte-identical to the baked behaviour on every path,
  - nested sub-agent runs shadow the outer observation (pinned by test).
- **Ordering**: `PromptPreparation` sits **first** in both `capabilities=[...]` blocks so compaction sees the folded first message exactly as it did when the fold arrived pre-baked (pinned by test).
- Core mirrors at its **state-custody boundaries** — the main run-task `finally` and the sub-agent partial-session save — so cancellation/crash checkpoints also persist the prepared form (idempotent; #828's injectable-mirror precedent).

## Feature-parity notes (the honest bits)

- **Empty-prompt degenerate case**: payload building drops empty prompts, so there's no user part to anchor a request-time swap on. The fold is baked eagerly for that case, exactly as before.
- **Resumed sub-agent sessions**: `prepare_prompt_for_model(prepend_system_to_user=False)` leaves the user prompt untouched under the plugin contract (verified against the claude_code_oauth plugin), so the eager pass-through stays — an identity transform either way.
- **Sub-agent session saves** (`initial_prompt=`) now pass the prepared string explicitly, matching what the old code saved.
- **One bounded divergence**: *during* a turn, in-memory checkpoints hold the raw first message until a custody boundary mirrors it (the old code baked it up front). Model-visible bytes are unaffected (the swap applies per request); the window closes at run end / cancellation / crash-save.

## Tests

19 contract tests in `tests/agents/test_prompt_preparation_capability.py`, including wire + stored-history parity against the old baked-prompt behaviour through a real `Agent.run()`, checkpoint-resume folding, compaction-ordering, and nested-observation shadowing.

Full suite: **7616 passed, 0 failed** (28 skipped, 1 xpassed).

## Review

code-puppy clone, two passes: APPROVE pass 1 with 2 non-blocking findings + 1 nit (both findings applied in `e5623438`: exact checkpoint-copy semantics pinned, production-shaped custody-boundary tests for the main-task finally and the sub-agent partial save; full `_run_with_mcp_impl` integration test declined — would mostly test the mocks, YAGNI). Final verdict pass 2: APPROVE, zero new findings.
