### PR TITLE
feat(agents): SubagentSessionPersistence capability on the wrap_run seam

### DIFF
--- a/code_puppy/agents/_subagent_sessions.py
+++ b/code_puppy/agents/_subagent_sessions.py
@@ -1,0 +1,180 @@
+"""Sub-agent session persistence as a first-class pydantic-ai capability.
+
+Previously the sub-agent invocation layer persisted sessions eagerly around
+the run: a success-path ``_save_session_history`` call after rendering and
+usage capture, plus ``_save_partial_session`` calls in the ``except
+BaseException`` block for crashes and interruptions. That worked, but the
+persistence contract ("the transcript survives however the run ends") lived
+as scattered call sites instead of riding the run itself.
+
+:class:`SubagentSessionPersistence` moves the contract onto pydantic-ai's
+``wrap_run`` seam -- the documented home for cancellation-safe cleanup: the
+handler task delivers run failures *and* ``CancelledError`` into the wrapping
+coroutine, so one ``try``/``except`` owns every exit path of the run proper.
+
+* **Success** -- the full transcript from ``result.all_messages()`` is saved
+  at the run boundary (byte-identical payload to the old post-render save).
+* **Failure / cancellation** -- the partial progress checkpointed on
+  ``agent_config._message_history`` by the history processor is saved via
+  the same ``_save_partial_session`` helper the eager path used.
+
+The invocation layer keeps all messaging (interrupt warnings, resume hints,
+breadcrumbs) and reads this capability's custody records via
+:meth:`SubagentSessionPersistence.recorded_save` after the run unwinds. The
+eager save calls are demoted to a fallback for exits the run boundary never
+sees -- failures before/after the run itself (agent build, MCP autostart,
+rendering) -- mirroring the explicit-when-ours / fallback-for-guests split
+used by earlier capability conversions.
+
+Bounded divergences from the eager implementation (all documented in tests):
+
+* Transient failures that ``streaming_retry`` goes on to retry now checkpoint
+  partial progress at each failed attempt (the eager path saved only when the
+  failure escaped every retry). The final file state converges; intermediate
+  saves are atomic overwrites of the same session file.
+* The success save now happens inside the run boundary, before high-mode
+  fallback rendering and usage capture (the eager save ran after both). For
+  ``invoke_agent_with_model`` callers this folds one atomic local file write
+  into ``duration_ms``.
+* A crash between a successful run and the invocation layer's bookkeeping
+  used to overwrite the session with the (possibly older) live checkpoint;
+  the run-boundary save now stands, so the persisted transcript keeps the
+  final response.
+
+Save helpers are resolved through ``code_puppy.tools.subagent_invocation`` at
+call time so test patches on that module's attributes keep intercepting the
+writes, exactly as they did for the eager calls.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional, Tuple
+
+from pydantic_ai import RunContext
+from pydantic_ai.capabilities import AbstractCapability, WrapRunHandler
+from pydantic_ai.run import AgentRunResult
+
+
+@dataclass
+class SubagentSessionPersistence(AbstractCapability[Any]):
+    """Persist one sub-agent invocation's session at the run boundary.
+
+    Constructed per invocation (the sub-agent's pydantic agent is itself
+    per-invocation), so instance state is naturally run-scoped: the default
+    ``for_run`` returns ``self`` and the custody records written by
+    ``wrap_run`` are readable on the very instance the invocation layer
+    holds. One instance may see several ``wrap_run`` calls when
+    ``streaming_retry`` re-invokes the run; the latest attempt's record wins,
+    which is exactly what the post-run reader needs.
+    """
+
+    agent_config: Any
+    session_id: str
+    agent_name: str
+    baseline_count: int
+    initial_prompt: Optional[str]
+
+    # Custody records, read by the invocation layer after the run unwinds.
+    final_saved: bool = field(default=False, init=False)
+    final_saved_count: Optional[int] = field(default=None, init=False)
+    partial_save_attempted: bool = field(default=False, init=False)
+    partial_saved_count: Optional[int] = field(default=None, init=False)
+
+    async def wrap_run(
+        self,
+        ctx: RunContext[Any],
+        *,
+        handler: WrapRunHandler,
+    ) -> AgentRunResult[Any]:
+        try:
+            result = await handler()
+        except BaseException as error:
+            # Everything the run can die of funnels through here, including
+            # CancelledError (the seam's documented cleanup contract). The
+            # save is synchronous, so it is safe mid-cancellation.
+            if self._should_record(error):
+                self.record_partial_save()
+            raise
+        self._save_final(result)
+        return result
+
+    @staticmethod
+    def _should_record(error: BaseException) -> bool:
+        """Mirror the invocation layer's save triage exactly.
+
+        Crashes (``Exception``) and interruptions (``KeyboardInterrupt``,
+        ``CancelledError`` -- possibly nested in a ``BaseExceptionGroup``
+        from async teardown) persist progress. Other ``BaseException``s
+        (``SystemExit``, ``GeneratorExit``) pass through untouched, just as
+        the eager ``except`` block re-raised them without saving.
+        """
+        from code_puppy.tools import subagent_invocation as _invocation
+
+        if isinstance(error, (Exception, KeyboardInterrupt)):
+            return True
+        return _invocation._contains_cancellation(error)
+
+    def record_partial_save(self) -> None:
+        """Persist pre-exit progress off the live history checkpoint.
+
+        Delegates to the invocation module's ``_save_partial_session`` --
+        the exact helper the eager path called -- which never raises and
+        returns the saved message count (or ``None`` when nothing new was
+        persisted). ``partial_save_attempted`` flips regardless so the
+        invocation layer's fallback does not double-save.
+        """
+        from code_puppy.tools import subagent_invocation as _invocation
+
+        self.partial_save_attempted = True
+        self.partial_saved_count = _invocation._save_partial_session(
+            agent_config=self.agent_config,
+            session_id=self.session_id,
+            agent_name=self.agent_name,
+            baseline_count=self.baseline_count,
+            initial_prompt=self.initial_prompt,
+        )
+
+    def _save_final(self, result: AgentRunResult[Any]) -> None:
+        """Save the complete transcript produced by a successful run.
+
+        A save failure here propagates: the eager path likewise turned a
+        failed post-run save into a failed invocation (the parent gets an
+        error output, and the fallback partial save still runs).
+        """
+        from code_puppy.tools import subagent_invocation as _invocation
+
+        history = list(result.all_messages())
+        _invocation._save_session_history(
+            session_id=self.session_id,
+            message_history=history,
+            agent_name=self.agent_name,
+            initial_prompt=self.initial_prompt,
+        )
+        self.final_saved = True
+        self.final_saved_count = len(history)
+
+    def recorded_save(self) -> Tuple[bool, Optional[int]]:
+        """Return ``(handled, saved_count)`` for the invocation layer.
+
+        ``handled`` is ``True`` when the run boundary already persisted the
+        session (fully or partially); the caller must then skip its eager
+        fallback -- re-saving would overwrite a complete transcript with the
+        possibly older live checkpoint. ``saved_count`` feeds the user-facing
+        "N message(s) saved" messaging and may be ``None`` when the boundary
+        ran but had nothing new to persist.
+        """
+        if self.final_saved:
+            return True, self.final_saved_count
+        if self.partial_save_attempted:
+            return True, self.partial_saved_count
+        return False, None
+
+    @classmethod
+    def get_serialization_name(cls) -> str | None:
+        # Carries live references (the BaseAgent config wrapper); not
+        # spec-constructible.
+        return None
+
+
+__all__ = ["SubagentSessionPersistence"]

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -293,6 +293,7 @@ async def _invoke_agent_impl(
     # if load_agent() itself fails before assignment.
     agent_config = None
     effective_model_name = model_name
+    session_persistence = None
 
     try:
         # Lazy import to break circular dependency with messaging module
@@ -405,6 +406,24 @@ async def _invoke_agent_impl(
                 build_model_message_transform,
             )
 
+            # Persist the session at the run boundary (wrap_run): success
+            # saves the full transcript, failure/cancellation saves partial
+            # progress. The invocation layer reads the custody records after
+            # the run unwinds; the eager save calls below survive only as
+            # fallback for exits the boundary never sees. Lazy import: a
+            # top-level import would cycle through code_puppy.agents.__init__.
+            from code_puppy.agents._subagent_sessions import (
+                SubagentSessionPersistence,
+            )
+
+            session_persistence = SubagentSessionPersistence(
+                agent_config=agent_config,
+                session_id=session_id,
+                agent_name=agent_name,
+                baseline_count=len(message_history),
+                initial_prompt=prompt if is_new_session else None,
+            )
+
             # Build the pydantic-ai agent. MCP servers always included; plugins
             # (e.g. DBOS) may swap them via the agent_run_context hook.
             temp_agent = Agent(
@@ -423,6 +442,9 @@ async def _invoke_agent_impl(
                 capabilities=[
                     ProcessHistory(make_history_processor(agent_config)),
                     build_model_message_transform(agent_name),
+                    # wrap_run seam -- position relative to the request-path
+                    # capabilities above is inert.
+                    session_persistence,
                 ],
                 model_settings=model_settings,
             )
@@ -551,13 +573,18 @@ async def _invoke_agent_impl(
             # The result contains all_messages which includes the full conversation
             updated_history = result.all_messages()
 
-            # Save to filesystem (include initial prompt only for new sessions)
-            _save_session_history(
-                session_id=session_id,
-                message_history=updated_history,
-                agent_name=agent_name,
-                initial_prompt=prompt if is_new_session else None,
-            )
+            # ``SubagentSessionPersistence`` already saved this transcript at
+            # the run boundary. Guest fallback: if a plugin wrapper produced an
+            # agent that never ran our capability, keep the eager save so no
+            # session is ever lost (include initial prompt only for new
+            # sessions).
+            if not session_persistence.final_saved:
+                _save_session_history(
+                    session_id=session_id,
+                    message_history=updated_history,
+                    agent_name=agent_name,
+                    initial_prompt=prompt if is_new_session else None,
+                )
 
             # Emit via MessageBus; skip in high mode when streaming already
             # rendered the response (avoids future double-render).
@@ -604,17 +631,32 @@ async def _invoke_agent_impl(
             e, (asyncio.CancelledError, KeyboardInterrupt)
         ) or _contains_cancellation(e)
 
-        if interrupted:
-            # CancelledError derives from BaseException, so it slipped past the
-            # old ``except Exception`` save path. Persist progress, tell the user
-            # how to resume, then re-raise (persistence must not mask cancel).
-            saved = _save_partial_session(
+        # Run-boundary custody: ``SubagentSessionPersistence`` (wrap_run)
+        # already persisted the session for any failure inside the run
+        # itself. Fall back to the eager save only when the boundary never
+        # ran (failures before/after the run: agent build, MCP autostart,
+        # rendering) -- and never clobber a completed run's full transcript
+        # with the older live checkpoint.
+        handled, boundary_saved = (
+            session_persistence.recorded_save()
+            if session_persistence is not None
+            else (False, None)
+        )
+
+        def _fallback_partial_save() -> int | None:
+            return _save_partial_session(
                 agent_config=agent_config,
                 session_id=session_id,
                 agent_name=agent_name,
                 baseline_count=len(message_history),
                 initial_prompt=prompt if is_new_session else None,
             )
+
+        if interrupted:
+            # CancelledError derives from BaseException, so it slipped past the
+            # old ``except Exception`` save path. Persist progress, tell the user
+            # how to resume, then re-raise (persistence must not mask cancel).
+            saved = boundary_saved if handled else _fallback_partial_save()
             detail = (
                 f"{saved} message(s) saved"
                 if saved is not None
@@ -646,13 +688,7 @@ async def _invoke_agent_impl(
         emit_error(error_msg, message_group=group_id)
 
         # Save whatever progress the agent made before crashing.
-        saved = _save_partial_session(
-            agent_config=agent_config,
-            session_id=session_id,
-            agent_name=agent_name,
-            baseline_count=len(message_history),
-            initial_prompt=prompt if is_new_session else None,
-        )
+        saved = boundary_saved if handled else _fallback_partial_save()
         if saved is not None:
             emit_info(
                 f"Saved partial session '{session_id}' "

--- a/tests/agents/test_subagent_session_persistence_capability.py
+++ b/tests/agents/test_subagent_session_persistence_capability.py
@@ -225,6 +225,45 @@ async def test_wrap_run_skips_save_for_system_exit():
 
 
 # ---------------------------------------------------------------------------
+# Real CombinedCapability composition
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_combined_capability_composition_saves_once_on_original_instance():
+    """Production shape: the sub-agent site wires THREE capabilities. The
+    run must route through pydantic-ai's real CombinedCapability, produce
+    exactly one boundary save, and record custody on the ORIGINAL instance
+    the invocation layer holds (default ``for_run`` returns ``self``)."""
+    from pydantic_ai.capabilities import ProcessHistory
+
+    from code_puppy.agents._model_message_transform import (
+        build_model_message_transform,
+    )
+
+    cap = _capability()
+    agent = Agent(
+        model=TestModel(),
+        instructions="be terse",
+        output_type=str,
+        capabilities=[
+            ProcessHistory(lambda messages: messages),
+            build_model_message_transform("tester"),
+            cap,
+        ],
+    )
+    saves = []
+    with patch(SAVE_HISTORY, side_effect=lambda **kw: saves.append(kw)):
+        result = await agent.run("hello")
+
+    assert len(saves) == 1
+    assert saves[0]["message_history"] == list(result.all_messages())
+    # Custody landed on the exact instance the invocation layer constructed.
+    assert cap.final_saved is True
+    assert cap.recorded_save() == (True, len(saves[0]["message_history"]))
+
+
+# ---------------------------------------------------------------------------
 # recorded_save triage + retry semantics
 # ---------------------------------------------------------------------------
 
@@ -333,7 +372,7 @@ def _invocation_harness(capture):
         )
         capture["save"] = p(patch(SAVE_HISTORY))
         capture["partial"] = p(patch(SAVE_PARTIAL, return_value=None))
-        p(
+        capture["load"] = p(
             patch(
                 "code_puppy.tools.subagent_invocation._load_session_history",
                 return_value=[],
@@ -409,17 +448,20 @@ def _capability_from(capture):
     return ours[0]
 
 
-async def _drive_invocation(capture, run_side_effect):
+async def _drive_invocation(capture, run_side_effect, *, session_id=None):
     from code_puppy.tools.subagent_invocation import _invoke_agent_impl
 
     temp_agent = MagicMock()
     temp_agent.run = AsyncMock(side_effect=run_side_effect)
     capture["temp_agent"] = temp_agent
     with _invocation_harness(capture):
+        if loaded := capture.get("loaded_history"):
+            capture["load"].return_value = list(loaded)
         return await _invoke_agent_impl(
             MagicMock(),
             agent_name="test-agent",
             prompt="Hello",
+            session_id=session_id,
         )
 
 
@@ -445,6 +487,35 @@ async def test_invocation_constructs_capability_with_prepared_prompt():
     # New session: the initial prompt is the PREPARED prompt, matching what
     # the eager save wrote after prepare_prompt_for_model rewrote it.
     assert cap.initial_prompt == "prepared prompt"
+
+
+@pytest.mark.asyncio
+async def test_invocation_resumed_session_baseline_and_no_initial_prompt():
+    """Resumed sessions: baseline reflects the loaded history and the
+    initial prompt stays ``None`` -- both for the capability's saves and
+    for the eager fallback (the .txt metadata is written once, on first
+    save, and must not be re-seeded on resume)."""
+    capture = {"loaded_history": ["old1", "old2", "old3"]}
+
+    output = await _drive_invocation(
+        capture,
+        RuntimeError("guest run exploded"),
+        session_id="existing-session",
+    )
+
+    assert output.error is not None
+    cap = _capability_from(capture)
+    assert cap.session_id == "existing-session"
+    assert cap.baseline_count == 3
+    assert cap.initial_prompt is None
+    # Guest failure -> eager fallback keeps the same resumed-session custody.
+    capture["partial"].assert_called_once_with(
+        agent_config=capture["agent_config"],
+        session_id="existing-session",
+        agent_name="test-agent",
+        baseline_count=3,
+        initial_prompt=None,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/agents/test_subagent_session_persistence_capability.py
+++ b/tests/agents/test_subagent_session_persistence_capability.py
@@ -1,0 +1,565 @@
+"""Contract tests for the ``SubagentSessionPersistence`` capability.
+
+The capability moves sub-agent session persistence onto pydantic-ai's
+``wrap_run`` seam: success saves the full transcript at the run boundary,
+failure/cancellation saves the partial checkpoint via the same
+``_save_partial_session`` helper the eager path used, and the invocation
+layer reads the custody records (``recorded_save``) instead of saving
+eagerly -- falling back to the eager saves only when the boundary never ran.
+
+Covers:
+* seam-signature parity with ``AbstractCapability.wrap_run``
+* success/failure/cancellation custody through a REAL pydantic-ai ``Agent``
+* the eager triage mirrored exactly (``SystemExit``/``GeneratorExit`` never save)
+* call-time helper resolution (existing test patches keep intercepting writes)
+* ``recorded_save`` triage and latest-attempt-wins retry semantics
+* invocation-layer wiring: capability construction, fallback-when-guest,
+  and the no-clobber guard for crashes after a successful run
+"""
+
+import asyncio
+import inspect
+from contextlib import ExitStack, contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
+
+from code_puppy.agents._subagent_sessions import SubagentSessionPersistence
+
+SAVE_HISTORY = "code_puppy.tools.subagent_invocation._save_session_history"
+SAVE_PARTIAL = "code_puppy.tools.subagent_invocation._save_partial_session"
+
+
+class FakeConfig:
+    """Minimal stand-in for the BaseAgent config wrapper."""
+
+    def __init__(self, history=None):
+        self._message_history = list(history or [])
+
+    def get_message_history(self):
+        return self._message_history
+
+
+def _capability(**overrides):
+    kwargs = dict(
+        agent_config=FakeConfig(),
+        session_id="tester-session-abc123",
+        agent_name="tester",
+        baseline_count=0,
+        initial_prompt="hi there",
+    )
+    kwargs.update(overrides)
+    return SubagentSessionPersistence(**kwargs)
+
+
+def _agent_with(cap, model):
+    return Agent(
+        model=model,
+        instructions="be terse",
+        output_type=str,
+        capabilities=[cap],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Seam contract
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_run_signature_matches_base_seam():
+    base = inspect.signature(AbstractCapability.wrap_run)
+    ours = inspect.signature(SubagentSessionPersistence.wrap_run)
+    assert [(p.name, p.kind) for p in ours.parameters.values()] == [
+        (p.name, p.kind) for p in base.parameters.values()
+    ]
+    # ``handler`` must stay keyword-only, matching the seam's calling convention.
+    assert ours.parameters["handler"].kind is inspect.Parameter.KEYWORD_ONLY
+
+
+def test_not_spec_constructible():
+    assert SubagentSessionPersistence.get_serialization_name() is None
+
+
+# ---------------------------------------------------------------------------
+# Success custody through a real agent run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_successful_run_saves_full_transcript_at_boundary():
+    cap = _capability()
+    agent = _agent_with(cap, TestModel())
+    saves = []
+    with patch(SAVE_HISTORY, side_effect=lambda **kw: saves.append(kw)):
+        result = await agent.run("hello")
+
+    assert cap.final_saved is True
+    assert cap.recorded_save() == (True, cap.final_saved_count)
+    assert len(saves) == 1
+    save = saves[0]
+    assert save["session_id"] == "tester-session-abc123"
+    assert save["agent_name"] == "tester"
+    assert save["initial_prompt"] == "hi there"
+    # Byte-identical payload to the eager post-run save.
+    assert save["message_history"] == list(result.all_messages())
+    assert cap.final_saved_count == len(save["message_history"])
+
+
+@pytest.mark.asyncio
+async def test_final_save_resolves_helper_at_call_time():
+    """Patching the invocation module attr intercepts the capability's save.
+
+    This is the compatibility contract the existing suites rely on: they
+    patch ``subagent_invocation._save_session_history`` and must keep
+    seeing every write.
+    """
+    cap = _capability()
+    agent = _agent_with(cap, TestModel())
+    mock_save = MagicMock()
+    with patch(SAVE_HISTORY, mock_save):
+        await agent.run("hello")
+    mock_save.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_final_save_failure_propagates_and_leaves_no_record():
+    """A failed boundary save fails the run, exactly as the eager save
+    failing failed the invocation. No partial record is written for it --
+    the invocation layer's fallback then takes over."""
+    cap = _capability()
+    agent = _agent_with(cap, TestModel())
+    with patch(SAVE_HISTORY, side_effect=OSError("disk full")):
+        with pytest.raises(BaseException) as excinfo:
+            await agent.run("hello")
+    assert "disk full" in repr(excinfo.getrepr(style="value"))
+    assert cap.final_saved is False
+    assert cap.partial_save_attempted is False
+    assert cap.recorded_save() == (False, None)
+
+
+# ---------------------------------------------------------------------------
+# Failure / cancellation custody through a real agent run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failure_inside_run_records_partial_save_and_reraises():
+    def explode(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        raise RuntimeError("model on fire")
+
+    cap = _capability(agent_config=FakeConfig(["m1", "m2"]), baseline_count=1)
+    agent = _agent_with(cap, FunctionModel(explode))
+    partial = MagicMock(return_value=2)
+    with patch(SAVE_PARTIAL, partial):
+        with pytest.raises(BaseException) as excinfo:
+            await agent.run("hello")
+
+    assert "model on fire" in repr(excinfo.getrepr(style="value"))
+    assert cap.partial_save_attempted is True
+    assert cap.partial_saved_count == 2
+    assert cap.recorded_save() == (True, 2)
+    partial.assert_called_once_with(
+        agent_config=cap.agent_config,
+        session_id="tester-session-abc123",
+        agent_name="tester",
+        baseline_count=1,
+        initial_prompt="hi there",
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancellation_records_partial_save():
+    started = asyncio.Event()
+
+    async def hang(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        started.set()
+        await asyncio.sleep(3600)
+        return ModelResponse(parts=[TextPart("unreachable")])
+
+    cap = _capability()
+    agent = _agent_with(cap, FunctionModel(hang))
+    partial = MagicMock(return_value=None)
+    with patch(SAVE_PARTIAL, partial):
+        task = asyncio.create_task(agent.run("hello"))
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert cap.partial_save_attempted is True
+    assert cap.partial_saved_count is None
+    assert cap.recorded_save() == (True, None)
+    partial.assert_called_once()
+
+
+def test_should_record_mirrors_eager_triage():
+    should = SubagentSessionPersistence._should_record
+    assert should(RuntimeError("boom")) is True
+    assert should(KeyboardInterrupt()) is True
+    assert should(asyncio.CancelledError()) is True
+    # Async teardown wraps cancellation in a group; still an interruption.
+    group = BaseExceptionGroup("teardown", [asyncio.CancelledError()])
+    assert should(group) is True
+    # The eager ``except`` block re-raised these without saving.
+    assert should(SystemExit(1)) is False
+    assert should(GeneratorExit()) is False
+
+
+@pytest.mark.asyncio
+async def test_wrap_run_skips_save_for_system_exit():
+    async def boom():
+        raise SystemExit(3)
+
+    cap = _capability()
+    partial = MagicMock()
+    with patch(SAVE_PARTIAL, partial):
+        with pytest.raises(SystemExit):
+            await cap.wrap_run(None, handler=boom)
+    partial.assert_not_called()
+    assert cap.recorded_save() == (False, None)
+
+
+# ---------------------------------------------------------------------------
+# recorded_save triage + retry semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_reinvocation_latest_attempt_wins():
+    """``streaming_retry`` re-invokes ``run()`` on the same agent, so one
+    capability instance sees several ``wrap_run`` calls. A transient failure
+    checkpoints partial progress; the successful retry's full save then
+    takes precedence in ``recorded_save``."""
+    cap = _capability()
+
+    async def fail():
+        raise RuntimeError("transient 503")
+
+    async def succeed():
+        result = MagicMock()
+        result.all_messages.return_value = ["m1", "m2", "m3"]
+        return result
+
+    with patch(SAVE_PARTIAL, return_value=1) as partial, patch(SAVE_HISTORY) as final:
+        with pytest.raises(RuntimeError):
+            await cap.wrap_run(None, handler=fail)
+        assert cap.recorded_save() == (True, 1)
+
+        returned = await cap.wrap_run(None, handler=succeed)
+
+    assert returned.all_messages.return_value == ["m1", "m2", "m3"]
+    partial.assert_called_once()
+    final.assert_called_once()
+    assert cap.final_saved is True
+    # Full save outranks the earlier attempt's partial record.
+    assert cap.recorded_save() == (True, 3)
+
+
+def test_recorded_save_three_states():
+    cap = _capability()
+    assert cap.recorded_save() == (False, None)
+
+    cap.partial_save_attempted = True
+    cap.partial_saved_count = None
+    assert cap.recorded_save() == (True, None)
+
+    cap.final_saved = True
+    cap.final_saved_count = 7
+    assert cap.recorded_save() == (True, 7)
+
+
+# ---------------------------------------------------------------------------
+# Invocation-layer wiring
+# ---------------------------------------------------------------------------
+
+
+def _passthrough_retry(*_args, **_kwargs):
+    def _decorator(func):
+        return func
+
+    return _decorator
+
+
+def _build_agent_config():
+    config = MagicMock()
+
+    @contextmanager
+    def temporary_override(_model_name):
+        yield
+
+    config.temporary_model_name_override.side_effect = temporary_override
+    config.get_model_name.return_value = "test-model"
+    config.get_full_system_prompt.return_value = "Test instructions"
+    config.get_available_tools.return_value = ["list_files"]
+    config.get_message_history.return_value = []
+    return config
+
+
+@contextmanager
+def _invocation_harness(capture):
+    """Patch the invocation layer's collaborators; capture Agent kwargs.
+
+    The mocked ``Agent`` never executes capabilities itself; individual
+    tests decide whether the captured capability runs (production-shaped)
+    or stays inert (guest-fallback shape).
+    """
+    agent_config = _build_agent_config()
+    capture["agent_config"] = agent_config
+
+    def fake_agent(*args, **kwargs):
+        capture["agent_kwargs"] = kwargs
+        return capture["temp_agent"]
+
+    with ExitStack() as stack:
+        p = stack.enter_context
+        p(patch("code_puppy.tools.subagent_invocation.get_message_bus"))
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation.get_session_context",
+                return_value="parent",
+            )
+        )
+        p(patch("code_puppy.tools.subagent_invocation.set_session_context"))
+        capture["info"] = p(patch("code_puppy.tools.subagent_invocation.emit_info"))
+        p(patch("code_puppy.tools.subagent_invocation.emit_error"))
+        p(patch("code_puppy.tools.subagent_invocation.emit_success"))
+        capture["warning"] = p(
+            patch("code_puppy.tools.subagent_invocation.emit_warning")
+        )
+        capture["save"] = p(patch(SAVE_HISTORY))
+        capture["partial"] = p(patch(SAVE_PARTIAL, return_value=None))
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation._load_session_history",
+                return_value=[],
+            )
+        )
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation._generate_session_hash_suffix",
+                return_value="abc123",
+            )
+        )
+        p(
+            patch(
+                "code_puppy.agents.agent_manager.load_agent",
+                return_value=agent_config,
+            )
+        )
+        p(
+            patch(
+                "code_puppy.model_factory.ModelFactory.load_config",
+                return_value={"test-model": {}},
+            )
+        )
+        p(patch("code_puppy.model_factory.ModelFactory.get_model"))
+        p(patch("code_puppy.model_factory.make_model_settings"))
+        p(patch("code_puppy.agents._builder.load_puppy_rules", return_value=None))
+        p(patch("code_puppy.callbacks.on_load_prompt", return_value=[]))
+        prepare = p(patch("code_puppy.model_utils.prepare_prompt_for_model"))
+        prepare.return_value = MagicMock(
+            instructions="prepared instructions", user_prompt="prepared prompt"
+        )
+        p(
+            patch(
+                "code_puppy.agents._builder.autostart_bound_servers_async",
+                new=AsyncMock(),
+            )
+        )
+        p(patch("code_puppy.config.get_value", return_value="true"))
+        p(patch("code_puppy.config.get_output_level", return_value="medium"))
+        p(
+            patch(
+                "code_puppy.agents._compaction.make_history_processor",
+                return_value=lambda messages: messages,
+            )
+        )
+        p(patch("code_puppy.tools.subagent_invocation.Agent", side_effect=fake_agent))
+        p(patch("code_puppy.tools.register_tools_for_agent"))
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation.on_wrap_pydantic_agent",
+                side_effect=lambda _cfg, agent, **_kwargs: agent,
+            )
+        )
+        p(
+            patch(
+                "code_puppy.tools.subagent_invocation.on_agent_run_context",
+                return_value=[],
+            )
+        )
+        p(
+            patch(
+                "code_puppy.agents.retry_profiles.make_streaming_retry",
+                new=_passthrough_retry,
+            )
+        )
+        yield
+
+
+def _capability_from(capture):
+    caps = capture["agent_kwargs"]["capabilities"]
+    ours = [c for c in caps if isinstance(c, SubagentSessionPersistence)]
+    assert len(ours) == 1
+    return ours[0]
+
+
+async def _drive_invocation(capture, run_side_effect):
+    from code_puppy.tools.subagent_invocation import _invoke_agent_impl
+
+    temp_agent = MagicMock()
+    temp_agent.run = AsyncMock(side_effect=run_side_effect)
+    capture["temp_agent"] = temp_agent
+    with _invocation_harness(capture):
+        return await _invoke_agent_impl(
+            MagicMock(),
+            agent_name="test-agent",
+            prompt="Hello",
+        )
+
+
+def _successful_result():
+    result = MagicMock()
+    result.output = "subagent response"
+    result.all_messages.return_value = ["m1", "m2"]
+    return result
+
+
+@pytest.mark.asyncio
+async def test_invocation_constructs_capability_with_prepared_prompt():
+    capture = {}
+    result = _successful_result()
+
+    await _drive_invocation(capture, lambda *a, **kw: result)
+
+    cap = _capability_from(capture)
+    assert cap.agent_config is capture["agent_config"]
+    assert cap.session_id == "test-agent-session-abc123"
+    assert cap.agent_name == "test-agent"
+    assert cap.baseline_count == 0
+    # New session: the initial prompt is the PREPARED prompt, matching what
+    # the eager save wrote after prepare_prompt_for_model rewrote it.
+    assert cap.initial_prompt == "prepared prompt"
+
+
+@pytest.mark.asyncio
+async def test_guest_run_falls_back_to_eager_save():
+    """The mocked run never executes capabilities -- exactly the shape of a
+    plugin wrapper that bypasses them. The eager save must still fire."""
+    capture = {}
+    result = _successful_result()
+
+    output = await _drive_invocation(capture, lambda *a, **kw: result)
+
+    assert output.error is None
+    capture["save"].assert_called_once_with(
+        session_id="test-agent-session-abc123",
+        message_history=["m1", "m2"],
+        agent_name="test-agent",
+        initial_prompt="prepared prompt",
+    )
+
+
+@pytest.mark.asyncio
+async def test_boundary_save_skips_eager_save():
+    """Production shape: the run routes through the capability's wrap_run,
+    so the invocation layer must not save a second time."""
+    capture = {}
+    result = _successful_result()
+
+    async def run_through_capability(*_args, **_kwargs):
+        cap = _capability_from(capture)
+
+        async def produce():
+            return result
+
+        return await cap.wrap_run(None, handler=produce)
+
+    output = await _drive_invocation(capture, run_through_capability)
+
+    assert output.error is None
+    # Exactly one write: the boundary save (through the patched module attr).
+    capture["save"].assert_called_once()
+    assert _capability_from(capture).final_saved is True
+
+
+@pytest.mark.asyncio
+async def test_failure_inside_run_uses_boundary_record_no_double_save():
+    capture = {}
+
+    async def run_through_capability(*_args, **_kwargs):
+        cap = _capability_from(capture)
+
+        async def explode():
+            raise RuntimeError("boom")
+
+        return await cap.wrap_run(None, handler=explode)
+
+    output = await _drive_invocation(capture, run_through_capability)
+
+    assert output.error is not None
+    cap = _capability_from(capture)
+    assert cap.partial_save_attempted is True
+    # The boundary already saved; the invocation layer must not save again.
+    capture["partial"].assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_crash_after_successful_run_keeps_full_transcript():
+    """A crash between the run and the invocation layer's bookkeeping used
+    to overwrite the session with the older live checkpoint; the boundary
+    save now stands (no partial fallback runs at all)."""
+    capture = {}
+    result = MagicMock()
+    result.output = "subagent response"
+    # First call feeds the boundary save; second (invocation layer) crashes.
+    result.all_messages = MagicMock(
+        side_effect=[["m1", "m2", "m3"], RuntimeError("post-run bookkeeping crash")]
+    )
+
+    async def run_through_capability(*_args, **_kwargs):
+        cap = _capability_from(capture)
+
+        async def produce():
+            return result
+
+        return await cap.wrap_run(None, handler=produce)
+
+    output = await _drive_invocation(capture, run_through_capability)
+
+    assert output.error is not None
+    cap = _capability_from(capture)
+    assert cap.final_saved is True
+    assert cap.recorded_save() == (True, 3)
+    capture["save"].assert_called_once()
+    capture["partial"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_failure_without_boundary_falls_back_to_eager_partial_save():
+    """When the run fails without the capability ever running (a guest
+    wrapper bypassing capabilities, or a failure before the run proper),
+    the eager partial-save path takes over."""
+    capture = {}
+
+    output = await _drive_invocation(capture, RuntimeError("guest run exploded"))
+
+    assert output.error is not None
+    cap = _capability_from(capture)
+    assert cap.recorded_save() == (False, None)
+    capture["partial"].assert_called_once()
+    capture["save"].assert_not_called()
+
+
+def test_main_builder_does_not_carry_subagent_persistence():
+    """The capability is sub-agent-only: main-agent sessions are persisted
+    by the autosave pipeline, not at the pydantic-ai run boundary."""
+    import code_puppy.agents._builder as builder
+
+    source = inspect.getsource(builder)
+    assert "SubagentSessionPersistence" not in source


### PR DESCRIPTION
## What

Fourteenth entry in the capability-conversion series (#828–#836, #838–#841). Promotes **sub-agent session persistence** — the success-path `_save_session_history` call and the crash/interrupt `_save_partial_session` calls in `_invoke_agent_impl` — to a first-class pydantic-ai capability, **`SubagentSessionPersistence`**, on the **`wrap_run`** seam (a previously unclaimed seam; pydantic-ai documents it as the home for cancellation-safe cleanup, and its handler task delivers both run failures and `CancelledError` into the wrapping coroutine).

## Design

- **New `code_puppy/agents/_subagent_sessions.py`** — per-invocation dataclass capability (the sub-agent's pydantic agent is itself per-invocation, so instance state is naturally run-scoped; default `for_run` returns `self`, and one instance correctly sees every `streaming_retry` re-invocation — latest attempt's record wins).
  - success → full transcript from `result.all_messages()` saved at the run boundary (byte-identical payload to the eager save)
  - failure/cancel → partial progress saved via the *same* `_save_partial_session` helper the eager path used
  - eager triage mirrored exactly: `Exception`, `KeyboardInterrupt`, and (group-nested) `CancelledError` save; `SystemExit`/`GeneratorExit` pass through untouched
- **Explicit-when-ours, fallback-for-guests** (the #838/#841 split): the invocation layer reads the capability's custody records via `recorded_save()` and keeps its messaging/breadcrumbs; the eager saves survive only as fallback for exits the boundary never sees (guest wrappers bypassing capabilities, failures before/after the run proper).
- **Test-patch compatibility**: save helpers resolve through `code_puppy.tools.subagent_invocation` at call time, so the existing suites' patches on that module keep intercepting every write (pinned by test).

## Bounded divergences (documented + pinned)

1. Transient failures that `streaming_retry` recovers now checkpoint partial progress per failed attempt (eager saved only when the failure escaped every retry). Final file state converges; strictly more durable.
2. The success save happens inside the run boundary, before high-mode fallback rendering and usage capture — one atomic local file write folds into `invoke_agent_with_model`'s `duration_ms`.
3. A crash between a successful run and the invocation layer's bookkeeping used to overwrite the session with the older live checkpoint; the boundary save now stands, so the persisted transcript keeps the final response.

## Scope notes

- Sub-agent site only: main-agent sessions are persisted by the autosave pipeline, not at the pydantic-ai run boundary (pinned by source test).
- Not spec-constructible (carries a live BaseAgent config reference): `get_serialization_name() -> None`, per series precedent.

## Tests

18 contract tests in `tests/agents/test_subagent_session_persistence_capability.py`, including real-`Agent` success/failure/cancellation custody, triage parity, retry latest-wins, and invocation-layer wiring (boundary-save skip, guest fallback, no-clobber guard).

Full suite: **7615 passed, 0 failed** (28 skipped, 1 xpassed).

**Do not merge yet** — review round pending.