### PR TITLE
feat(agents): PerRequestUsageCapture capability on the after_model_request seam

### DIFF
--- a/code_puppy/agents/_subagent_usage.py
+++ b/code_puppy/agents/_subagent_usage.py
@@ -26,7 +26,17 @@ Parity is guaranteed structurally rather than promised:
   never saw those.
 * Every rejection converges on the caller's eager fallback, which feeds
   the exact same extraction helpers (``extract_per_request_usage`` /
-  ``extract_final_context_tokens``) -- so both paths are byte-identical.
+  ``extract_final_context_tokens``) -- so for a real ``AgentRunResult``
+  (whose ``new_messages()`` is a stable view over run state) both paths
+  report identical entries. The consistency gate itself calls
+  ``new_messages()`` once, which only a pathological result object with
+  stateful ``new_messages()`` semantics could observe.
+
+Ordering note: ``CombinedCapability`` applies after-hooks in REVERSE list
+order (onion semantics), so the call site splices this capability FIRST
+-- it then executes last in ``after_model_request`` and records the
+response object that actually reaches run state, even if another
+capability replaced it.
 
 Scope: the run-total ``usage_metrics`` (``result.usage``) and the
 wall-clock ``duration_ms`` deliberately stay at the call site. The timing
@@ -37,7 +47,7 @@ cannot live inside a per-run capability with parity.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, List, Optional, Sequence, Tuple
+from typing import Any
 
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.messages import ModelResponse
@@ -55,15 +65,15 @@ class PerRequestUsageCapture(AbstractCapability[Any]):
     """
 
     # One-slot last-capture buffer: [(result, responses)]. A list (not an
-    # Optional field) so per-run collectors can share it by reference.
-    _capture: List[Tuple[Any, Tuple[ModelResponse, ...]]] = field(
+    # optional field) so per-run collectors can share it by reference.
+    _capture: list[tuple[Any, tuple[ModelResponse, ...]]] = field(
         default_factory=list, init=False, repr=False
     )
 
     async def for_run(self, ctx: Any) -> AbstractCapability[Any]:
         return _PerRequestUsageRun(capture_slot=self._capture)
 
-    def consume(self, result: Any) -> Optional[Sequence[ModelResponse]]:
+    def consume(self, result: Any) -> list[ModelResponse] | None:
         """Return the owned capture for ``result``, or ``None`` to fall back.
 
         Read-and-clear: stale captures are discarded on the way out so a
@@ -101,8 +111,8 @@ class PerRequestUsageCapture(AbstractCapability[Any]):
 class _PerRequestUsageRun(AbstractCapability[Any]):
     """Run-scoped collector resolved by ``PerRequestUsageCapture.for_run``."""
 
