### PR TITLE
feat(agents): promote tool-call JSON repair to a ToolCallJsonRepair capability

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -19,6 +19,7 @@ from pydantic_ai import Agent as PydanticAgent
 from pydantic_ai.capabilities import ProcessHistory
 
 from code_puppy.agents._compaction import make_history_processor
+from code_puppy.agents._json_repair import build_tool_call_json_repair
 from code_puppy.agents._model_message_transform import build_model_message_transform
 from code_puppy.agents._output_limits import (
     build_response_clamp,
@@ -660,8 +661,12 @@ def build_pydantic_agent(
             # hook (after_tool_execute), so its position is inert; the
             # response clamp runs before_model_request after both history
             # processors. The plugin transform wraps the final model request.
+            # ToolCallJsonRepair rides the before_tool_validate seam, which
+            # never interacts with the history hooks, so its position is
+            # inert too.
             capabilities=[
                 *build_tool_output_limits(),
+                *build_tool_call_json_repair(),
                 ProcessHistory(history_processor),
                 ProcessHistory(steer_processor),
                 build_response_clamp(),

--- a/code_puppy/agents/_json_repair.py
+++ b/code_puppy/agents/_json_repair.py
@@ -1,0 +1,109 @@
+"""Tool-call JSON repair as a first-class pydantic-ai capability.
+
+Promotes the ``patch_tool_call_json_repair`` monkeypatch (see
+``code_puppy.pydantic_patches``) to the ``before_tool_validate`` capability
+seam. LLMs sometimes emit slightly broken JSON in tool-call arguments
+(trailing commas, missing quotes, unclosed braces); repairing the raw args
+before validation prevents an unnecessary retry round-trip.
+
+**Delivery model — explicit-when-ours, fallback-for-guests** (the same
+split ``Instrumentation`` uses for tracing): agents built by code_puppy's
+own construction sites carry an explicit :class:`ToolCallJsonRepair`
+capability, and the monkeypatch detects it (via the run's
+``ToolManager.root_capability`` tree) and steps aside. Raw pydantic-ai
+agents built by plugins (e.g. wiggum's judge, which registers real
+read-only tools) carry no capability, so the patch keeps repairing for
+them exactly as before.
+
+Parity notes versus the eager patch:
+
+* **Same repair, same custody.** The hook receives the *live*
+  ``ToolCallPart`` — the object recorded in the run's message state — so
+  assigning ``call.args`` here lands the repaired JSON in message history
+  exactly as the patch's in-place mutation did, while the returned args
+  feed validation.
+* **Unknown/unavailable tools are a bounded divergence.**
+  ``ToolManager._resolve_tool`` raises before ``before_tool_validate``
+  fires, so a call to a nonexistent tool no longer gets its recorded args
+  repaired (the patch repaired first, resolution failed after). The call
+  fails with the identical ``ModelRetry`` either way; history now keeps
+  the model's true emitted bytes, which is arguably more honest.
+* **Output tools were never covered.** On pydantic-ai 2.31.0, tool-based
+  structured output validates through ``validate_output_tool_call`` — a
+  method the patch never wrapped — so skipping the ``kind == 'output'``
+  carve-out here (pydantic-ai excludes output tools from tool hooks
+  anyway) changes nothing.
+
+``json_repair`` is an optional dependency: :func:`build_tool_call_json_repair`
+returns ``[]`` when it is missing (mirroring the patch's quiet skip and the
+``build_tool_output_limits`` conditional-splice pattern), and the hook
+no-ops defensively if a capability instance is constructed anyway.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, List
+
+from pydantic_ai import RunContext
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.messages import ToolCallPart
+from pydantic_ai.tools import ToolDefinition
+
+try:  # pragma: no cover - exercised via the None-fallback tests
+    import json_repair
+except ImportError:  # pragma: no cover - optional dependency absent
+    json_repair = None  # type: ignore[assignment]
+
+__all__ = ["ToolCallJsonRepair", "build_tool_call_json_repair"]
+
+
+@dataclass
+class ToolCallJsonRepair(AbstractCapability[Any]):
+    """Repair malformed JSON tool-call arguments before validation.
+
+    Stateless: safe to share across construction passes and spec-construct
+    (the default ``get_serialization_name``/``from_spec`` apply).
+    """
+
+    async def before_tool_validate(
+        self,
+        ctx: RunContext[Any],
+        *,
+        call: ToolCallPart,
+        tool_def: ToolDefinition,
+        args: str | dict[str, Any],
+    ) -> str | dict[str, Any]:
+        """Return repaired raw args; mirror the repair onto ``call.args``.
+
+        Only string args are candidates (dict args already parsed upstream).
+        Repair failures are swallowed — the original args proceed to
+        validation, which produces the retry the model would have earned
+        anyway. Both guards match the patch byte-for-byte.
+        """
+        if json_repair is None:
+            return args
+        if isinstance(args, str) and args:
+            try:
+                repaired = json_repair.repair_json(args)
+                if repaired != args:
+                    # Same in-place custody the patch performed: this is the
+                    # ToolCallPart recorded in the run's message state, so
+                    # history shows the repaired JSON the tool actually ran
+                    # with.
+                    call.args = repaired
+                    return repaired
+            except Exception:
+                pass  # let validation surface the original breakage
+        return args
+
+
+def build_tool_call_json_repair() -> List[ToolCallJsonRepair]:
+    """Build the repair capability, or ``[]`` when ``json_repair`` is absent.
+
+    Returned as a list so callers can splice it into ``capabilities=[...]``
+    unconditionally, exactly like ``build_tool_output_limits``.
+    """
+    if json_repair is None:
+        return []
+    return [ToolCallJsonRepair()]

--- a/code_puppy/pydantic_patches.py
+++ b/code_puppy/pydantic_patches.py
@@ -136,6 +136,35 @@ def patch_message_history_cleaning() -> bool:
         )
 
 
+def _run_owns_json_repair(tool_manager: Any) -> bool:
+    """True when the run's capability tree contains ``ToolCallJsonRepair``.
+
+    Walks the run's ``ToolManager.root_capability`` with the public
+    ``AbstractCapability.apply`` visitor (the same traversal the run layer
+    uses for its own explicit-capability checks). Any failure reads as
+    ``False`` — the patch then repairs eagerly, which is the old behavior
+    and idempotent alongside the capability (repairing already-repaired
+    JSON is a no-op).
+    """
+    try:
+        root = getattr(tool_manager, "root_capability", None)
+        if root is None:
+            return False
+        from code_puppy.agents._json_repair import ToolCallJsonRepair
+
+        found = False
+
+        def _visit(leaf: Any) -> None:
+            nonlocal found
+            if isinstance(leaf, ToolCallJsonRepair):
+                found = True
+
+        root.apply(_visit)
+        return found
+    except Exception:
+        return False
+
+
 def patch_tool_call_json_repair() -> bool:
     """Patch pydantic-ai's tool-call validation to auto-repair malformed JSON.
 
@@ -145,6 +174,16 @@ def patch_tool_call_json_repair() -> bool:
     execution in the public ``pydantic_ai.tool_manager`` module) and runs
     json_repair on the raw arguments before validation, preventing
     unnecessary retries.
+
+    **Fallback tier only.** Agents built by code_puppy's own construction
+    sites carry an explicit ``ToolCallJsonRepair`` capability (see
+    ``code_puppy.agents._json_repair``), which repairs on the
+    ``before_tool_validate`` seam; when it is present in the run's
+    capability tree this patch steps aside. The eager repair below remains
+    for *guest* agents — raw pydantic-ai agents built by plugins (e.g.
+    wiggum's tool-wielding judge) that never pass through our builders.
+    Same explicit-when-ours, fallback-for-guests split as Logfire
+    instrumentation.
     """
     try:
         import json_repair
@@ -160,8 +199,13 @@ def patch_tool_call_json_repair() -> bool:
 
         async def _patched_validate_tool_call(self, call, **kwargs):
             """Repair malformed JSON args before pydantic-ai validates them."""
-            # Only attempt repair if args is a string (JSON)
-            if isinstance(call.args, str) and call.args:
+            # Only attempt repair if args is a string (JSON), and only when
+            # no ToolCallJsonRepair capability owns the job for this run.
+            if (
+                isinstance(call.args, str)
+                and call.args
+                and not _run_owns_json_repair(self)
+            ):
                 try:
                     repaired = json_repair.repair_json(call.args)
                     if repaired != call.args:

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -401,6 +401,7 @@ async def _invoke_agent_impl(
                 mcp_servers = manager.get_servers_for_agent(agent_name=bound_agent_name)
 
             from code_puppy.agents._compaction import make_history_processor
+            from code_puppy.agents._json_repair import build_tool_call_json_repair
             from code_puppy.agents._model_message_transform import (
                 build_model_message_transform,
             )
@@ -420,7 +421,10 @@ async def _invoke_agent_impl(
                 toolsets=mcp_servers,
                 # ProcessHistory capability replaces the deprecated
                 # `history_processors=` kwarg (removed in pydantic-ai v2).
+                # ToolCallJsonRepair rides the before_tool_validate seam
+                # (position inert relative to the history hooks).
                 capabilities=[
+                    *build_tool_call_json_repair(),
                     ProcessHistory(make_history_processor(agent_config)),
                     build_model_message_transform(agent_name),
                 ],

--- a/tests/agents/test_tool_call_json_repair_capability.py
+++ b/tests/agents/test_tool_call_json_repair_capability.py
@@ -1,0 +1,356 @@
+"""Contract tests for the ``ToolCallJsonRepair`` capability.
+
+Covers the promotion of ``patch_tool_call_json_repair`` (an eager
+``ToolManager.validate_tool_call`` monkeypatch) onto pydantic-ai's
+``before_tool_validate`` capability seam:
+
+* direct-seam semantics (repair, custody via ``call.args``, pass-throughs,
+  swallowed repair failures, optional-dependency fallback);
+* end-to-end ``Agent.run()`` proof that the tool executes with repaired
+  args AND the recorded history carries the repaired JSON (byte parity
+  with the patch's in-place mutation);
+* the explicit-when-ours / fallback-for-guests split: the patch steps
+  aside when the run's capability tree contains ``ToolCallJsonRepair``,
+  and keeps repairing for raw guest agents;
+* the documented bounded divergence: unknown-tool calls keep their raw
+  (unrepaired) args in history, failing identically either way;
+* construction-site wiring at both ``capabilities=[...]`` blocks.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.tools import ToolDefinition
+
+from code_puppy.agents import _json_repair as json_repair_module
+from code_puppy.agents._json_repair import (
+    ToolCallJsonRepair,
+    build_tool_call_json_repair,
+)
+
+BROKEN_ARGS = '{"x": 1,}'  # trailing comma — json_repair's bread and butter
+REPAIRED_ARGS = '{"x": 1}'
+
+
+def _tool_def(name: str = "grab") -> ToolDefinition:
+    return ToolDefinition(name=name)
+
+
+def _call(args: Any, name: str = "grab") -> ToolCallPart:
+    return ToolCallPart(tool_name=name, args=args)
+
+
+async def _invoke_seam(call: ToolCallPart, args: Any) -> Any:
+    """Drive before_tool_validate exactly as _run_validate_hooks does."""
+    cap = ToolCallJsonRepair()
+    return await cap.before_tool_validate(
+        None,  # RunContext unused by the hook
+        call=call,
+        tool_def=_tool_def(call.tool_name),
+        args=args,
+    )
+
+
+def _tool_call_args_in(messages: list[ModelMessage]) -> list[Any]:
+    return [
+        part.args
+        for message in messages
+        for part in message.parts
+        if isinstance(part, ToolCallPart)
+    ]
+
+
+def _broken_then_done_model() -> FunctionModel:
+    """First response: tool call with broken JSON args. Then: plain text."""
+
+    def fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(
+                parts=[ToolCallPart(tool_name="grab", args=BROKEN_ARGS)]
+            )
+        return ModelResponse(parts=[TextPart("done")])
+
+    return FunctionModel(fn)
+
+
+def _register_grab(agent: Agent, seen: list[int]) -> None:
+    @agent.tool_plain
+    def grab(x: int) -> str:
+        seen.append(x)
+        return "ok"
+
+
+@pytest.fixture
+def restore_validate_tool_call():
+    """Snapshot/restore ToolManager.validate_tool_call around patch tests.
+
+    The patch mutates the class process-globally; without this, one test's
+    patch application leaks into every later test in the session.
+    """
+    from pydantic_ai.tool_manager import ToolManager
+
+    original = ToolManager.validate_tool_call
+    yield
+    ToolManager.validate_tool_call = original
+
+
+# ---------------------------------------------------------------------------
+# Direct seam semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_broken_string_args_are_repaired_and_mirrored():
+    call = _call(BROKEN_ARGS)
+    result = await _invoke_seam(call, BROKEN_ARGS)
+    assert result == REPAIRED_ARGS
+    # Custody: the live ToolCallPart (recorded in run state) carries the
+    # repaired bytes — exactly the patch's in-place mutation.
+    assert call.args == REPAIRED_ARGS
+
+
+@pytest.mark.asyncio
+async def test_valid_json_args_pass_through_untouched():
+    call = _call(REPAIRED_ARGS)
+    result = await _invoke_seam(call, REPAIRED_ARGS)
+    assert result is REPAIRED_ARGS  # same object, no re-serialization
+    assert call.args == REPAIRED_ARGS
+
+
+@pytest.mark.asyncio
+async def test_dict_args_pass_through_untouched():
+    args = {"x": 1}
+    call = _call(args)
+    result = await _invoke_seam(call, args)
+    assert result is args
+    assert call.args is args
+
+
+@pytest.mark.asyncio
+async def test_empty_string_args_pass_through():
+    # Patch parity: the eager patch guarded `call.args` truthiness too.
+    call = _call("")
+    result = await _invoke_seam(call, "")
+    assert result == ""
+    assert call.args == ""
+
+
+@pytest.mark.asyncio
+async def test_repair_failure_is_swallowed(monkeypatch):
+    def explode(_args: str) -> str:
+        raise RuntimeError("repair go boom")
+
+    monkeypatch.setattr(json_repair_module.json_repair, "repair_json", explode)
+    call = _call(BROKEN_ARGS)
+    result = await _invoke_seam(call, BROKEN_ARGS)
+    # Original args proceed to validation; the model earns its retry.
+    assert result == BROKEN_ARGS
+    assert call.args == BROKEN_ARGS
+
+
+@pytest.mark.asyncio
+async def test_missing_json_repair_dependency_noops(monkeypatch):
+    monkeypatch.setattr(json_repair_module, "json_repair", None)
+    call = _call(BROKEN_ARGS)
+    result = await _invoke_seam(call, BROKEN_ARGS)
+    assert result == BROKEN_ARGS
+    assert call.args == BROKEN_ARGS
+
+
+def test_builder_skips_capability_without_dependency(monkeypatch):
+    monkeypatch.setattr(json_repair_module, "json_repair", None)
+    assert build_tool_call_json_repair() == []
+
+
+def test_builder_returns_single_capability():
+    caps = build_tool_call_json_repair()
+    assert len(caps) == 1
+    assert isinstance(caps[0], ToolCallJsonRepair)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end runs through the real capability chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_executes_tool_with_repaired_args_and_records_them():
+    seen: list[int] = []
+    agent = Agent(model=_broken_then_done_model(), capabilities=[ToolCallJsonRepair()])
+    _register_grab(agent, seen)
+
+    result = await agent.run("go")
+
+    assert seen == [1]  # tool ran with the repaired payload — no retry burned
+    assert result.output == "done"
+    assert _tool_call_args_in(result.all_messages()) == [REPAIRED_ARGS]
+
+
+@pytest.mark.asyncio
+async def test_wire_parity_with_eager_patch(restore_validate_tool_call):
+    """A guest agent under the patch and an agent under the capability
+    produce identical recorded tool-call args and identical output."""
+    from code_puppy.pydantic_patches import patch_tool_call_json_repair
+
+    seen_cap: list[int] = []
+    cap_agent = Agent(
+        model=_broken_then_done_model(), capabilities=[ToolCallJsonRepair()]
+    )
+    _register_grab(cap_agent, seen_cap)
+    cap_result = await cap_agent.run("go")
+
+    assert patch_tool_call_json_repair()
+    seen_patch: list[int] = []
+    guest_agent = Agent(model=_broken_then_done_model())
+    _register_grab(guest_agent, seen_patch)
+    patch_result = await guest_agent.run("go")
+
+    assert seen_cap == seen_patch == [1]
+    assert cap_result.output == patch_result.output == "done"
+    assert (
+        _tool_call_args_in(cap_result.all_messages())
+        == _tool_call_args_in(patch_result.all_messages())
+        == [REPAIRED_ARGS]
+    )
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_args_stay_raw_in_history():
+    """Documented bounded divergence: resolution fails before the seam
+    fires, so an unknown tool's recorded args keep the model's raw bytes.
+    The call fails with the identical ModelRetry either way."""
+
+    def fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(
+                parts=[ToolCallPart(tool_name="not_a_tool", args=BROKEN_ARGS)]
+            )
+        return ModelResponse(parts=[TextPart("recovered")])
+
+    seen: list[int] = []
+    agent = Agent(model=FunctionModel(fn), capabilities=[ToolCallJsonRepair()])
+    _register_grab(agent, seen)
+
+    result = await agent.run("go")
+
+    assert result.output == "recovered"
+    assert seen == []
+    assert _tool_call_args_in(result.all_messages()) == [BROKEN_ARGS]
+
+
+# ---------------------------------------------------------------------------
+# Patch gating: explicit-when-ours, fallback-for-guests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_steps_aside_when_capability_present(
+    monkeypatch, restore_validate_tool_call
+):
+    import json_repair as json_repair_lib
+
+    from code_puppy.pydantic_patches import patch_tool_call_json_repair
+
+    calls = {"n": 0}
+    real_repair = json_repair_lib.repair_json
+
+    def counting(args: str, *a: Any, **k: Any) -> str:
+        calls["n"] += 1
+        return real_repair(args, *a, **k)
+
+    # Both the patch and the capability resolve repair_json at call time
+    # through their own module handles; patch both.
+    monkeypatch.setattr(json_repair_lib, "repair_json", counting)
+    monkeypatch.setattr(json_repair_module.json_repair, "repair_json", counting)
+
+    assert patch_tool_call_json_repair()
+
+    seen: list[int] = []
+    agent = Agent(model=_broken_then_done_model(), capabilities=[ToolCallJsonRepair()])
+    _register_grab(agent, seen)
+    result = await agent.run("go")
+
+    assert seen == [1]
+    assert result.output == "done"
+    # Exactly one repair: the capability's. The gated patch never ran its own.
+    assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_patch_still_repairs_for_guest_agents(restore_validate_tool_call):
+    from code_puppy.pydantic_patches import patch_tool_call_json_repair
+
+    assert patch_tool_call_json_repair()
+
+    seen: list[int] = []
+    guest = Agent(model=_broken_then_done_model())
+    _register_grab(guest, seen)
+    result = await guest.run("go")
+
+    assert seen == [1]
+    assert _tool_call_args_in(result.all_messages()) == [REPAIRED_ARGS]
+
+
+def test_run_owns_json_repair_walks_capability_leaves():
+    from code_puppy.pydantic_patches import _run_owns_json_repair
+
+    class FakeToolManager:
+        def __init__(self, root: Any) -> None:
+            self.root_capability = root
+
+    assert not _run_owns_json_repair(FakeToolManager(None))
+    assert _run_owns_json_repair(FakeToolManager(ToolCallJsonRepair()))
+
+    # Nested inside a combined tree (the shape a real run produces).
+    from pydantic_ai.capabilities import CombinedCapability, ProcessHistory
+
+    combined = CombinedCapability(
+        [
+            ProcessHistory(lambda ctx, messages: messages),
+            ToolCallJsonRepair(),
+        ]
+    )
+    assert _run_owns_json_repair(FakeToolManager(combined))
+
+    without = CombinedCapability([ProcessHistory(lambda ctx, messages: messages)])
+    assert not _run_owns_json_repair(FakeToolManager(without))
+
+
+# ---------------------------------------------------------------------------
+# Construction-site wiring
+# ---------------------------------------------------------------------------
+
+
+def test_builder_splices_capability_into_main_agent():
+    from code_puppy.agents import _builder
+
+    source = inspect.getsource(_builder)
+    assert "*build_tool_call_json_repair()," in source
+
+
+def test_subagent_invocation_splices_capability():
+    from code_puppy.tools import subagent_invocation
+
+    source = inspect.getsource(subagent_invocation)
+    assert "*build_tool_call_json_repair()," in source
+
+
+def test_before_tool_validate_signature_matches_seam():
+    """Pin the seam signature so a pydantic-ai upgrade that changes the
+    hook contract fails loudly here instead of silently never firing."""
+    from pydantic_ai.capabilities import AbstractCapability
+
+    base = inspect.signature(AbstractCapability.before_tool_validate)
+    ours = inspect.signature(ToolCallJsonRepair.before_tool_validate)
+    assert list(base.parameters) == list(ours.parameters)

--- a/tests/agents/test_tool_call_json_repair_capability.py
+++ b/tests/agents/test_tool_call_json_repair_capability.py
@@ -27,6 +27,7 @@ from pydantic_ai import Agent
 from pydantic_ai.messages import (
     ModelMessage,
     ModelResponse,
+    RetryPromptPart,
     TextPart,
     ToolCallPart,
 )
@@ -225,12 +226,7 @@ async def test_wire_parity_with_eager_patch(restore_validate_tool_call):
     )
 
 
-@pytest.mark.asyncio
-async def test_unknown_tool_args_stay_raw_in_history():
-    """Documented bounded divergence: resolution fails before the seam
-    fires, so an unknown tool's recorded args keep the model's raw bytes.
-    The call fails with the identical ModelRetry either way."""
-
+def _unknown_tool_model() -> FunctionModel:
     def fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         if len(messages) == 1:
             return ModelResponse(
@@ -238,8 +234,26 @@ async def test_unknown_tool_args_stay_raw_in_history():
             )
         return ModelResponse(parts=[TextPart("recovered")])
 
+    return FunctionModel(fn)
+
+
+def _retry_prompt_contents(messages: list[ModelMessage]) -> list[Any]:
+    return [
+        part.content
+        for message in messages
+        for part in message.parts
+        if isinstance(part, RetryPromptPart)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_args_stay_raw_in_history():
+    """Documented bounded divergence: resolution fails before the seam
+    fires, so an unknown tool's recorded args keep the model's raw bytes.
+    (Unavailable tools share the same code path — ``_resolve_tool`` raises
+    before ``_run_validate_hooks`` runs any hook.)"""
     seen: list[int] = []
-    agent = Agent(model=FunctionModel(fn), capabilities=[ToolCallJsonRepair()])
+    agent = Agent(model=_unknown_tool_model(), capabilities=[ToolCallJsonRepair()])
     _register_grab(agent, seen)
 
     result = await agent.run("go")
@@ -247,6 +261,34 @@ async def test_unknown_tool_args_stay_raw_in_history():
     assert result.output == "recovered"
     assert seen == []
     assert _tool_call_args_in(result.all_messages()) == [BROKEN_ARGS]
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_retry_parity_with_eager_patch(restore_validate_tool_call):
+    """The divergence is history bytes ONLY: the unknown-tool call earns
+    the identical ModelRetry prompt and recovery under the eager patch and
+    under the capability."""
+    from code_puppy.pydantic_patches import patch_tool_call_json_repair
+
+    cap_agent = Agent(model=_unknown_tool_model(), capabilities=[ToolCallJsonRepair()])
+    _register_grab(cap_agent, [])
+    cap_result = await cap_agent.run("go")
+
+    assert patch_tool_call_json_repair()
+    guest_agent = Agent(model=_unknown_tool_model())
+    _register_grab(guest_agent, [])
+    patch_result = await guest_agent.run("go")
+
+    assert cap_result.output == patch_result.output == "recovered"
+    # Identical retry feedback to the model on both paths.
+    cap_retries = _retry_prompt_contents(cap_result.all_messages())
+    patch_retries = _retry_prompt_contents(patch_result.all_messages())
+    assert cap_retries == patch_retries
+    assert len(cap_retries) == 1
+    # The old patch repaired even a doomed call's recorded args; the
+    # capability leaves them raw. This is the entire divergence.
+    assert _tool_call_args_in(cap_result.all_messages()) == [BROKEN_ARGS]
+    assert _tool_call_args_in(patch_result.all_messages()) == [REPAIRED_ARGS]
 
 
 # ---------------------------------------------------------------------------
@@ -348,9 +390,15 @@ def test_subagent_invocation_splices_capability():
 
 def test_before_tool_validate_signature_matches_seam():
     """Pin the seam signature so a pydantic-ai upgrade that changes the
-    hook contract fails loudly here instead of silently never firing."""
+    hook contract fails loudly here instead of silently never firing.
+
+    Compares names, kinds, and defaults — not annotations, which
+    legitimately differ (the seam spells ``RawToolArgs``, we spell the
+    underlying union)."""
     from pydantic_ai.capabilities import AbstractCapability
 
     base = inspect.signature(AbstractCapability.before_tool_validate)
     ours = inspect.signature(ToolCallJsonRepair.before_tool_validate)
-    assert list(base.parameters) == list(ours.parameters)
+    base_shape = [(p.name, p.kind, p.default) for p in base.parameters.values()]
+    ours_shape = [(p.name, p.kind, p.default) for p in ours.parameters.values()]
+    assert base_shape == ours_shape


### PR DESCRIPTION
## `ToolCallJsonRepair` capability

Thirteenth in the capability series (#828–#836, #838–#840). Converts the **tool-call JSON repair** feature — until now an eager monkeypatch of `ToolManager.validate_tool_call` in `pydantic_patches.py` — into a first-class pydantic-ai capability on the `before_tool_validate` seam. This is the first conversion in the series that retires *monkeypatch surgery* rather than a constructor kwarg or a run-site closure.

### What the feature does

LLMs sometimes emit slightly broken JSON in tool-call arguments (trailing commas, missing quotes, unclosed braces). Repairing the raw args before validation via `json_repair` avoids burning a retry round-trip.

### How it moved

- **New `code_puppy/agents/_json_repair.py`** — stateless `ToolCallJsonRepair(AbstractCapability)`:
  - `before_tool_validate` repairs string args and **mirrors the repair onto the live `ToolCallPart`** (`call.args = repaired`) — the same in-place custody the patch performed, so message history records the JSON the tool actually ran with. Verified empirically: the part passed to the seam is the object recorded in run state.
  - `build_tool_call_json_repair()` returns `[]` when the optional `json_repair` dependency is absent (mirrors the patch's quiet skip and the `build_tool_output_limits` conditional-splice pattern).
  - Stateless plain dataclass → spec-constructible with inherited defaults.
- **Both construction sites** (`_builder.py`, `subagent_invocation.py`) splice the capability. Position is inert — the tool-validate seam never interacts with the history hooks.
- **The patch is demoted to a guest-agent fallback** — *explicit-when-ours, fallback-for-guests*, the same split #838 used for Logfire instrumentation. The patched `validate_tool_call` walks the run's `ToolManager.root_capability` tree with the **public** `AbstractCapability.apply` visitor and steps aside when `ToolCallJsonRepair` is present. Raw pydantic-ai agents built by plugins keep eager repair — the audit found one real dependent: **wiggum's judge**, which registers genuine read-only tools. `btw`'s side-query agent has no tools (inert either way); `shell_safety`'s agent builds through our builder (gets the capability).
  - The gate **fails open**: if the leaf-walk ever crashes, the patch repairs eagerly — old behavior, and idempotent alongside the capability (repairing repaired JSON is a no-op).

### Parity audit

- **Seam placement:** `before_tool_validate` is the only hook receiving raw pre-validation args; it fires exactly once per `validate_tool_call` (`allow_partial=False` only — no streaming-partial hazard).
- **Ordering vs the cp_ normalization patch:** runtime order changes from *repair args → normalize name → resolve* to *normalize name → resolve → repair args*. Name normalization and arg repair are independent — inert reordering.
- **Bounded divergence (documented + pinned):** calls to **unknown/unavailable tools** no longer get their recorded args repaired — `_resolve_tool` raises `ModelRetry` before the seam fires, where the patch repaired first and failed after. The call fails identically either way; history now keeps the model's true emitted bytes (arguably more honest). Pinned by `test_unknown_tool_args_stay_raw_in_history`.
- **Archaeology of the round:** on pydantic-ai 2.31.0, tool-based structured output validates through `validate_output_tool_call` — a method **the patch never wrapped**. Output tools were never covered by this feature, so pydantic-ai's `kind == 'output'` hook carve-out changes nothing. (An output-tool repair via `before_output_validate` would be *new* behavior, deliberately out of scope — noted for a future PR if wanted.)

### Tests

17 contract tests in `tests/agents/test_tool_call_json_repair_capability.py`:

- direct-seam semantics: repair + custody, valid/dict/empty pass-throughs (object identity), swallowed repair failures, missing-dependency no-ops;
- end-to-end `FunctionModel` runs: tool executes with repaired args, zero retries burned, history carries repaired bytes;
- wire parity: guest-agent-under-patch vs capability-agent produce identical recorded args and output, plus retry-feedback parity on the unknown-tool path;
- patch gating both ways: repair invoked **exactly once** with the capability present (patch stepped aside), guests still repaired; `_run_owns_json_repair` leaf-walk incl. `CombinedCapability` nesting;
- wiring pins for both `capabilities=[...]` blocks + a seam-signature pin so a pydantic-ai hook-contract change fails loudly.

Full suite: **7615 passed, 0 failed** (28 skipped, 1 xpassed). Reviewed by code-puppy clone: pass 1 APPROVE with 1 non-blocking + 1 nit (both applied in 103571ed), pass 2 APPROVE with zero findings.

### Merge-order note

Touches the same two `capabilities=[...]` blocks as the other twelve open capability PRs — whichever lands last eats a trivial rebase.
