### PR TITLE
fix(ACP execution): Permission requests silently failing

### DIFF
--- a/code_puppy/tools/common.py
+++ b/code_puppy/tools/common.py
@@ -1408,7 +1408,7 @@ async def _get_user_approval_async_impl(
 
     backend = get_approval_backend()
     if backend is not None:
-        # Use asyncio.to_thread to run the synchronous part of the 
+        # Use asyncio.to_thread to run the synchronous part of the
         # backend in a thread, allowing ContextVars to be preserved.
         return await asyncio.to_thread(
             backend, title, _approval_message_text(content), preview

--- a/code_puppy/tools/common.py
+++ b/code_puppy/tools/common.py
@@ -1408,9 +1408,10 @@ async def _get_user_approval_async_impl(
 
     backend = get_approval_backend()
     if backend is not None:
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(
-            None, backend, title, _approval_message_text(content), preview
+        # Use asyncio.to_thread to run the synchronous part of the 
+        # backend in a thread, allowing ContextVars to be preserved.
+        return await asyncio.to_thread(
+            backend, title, _approval_message_text(content), preview
         )
 
     if not _stdin_supports_interactive_approval():

--- a/code_puppy/tools/file_modifications.py
+++ b/code_puppy/tools/file_modifications.py
@@ -813,10 +813,11 @@ async def _delete_file_async(
     if _permission_denied(permission_results):
         return _create_rejection_response(file_path)
 
-    try:
-        if not fs_access.exists(file_path) or not fs_access.is_file(file_path):
-            res = {"error": f"File '{file_path}' does not exist.", "diff": ""}
-        else:
+    def _delete() -> Dict[str, Any]:
+        try:
+            if not fs_access.exists(file_path) or not fs_access.is_file(file_path):
+                return {"error": f"File '{file_path}' does not exist.", "diff": ""}
+
             original = fs_access.read_text(file_path)
             try:
                 original = original.encode("utf-8", errors="surrogatepass").decode(
@@ -836,16 +837,18 @@ async def _delete_file_async(
                 )
             )
             fs_access.delete_file(file_path)
-            res = {
+            return {
                 "success": True,
                 "path": file_path,
                 "message": f"File '{file_path}' deleted successfully.",
                 "changed": True,
                 "diff": diff_text,
             }
-    except Exception as exc:
-        _log_error("Unhandled exception in delete_file", exc)
-        res = {"error": str(exc), "diff": ""}
+        except Exception as exc:
+            _log_error("Unhandled exception in delete_file", exc)
+            return {"error": str(exc), "diff": ""}
+
+    res = await asyncio.to_thread(_delete)
 
     diff = res.get("diff", "")
     if diff:

--- a/code_puppy/tools/file_modifications.py
+++ b/code_puppy/tools/file_modifications.py
@@ -10,6 +10,7 @@ Key guarantees
 
 from __future__ import annotations
 
+import asyncio
 import difflib
 import json
 import os
@@ -513,8 +514,12 @@ async def delete_snippet_from_file_async(
     if _permission_denied(permission_results):
         return _create_rejection_response(file_path)
 
-    res = _delete_snippet_from_file(
-        context, file_path, snippet, message_group=message_group
+    res = await asyncio.to_thread(
+        _delete_snippet_from_file,
+        context,
+        file_path,
+        snippet,
+        message_group=message_group,
     )
     diff = res.get("diff", "")
     if diff:
@@ -539,8 +544,13 @@ async def write_to_file_async(
     if _permission_denied(permission_results):
         return _create_rejection_response(path)
 
-    res = _write_to_file(
-        context, path, content, overwrite=overwrite, message_group=message_group
+    res = await asyncio.to_thread(
+        _write_to_file,
+        context,
+        path,
+        content,
+        overwrite=overwrite,
+        message_group=message_group,
     )
     diff = res.get("diff", "")
     if diff:
@@ -565,7 +575,13 @@ async def replace_in_file_async(
     if _permission_denied(permission_results):
         return _create_rejection_response(path)
 
-    res = _replace_in_file(context, path, replacements, message_group=message_group)
+    res = await asyncio.to_thread(
+        _replace_in_file,
+        context,
+        path,
+        replacements,
+        message_group=message_group,
+    )
     diff = res.get("diff", "")
     if diff:
         _emit_diff_message(path, "modify", diff)

--- a/tests/test_acp_plugin.py
+++ b/tests/test_acp_plugin.py
@@ -35,7 +35,6 @@ from acp.schema import (
     TerminalOutputResponse,
     WaitForTerminalExitResponse,
 )
-
 from code_puppy_core_plugins.acp import (
     bridge as bridge_mod,
     capabilities,
@@ -594,6 +593,29 @@ async def test_approval_backend_async_runs_in_executor():
     finally:
         common.set_approval_backend(None)
     assert approved is False
+
+
+@pytest.mark.asyncio
+async def test_approval_backend_async_preserves_acp_run_context():
+    """Async approval dispatch must retain the ACP session for client routing."""
+    from code_puppy.tools import common
+
+    seen = []
+
+    def backend(title, message, preview):
+        seen.append(state.get_active_session_id())
+        return True, None
+
+    state.begin_run("approval-session")
+    common.set_approval_backend(backend)
+    try:
+        approved, _ = await common.get_user_approval_async("Op", "do it?")
+    finally:
+        common.set_approval_backend(None)
+        state.end_run()
+
+    assert approved is True
+    assert seen == ["approval-session"]
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_file_permissions.py
+++ b/tests/test_file_permissions.py
@@ -368,6 +368,37 @@ async def test_write_to_file_async_uses_backend_off_event_loop(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_delete_file_async_uses_backend_off_event_loop(tmp_path):
+    """Async deletes must not bridge a backend read from the event loop."""
+    from code_puppy.tools.file_modifications import _delete_file_async
+    from code_puppy.tools.io_backends import set_filesystem_backend
+
+    class LoopGuardBackend:
+        def exists(self, path):
+            return True
+
+        def is_file(self, path):
+            return True
+
+        def read_text_file(self, path, line=None, limit=None):
+            with pytest.raises(RuntimeError, match="no running event loop"):
+                asyncio.get_running_loop()
+            return "content\n"
+
+        def delete_file(self, path):
+            with pytest.raises(RuntimeError, match="no running event loop"):
+                asyncio.get_running_loop()
+
+    set_filesystem_backend(LoopGuardBackend())
+    try:
+        result = await _delete_file_async(MagicMock(), str(tmp_path / "worker.txt"))
+    finally:
+        set_filesystem_backend(None)
+
+    assert result["success"] is True
+
+
+@pytest.mark.asyncio
 async def test_replace_and_delete_async_permission_paths(tmp_path):
     from code_puppy.callbacks import register_callback
     from code_puppy.tools.file_modifications import (

--- a/tests/test_file_permissions.py
+++ b/tests/test_file_permissions.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Test script to verify file permission prompts work correctly."""
 
+import asyncio
 import os
 import sys
 import tempfile
@@ -336,6 +337,34 @@ async def test_write_to_file_async_none_only_does_not_deny(tmp_path):
 
     assert result["success"] is True
     assert target.read_text() == "created"
+
+
+@pytest.mark.asyncio
+async def test_write_to_file_async_uses_backend_off_event_loop(tmp_path):
+    """Synchronous filesystem backends must run from a worker thread."""
+    from code_puppy.tools.file_modifications import write_to_file_async
+    from code_puppy.tools.io_backends import set_filesystem_backend
+
+    class LoopGuardBackend:
+        def exists(self, path):
+            return False
+
+        def make_dirs(self, path):
+            return None
+
+        def write_text_file(self, path, content):
+            with pytest.raises(RuntimeError, match="no running event loop"):
+                asyncio.get_running_loop()
+
+    set_filesystem_backend(LoopGuardBackend())
+    try:
+        result = await write_to_file_async(
+            MagicMock(), str(tmp_path / "worker.txt"), "created", False
+        )
+    finally:
+        set_filesystem_backend(None)
+
+    assert result["success"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Under ACP, all permission requests were being silently denied.

## Root Cause

By the time _approval_backend was called in the ACP plugin (in core_plugins), the session_id was lost due to how the threads were being kicked off. This resulted in an automatic failure of all permission requests in ACP.

## Fix Overview

Made a small adjustment in code_puppy/tools/common.py to ask for approval through a thread instead in order to preserve the session_id. After changing this, the file operations needed to be updated since it was triggering a deadlock warning due to the ACP's synchronous filesystem bridge.

## Links

Fixes #843