-    capture_slot: List[Tuple[Any, Tuple[ModelResponse, ...]]]
-    _responses: List[ModelResponse] = field(
+    capture_slot: list[tuple[Any, tuple[ModelResponse, ...]]]
+    _responses: list[ModelResponse] = field(
         default_factory=list, init=False, repr=False
     )
 
@@ -119,7 +129,7 @@ class _PerRequestUsageRun(AbstractCapability[Any]):
 
 def build_per_request_usage_capture(
     include_usage_metrics: bool,
-) -> Tuple[Optional[PerRequestUsageCapture], List[PerRequestUsageCapture]]:
+) -> tuple[PerRequestUsageCapture | None, list[PerRequestUsageCapture]]:
     """Build the capture for one invocation, or nothing when metrics are off.
 
     Returns ``(capture, splice)`` so the call site can keep a handle for

--- a/code_puppy/agents/_subagent_usage.py
+++ b/code_puppy/agents/_subagent_usage.py
@@ -1,0 +1,138 @@
+"""Per-request usage capture for sub-agent invocations, as a capability.
+
+``invoke_agent_with_model`` reports token usage per model request
+(``per_request_usage``) and the final request's context size
+(``final_context_tokens``). Previously both were derived after the run by
+walking ``result.new_messages()`` for ``ModelResponse`` objects. This module
+moves the *observation* to pydantic-ai's ``after_model_request`` capability
+seam: each response is recorded at the exact moment the run appends it to
+state, and the recorded sequence is handed back to the invocation layer at
+the run boundary.
+
+Parity is guaranteed structurally rather than promised:
+
+* ``after_model_request`` receives the IDENTICAL ``ModelResponse`` object
+  that ``_finish_handling`` appends to run state (verified against
+  pydantic-ai 2.31.0 source and empirically for both streamed and
+  non-streamed requests), so the captured objects are the same objects an
+  eager ``new_messages()`` walk would visit.
+* ``consume()`` is read-and-clear and double-gated. The identity gate
+  (``captured result is result``) rejects stale captures from failed
+  earlier attempts (streaming-retry re-entry) and guest wrappers that
+  bypass capabilities. The consistency gate rejects captures whose
+  response sequence no longer matches the result's recorded
+  ``ModelResponse`` objects -- mid-run compaction may summarize away a
+  long run's own earlier responses, and the old ``new_messages()`` walk
+  never saw those.
+* Every rejection converges on the caller's eager fallback, which feeds
+  the exact same extraction helpers (``extract_per_request_usage`` /
+  ``extract_final_context_tokens``) -- so both paths are byte-identical.
+
+Scope: the run-total ``usage_metrics`` (``result.usage``) and the
+wall-clock ``duration_ms`` deliberately stay at the call site. The timing
+spans streaming-retry attempts -- multiple ``agent.run()`` calls -- so it
+cannot live inside a per-run capability with parity.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Sequence, Tuple
+
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.messages import ModelResponse
+
+
+@dataclass
+class PerRequestUsageCapture(AbstractCapability[Any]):
+    """Capture each run's ``ModelResponse`` objects at the seam.
+
+    One instance is constructed per sub-agent invocation. ``for_run``
+    hands each ``agent.run()`` a fresh collector so responses never leak
+    across streaming-retry attempts; the collector stows its capture in
+    this instance's one-slot buffer at ``after_run``, which only fires for
+    runs that produced a result.
+    """
+
+    # One-slot last-capture buffer: [(result, responses)]. A list (not an
+    # Optional field) so per-run collectors can share it by reference.
+    _capture: List[Tuple[Any, Tuple[ModelResponse, ...]]] = field(
+        default_factory=list, init=False, repr=False
+    )
+
+    async def for_run(self, ctx: Any) -> AbstractCapability[Any]:
+        return _PerRequestUsageRun(capture_slot=self._capture)
+
+    def consume(self, result: Any) -> Optional[Sequence[ModelResponse]]:
+        """Return the owned capture for ``result``, or ``None`` to fall back.
+
+        Read-and-clear: stale captures are discarded on the way out so a
+        later invocation can never inherit them. ``None`` means the caller
+        must derive usage eagerly from ``result.new_messages()`` -- the
+        pre-capability behavior.
+        """
+        if not self._capture:
+            return None
+        captured_result, responses = self._capture[0]
+        self._capture.clear()
+        if captured_result is not result:
+            return None
+
+        # Consistency gate: the capture is authoritative only while it
+        # matches the responses the result actually recorded. Guarded so a
+        # result whose ``new_messages()`` raises fails over to the eager
+        # path, preserving the old call-site failure mode.
+        try:
+            recorded = [
+                message
+                for message in result.new_messages()
+                if isinstance(message, ModelResponse)
+            ]
+        except Exception:
+            return None
+        if len(recorded) != len(responses):
+            return None
+        if any(seen is not kept for seen, kept in zip(responses, recorded)):
+            return None
+        return list(responses)
+
+
+@dataclass
+class _PerRequestUsageRun(AbstractCapability[Any]):
+    """Run-scoped collector resolved by ``PerRequestUsageCapture.for_run``."""
+
+    capture_slot: List[Tuple[Any, Tuple[ModelResponse, ...]]]
+    _responses: List[ModelResponse] = field(
+        default_factory=list, init=False, repr=False
+    )
+
+    async def after_model_request(
+        self, ctx: Any, *, request_context: Any, response: ModelResponse
+    ) -> ModelResponse:
+        self._responses.append(response)
+        return response
+
+    async def after_run(self, ctx: Any, *, result: Any) -> Any:
+        self.capture_slot[:] = [(result, tuple(self._responses))]
+        return result
+
+
+def build_per_request_usage_capture(
+    include_usage_metrics: bool,
+) -> Tuple[Optional[PerRequestUsageCapture], List[PerRequestUsageCapture]]:
+    """Build the capture for one invocation, or nothing when metrics are off.
+
+    Returns ``(capture, splice)`` so the call site can keep a handle for
+    ``consume()`` while splicing the capability into ``capabilities=[...]``
+    unconditionally (mirroring ``build_tool_output_limits``).
+    """
+    if not include_usage_metrics:
+        return None, []
+    capture = PerRequestUsageCapture()
+    return capture, [capture]
+
+
+__all__ = [
+    "PerRequestUsageCapture",
+    "build_per_request_usage_capture",
+]

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -404,6 +404,16 @@ async def _invoke_agent_impl(
             from code_puppy.agents._model_message_transform import (
                 build_model_message_transform,
             )
+            from code_puppy.agents._subagent_usage import (
+                build_per_request_usage_capture,
+            )
+
+            # Per-request usage rides the after_model_request seam; the
+            # handle feeds consume() at the success boundary below. Empty
+            # splice (and a None handle) when usage metrics are off.
+            usage_capture, usage_capture_splice = build_per_request_usage_capture(
+                include_usage_metrics
+            )
 
             # Build the pydantic-ai agent. MCP servers always included; plugins
             # (e.g. DBOS) may swap them via the agent_run_context hook.
@@ -420,9 +430,13 @@ async def _invoke_agent_impl(
                 toolsets=mcp_servers,
                 # ProcessHistory capability replaces the deprecated
                 # `history_processors=` kwarg (removed in pydantic-ai v2).
+                # Usage capture goes LAST: if an earlier capability ever
+                # replaced a response in after_model_request, the recorded
+                # object must be the one that reaches run state.
                 capabilities=[
                     ProcessHistory(make_history_processor(agent_config)),
                     build_model_message_transform(agent_name),
+                    *usage_capture_splice,
                 ],
                 model_settings=model_settings,
             )
@@ -576,6 +590,23 @@ async def _invoke_agent_impl(
                 f"✓ {agent_name} completed successfully", message_group=group_id
             )
 
+            if include_usage_metrics:
+                # Prefer the seam capture; anything it disowns (guest
+                # wrappers, stale attempts, mid-run compaction rewrites)
+                # falls back to the eager walk. Same helpers either way,
+                # so both paths report identical entries.
+                usage_source = (
+                    usage_capture.consume(result) if usage_capture is not None else None
+                )
+                if usage_source is None:
+                    # all_messages() would re-report calls from earlier runs.
+                    usage_source = result.new_messages()
+                per_request_usage = extract_per_request_usage(usage_source)
+                final_context_tokens = extract_final_context_tokens(usage_source)
+            else:
+                per_request_usage = None
+                final_context_tokens = None
+
             return build_invoke_output(
                 include_usage_metrics=include_usage_metrics,
                 response=response,
@@ -583,17 +614,8 @@ async def _invoke_agent_impl(
                 session_id=session_id,
                 model_name=effective_model_name,
                 usage_metrics=usage_metrics,
-                per_request_usage=(
-                    # all_messages() would re-report calls from earlier runs.
-                    extract_per_request_usage(result.new_messages())
-                    if include_usage_metrics
-                    else None
-                ),
-                final_context_tokens=(
-                    extract_final_context_tokens(result.new_messages())
-                    if include_usage_metrics
-                    else None
-                ),
+                per_request_usage=per_request_usage,
+                final_context_tokens=final_context_tokens,
                 start_time=start_time,
                 end_time=end_time,
                 duration_ms=duration_ms,

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -430,13 +430,15 @@ async def _invoke_agent_impl(
                 toolsets=mcp_servers,
                 # ProcessHistory capability replaces the deprecated
                 # `history_processors=` kwarg (removed in pydantic-ai v2).
-                # Usage capture goes LAST: if an earlier capability ever
-                # replaced a response in after_model_request, the recorded
-                # object must be the one that reaches run state.
+                # Usage capture goes FIRST: after-hooks apply in REVERSE
+                # list order (onion semantics), so first position executes
+                # last in after_model_request and records the response
+                # object that actually reaches run state even if a later
+                # capability replaced it.
                 capabilities=[
+                    *usage_capture_splice,
                     ProcessHistory(make_history_processor(agent_config)),
                     build_model_message_transform(agent_name),
-                    *usage_capture_splice,
                 ],
                 model_settings=model_settings,
             )

--- a/tests/agents/test_per_request_usage_capability.py
+++ b/tests/agents/test_per_request_usage_capability.py
@@ -1,0 +1,318 @@
+"""Contract tests for the ``PerRequestUsageCapture`` capability.
+
+The capability observes each ``ModelResponse`` on pydantic-ai's
+``after_model_request`` seam and hands the invocation layer an owned,
+consistency-checked capture at the run boundary. These tests pin:
+
+* seam capture parity with an eager ``new_messages()`` walk (identity,
+  order, streamed and non-streamed requests);
+* the read-and-clear + identity + consistency gates on ``consume()``,
+  including the mid-run history-rewrite case where the gates are the only
+  thing standing between us and a phantom usage entry;
+* per-run isolation across sequential runs on one agent (the
+  streaming-retry re-entry shape);
+* byte-identical extraction between the capability path and the eager
+  fallback path;
+* the conditional construction helper used by the call site.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import ProcessHistory
+from pydantic_ai.messages import (
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+)
+from pydantic_ai.models.function import (
+    AgentInfo,
+    DeltaToolCall,
+    FunctionModel,
+)
+
+from code_puppy.agents._subagent_usage import (
+    PerRequestUsageCapture,
+    build_per_request_usage_capture,
+)
+from code_puppy.tools.subagent_usage_metrics import (
+    extract_final_context_tokens,
+    extract_per_request_usage,
+)
+
+
+def _tool_then_text_model() -> FunctionModel:
+    """One tool-call response, then a final text response.
+
+    Termination is driven by the *visible* history (a tool-return part), so
+    the model behaves correctly for plain runs. Tests that rewrite history
+    mid-run use ``_counted_model`` instead.
+    """
+
+    def req_fn(messages, info: AgentInfo) -> ModelResponse:
+        has_tool_return = any(
+            getattr(part, "part_kind", "") == "tool-return"
+            for message in messages
+            for part in getattr(message, "parts", [])
+        )
+        if not has_tool_return:
+            return ModelResponse(parts=[ToolCallPart(tool_name="greet", args="{}")])
+        return ModelResponse(parts=[TextPart("done")])
+
+    async def stream_fn(messages, info: AgentInfo):
+        has_tool_return = any(
+            getattr(part, "part_kind", "") == "tool-return"
+            for message in messages
+            for part in getattr(message, "parts", [])
+        )
+        if not has_tool_return:
+            yield {1: DeltaToolCall(name="greet", json_args="{}")}
+        else:
+            yield "do"
+            yield "ne"
+
+    return FunctionModel(req_fn, stream_function=stream_fn)
+
+
+def _counted_model(counter: dict) -> FunctionModel:
+    """Tool call on the first request, text afterwards, regardless of history."""
+
+    def req_fn(messages, info: AgentInfo) -> ModelResponse:
+        counter["calls"] = counter.get("calls", 0) + 1
+        if counter["calls"] == 1:
+            return ModelResponse(parts=[ToolCallPart(tool_name="greet", args="{}")])
+        return ModelResponse(parts=[TextPart("done")])
+
+    return FunctionModel(req_fn)
+
+
+def _agent_with(model: FunctionModel, *capabilities) -> Agent:
+    agent = Agent(model, capabilities=list(capabilities))
+
+    @agent.tool_plain
+    def greet() -> str:
+        return "hi"
+
+    return agent
+
+
+def _recorded_responses(result) -> list[ModelResponse]:
+    return [m for m in result.new_messages() if isinstance(m, ModelResponse)]
+
+
+class TestSeamCapture:
+    def test_captures_every_response_object_in_order(self):
+        capture = PerRequestUsageCapture()
+        agent = _agent_with(_tool_then_text_model(), capture)
+
+        result = asyncio.run(agent.run("go"))
+
+        owned = capture.consume(result)
+        assert owned is not None
+        recorded = _recorded_responses(result)
+        assert len(owned) == len(recorded) == 2
+        assert all(a is b for a, b in zip(owned, recorded))
+
+    def test_streamed_requests_are_captured_identically(self):
+        capture = PerRequestUsageCapture()
+        agent = _agent_with(_tool_then_text_model(), capture)
+
+        async def handler(ctx, events):
+            async for _ in events:
+                pass
+
+        result = asyncio.run(agent.run("go", event_stream_handler=handler))
+
+        owned = capture.consume(result)
+        assert owned is not None
+        recorded = _recorded_responses(result)
+        assert len(owned) == len(recorded) == 2
+        assert all(a is b for a, b in zip(owned, recorded))
+
+    def test_capture_survives_neighbouring_capabilities(self):
+        # The production list runs ProcessHistory ahead of the capture; a
+        # pass-through processor must not disturb ownership.
+        capture = PerRequestUsageCapture()
+        agent = _agent_with(
+            _tool_then_text_model(), ProcessHistory(lambda messages: messages), capture
+        )
+
+        result = asyncio.run(agent.run("go"))
+
+        assert capture.consume(result) is not None
+
+
+class TestConsumeGates:
+    def test_consume_is_read_and_clear(self):
+        capture = PerRequestUsageCapture()
+        agent = _agent_with(_tool_then_text_model(), capture)
+
+        result = asyncio.run(agent.run("go"))
+
+        assert capture.consume(result) is not None
+        assert capture.consume(result) is None
+
+    def test_identity_gate_rejects_foreign_results(self):
+        capture = PerRequestUsageCapture()
+        agent = _agent_with(_tool_then_text_model(), capture)
+
+        asyncio.run(agent.run("go"))
+
+        assert capture.consume(object()) is None
+        # The stale capture was cleared on the way out.
+        assert capture._capture == []
+
+    def test_empty_slot_returns_none(self):
+        assert PerRequestUsageCapture().consume(object()) is None
+
+    def test_consistency_gate_rejects_mid_run_history_rewrite(self):
+        # A ProcessHistory pass that drops this run's own tool-call response
+        # (the shape mid-run compaction produces on a long sub-agent run):
+        # the seam saw two responses but the result records one. The eager
+        # walk on main never reported the dropped response, so the capture
+        # must disown itself rather than report a phantom usage entry.
+        def dropper(messages):
+            return [
+                m
+                for m in messages
+                if not (
+                    isinstance(m, ModelResponse)
+                    and any(isinstance(p, ToolCallPart) for p in m.parts)
+                )
+            ]
+
+        capture = PerRequestUsageCapture()
+        agent = _agent_with(
+            _counted_model({}), ProcessHistory(dropper), capture
+        )
+
+        result = asyncio.run(agent.run("go"))
+
+        assert len(capture._capture[0][1]) == 2
+        assert len(_recorded_responses(result)) == 1
+        assert capture.consume(result) is None
+
+    def test_consistency_gate_tolerates_new_messages_raising(self):
+        capture = PerRequestUsageCapture()
+        agent = _agent_with(_tool_then_text_model(), capture)
+
+        asyncio.run(agent.run("go"))
+
+        class ExplodingResult:
+            def new_messages(self):
+                raise RuntimeError("boom")
+
+        exploding = ExplodingResult()
+        # Force the identity gate to pass so the consistency gate runs.
+        capture._capture[0] = (exploding, capture._capture[0][1])
+        assert capture.consume(exploding) is None
+
+
+class TestPerRunIsolation:
+    def test_sequential_runs_do_not_accumulate(self):
+        # Streaming-retry re-entry shape: multiple run() calls on one agent.
+        capture = PerRequestUsageCapture()
+        agent = _agent_with(_tool_then_text_model(), capture)
+
+        first = asyncio.run(agent.run("go"))
+        second = asyncio.run(
+            agent.run("again", message_history=first.all_messages())
+        )
+
+        owned = capture.consume(second)
+        assert owned is not None
+        assert len(owned) == len(_recorded_responses(second)) == 1
+        # The first run's capture was overwritten, not merged.
+        assert capture.consume(first) is None
+
+    def test_stale_capture_from_earlier_run_is_disowned(self):
+        capture = PerRequestUsageCapture()
+        agent = _agent_with(_tool_then_text_model(), capture)
+
+        first = asyncio.run(agent.run("go"))
+        asyncio.run(agent.run("again", message_history=first.all_messages()))
+
+        # Consuming with the FIRST result must not surface the SECOND
+        # run's capture.
+        assert capture.consume(first) is None
+
+
+class TestExtractionParity:
+    def test_owned_capture_yields_identical_entries_to_eager_walk(self):
+        capture = PerRequestUsageCapture()
+        agent = _agent_with(_tool_then_text_model(), capture)
+
+        result = asyncio.run(agent.run("go"))
+
+        eager_entries = extract_per_request_usage(result.new_messages())
+        eager_context = extract_final_context_tokens(result.new_messages())
+
+        owned = capture.consume(result)
+        assert owned is not None
+        assert extract_per_request_usage(owned) == eager_entries
+        assert extract_final_context_tokens(owned) == eager_context
+        # FunctionModel reports real usage; make sure the parity assertion
+        # is not vacuous.
+        assert eager_entries and eager_entries[0].input_tokens
+
+    def test_fallback_path_is_the_old_behavior(self):
+        # When consume() disowns, the call site walks new_messages() -- the
+        # literal pre-capability code. Simulated here end to end.
+        capture = PerRequestUsageCapture()
+        agent = _agent_with(_tool_then_text_model(), capture)
+
+        result = asyncio.run(agent.run("go"))
+        capture._capture.clear()  # guest wrapper shape: seam never fired
+
+        source = capture.consume(result)
+        assert source is None
+        source = result.new_messages()
+        assert extract_per_request_usage(source) == extract_per_request_usage(
+            result.new_messages()
+        )
+
+
+class TestConstructionHelper:
+    def test_disabled_metrics_build_nothing(self):
+        capture, splice = build_per_request_usage_capture(False)
+        assert capture is None
+        assert splice == []
+
+    def test_enabled_metrics_share_one_instance(self):
+        capture, splice = build_per_request_usage_capture(True)
+        assert isinstance(capture, PerRequestUsageCapture)
+        assert splice == [capture]
+        assert splice[0] is capture
+
+    def test_capture_is_spec_constructible(self):
+        # No live references: the capability round-trips through the spec
+        # machinery with inherited defaults (series precedent: #844).
+        name = PerRequestUsageCapture.get_serialization_name()
+        assert name == "PerRequestUsageCapture"
+        rebuilt = PerRequestUsageCapture.from_spec()
+        assert isinstance(rebuilt, PerRequestUsageCapture)
+
+
+class TestCallSiteWiring:
+    def test_invocation_layer_wires_capture_and_consume(self):
+        # Source pin: the invocation layer builds the capture, splices it
+        # into capabilities, and consumes at the success boundary with the
+        # eager walk as fallback.
+        import inspect
+
+        from code_puppy.tools import subagent_invocation
+
+        source = inspect.getsource(subagent_invocation)
+        assert "build_per_request_usage_capture" in source
+        assert "usage_capture.consume(result)" in source
+        assert "*usage_capture_splice" in source
+        # The fallback is still the eager helpers on new_messages().
+        assert "extract_per_request_usage(usage_source)" in source
+        assert "extract_final_context_tokens(usage_source)" in source
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/agents/test_per_request_usage_capability.py
+++ b/tests/agents/test_per_request_usage_capability.py
@@ -20,9 +20,11 @@ from __future__ import annotations
 
 import asyncio
 
+import dataclasses
+
 import pytest
 from pydantic_ai import Agent
-from pydantic_ai.capabilities import ProcessHistory
+from pydantic_ai.capabilities import AbstractCapability, ProcessHistory
 from pydantic_ai.messages import (
     ModelResponse,
     TextPart,
@@ -103,6 +105,13 @@ def _recorded_responses(result) -> list[ModelResponse]:
     return [m for m in result.new_messages() if isinstance(m, ModelResponse)]
 
 
+class _ResponseReplacer(AbstractCapability):
+    """Swaps every response for an equal-but-distinct object at the seam."""
+
+    async def after_model_request(self, ctx, *, request_context, response):
+        return dataclasses.replace(response)
+
+
 class TestSeamCapture:
     def test_captures_every_response_object_in_order(self):
         capture = PerRequestUsageCapture()
@@ -133,16 +142,42 @@ class TestSeamCapture:
         assert all(a is b for a, b in zip(owned, recorded))
 
     def test_capture_survives_neighbouring_capabilities(self):
-        # The production list runs ProcessHistory ahead of the capture; a
+        # Production wiring: capture FIRST, ProcessHistory after. A
         # pass-through processor must not disturb ownership.
         capture = PerRequestUsageCapture()
         agent = _agent_with(
-            _tool_then_text_model(), ProcessHistory(lambda messages: messages), capture
+            _tool_then_text_model(), capture, ProcessHistory(lambda messages: messages)
         )
 
         result = asyncio.run(agent.run("go"))
 
         assert capture.consume(result) is not None
+
+    def test_first_position_records_replacements_from_later_capabilities(self):
+        # CombinedCapability applies after-hooks in REVERSE list order
+        # (onion semantics): the capture sits FIRST so it executes LAST
+        # and records the replacement object that reaches run state.
+        capture = PerRequestUsageCapture()
+        agent = _agent_with(_tool_then_text_model(), capture, _ResponseReplacer())
+
+        result = asyncio.run(agent.run("go"))
+
+        owned = capture.consume(result)
+        assert owned is not None
+        recorded = _recorded_responses(result)
+        assert all(a is b for a, b in zip(owned, recorded))
+
+    def test_misordered_capture_is_disowned_not_divergent(self):
+        # The adversarial ordering: capture LAST executes FIRST, so a
+        # later-executing replacer swaps the object after capture. The
+        # consistency gate must disown the capture (falling back to the
+        # eager walk) rather than report the pre-replacement objects.
+        capture = PerRequestUsageCapture()
+        agent = _agent_with(_tool_then_text_model(), _ResponseReplacer(), capture)
+
+        result = asyncio.run(agent.run("go"))
+
+        assert capture.consume(result) is None
 
 
 class TestConsumeGates:
@@ -185,9 +220,7 @@ class TestConsumeGates:
             ]
 
         capture = PerRequestUsageCapture()
-        agent = _agent_with(
-            _counted_model({}), ProcessHistory(dropper), capture
-        )
+        agent = _agent_with(_counted_model({}), ProcessHistory(dropper), capture)
 
         result = asyncio.run(agent.run("go"))
 
@@ -218,9 +251,7 @@ class TestPerRunIsolation:
         agent = _agent_with(_tool_then_text_model(), capture)
 
         first = asyncio.run(agent.run("go"))
-        second = asyncio.run(
-            agent.run("again", message_history=first.all_messages())
-        )
+        second = asyncio.run(agent.run("again", message_history=first.all_messages()))
 
         owned = capture.consume(second)
         assert owned is not None


### PR DESCRIPTION
# `PerRequestUsageCapture`: sub-agent per-request usage as a capability

Sixteenth in the capability-conversion series (#828-#836, #838-#842, #844). First claim of the **`after_model_request`** seam.

## The feature

`invoke_agent_with_model` reports token usage per model request (`per_request_usage` -- "use per_request_usage for pricing") and the final request's context size (`final_context_tokens`). On main, both are derived **after** the run by walking `result.new_messages()` for `ModelResponse` objects (`code_puppy/tools/subagent_usage_metrics.py`).

## The conversion

New `code_puppy/agents/_subagent_usage.py`:

- **`PerRequestUsageCapture`** -- one instance per invocation. `for_run` hands each `agent.run()` a fresh run-scoped collector (proven necessary: responses accumulate across runs on a shared instance, and streaming-retry re-entry means multiple `run()` calls per invocation). The collector records each `ModelResponse` on `after_model_request` and stows `(result, responses)` into a one-slot capture at `after_run` -- which only fires for runs that produced a result, so failed attempts never pollute the slot.
- **`consume(result)`** is read-and-clear and **double-gated**:
  - *Identity gate* (`captured result is result`, #844 precedent): rejects stale captures and guest wrappers that bypass capabilities.
  - *Consistency gate*: rejects captures whose response sequence no longer identity-matches the result's recorded `ModelResponse`s. This is not paranoia -- **mid-run history rewrites are real**: a `ProcessHistory` pass that drops one of this run's own responses (the shape mid-run compaction produces on a long sub-agent run) leaves the seam having seen N responses while `new_messages()` records N-1. The eager walk on main never reported the dropped response; without the gate the capability would report a phantom usage entry. Pinned by `test_consistency_gate_rejects_mid_run_history_rewrite`, which reproduces the divergence empirically.
- Every rejection converges on the call site's eager fallback -- the literal pre-capability `new_messages()` walk -- and both paths feed the **same** extraction helpers (`extract_per_request_usage` / `extract_final_context_tokens`, untouched), so both paths are byte-identical.

## Seam mechanics (2.31.0, verified empirically)

- `after_model_request` fires once per model response, for **both** streamed and non-streamed requests (all three `_finish_handling` call sites), and receives the **identical `ModelResponse` object** that `_append_response` commits to run state.
- `CombinedCapability` applies after-hooks in **reverse list order** (onion semantics) -- caught by the reviewer in pass 1. The capture therefore goes **first** in `capabilities=[...]`: it executes last in `after_model_request` and records the response object that actually reaches run state even if another capability replaced it. Pinned both ways: the production ordering owns replacements; the adversarial misordering is disowned by the consistency gate and falls back rather than reporting pre-replacement objects.
- `for_run` is `async` in 2.31.0 and resolves once per `run()`; `after_run` fires on the resolved run capability with the identical `AgentRunResult` the caller receives (re-confirmed from #844).

## Scope & bounded non-moves

- **Run-total `usage_metrics` (`result.usage`) and `duration_ms` stay at the call site.** The timing deliberately spans streaming-retry attempts -- multiple `agent.run()` calls -- so it cannot live inside a per-run capability with parity.
- The capability is only constructed when `include_usage_metrics` is set (`invoke_agent_with_model` only); plain `invoke_agent` invocations get an empty splice and zero new machinery -- mirroring the `build_tool_output_limits` conditional-splice pattern.
- Main-path telemetry untouched (that is #844's territory, in reverse).
- Extraction helpers in `subagent_usage_metrics.py` untouched -- all 42 existing helper tests pass unchanged.

## Behavioral divergences

**None** for real `AgentRunResult`s (whose `new_messages()` is a stable view over run state). The observation moved to the seam; the reported values are computed by the same helpers over the same objects, and every case where the seam data could differ from the eager walk is gated back onto the eager walk. The consistency gate adds one `new_messages()` call, observable only by a pathological result object with stateful `new_messages()` semantics.

## Tests

18 contract tests in `tests/agents/test_per_request_usage_capability.py`: seam capture identity/order (streamed + non-streamed), read-and-clear, identity gate, consistency gate (incl. the mid-run rewrite reproduction and a `new_messages()`-raising result preserving the old failure mode), per-run isolation across sequential runs, extraction parity vs the eager walk (non-vacuous: FunctionModel reports real usage), construction helper, spec-constructibility, and a call-site wiring pin.

## Merge-order note

Same story as the rest of the series: this PR touches the sub-agent `capabilities=[...]` block that #828-#842 also graze. Whoever lands last eats a trivial rebase. This one additionally shares the success-boundary region of `_invoke_agent_impl` with #842 (session persistence) -- also trivial.
