### PR TITLE
feat: InterruptedSubagentNotes capability (capability series, round 12)

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -19,6 +19,7 @@ from pydantic_ai import Agent as PydanticAgent
 from pydantic_ai.capabilities import ProcessHistory
 
 from code_puppy.agents._compaction import make_history_processor
+from code_puppy.agents._interrupt_notes import InterruptedSubagentNotes
 from code_puppy.agents._model_message_transform import build_model_message_transform
 from code_puppy.agents._output_limits import (
     build_response_clamp,
@@ -651,17 +652,20 @@ def build_pydantic_agent(
             output_type=output_type,
             retries=3,
             toolsets=toolsets,
-            # Order matters: compaction first (may trim history to fit
-            # context), THEN steer injection (a fresh steer must not be
-            # compacted away). ProcessHistory capabilities apply in
-            # registration order (replaces the deprecated
-            # `history_processors=` kwarg, removed in pydantic-ai v2).
-            # ToolOutputLimits reduces oversized tool returns on a different
-            # hook (after_tool_execute), so its position is inert; the
-            # response clamp runs before_model_request after both history
-            # processors. The plugin transform wraps the final model request.
+            # Order matters: interrupted-sub-agent notes land first (so
+            # compaction sees them exactly as it saw the old eager history
+            # append), compaction next (may trim history to fit context),
+            # THEN steer injection (a fresh steer must not be compacted
+            # away). ProcessHistory capabilities apply in registration order
+            # (replaces the deprecated `history_processors=` kwarg, removed
+            # in pydantic-ai v2). ToolOutputLimits reduces oversized tool
+            # returns on a different hook (after_tool_execute), so its
+            # position is inert; the response clamp runs before_model_request
+            # after both history processors. The plugin transform wraps the
+            # final model request.
             capabilities=[
                 *build_tool_output_limits(),
+                InterruptedSubagentNotes(),
                 ProcessHistory(history_processor),
                 ProcessHistory(steer_processor),
                 build_response_clamp(),

--- a/code_puppy/agents/_interrupt_notes.py
+++ b/code_puppy/agents/_interrupt_notes.py
@@ -37,10 +37,12 @@ Bounded divergences (all documented, none model-visible in practice):
   the pre-note history. The notes are a few short user messages; nothing in
   tree routes models off them.
 * A *nested* ``run_with_mcp`` run (a plugin starting a run inside the outer
-  run's task) inherits the ambient observation but never matches the outer
-  turn's prompt anchor, so it cannot steal the injection; the notes wait for
-  the outer run's own first request. Should that request never come, the
-  custody fallback applies.
+  run's task) shadows the ambient observation with ``None`` around its own
+  ``create_task``, so it cannot steal the injection; the notes wait for the
+  outer run's own first request. Should that request never come, the custody
+  fallback applies. For runs that bypass ``run_with_mcp`` entirely, the
+  prompt anchor in ``before_model_request`` still defers injection when the
+  trailing request is not the outer turn's own.
 * Sub-agents built by ``subagent_invocation`` deliberately do NOT get this
   capability: the notes belong to the main conversation, and injecting them
   into a sub-agent's transcript (while mirroring into the main agent's
@@ -95,14 +97,19 @@ def current_observation() -> Optional[InterruptNoteObservation]:
 def install_interrupt_note_observation(
     observation: Optional[InterruptNoteObservation],
 ) -> Iterator[None]:
-    """Install ``observation`` for the enclosed block (``None`` is a no-op).
+    """Install ``observation`` for the enclosed block.
 
     Wrap the ``create_task`` call so the run task's context snapshot carries
     the observation (the #835/#839 pattern); nested installs shadow.
+
+    ``None`` is installed too, ON PURPOSE: a nested ``run_with_mcp`` builds
+    no observation, and shadowing with ``None`` is what isolates its task
+    from the outer turn's ambient observation -- otherwise the nested run's
+    first model request could consume the outer turn's one-shot injection
+    state. The prompt anchor in ``before_model_request`` remains as defense
+    in depth for runs that enter the pydantic agent without this install
+    (e.g. a plugin calling ``pydantic_agent.run`` directly).
     """
-    if observation is None:
-        yield
-        return
     token = _note_observation.set(observation)
     try:
         yield

--- a/code_puppy/agents/_interrupt_notes.py
+++ b/code_puppy/agents/_interrupt_notes.py
@@ -1,0 +1,241 @@
+"""Interrupted-sub-agent notes as a first-class pydantic-ai capability.
+
+Ctrl+C cancels both a delegated sub-agent task and the parent run, and the
+parent's return-less ``invoke_agent`` tool call is pruned from history as a
+dangling call -- so without help the model would have no memory that it ever
+delegated. ``subagent_invocation`` records each interrupted session; this
+module surfaces those records to the model as one plain user-message note per
+session (the same injection shape the steer processor uses).
+
+Previously ``_run_signals.inject_interrupted_subagent_notes`` appended the
+notes to ``agent._message_history`` eagerly at run start. Now the notes ride
+a :class:`InterruptedSubagentNotes` capability on pydantic-ai's
+``before_model_request`` seam:
+
+* :func:`build_interrupt_note_observation` runs at the exact old call site
+  (run start, never nested) and keeps the old drain + ``emit_info`` timing
+  byte-identical. It packages the notes into a per-turn
+  :class:`InterruptNoteObservation` instead of mutating history.
+* :class:`InterruptedSubagentNotes` (stateless, shared across turns) resolves
+  the observation from a ``ContextVar`` installed around the run task and
+  splices the notes into the outbound messages immediately before the turn's
+  own user request -- the exact position the eager append produced. Returned
+  ``before_model_request`` messages feed the run's state, so the notes
+  persist into ``result.all_messages()`` (verified against pydantic-ai
+  2.31.0) and every later request of the turn.
+* At injection time the notes are also mirrored into
+  ``agent._message_history`` (the steer-processor pattern) so a
+  ``streaming_retry`` re-entry -- which re-seeds from that list -- keeps
+  them. :func:`mirror_uninjected` is the custody-boundary fallback: if the
+  turn dies before any model request fired, the runtime's ``finally`` mirrors
+  the notes so they surface on the *next* turn, exactly like a note the old
+  eager path had baked but the model never got to read.
+
+Bounded divergences (all documented, none model-visible in practice):
+
+* The ``model_select`` hook fires before any model request, so it now sees
+  the pre-note history. The notes are a few short user messages; nothing in
+  tree routes models off them.
+* A *nested* ``run_with_mcp`` run (a plugin starting a run inside the outer
+  run's task) inherits the ambient observation but never matches the outer
+  turn's prompt anchor, so it cannot steal the injection; the notes wait for
+  the outer run's own first request. Should that request never come, the
+  custody fallback applies.
+* Sub-agents built by ``subagent_invocation`` deliberately do NOT get this
+  capability: the notes belong to the main conversation, and injecting them
+  into a sub-agent's transcript (while mirroring into the main agent's
+  history) would be wrong on both ends.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field, replace
+from typing import Any, Callable, Iterator, List, Optional
+
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.messages import ModelMessage, ModelRequest, UserPromptPart
+from pydantic_ai.models import ModelRequestContext
+from pydantic_ai.tools import RunContext
+
+from code_puppy.messaging import emit_info
+
+
+@dataclass
+class InterruptNoteObservation:
+    """Per-turn state: the notes awaiting injection and how to persist them.
+
+    Built once per (non-nested) ``run_with_mcp`` turn when interrupted
+    sub-agent records exist. ``mirror`` appends messages to the owning
+    agent's ``_message_history`` -- injectable so tests can observe custody
+    without a full ``BaseAgent``.
+    """
+
+    notes: List[ModelRequest]
+    mirror: Callable[[List[ModelMessage]], None]
+    # The turn's ``run()`` prompt payload (str or [prompt, *attachments]),
+    # set by the runtime once the payload is built. Anchors the splice: the
+    # notes go immediately before the ModelRequest carrying this content.
+    turn_prompt: Any = None
+    injected: bool = field(default=False)
+
+
+_note_observation: ContextVar[Optional[InterruptNoteObservation]] = ContextVar(
+    "interrupt_note_observation", default=None
+)
+
+
+def current_observation() -> Optional[InterruptNoteObservation]:
+    """Return the ambient observation for this turn, if any."""
+    return _note_observation.get()
+
+
+@contextmanager
+def install_interrupt_note_observation(
+    observation: Optional[InterruptNoteObservation],
+) -> Iterator[None]:
+    """Install ``observation`` for the enclosed block (``None`` is a no-op).
+
+    Wrap the ``create_task`` call so the run task's context snapshot carries
+    the observation (the #835/#839 pattern); nested installs shadow.
+    """
+    if observation is None:
+        yield
+        return
+    token = _note_observation.set(observation)
+    try:
+        yield
+    finally:
+        _note_observation.reset(token)
+
+
+def build_interrupt_note_observation(
+    agent: Any,
+) -> Optional[InterruptNoteObservation]:
+    """Drain interrupted-sub-agent records into a per-turn observation.
+
+    Runs at the exact old ``inject_interrupted_subagent_notes`` call site
+    (run start, never nested), preserving its behaviour byte-for-byte:
+
+    * an agent without ``_message_history`` leaves the records queued;
+    * each record becomes one plain user-message note (same text, same
+      ``emit_info``);
+    * no records -> ``None`` (the capability stays inert for the turn).
+    """
+    from code_puppy.tools.subagent_invocation import drain_interrupted_subagents
+
+    if not hasattr(agent, "_message_history"):
+        return None
+    records = drain_interrupted_subagents()
+    if not records:
+        return None
+
+    notes: List[ModelRequest] = []
+    for rec in records:
+        session_id = rec["session_id"]
+        saved = rec["saved_count"]
+        saved_phrase = (
+            f"{saved} message(s) of its work were saved"
+            if saved is not None
+            else "no completed messages had been produced yet"
+        )
+        note = (
+            f"[system note] The sub-agent '{rec['agent_name']}' you invoked was "
+            f"interrupted by the user before it finished; {saved_phrase}. Its "
+            f"partial session is saved as '{session_id}'."
+        )
+        notes.append(ModelRequest(parts=[UserPromptPart(content=note)]))
+        emit_info(
+            f"Noting interrupted sub-agent '{rec['agent_name']}' "
+            f"(session {session_id}) for the agent's next turn."
+        )
+
+    def _mirror(messages: List[ModelMessage]) -> None:
+        agent._message_history = list(agent._message_history) + list(messages)
+
+    return InterruptNoteObservation(notes=notes, mirror=_mirror)
+
+
+def mirror_uninjected(observation: Optional[InterruptNoteObservation]) -> None:
+    """Custody-boundary fallback: persist notes that never reached a request.
+
+    Called from the run task's ``finally`` (before the interrupted-tool-call
+    prune, mirroring the runtime's existing boundary order). If the turn
+    ended -- cancel, crash, or a model that was never reached -- without the
+    capability firing, append the notes to history so they surface on the
+    next turn instead of vanishing with the drained records. Idempotent via
+    the ``injected`` flag.
+    """
+    if observation is None or observation.injected:
+        return
+    observation.injected = True
+    observation.mirror(observation.notes)
+
+
+def _is_turn_request(message: ModelMessage, turn_prompt: Any) -> bool:
+    """Whether ``message`` is the ModelRequest carrying this turn's prompt."""
+    if not isinstance(message, ModelRequest):
+        return False
+    return any(
+        isinstance(part, UserPromptPart) and part.content == turn_prompt
+        for part in message.parts
+    )
+
+
+@dataclass
+class InterruptedSubagentNotes(AbstractCapability[Any]):
+    """Splice this turn's interrupted-sub-agent notes into the model request.
+
+    Stateless: all per-turn state lives on the ambient
+    :class:`InterruptNoteObservation`. Wire it before the compaction
+    ``ProcessHistory`` so compaction sees the notes exactly as it saw the old
+    eager append.
+    """
+
+    async def before_model_request(
+        self,
+        ctx: RunContext[Any],
+        request_context: ModelRequestContext,
+    ) -> ModelRequestContext:
+        observation = _note_observation.get()
+        if observation is None or observation.injected:
+            return request_context
+
+        messages = request_context.messages
+        if messages and _is_turn_request(messages[-1], observation.turn_prompt):
+            # Normal turn: notes sit immediately before the new user request,
+            # the exact position the old eager history-append produced.
+            new_messages = (
+                list(messages[:-1]) + list(observation.notes) + [messages[-1]]
+            )
+        elif not observation.turn_prompt:
+            # Degenerate empty-prompt turn: no user request to anchor on; the
+            # old path appended the notes at the end of history, so do the same.
+            new_messages = list(messages) + list(observation.notes)
+        else:
+            # Not this turn's request (e.g. a nested run that inherited the
+            # ambient observation). Leave the notes for the outer run's own
+            # first request; the custody fallback covers the never-fires case.
+            return request_context
+
+        observation.injected = True
+        # Mirror now (steer-processor pattern) so a streaming_retry re-entry,
+        # which re-seeds from ``agent._message_history``, keeps the notes.
+        observation.mirror(observation.notes)
+        return replace(request_context, messages=new_messages)
+
+    def get_serialization_name(self) -> Optional[str]:
+        # Not spec-constructible: useless without the runtime-installed
+        # observation (SteerInjection/HistoryCompaction precedent).
+        return None
+
+
+__all__ = [
+    "InterruptNoteObservation",
+    "InterruptedSubagentNotes",
+    "build_interrupt_note_observation",
+    "current_observation",
+    "install_interrupt_note_observation",
+    "mirror_uninjected",
+]

--- a/code_puppy/agents/_run_signals.py
+++ b/code_puppy/agents/_run_signals.py
@@ -170,54 +170,6 @@ def prepare_queued_steer_injection(agent: Any, result: Any) -> Optional[Any]:
     return content
 
 
-def inject_interrupted_subagent_notes(agent: Any) -> None:
-    """Tell the agent about any sub-agents interrupted since the last run.
-
-    Ctrl+C cancels both the delegated sub-agent task and the parent run, and
-    the parent's return-less ``invoke_agent`` tool call is pruned from history
-    as a dangling call -- so without this the model would have no memory that
-    it ever delegated. We drain the records left by the sub-agent cancel path
-    and append one plain user-message note per interrupted session (the same
-    injection shape the steer processor uses), which survives the interrupted
-    tool-call prune because it is a valid standalone message.
-
-    Called at run start (never nested) so a foreground cancel surfaces on the
-    user's next turn, and a ``/fork`` cancelled while the agent was idle
-    surfaces on the next run too.
-    """
-    from pydantic_ai.messages import ModelRequest, UserPromptPart
-
-    from code_puppy.tools.subagent_invocation import drain_interrupted_subagents
-
-    if not hasattr(agent, "_message_history"):
-        return
-    records = drain_interrupted_subagents()
-    if not records:
-        return
-
-    injected = []
-    for rec in records:
-        session_id = rec["session_id"]
-        saved = rec["saved_count"]
-        saved_phrase = (
-            f"{saved} message(s) of its work were saved"
-            if saved is not None
-            else "no completed messages had been produced yet"
-        )
-        note = (
-            f"[system note] The sub-agent '{rec['agent_name']}' you invoked was "
-            f"interrupted by the user before it finished; {saved_phrase}. Its "
-            f"partial session is saved as '{session_id}'."
-        )
-        injected.append(ModelRequest(parts=[UserPromptPart(content=note)]))
-        emit_info(
-            f"Noting interrupted sub-agent '{rec['agent_name']}' "
-            f"(session {session_id}) for the agent's next turn."
-        )
-
-    agent._message_history = list(agent._message_history) + injected
-
-
 def drain_pause_state_on_cancel() -> None:
     """Clear ``PauseController`` state when a run is cancelled.
 
@@ -236,9 +188,8 @@ def drain_pause_state_on_cancel() -> None:
         )
 
 
-all__ = [
+__all__ = [
     "drain_pause_state_on_cancel",
-    "inject_interrupted_subagent_notes",
     "make_schedule_cancel",
     "prepare_queued_steer_injection",
     "reset_pause_state_at_run_start",

--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -76,9 +76,13 @@ from code_puppy.agents._non_streaming_render import (
     render_result_without_streaming,
     should_render_fallback,
 )
+from code_puppy.agents._interrupt_notes import (
+    build_interrupt_note_observation,
+    install_interrupt_note_observation,
+    mirror_uninjected,
+)
 from code_puppy.agents._run_signals import (
     drain_pause_state_on_cancel,
-    inject_interrupted_subagent_notes,
     make_schedule_cancel,
     prepare_queued_steer_injection,
     reset_pause_state_at_run_start,
@@ -673,11 +677,15 @@ async def _run_with_mcp_impl(
     # touching anything: without this, a leftover steer queue would silently
     # poison this run. NEVER from a nested run — the "stale" steers it would
     # drain are the OUTER run's live ones.
+    # Surface any sub-agent interrupted since the last run so the model knows
+    # the delegation was stopped and where to resume it. The records are
+    # drained here (same timing as the old eager history-append) but the notes
+    # are delivered by the InterruptedSubagentNotes capability at the turn's
+    # first model request; see ``_interrupt_notes``.
+    note_observation = None
     if not is_nested_run:
         reset_pause_state_at_run_start()
-        # Surface any sub-agent interrupted since the last run so the model
-        # knows the delegation was stopped and where to resume it.
-        inject_interrupted_subagent_notes(agent)
+        note_observation = build_interrupt_note_observation(agent)
 
     prompt = _sanitize_prompt(prompt)
     group_id = str(uuid.uuid4())
@@ -716,6 +724,10 @@ async def _run_with_mcp_impl(
 
     prompt = _should_prepend_system_prompt(agent, prompt)
     prompt_payload = _build_prompt_payload(prompt, attachments, link_attachments)
+    if note_observation is not None:
+        # Anchor the note splice: the capability inserts the notes right
+        # before the ModelRequest carrying this payload.
+        note_observation.turn_prompt = prompt_payload
 
     async def _do_run(prompt_to_use: Any) -> Any:
         """Run the agent once, then honour any plugin ``retry`` requests."""
@@ -932,6 +944,10 @@ async def _run_with_mcp_impl(
             from code_puppy.observability import clear_agent_context
 
             clear_agent_context(group_id)
+            # Mirror notes the capability never delivered (cancel/crash before
+            # the first model request) BEFORE pruning, so drained records
+            # still surface next turn -- exactly what the eager append gave.
+            mirror_uninjected(note_observation)
             agent._message_history = _history.prune_interrupted_tool_calls(
                 agent._message_history
             )
@@ -965,7 +981,11 @@ async def _run_with_mcp_impl(
         # MCP trouble must never block the agent run itself.
         pass
 
-    agent_task = asyncio.create_task(run_agent_task())
+    # Install around create_task so the task's context snapshot carries the
+    # observation into every model request of the turn (nested sub-agent
+    # installs shadow; a ``None`` observation is a no-op).
+    with install_interrupt_note_observation(note_observation):
+        agent_task = asyncio.create_task(run_agent_task())
 
     loop = asyncio.get_running_loop()
 

--- a/tests/agents/test_interrupt_notes_capability.py
+++ b/tests/agents/test_interrupt_notes_capability.py
@@ -1,0 +1,483 @@
+"""Contract tests for the InterruptedSubagentNotes capability.
+
+Pins feature parity with the retired eager
+``_run_signals.inject_interrupted_subagent_notes``:
+
+* drain + ``emit_info`` timing and text at the old call site;
+* model-visible note position (immediately before the turn's user request);
+* persistence into ``result.all_messages()`` and ``agent._message_history``
+  (injection-time mirror + custody-boundary fallback);
+* inertness without an observation, and the nested-run anchor guard.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, List
+
+import pytest
+
+from pydantic_ai import Agent
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    UserPromptPart,
+)
+from pydantic_ai.models import ModelRequestContext, ModelRequestParameters
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from code_puppy.agents import _runtime
+from code_puppy.agents._interrupt_notes import (
+    InterruptNoteObservation,
+    InterruptedSubagentNotes,
+    build_interrupt_note_observation,
+    current_observation,
+    install_interrupt_note_observation,
+    mirror_uninjected,
+)
+from code_puppy.callbacks import _callbacks, clear_callbacks
+from code_puppy.messaging.pause_controller import reset_pause_controller
+from code_puppy.tools.subagent_invocation import (
+    drain_interrupted_subagents,
+    record_interrupted_subagent,
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def _isolated_interrupt_queue():
+    drain_interrupted_subagents()
+    yield
+    drain_interrupted_subagents()
+
+
+@pytest.fixture(autouse=True)
+def _reset_pause_controller():
+    reset_pause_controller()
+    yield
+    reset_pause_controller()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_callbacks():
+    snapshot = {phase: list(cbs) for phase, cbs in _callbacks.items()}
+    clear_callbacks()
+    yield
+    clear_callbacks()
+    for phase, cbs in snapshot.items():
+        _callbacks[phase].extend(cbs)
+
+
+@pytest.fixture
+def _isolated_runtime(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(_runtime, "sigint_fallback_cancels", lambda: True)
+    monkeypatch.setattr(_runtime, "get_enable_streaming", lambda: False)
+    monkeypatch.setattr(_runtime, "should_render_fallback", lambda *_, **__: False)
+
+
+class _HistoryAgent:
+    """Minimal agent shape for observation building."""
+
+    name = "dummy-agent"
+
+    def __init__(self, history: List[Any] | None = None) -> None:
+        self._message_history: List[Any] = list(history or [])
+        self._mcp_servers: List[Any] = []
+        self._code_generation_agent: Any = None
+
+    def get_model_name(self) -> str:
+        return "dummy-model"
+
+    def get_full_system_prompt(self) -> str:
+        return "unused"
+
+
+def _record(session_id: str = "sess-1", saved: int | None = 2) -> None:
+    record_interrupted_subagent(
+        agent_name="test-agent", session_id=session_id, saved_count=saved
+    )
+
+
+def _observation_for(
+    agent: _HistoryAgent, turn_prompt: Any = None
+) -> InterruptNoteObservation:
+    observation = build_interrupt_note_observation(agent)
+    assert observation is not None
+    observation.turn_prompt = turn_prompt
+    return observation
+
+
+def _request_context(messages: List[Any]) -> ModelRequestContext:
+    return ModelRequestContext(
+        model=FunctionModel(lambda m, i: ModelResponse(parts=[TextPart(content="x")])),
+        messages=messages,
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(),
+    )
+
+
+def _note_texts(messages: List[Any]) -> List[str]:
+    out: List[str] = []
+    for message in messages:
+        for part in getattr(message, "parts", []) or []:
+            content = getattr(part, "content", "")
+            if isinstance(content, str) and content.startswith("[system note]"):
+                out.append(content)
+    return out
+
+
+# =============================================================================
+# Observation building (old call-site semantics)
+# =============================================================================
+
+
+def test_build_returns_none_and_keeps_records_without_history_attr():
+    """An agent without ``_message_history`` must not drain the queue."""
+
+    class _NoHistory:
+        pass
+
+    _record()
+    assert build_interrupt_note_observation(_NoHistory()) is None
+    assert len(drain_interrupted_subagents()) == 1
+
+
+def test_build_returns_none_when_no_records():
+    assert build_interrupt_note_observation(_HistoryAgent()) is None
+
+
+def test_build_drains_records_with_exact_note_and_emit_parity(monkeypatch):
+    infos: List[str] = []
+    monkeypatch.setattr(
+        "code_puppy.agents._interrupt_notes.emit_info",
+        lambda msg, *a, **k: infos.append(msg),
+    )
+    _record("sess-1", saved=2)
+    _record("sess-2", saved=None)
+
+    observation = build_interrupt_note_observation(_HistoryAgent())
+
+    assert observation is not None
+    assert drain_interrupted_subagents() == []
+    texts = [part.content for note in observation.notes for part in note.parts]
+    assert texts == [
+        "[system note] The sub-agent 'test-agent' you invoked was interrupted "
+        "by the user before it finished; 2 message(s) of its work were saved. "
+        "Its partial session is saved as 'sess-1'.",
+        "[system note] The sub-agent 'test-agent' you invoked was interrupted "
+        "by the user before it finished; no completed messages had been "
+        "produced yet. Its partial session is saved as 'sess-2'.",
+    ]
+    assert infos == [
+        "Noting interrupted sub-agent 'test-agent' (session sess-1) for the "
+        "agent's next turn.",
+        "Noting interrupted sub-agent 'test-agent' (session sess-2) for the "
+        "agent's next turn.",
+    ]
+    # Notes never carry instructions -- exactly the shape the eager append made.
+    assert all(note.instructions is None for note in observation.notes)
+
+
+# =============================================================================
+# Capability seam behaviour
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_capability_is_inert_without_observation():
+    context = _request_context([ModelRequest(parts=[UserPromptPart(content="hello")])])
+    result = await InterruptedSubagentNotes().before_model_request(None, context)
+    assert result is context  # identity: untouched, not a copy
+
+
+@pytest.mark.asyncio
+async def test_capability_is_inert_after_injection():
+    agent = _HistoryAgent()
+    _record()
+    observation = _observation_for(agent, turn_prompt="hello")
+    observation.injected = True
+    context = _request_context([ModelRequest(parts=[UserPromptPart(content="hello")])])
+    with install_interrupt_note_observation(observation):
+        result = await InterruptedSubagentNotes().before_model_request(None, context)
+    assert result is context
+
+
+@pytest.mark.asyncio
+async def test_empty_prompt_turn_appends_notes_at_end():
+    """No user request to anchor on -> notes go last, like the eager append."""
+    agent = _HistoryAgent()
+    _record()
+    observation = _observation_for(agent, turn_prompt="")
+    tail = ModelResponse(parts=[TextPart(content="old-answer")])
+    context = _request_context([tail])
+
+    with install_interrupt_note_observation(observation):
+        result = await InterruptedSubagentNotes().before_model_request(None, context)
+
+    assert result.messages == [tail, *observation.notes]
+    assert observation.injected is True
+    assert agent._message_history == list(observation.notes)  # mirror fired
+
+
+@pytest.mark.asyncio
+async def test_nonmatching_turn_request_defers_injection():
+    """A nested run's request must not steal the outer turn's notes."""
+    agent = _HistoryAgent()
+    _record()
+    observation = _observation_for(agent, turn_prompt="outer prompt")
+    context = _request_context(
+        [ModelRequest(parts=[UserPromptPart(content="nested prompt")])]
+    )
+
+    with install_interrupt_note_observation(observation):
+        result = await InterruptedSubagentNotes().before_model_request(None, context)
+
+    assert result is context
+    assert observation.injected is False
+    assert agent._message_history == []
+
+
+def test_install_is_none_safe_and_nested_installs_shadow():
+    agent = _HistoryAgent()
+    _record("outer")
+    outer = _observation_for(agent)
+    _record("inner")
+    inner = _observation_for(agent)
+
+    assert current_observation() is None
+    with install_interrupt_note_observation(None):
+        assert current_observation() is None
+    with install_interrupt_note_observation(outer):
+        assert current_observation() is outer
+        with install_interrupt_note_observation(inner):
+            assert current_observation() is inner
+        assert current_observation() is outer
+    assert current_observation() is None
+
+
+def test_mirror_uninjected_is_idempotent_and_respects_injection():
+    agent = _HistoryAgent(history=["seed"])
+    _record()
+    observation = _observation_for(agent)
+
+    mirror_uninjected(observation)
+    mirror_uninjected(observation)  # second call must not double-append
+    assert agent._message_history == ["seed", *observation.notes]
+
+    # Already-injected notes must not be mirrored again.
+    agent2 = _HistoryAgent()
+    _record("sess-9")
+    observation2 = _observation_for(agent2)
+    observation2.injected = True
+    mirror_uninjected(observation2)
+    assert agent2._message_history == []
+
+    mirror_uninjected(None)  # None-safe
+
+
+# =============================================================================
+# End-to-end through a real pydantic-ai Agent
+# =============================================================================
+
+
+def _make_scripted_model(seen_calls: List[List[str]], steps: int = 1) -> FunctionModel:
+    """FunctionModel that records per-call message part contents."""
+
+    def model_fn(messages: List[Any], info: AgentInfo) -> ModelResponse:
+        seen_calls.append(
+            [
+                str(getattr(part, "content", ""))
+                for message in messages
+                for part in message.parts
+            ]
+        )
+        if len(seen_calls) < steps:
+            return ModelResponse(parts=[ToolCallPart(tool_name="noop", args={})])
+        return ModelResponse(parts=[TextPart(content="done")])
+
+    return FunctionModel(model_fn)
+
+
+@pytest.mark.asyncio
+async def test_injection_lands_before_turn_request_and_persists():
+    agent = _HistoryAgent()
+    _record("sess-1", saved=2)
+    observation = _observation_for(agent, turn_prompt="hello")
+
+    seen_calls: List[List[str]] = []
+    pydantic_agent = Agent(
+        _make_scripted_model(seen_calls),
+        capabilities=[InterruptedSubagentNotes()],
+    )
+    history = [
+        ModelRequest(parts=[UserPromptPart(content="old-turn")]),
+        ModelResponse(parts=[TextPart(content="old-answer")]),
+    ]
+
+    with install_interrupt_note_observation(observation):
+        result = await pydantic_agent.run("hello", message_history=history)
+
+    note_text = observation.notes[0].parts[0].content
+    # Model-visible order matches the eager append: history, note, prompt.
+    assert seen_calls == [["old-turn", "old-answer", note_text, "hello"]]
+    # The note persists into recorded history, before the turn's request.
+    recorded = _note_texts(result.all_messages())
+    assert recorded == [note_text]
+    all_contents = [
+        getattr(part, "content", None)
+        for message in result.all_messages()
+        for part in message.parts
+    ]
+    assert all_contents.index(note_text) < all_contents.index("hello")
+    # Injection-time mirror: retry re-entry seeds see the note.
+    assert _note_texts(agent._message_history) == [note_text]
+
+
+@pytest.mark.asyncio
+async def test_single_injection_across_multi_step_run():
+    agent = _HistoryAgent()
+    _record("sess-1", saved=1)
+    observation = _observation_for(agent, turn_prompt="hello")
+
+    seen_calls: List[List[str]] = []
+    pydantic_agent = Agent(
+        _make_scripted_model(seen_calls, steps=2),
+        capabilities=[InterruptedSubagentNotes()],
+    )
+
+    @pydantic_agent.tool_plain
+    def noop() -> str:
+        return "ok"
+
+    with install_interrupt_note_observation(observation):
+        result = await pydantic_agent.run("hello")
+
+    note_text = observation.notes[0].parts[0].content
+    # The note appears exactly once per model call (persisted, not re-spliced)
+    assert [call.count(note_text) for call in seen_calls] == [1, 1]
+    assert _note_texts(result.all_messages()) == [note_text]
+    assert _note_texts(agent._message_history) == [note_text]
+
+
+# =============================================================================
+# Production-shaped: through run_with_mcp
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_run_with_mcp_delivers_notes_through_capability(_isolated_runtime):
+    """Full call-site wiring: drain at run start, ContextVar into the task,
+    anchor on the built prompt payload, injection + mirror."""
+    seen_calls: List[List[str]] = []
+    pydantic_agent = Agent(
+        _make_scripted_model(seen_calls),
+        capabilities=[InterruptedSubagentNotes()],
+    )
+    agent = _HistoryAgent(
+        history=[
+            ModelRequest(parts=[UserPromptPart(content="old-turn")]),
+            ModelResponse(parts=[TextPart(content="old-answer")]),
+        ]
+    )
+    agent._code_generation_agent = pydantic_agent
+    _record("sess-42", saved=3)
+
+    result = await _runtime.run_with_mcp(agent, "fresh prompt")
+
+    assert result is not None
+    notes = _note_texts(result.all_messages())
+    assert notes == [
+        "[system note] The sub-agent 'test-agent' you invoked was interrupted "
+        "by the user before it finished; 3 message(s) of its work were saved. "
+        "Its partial session is saved as 'sess-42'."
+    ]
+    # Model saw the note between prior history and this turn's prompt.
+    assert seen_calls == [["old-turn", "old-answer", notes[0], "fresh prompt"]]
+    # Mirror persisted it for retry re-entries / crash custody.
+    assert _note_texts(agent._message_history) == notes
+    # Records were drained at run start.
+    assert drain_interrupted_subagents() == []
+
+
+class _CancelledPydanticAgent:
+    async def run(self, prompt: Any, **kwargs: Any) -> Any:
+        raise asyncio.CancelledError()
+
+
+@pytest.mark.asyncio
+async def test_run_with_mcp_custody_fallback_on_cancel_before_request(
+    _isolated_runtime,
+):
+    """A run cancelled before any model request still persists the notes,
+    exactly like the old eager history append."""
+    agent = _HistoryAgent(
+        history=[ModelRequest(parts=[UserPromptPart(content="old-turn")])]
+    )
+    agent._code_generation_agent = _CancelledPydanticAgent()
+    _record("sess-7", saved=None)
+
+    result = await _runtime.run_with_mcp(agent, "doomed prompt")
+
+    assert result is None  # cancellation is absorbed by the runtime
+    notes = _note_texts(agent._message_history)
+    assert notes == [
+        "[system note] The sub-agent 'test-agent' you invoked was interrupted "
+        "by the user before it finished; no completed messages had been "
+        "produced yet. Its partial session is saved as 'sess-7'."
+    ]
+    assert drain_interrupted_subagents() == []
+
+
+@pytest.mark.asyncio
+async def test_nested_run_does_not_drain_records(_isolated_runtime):
+    """Nested runs must leave the record queue for the outer run."""
+    seen_calls: List[List[str]] = []
+    pydantic_agent = Agent(_make_scripted_model(seen_calls))
+    agent = _HistoryAgent(
+        history=[ModelRequest(parts=[UserPromptPart(content="old-turn")])]
+    )
+    agent._code_generation_agent = pydantic_agent
+    _record("sess-nested")
+
+    _runtime._active_run_depth += 1  # simulate an outer run in flight
+    try:
+        await _runtime.run_with_mcp(agent, "inner prompt")
+    finally:
+        _runtime._active_run_depth -= 1
+
+    assert _note_texts(agent._message_history) == []
+    assert len(drain_interrupted_subagents()) == 1
+
+
+# =============================================================================
+# Wiring pins
+# =============================================================================
+
+
+def test_builder_orders_notes_before_compaction():
+    """The capability must precede the compaction ProcessHistory so
+    compaction sees the notes exactly as it saw the old eager append."""
+    import inspect
+
+    from code_puppy.agents import _builder
+
+    source = inspect.getsource(_builder)
+    notes_pos = source.index("InterruptedSubagentNotes(),")
+    compaction_pos = source.index("ProcessHistory(history_processor)")
+    assert notes_pos < compaction_pos
+
+
+def test_subagent_site_has_no_interrupt_notes_capability():
+    """Sub-agents must never inject the main conversation's notes."""
+    import inspect
+
+    from code_puppy.tools import subagent_invocation
+
+    source = inspect.getsource(subagent_invocation)
+    assert "InterruptedSubagentNotes" not in source

--- a/tests/agents/test_interrupt_notes_capability.py
+++ b/tests/agents/test_interrupt_notes_capability.py
@@ -243,7 +243,7 @@ async def test_nonmatching_turn_request_defers_injection():
     assert agent._message_history == []
 
 
-def test_install_is_none_safe_and_nested_installs_shadow():
+def test_install_shadows_including_none_installs():
     agent = _HistoryAgent()
     _record("outer")
     outer = _observation_for(agent)
@@ -257,6 +257,11 @@ def test_install_is_none_safe_and_nested_installs_shadow():
         assert current_observation() is outer
         with install_interrupt_note_observation(inner):
             assert current_observation() is inner
+        assert current_observation() is outer
+        # A nested run installs None -- it must SHADOW the outer observation,
+        # not fall through to it (nested-run isolation).
+        with install_interrupt_note_observation(None):
+            assert current_observation() is None
         assert current_observation() is outer
     assert current_observation() is None
 
@@ -432,6 +437,71 @@ async def test_run_with_mcp_custody_fallback_on_cancel_before_request(
         "produced yet. Its partial session is saved as 'sess-7'."
     ]
     assert drain_interrupted_subagents() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("outer_prompt", "nested_prompt"),
+    [
+        ("", "nested prompt"),  # empty outer anchor: append branch bait
+        ("continue", "continue"),  # identical prompts: anchor-match bait
+    ],
+)
+async def test_nested_run_cannot_steal_outer_notes(
+    _isolated_runtime, outer_prompt, nested_prompt
+):
+    """A nested run started while the outer observation is ambient must not
+    consume the outer turn's one-shot injection state -- even when the outer
+    anchor is empty or the prompts are identical (reviewer finding, PR #840).
+    """
+    agent = _HistoryAgent()
+    _record("sess-outer", saved=1)
+    outer_observation = _observation_for(agent, turn_prompt=outer_prompt)
+
+    seen_calls: List[List[str]] = []
+    nested_pydantic_agent = Agent(
+        _make_scripted_model(seen_calls),
+        capabilities=[InterruptedSubagentNotes()],
+    )
+    nested_agent = _HistoryAgent()
+    nested_agent._code_generation_agent = nested_pydantic_agent
+
+    # Simulate the outer run's task context: observation ambient, run depth 1.
+    with install_interrupt_note_observation(outer_observation):
+        _runtime._active_run_depth += 1
+        try:
+            await _runtime.run_with_mcp(nested_agent, nested_prompt)
+        finally:
+            _runtime._active_run_depth -= 1
+
+    note_text = outer_observation.notes[0].parts[0].content
+    # The nested model never saw the outer turn's notes...
+    assert all(note_text not in call for call in seen_calls)
+    # ...and the outer turn's delivery state is untouched.
+    assert outer_observation.injected is False
+    assert _note_texts(agent._message_history) == []
+    assert _note_texts(nested_agent._message_history) == []
+
+
+@pytest.mark.asyncio
+async def test_multimodal_turn_prompt_anchors_the_splice():
+    """A [prompt, *attachments] payload rides one UserPromptPart whose content
+    is the original list (pydantic-ai 2.31.0); the anchor must match it."""
+    from pydantic_ai.messages import BinaryContent
+
+    agent = _HistoryAgent()
+    _record()
+    payload = ["look at this", BinaryContent(data=b"\x89PNG", media_type="image/png")]
+    observation = _observation_for(agent, turn_prompt=payload)
+    turn_request = ModelRequest(parts=[UserPromptPart(content=payload)])
+    tail = ModelResponse(parts=[TextPart(content="old-answer")])
+    context = _request_context([tail, turn_request])
+
+    with install_interrupt_note_observation(observation):
+        result = await InterruptedSubagentNotes().before_model_request(None, context)
+
+    assert result.messages == [tail, *observation.notes, turn_request]
+    assert observation.injected is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Twelfth entry in the capability-conversion series (#828–#836, #838, #839). After round 11 declared the candidate well "genuinely dry at the seams", this round found the feature that was hiding in `_run_signals.py` the whole time: **interrupted-sub-agent notes** — the run-start injection that tells the model a Ctrl+C'd delegation existed and where to resume it.

Previously `inject_interrupted_subagent_notes` eagerly appended the notes to `agent._message_history` at run start. Now the notes ride a first-class pydantic-ai capability, `InterruptedSubagentNotes`, on the `before_model_request` seam.

## How

- **New `code_puppy/agents/_interrupt_notes.py`**
  - `build_interrupt_note_observation(agent)` runs at the *exact old call site* (run start, never nested) — drain timing, `emit_info` text/count, and the no-`_message_history` early-out are byte-identical. It packages the notes into a per-turn `InterruptNoteObservation` instead of mutating history.
  - `InterruptedSubagentNotes` (stateless dataclass, shared across turns) resolves the observation from a ContextVar installed around `create_task` (#835/#839 pattern) and splices the notes **immediately before the turn's own user request** — the exact position the eager append produced. The splice is anchored on the turn's built prompt payload (`observation.turn_prompt`), so a nested run inheriting the ambient observation can't steal the injection.
  - **Key unlock (verified empirically against pydantic-ai 2.31.0):** `before_model_request`'s returned messages feed the run's state — injected messages persist into subsequent requests of the same run *and* into `result.all_messages()`. So success-path custody is automatic.
  - Injection-time mirror into `agent._message_history` (the steer-processor pattern) keeps the notes across `streaming_retry` re-entries, which re-seed from that list.
  - `mirror_uninjected` is the custody-boundary fallback in the run task's `finally` (before the interrupted-tool-call prune, matching the existing boundary order): a turn that dies before any model request still persists the notes for the next turn — exactly what the eager append gave.

- **`_builder.py`**: capability wired before the compaction `ProcessHistory`, so compaction sees the notes exactly as it saw the old eager append. Ordering pinned by test.
- **`_run_signals.py`**: old injector removed; fixed a pre-existing `all__` → `__all__` typo while editing that list (the module's exports were silently never declared).
- **Sub-agent site deliberately untouched**: the notes belong to the main conversation; injecting them into a sub-agent's transcript while mirroring into the main agent's history would be wrong on both ends. Pinned by test.

## Bounded divergences (documented in the module docstring)

- The `model_select` hook fires before any model request, so it now sees pre-note history. Notes are a few short user messages; nothing in tree routes models off them.
- During the sliver between run start and the first model request, `agent._message_history` holds no notes (the old path baked them eagerly). Model-visible bytes are unaffected; every exit path converges via mirror or fallback.

## Tests

19 contract tests in `tests/agents/test_interrupt_notes_capability.py`: exact note-text/emit parity, splice position end-to-end through a real `Agent` + `FunctionModel`, single-injection across multi-step tool runs, empty-prompt append-at-end parity, nested-run anchor guard, ContextVar shadowing, mirror idempotence, multimodal [prompt, *attachments] anchor pinning, and production-shaped runs through `run_with_mcp` (happy path, cancel-before-request custody, nested-run no-drain, and both nested-run note-stealing sequences from review pass 1).

Full suite: **7616 passed, 0 failed** (10 skipped, 1 xpassed).

## Notes

Do not merge yet — same review protocol as the rest of the series. Like its eleven siblings, this grazes the shared `capabilities=[...]` block in `_builder.py`; whichever lands last eats a trivial rebase.

## Review

Reviewed by code-puppy clone (session `pr-840-review-f76d4d-52543e`), two passes: REQUEST_CHANGES on pass 1 (real find: `install_interrupt_note_observation(None)` was a no-op, so nested runs inherited the outer observation through the ContextVar and could steal the one-shot injection — fixed at the root in `ca39aad8` by making None installs shadow, plus regression tests for both exact stealing sequences). Final verdict pass 2: APPROVE, zero findings.
