### PR TITLE
feat(agents): promote run-end telemetry to a RunTelemetry capability (after_run seam)

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -24,6 +24,7 @@ from code_puppy.agents._output_limits import (
     build_response_clamp,
     build_tool_output_limits,
 )
+from code_puppy.agents._run_telemetry import RunTelemetry
 from code_puppy.agents._steer_processor import make_steer_history_processor
 from code_puppy.agents.event_stream_handler import event_stream_handler
 from code_puppy.callbacks import (
@@ -614,6 +615,8 @@ def build_pydantic_agent(
     - ``agent.pydantic_agent``        ← the final (possibly plugin-wrapped) agent
     - ``agent._code_generation_agent`` ← same as ``pydantic_agent``
     - ``agent._mcp_servers``          ← MCP toolsets (post-filter)
+    - ``agent._run_telemetry``        ← the ``RunTelemetry`` capability instance
+      (``run_with_mcp`` consumes its run-end capture; see ``_run_telemetry.py``)
 
     The build happens in two passes: we construct once with ``toolsets=[]`` so
     we can introspect registered tool names, then rebuild with MCP servers
@@ -639,6 +642,11 @@ def build_pydantic_agent(
     history_processor = make_history_processor(agent)
     steer_processor = make_steer_history_processor(agent)
     logical_agent_name = getattr(agent, "name", None) or agent.__class__.__name__
+    # One instance shared by both construction passes (the probe never runs,
+    # so its capture slot stays empty) — mirrors the single-instance hoists
+    # elsewhere in this builder; safe because the defaults of for_agent /
+    # for_run return self and binding never mutates the instance.
+    run_telemetry = RunTelemetry()
 
     def _new_pydantic_agent(toolsets: List[Any]) -> PydanticAgent:
         return PydanticAgent(
@@ -660,12 +668,15 @@ def build_pydantic_agent(
             # hook (after_tool_execute), so its position is inert; the
             # response clamp runs before_model_request after both history
             # processors. The plugin transform wraps the final model request.
+            # RunTelemetry observes the finished result on after_run — a
+            # seam disjoint from every hook above, so its position is inert.
             capabilities=[
                 *build_tool_output_limits(),
                 ProcessHistory(history_processor),
                 ProcessHistory(steer_processor),
                 build_response_clamp(),
                 build_model_message_transform(logical_agent_name),
+                run_telemetry,
             ],
             model_settings=model_settings,
         )
@@ -699,6 +710,7 @@ def build_pydantic_agent(
     agent.cur_model = model
     agent._last_model_name = resolved_model_name
     agent._mcp_servers = filtered_mcp_servers
+    agent._run_telemetry = run_telemetry
 
     wrapped = on_wrap_pydantic_agent(
         agent,

--- a/code_puppy/agents/_run_telemetry.py
+++ b/code_puppy/agents/_run_telemetry.py
@@ -13,9 +13,13 @@ Semantics, verified against pydantic-ai 2.31.0:
   contain several runs (the initial call plus queued-steer / hook-retry
   follow-ups); each capture overwrites the last, so the surviving snapshot
   always describes the run whose result ``run_with_mcp`` ultimately returns.
-* ``after_run`` is NOT called when a run ends without a result, so failed or
-  cancelled turns never capture — matching the eager code, which only
-  extracted after a successful ``await``.
+* ``after_run`` is NOT called when a run ends without a result, so failed
+  turns never capture — matching the eager code, which only extracted after
+  a successful ``await``. One upstream nuance: it IS called when a result
+  was produced while a cancellation was pending, and the run still ends
+  cancelled afterwards. Harmless here — the cancelled task yields no result
+  to ``run_with_mcp``, so ``consume(None)`` clears that capture unmatched
+  and the turn reports empty telemetry, exactly as the eager code did.
 
 Custody handshake (the explicit-when-ours, fallback-for-guests split):
 ``run_with_mcp`` calls :meth:`RunTelemetry.consume` with the result it is

--- a/code_puppy/agents/_run_telemetry.py
+++ b/code_puppy/agents/_run_telemetry.py
@@ -1,0 +1,142 @@
+"""Run-end telemetry captured at the pydantic-ai run boundary.
+
+Promotes the ``agent_run_end`` payload extraction — human-readable response
+text plus usage token metadata — from eager post-``await`` bookkeeping in
+``_runtime.run_with_mcp`` to a first-class capability on pydantic-ai's
+``after_run`` seam (its first claim in this codebase).
+
+Semantics, verified against pydantic-ai 2.31.0:
+
+* ``after_run`` fires once per successful ``Agent.run()`` and receives the
+  **identical** ``AgentRunResult`` object the caller gets back — including
+  when the capability rides inside a ``CombinedCapability``. A turn may
+  contain several runs (the initial call plus queued-steer / hook-retry
+  follow-ups); each capture overwrites the last, so the surviving snapshot
+  always describes the run whose result ``run_with_mcp`` ultimately returns.
+* ``after_run`` is NOT called when a run ends without a result, so failed or
+  cancelled turns never capture — matching the eager code, which only
+  extracted after a successful ``await``.
+
+Custody handshake (the explicit-when-ours, fallback-for-guests split):
+``run_with_mcp`` calls :meth:`RunTelemetry.consume` with the result it is
+about to report. ``consume`` hands back the captured telemetry only when the
+captured result **is** that exact object; anything else (a guest wrapper
+that bypassed capabilities, a ``None`` result from a swallowed
+``UsageLimitExceeded``, a stale capture from an earlier turn whose task
+failed before consuming) falls through to the eager extraction helpers
+below — which are the same functions the capability itself uses, so both
+paths produce byte-identical payloads.
+
+The capability holds no live agent references and needs no constructor
+arguments, so it keeps the inherited ``get_serialization_name`` default and
+stays spec-constructible; a fresh instance simply hasn't captured anything
+yet.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional, Tuple
+
+from pydantic_ai.capabilities import AbstractCapability
+
+# One entry per usage figure forwarded to ``agent_run_end`` consumers (e.g.
+# run-stats calibration, the kennel, token tracking plugins).
+_USAGE_KEYS = (
+    "usage_input_tokens",
+    "usage_output_tokens",
+    "usage_total_tokens",
+    "usage_cached_read_tokens",
+    "usage_cached_write_tokens",
+    "usage_thought_tokens",
+)
+
+
+def empty_usage_metadata() -> dict[str, int | None]:
+    """Fresh all-``None`` usage dict (each caller gets its own to mutate)."""
+    return {key: None for key in _USAGE_KEYS}
+
+
+def extract_response_text(result: Any) -> str:
+    """Best-effort extraction of human-readable text from a pydantic-ai result."""
+    if result is None:
+        return ""
+    if hasattr(result, "data"):
+        return str(result.data) if result.data else ""
+    if hasattr(result, "output"):
+        return str(result.output) if result.output else ""
+    return str(result)
+
+
+def extract_usage_metadata(result: Any) -> dict[str, int | None]:
+    """Best-effort usage-token extraction; all-``None`` dict on any failure."""
+    try:
+        # Property access (not a call): `result.usage()` is a deprecated
+        # callable-property since pydantic-ai 1.107 and warns when called.
+        usage = result.usage
+
+        def _pick_usage_int(*names: str) -> int | None:
+            for name in names:
+                value = getattr(usage, name, None)
+                if value is not None:
+                    return int(value) or None
+            return None
+
+        return {
+            "usage_input_tokens": _pick_usage_int(
+                "input_tokens", "request_tokens", "prompt_tokens"
+            ),
+            # Real billed output tokens -- calibrates the run-stats TG
+            # estimate (see run_stats.snapshot_cycle_into_aggregates).
+            "usage_output_tokens": _pick_usage_int(
+                "output_tokens", "response_tokens", "completion_tokens"
+            ),
+            "usage_total_tokens": _pick_usage_int("total_tokens"),
+            "usage_cached_read_tokens": _pick_usage_int(
+                "cache_read_tokens", "cached_read_tokens"
+            ),
+            "usage_cached_write_tokens": _pick_usage_int(
+                "cache_write_tokens", "cached_write_tokens"
+            ),
+            "usage_thought_tokens": _pick_usage_int(
+                "thinking_tokens", "thought_tokens", "reasoning_tokens"
+            ),
+        }
+    except Exception:
+        return empty_usage_metadata()
+
+
+@dataclass
+class RunTelemetry(AbstractCapability[Any]):
+    """Capture ``agent_run_end`` telemetry at the run boundary.
+
+    Instance state is a single last-capture slot: ``(result, text, usage)``.
+    The result reference anchors the identity check in :meth:`consume`; it is
+    released on every consume, so nothing outlives the turn that reads it.
+    """
+
+    _captured: Optional[Tuple[Any, str, dict[str, int | None]]] = field(
+        default=None, init=False, repr=False, compare=False
+    )
+
+    async def after_run(self, ctx: Any, *, result: Any) -> Any:
+        self._captured = (
+            result,
+            extract_response_text(result),
+            extract_usage_metadata(result),
+        )
+        return result
+
+    def consume(self, result: Any) -> Optional[Tuple[str, dict[str, int | None]]]:
+        """Return ``(response_text, usage_metadata)`` captured for ``result``.
+
+        Read-and-clear. ``None`` (caller must fall back to eager extraction)
+        unless the last captured result is *identical* to ``result`` — the
+        identity check is what makes stale captures from earlier turns, guest
+        wrappers that bypass capabilities, and ``None`` results all converge
+        on the fallback path instead of reporting the wrong run's telemetry.
+        """
+        captured, self._captured = self._captured, None
+        if captured is not None and result is not None and captured[0] is result:
+            return captured[1], captured[2]
+        return None

--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -76,6 +76,11 @@ from code_puppy.agents._non_streaming_render import (
     render_result_without_streaming,
     should_render_fallback,
 )
+from code_puppy.agents._run_telemetry import (
+    empty_usage_metadata,
+    extract_response_text,
+    extract_usage_metadata,
+)
 from code_puppy.agents._run_signals import (
     drain_pause_state_on_cancel,
     inject_interrupted_subagent_notes,
@@ -542,17 +547,6 @@ def _build_prompt_payload(
     return payload
 
 
-def _extract_response_text(result: Any) -> str:
-    """Best-effort extraction of human-readable text from a pydantic-ai result."""
-    if result is None:
-        return ""
-    if hasattr(result, "data"):
-        return str(result.data) if result.data else ""
-    if hasattr(result, "output"):
-        return str(result.output) if result.output else ""
-    return str(result)
-
-
 def _should_prepend_system_prompt(agent: Any, prompt: str) -> str:
     """Prepend system prompt to user prompt on the first turn (claude-code etc)."""
     from code_puppy.agents._builder import load_puppy_rules
@@ -1012,14 +1006,7 @@ async def _run_with_mcp_impl(
     run_success = False
     run_error: Optional[BaseException] = None
     run_response_text = ""
-    run_usage_metadata: dict[str, int | None] = {
-        "usage_input_tokens": None,
-        "usage_output_tokens": None,
-        "usage_total_tokens": None,
-        "usage_cached_read_tokens": None,
-        "usage_cached_write_tokens": None,
-        "usage_thought_tokens": None,
-    }
+    run_usage_metadata: dict[str, int | None] = empty_usage_metadata()
 
     try:
         # Nested runs leave the SIGINT handler/cancel hotkey alone — the outer
@@ -1061,41 +1048,19 @@ async def _run_with_mcp_impl(
 
         result = await agent_task
         run_success = True
-        run_response_text = _extract_response_text(result)
-        try:
-            # Property access (not a call): `result.usage()` is a deprecated
-            # callable-property since pydantic-ai 1.107 and warns when called.
-            usage = result.usage
-
-            def _pick_usage_int(*names: str) -> int | None:
-                for name in names:
-                    value = getattr(usage, name, None)
-                    if value is not None:
-                        return int(value) or None
-                return None
-
-            run_usage_metadata = {
-                "usage_input_tokens": _pick_usage_int(
-                    "input_tokens", "request_tokens", "prompt_tokens"
-                ),
-                # Real billed output tokens -- calibrates the run-stats TG
-                # estimate (see run_stats.snapshot_cycle_into_aggregates).
-                "usage_output_tokens": _pick_usage_int(
-                    "output_tokens", "response_tokens", "completion_tokens"
-                ),
-                "usage_total_tokens": _pick_usage_int("total_tokens"),
-                "usage_cached_read_tokens": _pick_usage_int(
-                    "cache_read_tokens", "cached_read_tokens"
-                ),
-                "usage_cached_write_tokens": _pick_usage_int(
-                    "cache_write_tokens", "cached_write_tokens"
-                ),
-                "usage_thought_tokens": _pick_usage_int(
-                    "thinking_tokens", "thought_tokens", "reasoning_tokens"
-                ),
-            }
-        except Exception:
-            pass
+        # Explicit-when-ours, fallback-for-guests: the RunTelemetry capability
+        # captured (text, usage) on after_run for the exact result object we
+        # just received — consume() hands it over only on identity match.
+        # Guest wrappers that bypass capabilities, None results (a swallowed
+        # UsageLimitExceeded), and stale captures from an earlier turn all
+        # fall back to the same extraction helpers the capability uses.
+        telemetry_cap = getattr(agent, "_run_telemetry", None)
+        telemetry = telemetry_cap.consume(result) if telemetry_cap is not None else None
+        if telemetry is not None:
+            run_response_text, run_usage_metadata = telemetry
+        else:
+            run_response_text = extract_response_text(result)
+            run_usage_metadata = extract_usage_metadata(result)
         return result
     except asyncio.CancelledError:
         run_response_text = ""

--- a/tests/agents/test_run_telemetry_capability.py
+++ b/tests/agents/test_run_telemetry_capability.py
@@ -1,0 +1,464 @@
+"""Contract tests for the ``RunTelemetry`` capability (``after_run`` seam).
+
+Covers the three layers of the conversion:
+
+* the pure extraction helpers (byte-parity with the old eager code in
+  ``_runtime.run_with_mcp``, including the ``int(value) or None`` zero-token
+  quirk and the alias fallback chains);
+* the capability seam itself (capture on ``after_run``, identity-gated
+  read-and-clear ``consume``, behaviour under ``CombinedCapability``);
+* the wiring (builder installs + stashes the instance; ``run_with_mcp``
+  consumes the capture when ours, falls back for guests; sub-agent scope pin).
+"""
+
+from __future__ import annotations
+
+import inspect
+from contextlib import ExitStack
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import AbstractCapability, CombinedCapability
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.test import TestModel
+
+from code_puppy.agents import _builder, _runtime
+from code_puppy.agents._run_telemetry import (
+    RunTelemetry,
+    empty_usage_metadata,
+    extract_response_text,
+    extract_usage_metadata,
+)
+from code_puppy.callbacks import _callbacks, clear_callbacks, register_callback
+
+
+def _model_func(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+    return ModelResponse(parts=[TextPart("hello world")])
+
+
+# ---------------------------------------------------------------------------
+# Extraction helpers: byte-parity with the retired eager code
+# ---------------------------------------------------------------------------
+
+
+class _Result:
+    """Configurable stand-in for an ``AgentRunResult``."""
+
+    def __init__(self, **attrs: Any) -> None:
+        for key, value in attrs.items():
+            setattr(self, key, value)
+
+
+class _Usage:
+    def __init__(self, **attrs: Any) -> None:
+        for key, value in attrs.items():
+            setattr(self, key, value)
+
+
+def test_extract_response_text_contract():
+    assert extract_response_text(None) == ""
+    assert extract_response_text(_Result(data="from-data")) == "from-data"
+    assert extract_response_text(_Result(data="")) == ""
+    assert extract_response_text(_Result(output="from-output")) == "from-output"
+    assert extract_response_text(_Result(output=None)) == ""
+    # ``data`` wins over ``output`` (same branch order as the eager helper).
+    assert extract_response_text(_Result(data="d", output="o")) == "d"
+    assert extract_response_text("plain") == "plain"
+
+
+def test_extract_usage_metadata_reads_primary_names():
+    result = _Result(
+        usage=_Usage(
+            input_tokens=11,
+            output_tokens=22,
+            total_tokens=33,
+            cache_read_tokens=44,
+            cache_write_tokens=55,
+            thinking_tokens=66,
+        )
+    )
+    assert extract_usage_metadata(result) == {
+        "usage_input_tokens": 11,
+        "usage_output_tokens": 22,
+        "usage_total_tokens": 33,
+        "usage_cached_read_tokens": 44,
+        "usage_cached_write_tokens": 55,
+        "usage_thought_tokens": 66,
+    }
+
+
+def test_extract_usage_metadata_alias_fallbacks():
+    result = _Result(
+        usage=_Usage(
+            request_tokens=7,
+            completion_tokens=8,
+            cached_read_tokens=9,
+            cached_write_tokens=10,
+            reasoning_tokens=12,
+        )
+    )
+    metadata = extract_usage_metadata(result)
+    assert metadata["usage_input_tokens"] == 7
+    assert metadata["usage_output_tokens"] == 8
+    assert metadata["usage_total_tokens"] is None
+    assert metadata["usage_cached_read_tokens"] == 9
+    assert metadata["usage_cached_write_tokens"] == 10
+    assert metadata["usage_thought_tokens"] == 12
+
+
+def test_extract_usage_metadata_zero_short_circuits_alias_chain():
+    """Pin the eager quirk: ``int(value) or None`` maps 0 -> None AND stops
+    the alias chain — a present-but-zero primary name shadows later aliases."""
+    result = _Result(usage=_Usage(input_tokens=0, request_tokens=5))
+    assert extract_usage_metadata(result)["usage_input_tokens"] is None
+
+
+def test_extract_usage_metadata_missing_usage_is_all_none():
+    assert extract_usage_metadata(_Result(data="x")) == empty_usage_metadata()
+    assert extract_usage_metadata(None) == empty_usage_metadata()
+
+
+def test_empty_usage_metadata_returns_fresh_dict_each_call():
+    first = empty_usage_metadata()
+    second = empty_usage_metadata()
+    assert first == second
+    assert first is not second
+
+
+# ---------------------------------------------------------------------------
+# The capability seam: capture + identity-gated consume
+# ---------------------------------------------------------------------------
+
+
+async def test_after_run_captures_the_identical_result_object():
+    telemetry = RunTelemetry()
+    agent = Agent(FunctionModel(_model_func), capabilities=[telemetry])
+
+    result = await agent.run("go")
+
+    consumed = telemetry.consume(result)
+    assert consumed is not None
+    text, usage = consumed
+    assert text == "hello world"
+    assert (
+        usage["usage_input_tokens"]
+        == extract_usage_metadata(result)["usage_input_tokens"]
+    )
+    assert usage == extract_usage_metadata(result)
+
+
+async def test_capability_and_eager_fallback_produce_identical_payloads():
+    telemetry = RunTelemetry()
+    agent = Agent(FunctionModel(_model_func), capabilities=[telemetry])
+
+    result = await agent.run("go")
+
+    text, usage = telemetry.consume(result)
+    assert text == extract_response_text(result)
+    assert usage == extract_usage_metadata(result)
+
+
+async def test_after_run_fires_under_combined_capability():
+    telemetry = RunTelemetry()
+    combined = CombinedCapability([AbstractCapability(), telemetry])
+    agent = Agent(FunctionModel(_model_func), capabilities=[combined])
+
+    result = await agent.run("go")
+
+    assert telemetry.consume(result) is not None
+
+
+async def test_consume_is_read_and_clear():
+    telemetry = RunTelemetry()
+    result = _Result(output="once")
+    await telemetry.after_run(None, result=result)
+
+    assert telemetry.consume(result) == ("once", empty_usage_metadata())
+    assert telemetry.consume(result) is None
+
+
+async def test_consume_requires_identity_match_and_clears_on_mismatch():
+    telemetry = RunTelemetry()
+    captured = _Result(output="captured")
+    other = _Result(output="captured")  # equal-looking, different object
+    await telemetry.after_run(None, result=captured)
+
+    assert telemetry.consume(other) is None
+    # The stale capture must be gone: even the right object now misses.
+    assert telemetry.consume(captured) is None
+
+
+async def test_consume_none_result_never_matches():
+    telemetry = RunTelemetry()
+    await telemetry.after_run(None, result=_Result(output="x"))
+    assert telemetry.consume(None) is None
+
+
+async def test_multi_run_last_capture_wins():
+    telemetry = RunTelemetry()
+    agent = Agent(FunctionModel(_model_func), capabilities=[telemetry])
+
+    first = await agent.run("one")
+    second = await agent.run("two")
+
+    # Only the latest run's result matches — exactly the object
+    # ``run_with_mcp`` ends up returning after steer/hook follow-ups.
+    assert telemetry.consume(first) is None
+    # consume cleared the slot above; recapture to prove second matched.
+    await telemetry.after_run(None, result=second)
+    assert telemetry.consume(second) is not None
+
+
+async def test_after_run_returns_result_unchanged():
+    telemetry = RunTelemetry()
+    result = _Result(output="pass-through")
+    assert await telemetry.after_run(None, result=result) is result
+
+
+def test_spec_constructible_with_inherited_defaults():
+    instance = RunTelemetry.from_spec()
+    assert isinstance(instance, RunTelemetry)
+    assert instance.consume(_Result(output="x")) is None
+
+
+# ---------------------------------------------------------------------------
+# Builder wiring
+# ---------------------------------------------------------------------------
+
+
+class _AgentConfig:
+    name = "test-agent"
+
+    def __init__(self):
+        self._message_history = []
+        self._compacted_message_hashes = set()
+        self._puppy_rules = None
+
+    def get_model_name(self):
+        return "test-model"
+
+    def get_full_system_prompt(self):
+        return "Test instructions"
+
+    def get_available_tools(self):
+        return []
+
+    def get_message_history(self):
+        return self._message_history
+
+    def set_message_history(self, history):
+        self._message_history = history
+
+    def __getattr__(self, item):
+        if item.startswith("__"):
+            raise AttributeError(item)
+        return lambda *_args, **_kwargs: 0
+
+
+def _load_test_model(*_args, **_kwargs):
+    return TestModel(custom_output_text="done"), "test-model"
+
+
+def _builder_patches():
+    return (
+        patch.object(_builder, "load_model_with_fallback", _load_test_model),
+        patch.object(_builder.ModelFactory, "load_config", staticmethod(dict)),
+        patch.object(_builder, "load_mcp_servers", lambda **_kwargs: []),
+        patch.object(_builder, "make_model_settings", lambda *_args, **_kwargs: None),
+        patch(
+            "code_puppy.tools.register_tools_for_agent", lambda *_args, **_kwargs: None
+        ),
+    )
+
+
+async def test_builder_stashes_and_installs_the_capability():
+    config = _AgentConfig()
+    with ExitStack() as stack:
+        for patcher in _builder_patches():
+            stack.enter_context(patcher)
+        agent = _builder.build_pydantic_agent(config)
+        result = await agent.run("start")
+
+    telemetry = config._run_telemetry
+    assert isinstance(telemetry, RunTelemetry)
+    # The stashed instance IS the one riding the built agent: it captured the
+    # exact result object the run returned.
+    consumed = telemetry.consume(result)
+    assert consumed is not None
+    assert consumed[0] == "done"
+
+
+def test_subagent_invocation_stays_out_of_scope():
+    """Scope pin (mirrors #842): the sub-agent path keeps its own usage
+    capture (``include_usage_metrics``); RunTelemetry is main-path only."""
+    source = Path(inspect.getfile(_builder)).parent.parent
+    subagent_source = (source / "tools" / "subagent_invocation.py").read_text(
+        encoding="utf-8"
+    )
+    builder_source = (source / "agents" / "_builder.py").read_text(encoding="utf-8")
+    assert "RunTelemetry" not in subagent_source
+    assert "RunTelemetry" in builder_source  # positive control
+
+
+# ---------------------------------------------------------------------------
+# run_with_mcp custody: explicit-when-ours, fallback-for-guests
+# ---------------------------------------------------------------------------
+
+
+class _DummyResult:
+    def __init__(self, data: str) -> None:
+        self.data = data
+
+    def all_messages(self) -> list[Any]:
+        return []
+
+
+class _ScriptedPydanticAgent:
+    """Stand-in that can optionally deliver results through ``after_run``."""
+
+    def __init__(self, *outcomes: Any, telemetry: RunTelemetry | None = None) -> None:
+        self._outcomes = list(outcomes)
+        self._telemetry = telemetry
+
+    async def run(self, prompt: Any, **kwargs: Any) -> Any:
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        if self._telemetry is not None:
+            # Simulate pydantic-ai dispatching the after_run seam.
+            await self._telemetry.after_run(None, result=outcome)
+        return outcome
+
+
+class _DummyAgent:
+    name = "dummy-agent"
+
+    def __init__(self, pydantic_agent: Any) -> None:
+        self._code_generation_agent = pydantic_agent
+        self._message_history = ["already-started"]
+        self._mcp_servers: list[Any] = []
+
+    def get_model_name(self) -> str:
+        return "dummy-model"
+
+    def get_full_system_prompt(self) -> str:
+        return "unused because message history is non-empty"
+
+
+@pytest.fixture(autouse=True)
+def isolated_runtime_callbacks(monkeypatch: pytest.MonkeyPatch):
+    snapshot = {phase: list(callbacks) for phase, callbacks in _callbacks.items()}
+    clear_callbacks()
+    monkeypatch.setattr(_runtime, "sigint_fallback_cancels", lambda: True)
+    monkeypatch.setattr(_runtime, "get_enable_streaming", lambda: False)
+    monkeypatch.setattr(_runtime, "should_render_fallback", lambda *_, **__: False)
+
+    yield
+
+    clear_callbacks()
+    for phase, callbacks in snapshot.items():
+        _callbacks[phase].extend(callbacks)
+
+
+@pytest.fixture
+def run_end_events() -> list[dict[str, Any]]:
+    seen: list[dict[str, Any]] = []
+
+    def spy(
+        agent_name: str,
+        model_name: str,
+        session_id: Any = None,
+        success: bool = True,
+        error: Any = None,
+        response_text: Any = None,
+        metadata: Any = None,
+    ) -> None:
+        seen.append(
+            {
+                "agent_name": agent_name,
+                "model_name": model_name,
+                "session_id": session_id,
+                "success": success,
+                "error": error,
+                "response_text": response_text,
+                "metadata": metadata,
+            }
+        )
+
+    register_callback("agent_run_end", spy)
+    return seen
+
+
+async def test_run_with_mcp_uses_capability_capture_when_ours(
+    monkeypatch: pytest.MonkeyPatch, run_end_events: list[dict[str, Any]]
+) -> None:
+    telemetry = RunTelemetry()
+    pydantic_agent = _ScriptedPydanticAgent(_DummyResult("ok"), telemetry=telemetry)
+    agent = _DummyAgent(pydantic_agent)
+    agent._run_telemetry = telemetry
+
+    # Sentinel the module-level fallback: if the tail ignored the capability,
+    # the sentinel would leak into the reported response text.
+    monkeypatch.setattr(_runtime, "extract_response_text", lambda _r: "FALLBACK")
+
+    result = await _runtime.run_with_mcp(agent, "hello")
+
+    assert result.data == "ok"
+    assert len(run_end_events) == 1
+    assert run_end_events[0]["response_text"] == "ok"
+    assert run_end_events[0]["success"] is True
+    # Capture was consumed at the tail — nothing left for a later turn.
+    assert telemetry.consume(result) is None
+
+
+async def test_run_with_mcp_falls_back_when_capability_bypassed(
+    monkeypatch: pytest.MonkeyPatch, run_end_events: list[dict[str, Any]]
+) -> None:
+    telemetry = RunTelemetry()
+    # Guest wrapper simulation: run() never dispatches after_run.
+    pydantic_agent = _ScriptedPydanticAgent(_DummyResult("ok"), telemetry=None)
+    agent = _DummyAgent(pydantic_agent)
+    agent._run_telemetry = telemetry
+
+    monkeypatch.setattr(_runtime, "extract_response_text", lambda _r: "FALLBACK")
+
+    await _runtime.run_with_mcp(agent, "hello")
+
+    assert len(run_end_events) == 1
+    assert run_end_events[0]["response_text"] == "FALLBACK"
+
+
+async def test_run_with_mcp_ignores_stale_capture_from_an_earlier_turn(
+    run_end_events: list[dict[str, Any]],
+) -> None:
+    telemetry = RunTelemetry()
+    # A previous turn captured, then its task failed before consuming.
+    await telemetry.after_run(None, result=_DummyResult("stale"))
+
+    pydantic_agent = _ScriptedPydanticAgent(_DummyResult("fresh"), telemetry=None)
+    agent = _DummyAgent(pydantic_agent)
+    agent._run_telemetry = telemetry
+
+    await _runtime.run_with_mcp(agent, "hello")
+
+    assert len(run_end_events) == 1
+    # Identity gate rejected the stale capture; eager extraction reported the
+    # real result — never the earlier turn's text.
+    assert run_end_events[0]["response_text"] == "fresh"
+
+
+async def test_run_with_mcp_without_capability_attribute_uses_fallback(
+    run_end_events: list[dict[str, Any]],
+) -> None:
+    pydantic_agent = _ScriptedPydanticAgent(_DummyResult("plain"))
+    agent = _DummyAgent(pydantic_agent)  # no _run_telemetry attribute at all
+
+    await _runtime.run_with_mcp(agent, "hello")
+
+    assert len(run_end_events) == 1
+    assert run_end_events[0]["response_text"] == "plain"
+    assert run_end_events[0]["metadata"]["usage_input_tokens"] is None


### PR DESCRIPTION
## What

Fifteenth entry in the capability series (#828–#836, #838–#842). The `agent_run_end` payload extraction — human-readable **response text** plus the six-figure **usage token metadata** dict — moves from eager post-`await` bookkeeping at the tail of `_runtime.run_with_mcp` to a first-class capability, **`RunTelemetry`**, on pydantic-ai 2.31.0's **`after_run`** seam. This is the first claim of `after_run` in this codebase.

## Why this feature

After #842 converted the sub-agent invocation layer's around-the-run bookkeeping, the main path's mirror-image bookkeeping was the last unclaimed custody on the run boundary: the tail of `run_with_mcp` fishes `response_text` and usage numbers out of the returned `AgentRunResult` and feeds them to `on_agent_run_end` consumers (run-stats calibration, the kennel, token-tracking plugins). That extraction describes *the result of a run* — exactly what `after_run` exists to observe.

**Scouting note (kennel'd):** the round's first candidate — the main-run cancellation checkpoint (`_checkpoint_cancelled_history`) via `wrap_run` — was **rejected on empirical evidence**: at the `wrap_run` boundary the delivered `CancelledError` is a fresh injected exception *without* the `RunCancelled` snapshot (`_translate_cancellation`'s `_attach_to` runs above the seam), and the seam's `RunContext` is pre-run state (`ctx.messages == []` even mid-run). Cancelled-run history custody cannot move inside the run boundary with parity. Spiked before writing, saved to the kennel so no future round chases it.

## Seam mechanics (verified against installed pydantic-ai 2.31.0)

- `after_run(ctx, *, result)` fires once per successful `Agent.run()` and receives the **identical `AgentRunResult` object** the caller gets back — verified under direct registration and under `CombinedCapability` composition.
- It is **not called** when the run ends without a result (failure/cancellation) — matching the eager code, which only extracted after a successful `await`.
- A turn may contain several runs (initial call + queued-steer / hook-retry follow-ups). Each capture overwrites the last, so the surviving snapshot always describes the run whose result `run_with_mcp` ultimately returns.

## Design: identity-gated custody

`RunTelemetry` holds one last-capture slot `(result, text, usage)`. The consumer calls `consume(result)` — **read-and-clear**, returning telemetry only when the captured result **is** (object identity) the result about to be reported. Everything else converges on the fallback:

- **guest wrappers** that bypass capabilities (`wrap_pydantic_agent` swaps),
- **`None` results** (a swallowed `UsageLimitExceeded` returns `None` from the task body),
- **stale captures** from an earlier turn whose task failed before consuming.

The fallback is the *same pair of helper functions* the capability itself uses (`extract_response_text` / `extract_usage_metadata`, moved verbatim from `_runtime` — including the `int(value) or None` zero-token quirk, which is pinned by a dedicated test, and the provider alias fallback chains). Both paths produce byte-identical payloads; ownership only changes *where* the extraction runs, not what it produces. This is the #838/#841/#842 *explicit-when-ours, fallback-for-guests* split with the cheapest ownership check in the series: `is`.

## Wiring

- `_builder.build_pydantic_agent` hoists **one instance** shared by the probe + final construction passes (series precedent from #831/#832/#833; the probe never runs, so its slot stays empty) and stashes it as `agent._run_telemetry` — documented alongside the other build side effects in the docstring.
- The `run_with_mcp` success tail consumes-or-falls-back; init uses the shared `empty_usage_metadata()` factory instead of a hand-rolled literal.
- **Scope: main path only.** The sub-agent invoker keeps its separate `include_usage_metrics` capture; pinned by a source test asserting `subagent_invocation.py` never mentions `RunTelemetry` (mirrors #842's scope pin, in reverse).

## Feature parity checklist

-  response text extraction: same branch order (`None` → `""`, `.data` wins over `.output`, `str` fallback)
-  usage extraction: same alias chains, same `int(value) or None` zero→`None` short-circuit, same all-`None` dict on any failure (property access, not the deprecated callable)
-  success-only: failed/cancelled turns report `""` + all-`None` exactly as before (`after_run` doesn't fire; fallback sees `None`/no capture)
-  `UsageLimitExceeded` swallowed → task returns `None` → `""` + all-`None` (identity gate can't match `None`)
-  multi-run turns: last capture == returned result (verified identity per run)
-  no behavioral divergences found — extraction is pure and runs on the same object either way; the only delta is *when* (run boundary vs. post-await), which is unobservable to consumers

## Tests

21 contract tests in `tests/agents/test_run_telemetry_capability.py`:
- extraction-helper parity (incl. the zero-token quirk pin and alias fallbacks)
- seam contract: identical-object capture, `CombinedCapability` composition, read-and-clear + identity-gate semantics, result pass-through, `from_spec`
- builder wiring: real `build_pydantic_agent` drive proving the stashed instance is the one riding the built agent
- `run_with_mcp` custody: capability-owns (sentinel-proof the fallback wasn't used), guest-bypass fallback, stale-capture rejection, no-attribute fallback
- sub-agent scope pin

Full suite: **7618 passed, 0 failed** (up from 7617 on the previous branch — the 21 new tests net against the moved helpers' old coverage).

## Series context

Fifteen capability PRs (#828–#836, #838–#842, this one) now share the `capabilities=[...]` blocks. This one touches only the **main** builder block, so it collides mildly with the main-path subset. Rebases remain trivial in any merge order.

**Not merged** — awaiting human review, per standing orders.
