### PR TITLE
feat(agents): HistoryPersistence capability — success-path history custody on after_run

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -19,6 +19,7 @@ from pydantic_ai import Agent as PydanticAgent
 from pydantic_ai.capabilities import ProcessHistory
 
 from code_puppy.agents._compaction import make_history_processor
+from code_puppy.agents._history_persistence import HistoryPersistence
 from code_puppy.agents._model_message_transform import build_model_message_transform
 from code_puppy.agents._output_limits import (
     build_response_clamp,
@@ -614,6 +615,9 @@ def build_pydantic_agent(
     - ``agent.pydantic_agent``        ← the final (possibly plugin-wrapped) agent
     - ``agent._code_generation_agent`` ← same as ``pydantic_agent``
     - ``agent._mcp_servers``          ← MCP toolsets (post-filter)
+    - ``agent._history_persistence``  ← the ``HistoryPersistence`` capability,
+      so ``persist_result_history`` call sites can tell capability-owned runs
+      from guest wrappers that bypass capabilities
 
     The build happens in two passes: we construct once with ``toolsets=[]`` so
     we can introspect registered tool names, then rebuild with MCP servers
@@ -639,6 +643,9 @@ def build_pydantic_agent(
     history_processor = make_history_processor(agent)
     steer_processor = make_steer_history_processor(agent)
     logical_agent_name = getattr(agent, "name", None) or agent.__class__.__name__
+    # One instance shared by both construction passes: the pass-1 probe agent
+    # never runs, so only the final agent's runs ever reach ``after_run``.
+    history_persistence = HistoryPersistence(agent)
 
     def _new_pydantic_agent(toolsets: List[Any]) -> PydanticAgent:
         return PydanticAgent(
@@ -660,12 +667,17 @@ def build_pydantic_agent(
             # hook (after_tool_execute), so its position is inert; the
             # response clamp runs before_model_request after both history
             # processors. The plugin transform wraps the final model request.
+            # HistoryPersistence is the only after_run capability here, so its
+            # position is inert too (NB: CombinedCapability applies after_run
+            # hooks in REVERSED list order — onion semantics — should another
+            # after_run capability ever join this list).
             capabilities=[
                 *build_tool_output_limits(),
                 ProcessHistory(history_processor),
                 ProcessHistory(steer_processor),
                 build_response_clamp(),
                 build_model_message_transform(logical_agent_name),
+                history_persistence,
             ],
             model_settings=model_settings,
         )
@@ -699,6 +711,7 @@ def build_pydantic_agent(
     agent.cur_model = model
     agent._last_model_name = resolved_model_name
     agent._mcp_servers = filtered_mcp_servers
+    agent._history_persistence = history_persistence
 
     wrapped = on_wrap_pydantic_agent(
         agent,

--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -615,9 +615,6 @@ def build_pydantic_agent(
     - ``agent.pydantic_agent``        ← the final (possibly plugin-wrapped) agent
     - ``agent._code_generation_agent`` ← same as ``pydantic_agent``
     - ``agent._mcp_servers``          ← MCP toolsets (post-filter)
-    - ``agent._history_persistence``  ← the ``HistoryPersistence`` capability,
-      so ``persist_result_history`` call sites can tell capability-owned runs
-      from guest wrappers that bypass capabilities
 
     The build happens in two passes: we construct once with ``toolsets=[]`` so
     we can introspect registered tool names, then rebuild with MCP servers
@@ -711,7 +708,6 @@ def build_pydantic_agent(
     agent.cur_model = model
     agent._last_model_name = resolved_model_name
     agent._mcp_servers = filtered_mcp_servers
-    agent._history_persistence = history_persistence
 
     wrapped = on_wrap_pydantic_agent(
         agent,

--- a/code_puppy/agents/_history_persistence.py
+++ b/code_puppy/agents/_history_persistence.py
@@ -15,14 +15,22 @@ Historically that writeback was duplicated across seven eager call sites:
   continuation loop, headless run).
 
 :class:`HistoryPersistence` promotes the feature onto pydantic-ai's
-``after_run`` capability seam: the write happens exactly once per successful
-run, at the moment the run commits its result — with the *identical*
+``after_run`` capability seam: the write happens once per successful run, at
+the moment the run commits its result — with the *identical*
 ``AgentRunResult`` object the caller receives (``after_run`` contract,
-verified empirically on pydantic-ai 2.31.0). The eager sites are demoted to
-the :func:`persist_result_history` guest fallback, which steps aside when the
-capability already persisted that exact result (identity gate) and otherwise
-performs the old write verbatim — so wrappers that bypass capabilities keep
-byte-identical behavior.
+verified empirically on pydantic-ai 2.31.0). That closes the durability gap
+where a cancellation landing between run-end and the old turn-end writeback
+lost the completed run's trailing response.
+
+The call sites now route through :func:`persist_result_history`, which
+performs the old write **verbatim and unconditionally**. The write is
+idempotent next to the capability's, and keeping it unconditional preserves
+the sites' exact clobber semantics: anything that mutated the durable history
+after the run (however exotic) gets overwritten with the completed transcript,
+exactly as before. It also covers guest wrappers that bypass capabilities
+entirely. Deliberately NO ownership gate here — a "skip if the capability
+already persisted this result" check cannot prove the history *still* holds
+that transcript, and a wrong skip would silently change site behavior.
 
 Scope: MAIN construction site only (``_builder.build_pydantic_agent``).
 Sub-agent invocations own their history through session persistence and the
@@ -31,8 +39,8 @@ result-scoped bookkeeping in ``tools/subagent_invocation.py``; they get no
 
 Concurrency note: the capability's default ``for_run`` returns ``self``, so
 one instance observes every run of its agent. The main conversation loop is
-strictly sequential (one turn at a time), so the single ``_last_persisted``
-slot cannot race.
+strictly sequential (one turn at a time), so the single ``last_result`` slot
+cannot race.
 """
 
 from __future__ import annotations
@@ -52,7 +60,7 @@ def _write_history(agent: Any, result: Any) -> None:
     (the cli_runner sites' spelling); falls back to the direct attribute
     assignment the runtime sites used. Both are plain assignments on
     ``BaseAgent`` — this just preserves each call site's exact semantics for
-    test doubles.
+    test doubles and subclasses that override the setter.
     """
     messages = list(result.all_messages())
     setter = getattr(agent, "set_message_history", None)
@@ -68,10 +76,15 @@ class HistoryPersistence(AbstractCapability[Any]):
 
     Holds a live reference to the owning ``BaseAgent``-shaped config, so it is
     deliberately not spec-constructible (``get_serialization_name() -> None``).
+
+    ``last_result`` records the exact result object most recently persisted.
+    It is an observability/testing seam pinning the ``after_run`` contract
+    (the seam receives the identical object the caller gets) — it is NOT
+    consulted by :func:`persist_result_history`, which always rewrites.
     """
 
     agent: Any
-    _last_persisted: Optional[Any] = field(default=None, init=False, repr=False)
+    last_result: Optional[Any] = field(default=None, init=False, repr=False)
 
     def get_serialization_name(self) -> Optional[str]:
         # Live agent reference — never constructible from a serialized spec.
@@ -84,32 +97,21 @@ class HistoryPersistence(AbstractCapability[Any]):
         # existing checkpoint/prune custody untouched.
         if hasattr(result, "all_messages"):
             _write_history(self.agent, result)
-            self._last_persisted = result
+            self.last_result = result
         return result
-
-    def persisted(self, result: Any) -> bool:
-        """True when this capability already persisted exactly ``result``.
-
-        Identity-gated (``is``): a different result object — including a new
-        run's result — never matches. A stale match is impossible to abuse:
-        the same object implies the same messages, and the write is
-        idempotent.
-        """
-        return result is not None and self._last_persisted is result
 
 
 def persist_result_history(agent: Any, result: Any) -> bool:
-    """Persist ``result``'s messages unless the capability already did.
+    """Persist ``result``'s messages into ``agent``'s durable history.
 
-    Shared fallback for the previously-eager call sites. Returns ``True``
-    when the history is known to hold ``result.all_messages()`` afterwards
-    (either persisted here or already persisted by the capability), ``False``
+    Shared spelling of the previously-eager call sites' writeback. Always
+    writes when ``result`` carries messages — idempotent next to the
+    capability's ``after_run`` persist, and unconditional so the sites keep
+    their exact historical clobber semantics (see module docstring). Returns
+    ``True`` when the history now holds ``result.all_messages()``, ``False``
     when ``result`` carries no messages to persist.
     """
     if result is None or not hasattr(result, "all_messages"):
         return False
-    persistence = getattr(agent, "_history_persistence", None)
-    if persistence is not None and persistence.persisted(result):
-        return True
     _write_history(agent, result)
     return True

--- a/code_puppy/agents/_history_persistence.py
+++ b/code_puppy/agents/_history_persistence.py
@@ -1,0 +1,115 @@
+"""Success-path conversation-history custody as a pydantic-ai capability.
+
+After each successful ``Agent.run()`` on the MAIN conversation path, the
+durable history on the owning :class:`~code_puppy.agents.base_agent.BaseAgent`
+must absorb ``result.all_messages()`` — the complete run transcript including
+the trailing final response, which never passes through a
+``before_model_request`` hook (there is no subsequent request to carry it).
+
+Historically that writeback was duplicated across seven eager call sites:
+
+- ``_run_signals.prepare_queued_steer_injection`` (persist-before-steer side
+  effect, only when a queued steer was pending),
+- ``_runtime._do_run``'s hook-retry branch (persist before the follow-up run),
+- four turn-end sites in ``cli_runner`` (initial command, interactive turn,
+  continuation loop, headless run).
+
+:class:`HistoryPersistence` promotes the feature onto pydantic-ai's
+``after_run`` capability seam: the write happens exactly once per successful
+run, at the moment the run commits its result — with the *identical*
+``AgentRunResult`` object the caller receives (``after_run`` contract,
+verified empirically on pydantic-ai 2.31.0). The eager sites are demoted to
+the :func:`persist_result_history` guest fallback, which steps aside when the
+capability already persisted that exact result (identity gate) and otherwise
+performs the old write verbatim — so wrappers that bypass capabilities keep
+byte-identical behavior.
+
+Scope: MAIN construction site only (``_builder.build_pydantic_agent``).
+Sub-agent invocations own their history through session persistence and the
+result-scoped bookkeeping in ``tools/subagent_invocation.py``; they get no
+``HistoryPersistence`` (pinned by test).
+
+Concurrency note: the capability's default ``for_run`` returns ``self``, so
+one instance observes every run of its agent. The main conversation loop is
+strictly sequential (one turn at a time), so the single ``_last_persisted``
+slot cannot race.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from pydantic_ai.capabilities import AbstractCapability
+
+__all__ = ["HistoryPersistence", "persist_result_history"]
+
+
+def _write_history(agent: Any, result: Any) -> None:
+    """Replace ``agent``'s durable history with ``result.all_messages()``.
+
+    Uses the public ``set_message_history`` setter when the agent exposes one
+    (the cli_runner sites' spelling); falls back to the direct attribute
+    assignment the runtime sites used. Both are plain assignments on
+    ``BaseAgent`` — this just preserves each call site's exact semantics for
+    test doubles.
+    """
+    messages = list(result.all_messages())
+    setter = getattr(agent, "set_message_history", None)
+    if callable(setter):
+        setter(messages)
+    else:
+        agent._message_history = messages
+
+
+@dataclass
+class HistoryPersistence(AbstractCapability[Any]):
+    """Persist each successful run's ``all_messages()`` into durable history.
+
+    Holds a live reference to the owning ``BaseAgent``-shaped config, so it is
+    deliberately not spec-constructible (``get_serialization_name() -> None``).
+    """
+
+    agent: Any
+    _last_persisted: Optional[Any] = field(default=None, init=False, repr=False)
+
+    def get_serialization_name(self) -> Optional[str]:
+        # Live agent reference — never constructible from a serialized spec.
+        return None
+
+    async def after_run(self, ctx: Any, *, result: Any) -> Any:
+        # ``after_run`` fires once per successful ``Agent.run()`` with the
+        # identical result object the caller receives; it is NOT called when
+        # the run ends without a result, so cancelled/crashed runs keep their
+        # existing checkpoint/prune custody untouched.
+        if hasattr(result, "all_messages"):
+            _write_history(self.agent, result)
+            self._last_persisted = result
+        return result
+
+    def persisted(self, result: Any) -> bool:
+        """True when this capability already persisted exactly ``result``.
+
+        Identity-gated (``is``): a different result object — including a new
+        run's result — never matches. A stale match is impossible to abuse:
+        the same object implies the same messages, and the write is
+        idempotent.
+        """
+        return result is not None and self._last_persisted is result
+
+
+def persist_result_history(agent: Any, result: Any) -> bool:
+    """Persist ``result``'s messages unless the capability already did.
+
+    Shared fallback for the previously-eager call sites. Returns ``True``
+    when the history is known to hold ``result.all_messages()`` afterwards
+    (either persisted here or already persisted by the capability), ``False``
+    when ``result`` carries no messages to persist.
+    """
+    if result is None or not hasattr(result, "all_messages"):
+        return False
+    persistence = getattr(agent, "_history_persistence", None)
+    if persistence is not None and persistence.persisted(result):
+        return True
+    _write_history(agent, result)
+    return True

--- a/code_puppy/agents/_run_signals.py
+++ b/code_puppy/agents/_run_signals.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Callable, Optional
 
+from code_puppy.agents._history_persistence import persist_result_history
 from code_puppy.command_line.attachments import resolve_steer_content
 from code_puppy.messaging import emit_info, emit_warning
 from code_puppy.tools.agent_tools import _active_subagent_tasks
@@ -143,8 +144,11 @@ def prepare_queued_steer_injection(agent: Any, result: Any) -> Optional[Any]:
     queue-mode steer is pending.
 
     Side-effects:
-      - Persists ``result.all_messages()`` into ``agent._message_history``
-        so the steer turn sees the just-completed turn's context.
+      - Ensures ``result.all_messages()`` is persisted into
+        ``agent._message_history`` so the steer turn sees the just-completed
+        turn's context (normally already done by the ``HistoryPersistence``
+        capability at the ``after_run`` seam; the fallback covers wrappers
+        that bypass capabilities).
       - Re-queues any leftover steers (we deliberately process ONE per
         loop iteration to keep turn boundaries clean for the model).
       - Emits a diagnostic with a preview of the steer text.
@@ -155,8 +159,7 @@ def prepare_queued_steer_injection(agent: Any, result: Any) -> Optional[Any]:
     pending = pc.drain_pending_steer_queued()
     if not pending:
         return None
-    if hasattr(result, "all_messages"):
-        agent._message_history = list(result.all_messages())
+    persist_result_history(agent, result)
     steer_text = pending[0]
     for leftover in pending[1:]:
         pc.request_steer(leftover, mode="queue")

--- a/code_puppy/agents/_run_signals.py
+++ b/code_puppy/agents/_run_signals.py
@@ -144,11 +144,11 @@ def prepare_queued_steer_injection(agent: Any, result: Any) -> Optional[Any]:
     queue-mode steer is pending.
 
     Side-effects:
-      - Ensures ``result.all_messages()`` is persisted into
-        ``agent._message_history`` so the steer turn sees the just-completed
-        turn's context (normally already done by the ``HistoryPersistence``
-        capability at the ``after_run`` seam; the fallback covers wrappers
-        that bypass capabilities).
+      - Persists ``result.all_messages()`` into ``agent._message_history``
+        so the steer turn sees the just-completed turn's context (idempotent
+        next to the ``HistoryPersistence`` capability's ``after_run``
+        persist; kept unconditional for exact clobber parity and to cover
+        wrappers that bypass capabilities).
       - Re-queues any leftover steers (we deliberately process ONE per
         loop iteration to keep turn boundaries clean for the model).
       - Emits a diagnostic with a preview of the steer text.

--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -71,6 +71,7 @@ from code_puppy.agent_execution_context import executing_agent_context
 from code_puppy.agents import _history, _key_listeners
 from code_puppy.agents._builder import build_pydantic_agent
 from code_puppy.agents._diagnostics import emit_exception_diagnostics
+from code_puppy.agents._history_persistence import persist_result_history
 from code_puppy.agents._non_streaming_render import (
     StreamingTextDetector,
     render_result_without_streaming,
@@ -835,8 +836,9 @@ async def _run_with_mcp_impl(
 
             retry_prompt = retry_req.get("prompt", "Please continue.")
             retry_delay = retry_req.get("delay", 1.0)
-            if hasattr(result, "all_messages"):
-                agent._message_history = list(result.all_messages())
+            # Normally a no-op: HistoryPersistence already persisted this
+            # result at the after_run seam. Fallback for guest wrappers.
+            persist_result_history(agent, result)
             await asyncio.sleep(retry_delay)
             result = await _follow_up_run(retry_prompt)
             hook_retries_used += 1

--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -836,8 +836,8 @@ async def _run_with_mcp_impl(
 
             retry_prompt = retry_req.get("prompt", "Please continue.")
             retry_delay = retry_req.get("delay", 1.0)
-            # Normally a no-op: HistoryPersistence already persisted this
-            # result at the after_run seam. Fallback for guest wrappers.
+            # Idempotent next to HistoryPersistence's after_run persist;
+            # unconditional for exact clobber parity + guest wrappers.
             persist_result_history(agent, result)
             await asyncio.sleep(retry_delay)
             result = await _follow_up_run(retry_prompt)

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -809,9 +809,9 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
                 agent_response = response.output
 
                 # Update agent history with the complete conversation (incl.
-                # final response). Normally already persisted by the
-                # HistoryPersistence capability at the after_run seam; this
-                # is the guest fallback.
+                # final response). Idempotent next to the HistoryPersistence
+                # capability's after_run persist; unconditional for exact
+                # clobber parity + guest wrappers.
                 persist_result_history(agent, response)
 
                 # Emit structured message for proper markdown rendering
@@ -1214,9 +1214,9 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
                 get_message_bus().emit(response_msg)
 
                 # Update history with the complete conversation — history
-                # processors may miss the final message, so the
-                # HistoryPersistence capability persists result.all_messages()
-                # at the after_run seam; this is the guest fallback.
+                # processors may miss the final message. Idempotent next to
+                # the HistoryPersistence capability's after_run persist;
+                # unconditional for exact clobber parity + guest wrappers.
                 persist_result_history(current_agent, result)
 
                 turn_result = result
@@ -1546,8 +1546,9 @@ async def execute_single_prompt(
             _write_usage_file(usage_file, usage() if callable(usage) else usage)
 
         # The runtime result includes the final assistant response that the
-        # incremental history can otherwise miss (persisted by the
-        # HistoryPersistence capability at the after_run seam; guest fallback).
+        # incremental history can otherwise miss. Idempotent next to the
+        # HistoryPersistence capability's after_run persist; unconditional
+        # for exact clobber parity + guest wrappers.
         persist_result_history(agent, result)
 
     except asyncio.CancelledError:

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -22,6 +22,7 @@ from rich.console import Console
 
 from code_puppy import __version__, callbacks, get_core_plugins_version, plugins
 from code_puppy.agents import get_current_agent
+from code_puppy.agents._history_persistence import persist_result_history
 from code_puppy.i18n import t
 from code_puppy.command_line.attachments import (
     parse_prompt_attachments,
@@ -807,9 +808,11 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
             if response is not None:
                 agent_response = response.output
 
-                # Update agent history with the complete conversation (incl. final response).
-                if hasattr(response, "all_messages"):
-                    agent.set_message_history(list(response.all_messages()))
+                # Update agent history with the complete conversation (incl.
+                # final response). Normally already persisted by the
+                # HistoryPersistence capability at the after_run seam; this
+                # is the guest fallback.
+                persist_result_history(agent, response)
 
                 # Emit structured message for proper markdown rendering
                 from code_puppy.messaging import get_message_bus
@@ -1210,10 +1213,11 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
                 )
                 get_message_bus().emit(response_msg)
 
-                # Update history with the complete conversation — history_processors
-                # may miss the final message, so use result.all_messages().
-                if hasattr(result, "all_messages"):
-                    current_agent.set_message_history(list(result.all_messages()))
+                # Update history with the complete conversation — history
+                # processors may miss the final message, so the
+                # HistoryPersistence capability persists result.all_messages()
+                # at the after_run seam; this is the guest fallback.
+                persist_result_history(current_agent, result)
 
                 turn_result = result
                 turn_success = True
@@ -1315,8 +1319,7 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
                     )
                     get_message_bus().emit(response_msg)
 
-                    if hasattr(result, "all_messages"):
-                        current_agent.set_message_history(list(result.all_messages()))
+                    persist_result_history(current_agent, result)
 
                     if hasattr(display_console.file, "flush"):
                         display_console.file.flush()
@@ -1543,9 +1546,9 @@ async def execute_single_prompt(
             _write_usage_file(usage_file, usage() if callable(usage) else usage)
 
         # The runtime result includes the final assistant response that the
-        # incremental history can otherwise miss.
-        if hasattr(result, "all_messages"):
-            agent.set_message_history(list(result.all_messages()))
+        # incremental history can otherwise miss (persisted by the
+        # HistoryPersistence capability at the after_run seam; guest fallback).
+        persist_result_history(agent, result)
 
     except asyncio.CancelledError:
         emit_warning(t("cli.headless.cancelled"))

--- a/tests/agents/test_history_persistence_capability.py
+++ b/tests/agents/test_history_persistence_capability.py
@@ -73,7 +73,7 @@ async def test_after_run_persists_all_messages_via_setter():
     # into the result's internal message list.
     assert agent._message_history is not messages
     assert agent.setter_calls == 1
-    assert cap.persisted(result) is True
+    assert cap.last_result is result
 
 
 async def test_after_run_uses_direct_assignment_without_setter():
@@ -84,7 +84,7 @@ async def test_after_run_uses_direct_assignment_without_setter():
     await cap.after_run(None, result=result)
 
     assert agent._message_history == ["a", "b"]
-    assert cap.persisted(result) is True
+    assert cap.last_result is result
 
 
 async def test_after_run_ignores_result_without_all_messages():
@@ -97,19 +97,7 @@ async def test_after_run_ignores_result_without_all_messages():
 
     assert returned is bare
     assert agent._message_history == ["keep me"]
-    assert cap.persisted(bare) is False
-
-
-def test_persisted_is_identity_gated():
-    agent = _FakeAgent()
-    cap = HistoryPersistence(agent)
-    captured = _FakeResult(["x"])
-    cap._last_persisted = captured
-
-    assert cap.persisted(captured) is True
-    # An equal-but-distinct result never matches — ownership is per-object.
-    assert cap.persisted(_FakeResult(["x"])) is False
-    assert cap.persisted(None) is False
+    assert cap.last_result is None
 
 
 def test_get_serialization_name_is_none():
@@ -137,31 +125,21 @@ def test_fallback_writes_via_direct_assignment_without_setter():
     assert agent._message_history == ["m1"]
 
 
-async def test_fallback_skips_when_capability_owns_result():
+async def test_fallback_clobbers_post_run_history_mutations():
+    """Exact-parity pin: the demoted sites always rewrote with the completed
+    transcript, clobbering anything that mutated durable history after the
+    run (e.g. an ``agent_run_end`` plugin). The helper must NOT skip just
+    because the capability already persisted this result once."""
     agent = _FakeAgent()
     cap = HistoryPersistence(agent)
-    agent._history_persistence = cap
-    result = _FakeResult(["m1"])
+    result = _FakeResult(["m1", "m2"])
     await cap.after_run(None, result=result)
 
-    # Plant a sentinel: an owned result must NOT trigger a second write.
-    sentinel = ["sentinel"]
-    agent._message_history = sentinel
+    # A plugin replaces the history between run-end and the turn-end site.
+    agent._message_history = ["mutated by plugin"]
 
     assert persist_result_history(agent, result) is True
-    assert agent._message_history is sentinel
-    assert agent.setter_calls == 1  # only the capability's write
-
-
-async def test_fallback_writes_when_capability_captured_a_different_result():
-    agent = _FakeAgent()
-    cap = HistoryPersistence(agent)
-    agent._history_persistence = cap
-    await cap.after_run(None, result=_FakeResult(["old"]))
-
-    fresh = _FakeResult(["new"])
-    assert persist_result_history(agent, fresh) is True
-    assert agent._message_history == ["new"]
+    assert agent._message_history == ["m1", "m2"]  # transcript restored
 
 
 def test_fallback_rejects_none_and_messageless_results():
@@ -188,7 +166,7 @@ async def test_real_run_persists_identical_result_state():
     result = await pyd_agent.run("hello")
 
     # after_run saw the exact result object the caller received...
-    assert cap.persisted(result) is True
+    assert cap.last_result is result
     # ...and persisted exactly its full transcript.
     assert agent._message_history == list(result.all_messages())
 
@@ -234,7 +212,7 @@ async def test_real_run_composes_with_other_capabilities():
 
     result = await pyd_agent.run("hello")
 
-    assert cap.persisted(result) is True
+    assert cap.last_result is result
     assert agent._message_history == list(result.all_messages())
 
 
@@ -290,20 +268,23 @@ def _make_builder_config():
     return _FakeAgentConfig()
 
 
-def test_builder_stashes_capability_and_wires_seam():
+def _find_history_persistence(built):
+    """Walk the built agent's capability tree with the public ``apply``
+    visitor and return the (single) HistoryPersistence leaf."""
+    leaves = []
+    built.root_capability.apply(leaves.append)
+    caps = [leaf for leaf in leaves if isinstance(leaf, HistoryPersistence)]
+    assert len(caps) == 1
+    return caps[0]
+
+
+def test_builder_wires_capability_bound_to_the_config():
     cfg = _make_builder_config()
     with _builder_harness() as _builder:
         built = _builder.build_pydantic_agent(cfg)
 
-    cap = getattr(cfg, "_history_persistence", None)
-    assert isinstance(cap, HistoryPersistence)
+    cap = _find_history_persistence(built)
     assert cap.agent is cfg
-
-    # The exact stashed instance is spliced into the built agent's
-    # capability tree (walk leaves with the public ``apply`` visitor).
-    leaves = []
-    built.root_capability.apply(leaves.append)
-    assert any(leaf is cap for leaf in leaves)
 
 
 async def test_built_agent_run_persists_history_end_to_end():
@@ -313,7 +294,7 @@ async def test_built_agent_run_persists_history_end_to_end():
 
     result = await built.run("hello")
 
-    assert cfg._history_persistence.persisted(result) is True
+    assert _find_history_persistence(built).last_result is result
     assert cfg.get_message_history() == list(result.all_messages())
 
 
@@ -348,18 +329,18 @@ def test_no_inline_writebacks_remain():
 # ---------- turn-loop interplay ----------------------------------------------
 
 
-async def test_steer_drain_skips_rewrite_for_owned_result():
-    """prepare_queued_steer_injection must not clobber capability-persisted
-    history with a redundant write (identity of the list is preserved)."""
+async def test_steer_drain_persists_alongside_the_capability():
+    """prepare_queued_steer_injection keeps its unconditional idempotent
+    persist — the steer turn is seeded from the completed transcript even if
+    something mutated durable history after ``after_run``."""
     from code_puppy.agents._run_signals import prepare_queued_steer_injection
     from code_puppy.messaging.pause_controller import get_pause_controller
 
     agent = _FakeAgent()
     cap = HistoryPersistence(agent)
-    agent._history_persistence = cap
     result = _FakeResult(["m1", "m2"])
     await cap.after_run(None, result=result)
-    persisted_list = agent._message_history
+    agent._message_history = ["mutated after the run"]
 
     pc = get_pause_controller()
     pc.request_steer("focus", mode="queue")
@@ -369,10 +350,10 @@ async def test_steer_drain_skips_rewrite_for_owned_result():
         pc.drain_pending_steer_queued()
 
     assert steer == "focus"
-    assert agent._message_history is persisted_list  # no redundant rewrite
+    assert agent._message_history == ["m1", "m2"]
 
 
-def test_steer_drain_falls_back_for_guest_results():
+def test_steer_drain_persists_for_guest_results():
     """Without the capability (guest wrapper), the steer drain still persists
     the result's messages exactly as the old eager side effect did."""
     from code_puppy.agents._run_signals import prepare_queued_steer_injection

--- a/tests/agents/test_history_persistence_capability.py
+++ b/tests/agents/test_history_persistence_capability.py
@@ -105,10 +105,10 @@ def test_get_serialization_name_is_none():
     assert HistoryPersistence(_FakeAgent()).get_serialization_name() is None
 
 
-# ---------- guest fallback helper --------------------------------------------
+# ---------- unconditional writeback helper ------------------------------------
 
 
-def test_fallback_writes_when_no_capability():
+def test_helper_writes_when_no_capability():
     agent = _FakeAgent()
     result = _FakeResult(["m1"])
 
@@ -117,7 +117,7 @@ def test_fallback_writes_when_no_capability():
     assert agent.setter_calls == 1
 
 
-def test_fallback_writes_via_direct_assignment_without_setter():
+def test_helper_writes_via_direct_assignment_without_setter():
     agent = _BareAgent()
     result = _FakeResult(["m1"])
 
@@ -125,7 +125,7 @@ def test_fallback_writes_via_direct_assignment_without_setter():
     assert agent._message_history == ["m1"]
 
 
-async def test_fallback_clobbers_post_run_history_mutations():
+async def test_helper_clobbers_post_run_history_mutations():
     """Exact-parity pin: the demoted sites always rewrote with the completed
     transcript, clobbering anything that mutated durable history after the
     run (e.g. an ``agent_run_end`` plugin). The helper must NOT skip just
@@ -142,7 +142,7 @@ async def test_fallback_clobbers_post_run_history_mutations():
     assert agent._message_history == ["m1", "m2"]  # transcript restored
 
 
-def test_fallback_rejects_none_and_messageless_results():
+def test_helper_rejects_none_and_messageless_results():
     agent = _FakeAgent()
     agent._message_history = ["keep me"]
 
@@ -310,7 +310,7 @@ def test_subagent_site_gets_no_history_persistence():
 
 def test_no_inline_writebacks_remain():
     """Every previously-eager writeback site must route through the shared
-    fallback helper — no hand-rolled all_messages() persists left behind."""
+    writeback helper — no hand-rolled all_messages() persists left behind."""
     import code_puppy.cli_runner as cli_runner
     from code_puppy.agents import _run_signals, _runtime
 

--- a/tests/agents/test_history_persistence_capability.py
+++ b/tests/agents/test_history_persistence_capability.py
@@ -1,0 +1,425 @@
+"""Contract tests for the ``HistoryPersistence`` capability.
+
+The feature under test: success-path main-conversation history custody —
+persisting ``result.all_messages()`` into the owning agent's durable
+``_message_history`` — promoted from seven eager call sites onto pydantic-ai's
+``after_run`` seam. See ``code_puppy/agents/_history_persistence.py`` for the
+migration story.
+"""
+
+import inspect
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from pydantic_ai import Agent as PydanticAgent
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.messages import (
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+)
+from pydantic_ai.models.function import FunctionModel
+from pydantic_ai.models.test import TestModel
+
+from code_puppy.agents._history_persistence import (
+    HistoryPersistence,
+    persist_result_history,
+)
+
+
+class _FakeAgent:
+    """BaseAgent-shaped double: history list + the plain public setter."""
+
+    def __init__(self):
+        self._message_history = []
+        self.setter_calls = 0
+
+    def set_message_history(self, history):
+        self.setter_calls += 1
+        self._message_history = history
+
+
+class _BareAgent:
+    """Agent double WITHOUT the public setter (runtime-site spelling)."""
+
+    def __init__(self):
+        self._message_history = []
+
+
+class _FakeResult:
+    """AgentRunResult-shaped double."""
+
+    def __init__(self, messages):
+        self._messages = messages
+
+    def all_messages(self):
+        return self._messages
+
+
+# ---------- direct seam contract ---------------------------------------------
+
+
+async def test_after_run_persists_all_messages_via_setter():
+    agent = _FakeAgent()
+    cap = HistoryPersistence(agent)
+    messages = ["m1", "m2", "m3"]
+    result = _FakeResult(messages)
+
+    returned = await cap.after_run(None, result=result)
+
+    assert returned is result  # result passes through unchanged
+    assert agent._message_history == messages
+    # Fresh list copy — mutating the persisted history must not reach back
+    # into the result's internal message list.
+    assert agent._message_history is not messages
+    assert agent.setter_calls == 1
+    assert cap.persisted(result) is True
+
+
+async def test_after_run_uses_direct_assignment_without_setter():
+    agent = _BareAgent()
+    cap = HistoryPersistence(agent)
+    result = _FakeResult(["a", "b"])
+
+    await cap.after_run(None, result=result)
+
+    assert agent._message_history == ["a", "b"]
+    assert cap.persisted(result) is True
+
+
+async def test_after_run_ignores_result_without_all_messages():
+    agent = _FakeAgent()
+    agent._message_history = ["keep me"]
+    cap = HistoryPersistence(agent)
+    bare = object()
+
+    returned = await cap.after_run(None, result=bare)
+
+    assert returned is bare
+    assert agent._message_history == ["keep me"]
+    assert cap.persisted(bare) is False
+
+
+def test_persisted_is_identity_gated():
+    agent = _FakeAgent()
+    cap = HistoryPersistence(agent)
+    captured = _FakeResult(["x"])
+    cap._last_persisted = captured
+
+    assert cap.persisted(captured) is True
+    # An equal-but-distinct result never matches — ownership is per-object.
+    assert cap.persisted(_FakeResult(["x"])) is False
+    assert cap.persisted(None) is False
+
+
+def test_get_serialization_name_is_none():
+    # Live agent reference — must never be spec-constructible.
+    assert HistoryPersistence(_FakeAgent()).get_serialization_name() is None
+
+
+# ---------- guest fallback helper --------------------------------------------
+
+
+def test_fallback_writes_when_no_capability():
+    agent = _FakeAgent()
+    result = _FakeResult(["m1"])
+
+    assert persist_result_history(agent, result) is True
+    assert agent._message_history == ["m1"]
+    assert agent.setter_calls == 1
+
+
+def test_fallback_writes_via_direct_assignment_without_setter():
+    agent = _BareAgent()
+    result = _FakeResult(["m1"])
+
+    assert persist_result_history(agent, result) is True
+    assert agent._message_history == ["m1"]
+
+
+async def test_fallback_skips_when_capability_owns_result():
+    agent = _FakeAgent()
+    cap = HistoryPersistence(agent)
+    agent._history_persistence = cap
+    result = _FakeResult(["m1"])
+    await cap.after_run(None, result=result)
+
+    # Plant a sentinel: an owned result must NOT trigger a second write.
+    sentinel = ["sentinel"]
+    agent._message_history = sentinel
+
+    assert persist_result_history(agent, result) is True
+    assert agent._message_history is sentinel
+    assert agent.setter_calls == 1  # only the capability's write
+
+
+async def test_fallback_writes_when_capability_captured_a_different_result():
+    agent = _FakeAgent()
+    cap = HistoryPersistence(agent)
+    agent._history_persistence = cap
+    await cap.after_run(None, result=_FakeResult(["old"]))
+
+    fresh = _FakeResult(["new"])
+    assert persist_result_history(agent, fresh) is True
+    assert agent._message_history == ["new"]
+
+
+def test_fallback_rejects_none_and_messageless_results():
+    agent = _FakeAgent()
+    agent._message_history = ["keep me"]
+
+    assert persist_result_history(agent, None) is False
+    assert persist_result_history(agent, object()) is False
+    assert agent._message_history == ["keep me"]
+    assert agent.setter_calls == 0
+
+
+# ---------- real Agent.run() through the seam --------------------------------
+
+
+async def test_real_run_persists_identical_result_state():
+    agent = _FakeAgent()
+    cap = HistoryPersistence(agent)
+    pyd_agent = PydanticAgent(
+        model=TestModel(custom_output_text="woof"),
+        capabilities=[cap],
+    )
+
+    result = await pyd_agent.run("hello")
+
+    # after_run saw the exact result object the caller received...
+    assert cap.persisted(result) is True
+    # ...and persisted exactly its full transcript.
+    assert agent._message_history == list(result.all_messages())
+
+
+async def test_real_multi_step_run_persists_final_transcript():
+    """Tool-calling run: the persisted history must include the tool cycle
+    AND the trailing final response no before_model_request hook ever sees."""
+    agent = _FakeAgent()
+    cap = HistoryPersistence(agent)
+    calls = {"n": 0}
+
+    def model_func(messages, info):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return ModelResponse(
+                parts=[ToolCallPart(tool_name="fetch", args={}, tool_call_id="c1")]
+            )
+        return ModelResponse(parts=[TextPart(content="done")])
+
+    pyd_agent = PydanticAgent(model=FunctionModel(model_func), capabilities=[cap])
+
+    @pyd_agent.tool_plain
+    def fetch() -> str:
+        return "kibble"
+
+    result = await pyd_agent.run("go")
+
+    assert agent._message_history == list(result.all_messages())
+    final = agent._message_history[-1]
+    assert isinstance(final, ModelResponse)
+    assert final.parts[0].content == "done"
+
+
+async def test_real_run_composes_with_other_capabilities():
+    """The persist must survive CombinedCapability composition."""
+    agent = _FakeAgent()
+    cap = HistoryPersistence(agent)
+    pyd_agent = PydanticAgent(
+        model=TestModel(custom_output_text="woof"),
+        # A vanilla no-hook capability on either side forces composition.
+        capabilities=[AbstractCapability(), cap, AbstractCapability()],
+    )
+
+    result = await pyd_agent.run("hello")
+
+    assert cap.persisted(result) is True
+    assert agent._message_history == list(result.all_messages())
+
+
+async def test_followup_seeding_matches_eager_baseline():
+    """A follow-up run seeded from the capability-persisted history must feed
+    the model exactly what the old eager writeback would have seeded."""
+    agent = _FakeAgent()
+    cap = HistoryPersistence(agent)
+    seen_histories = []
+
+    def model_func(messages, info):
+        seen_histories.append(list(messages))
+        return ModelResponse(parts=[TextPart(content="ok")])
+
+    pyd_agent = PydanticAgent(model=FunctionModel(model_func), capabilities=[cap])
+
+    result1 = await pyd_agent.run("turn one")
+    eager_baseline = list(result1.all_messages())  # the old writeback's value
+    assert agent._message_history == eager_baseline
+
+    await pyd_agent.run("turn two", message_history=agent._message_history)
+
+    # The second request's prior-context prefix is byte-identical to what the
+    # eager writeback would have seeded.
+    follow_up_request = seen_histories[1]
+    assert follow_up_request[: len(eager_baseline)] == eager_baseline
+
+
+# ---------- production wiring ------------------------------------------------
+
+
+@contextmanager
+def _builder_harness():
+    from code_puppy.agents import _builder
+
+    with (
+        patch.object(
+            _builder,
+            "load_model_with_fallback",
+            lambda *a, **k: (TestModel(custom_output_text="woof"), "test-model"),
+        ),
+        patch.object(_builder.ModelFactory, "load_config", staticmethod(dict)),
+        patch.object(_builder, "load_mcp_servers", lambda **k: []),
+        patch.object(_builder, "make_model_settings", lambda *a, **k: None),
+        patch("code_puppy.tools.register_tools_for_agent", lambda *a, **k: None),
+    ):
+        yield _builder
+
+
+def _make_builder_config():
+    from tests.test_agent_span_naming import _FakeAgentConfig
+
+    return _FakeAgentConfig()
+
+
+def test_builder_stashes_capability_and_wires_seam():
+    cfg = _make_builder_config()
+    with _builder_harness() as _builder:
+        built = _builder.build_pydantic_agent(cfg)
+
+    cap = getattr(cfg, "_history_persistence", None)
+    assert isinstance(cap, HistoryPersistence)
+    assert cap.agent is cfg
+
+    # The exact stashed instance is spliced into the built agent's
+    # capability tree (walk leaves with the public ``apply`` visitor).
+    leaves = []
+    built.root_capability.apply(leaves.append)
+    assert any(leaf is cap for leaf in leaves)
+
+
+async def test_built_agent_run_persists_history_end_to_end():
+    cfg = _make_builder_config()
+    with _builder_harness() as _builder:
+        built = _builder.build_pydantic_agent(cfg)
+
+    result = await built.run("hello")
+
+    assert cfg._history_persistence.persisted(result) is True
+    assert cfg.get_message_history() == list(result.all_messages())
+
+
+def test_subagent_site_gets_no_history_persistence():
+    """Sub-agent history custody belongs to session persistence — the
+    capability is main-path only."""
+    from code_puppy.tools import subagent_invocation
+
+    source = inspect.getsource(subagent_invocation)
+    assert "HistoryPersistence" not in source
+    assert "persist_result_history" not in source
+
+
+def test_no_inline_writebacks_remain():
+    """Every previously-eager writeback site must route through the shared
+    fallback helper — no hand-rolled all_messages() persists left behind."""
+    import code_puppy.cli_runner as cli_runner
+    from code_puppy.agents import _run_signals, _runtime
+
+    runtime_src = inspect.getsource(_runtime)
+    signals_src = inspect.getsource(_run_signals)
+    cli_src = inspect.getsource(cli_runner)
+
+    assert "_message_history = list(result.all_messages())" not in runtime_src
+    assert "_message_history = list(result.all_messages())" not in signals_src
+    assert "set_message_history(list(result.all_messages()))" not in cli_src
+    assert "set_message_history(list(response.all_messages()))" not in cli_src
+    for src in (runtime_src, signals_src, cli_src):
+        assert "persist_result_history" in src
+
+
+# ---------- turn-loop interplay ----------------------------------------------
+
+
+async def test_steer_drain_skips_rewrite_for_owned_result():
+    """prepare_queued_steer_injection must not clobber capability-persisted
+    history with a redundant write (identity of the list is preserved)."""
+    from code_puppy.agents._run_signals import prepare_queued_steer_injection
+    from code_puppy.messaging.pause_controller import get_pause_controller
+
+    agent = _FakeAgent()
+    cap = HistoryPersistence(agent)
+    agent._history_persistence = cap
+    result = _FakeResult(["m1", "m2"])
+    await cap.after_run(None, result=result)
+    persisted_list = agent._message_history
+
+    pc = get_pause_controller()
+    pc.request_steer("focus", mode="queue")
+    try:
+        steer = prepare_queued_steer_injection(agent, result)
+    finally:
+        pc.drain_pending_steer_queued()
+
+    assert steer == "focus"
+    assert agent._message_history is persisted_list  # no redundant rewrite
+
+
+def test_steer_drain_falls_back_for_guest_results():
+    """Without the capability (guest wrapper), the steer drain still persists
+    the result's messages exactly as the old eager side effect did."""
+    from code_puppy.agents._run_signals import prepare_queued_steer_injection
+    from code_puppy.messaging.pause_controller import get_pause_controller
+
+    agent = _FakeAgent()
+    result = _FakeResult(["m1", "m2"])
+
+    pc = get_pause_controller()
+    pc.request_steer("focus", mode="queue")
+    try:
+        steer = prepare_queued_steer_injection(agent, result)
+    finally:
+        pc.drain_pending_steer_queued()
+
+    assert steer == "focus"
+    assert agent._message_history == ["m1", "m2"]
+
+
+# ---------- documented divergence pins ---------------------------------------
+
+
+async def test_prune_is_noop_on_a_completed_run_transcript():
+    """Bounded divergence pin: with per-run persistence, the task-body
+    ``finally`` prune now sees the completed transcript. A successful run
+    leaves no dangling tool calls, so the prune must be a no-op."""
+    from code_puppy.agents import _history
+
+    agent = _FakeAgent()
+    cap = HistoryPersistence(agent)
+    calls = {"n": 0}
+
+    def model_func(messages, info):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return ModelResponse(
+                parts=[ToolCallPart(tool_name="fetch", args={}, tool_call_id="c1")]
+            )
+        return ModelResponse(parts=[TextPart(content="done")])
+
+    pyd_agent = PydanticAgent(model=FunctionModel(model_func), capabilities=[cap])
+
+    @pyd_agent.tool_plain
+    def fetch() -> str:
+        return "kibble"
+
+    await pyd_agent.run("go")
+
+    pruned = _history.prune_interrupted_tool_calls(agent._message_history)
+    assert pruned == agent._message_history


### PR DESCRIPTION
# `HistoryPersistence` capability — success-path history custody on `after_run`

Seventeenth in the capability-conversion series (#828–#836, #838–#842, #844, #845). **Do not merge yet** — standalone against `main`, like its sixteen siblings.

## The feature

After each successful `Agent.run()` on the **main conversation path**, the durable history on the owning `BaseAgent` must absorb `result.all_messages()` — the complete run transcript **including the trailing final response**, which never passes through any `before_model_request` hook (there is no subsequent request to carry it).

That writeback was duplicated across **seven eager call sites**:

| Site | Spelling |
|---|---|
| `_run_signals.prepare_queued_steer_injection` | `agent._message_history = list(result.all_messages())` (only when a queued steer was pending) |
| `_runtime._do_run` hook-retry branch | same, before the follow-up run |
| `cli_runner` initial-command flow | `agent.set_message_history(list(response.all_messages()))` |
| `cli_runner` interactive turn | same |
| `cli_runner` continuation loop | same |
| `cli_runner` headless (`execute_single_prompt`) | same |

## The conversion

`code_puppy/agents/_history_persistence.py`:

- **`HistoryPersistence`** — `after_run` persists `list(result.all_messages())` into the agent's durable history the moment the run commits its result, with the **identical `AgentRunResult` object the caller receives** (seam contract verified empirically in the #844 round; re-pinned here via the `last_result` observability slot on the caller's own result object). `get_serialization_name() -> None` (live agent reference). Default `for_run` returns `self` — the main conversation loop is strictly sequential, so the single slot cannot race (documented). This closes a real durability gap: a cancellation landing between run-end and the old turn-end writeback used to lose the completed run's trailing response.
- **`persist_result_history(agent, result)`** — the shared spelling all seven sites now call. It performs the old write **verbatim and unconditionally** (public setter when present — the cli_runner spelling — else direct attribute assignment — the runtime spelling). Idempotent next to the capability's persist.

**Deliberately NO ownership gate.** The first cut of this PR had an identity-gated "skip if the capability already persisted this result" fast path; review pass 1 proved it wrong: result identity can't prove the history *still* holds that transcript, so a post-`after_run` history mutation (e.g. an `agent_run_end` plugin) would have survived where the old eager sites clobbered it back. The sites keep their exact historical clobber semantics; the redundant write costs one list copy — the same cost the eager code always paid. Pinned by `test_fallback_clobbers_post_run_history_mutations` (the reviewer's exact scenario).

Wiring (`_builder.build_pydantic_agent`): one instance hoisted across both construction passes (the pass-1 probe never runs), appended to `capabilities=[...]` (only `after_run` implementer in the list — position inert; reversed-order onion semantics noted in a comment for future joiners). No side-channel stash on the agent — the call sites don't need to know the capability exists.

**Scope:** main path only. Sub-agent history custody belongs to session persistence and the invocation layer's result-scoped bookkeeping — `subagent_invocation.py` gets zero new machinery (source-pinned).

## Parity notes & bounded divergences

- **Call-site behavior is byte-exact.** Every demoted site performs the same unconditional write it always did, via one helper.
- **Model-visible bytes are identical.** Follow-up runs (queued steers, hook retries) were already seeded from an explicit eager persist of the same result. Pinned by a wire-level seeding-parity test.
- **Bounded divergence (strictly more durable):** history now *additionally* updates at the run boundary, after every successful run. A cancellation between run-end and the old turn-end writeback now keeps the completed run's transcript. Same flavor as #842's per-attempt checkpoint divergence.
- **The task-body `finally` prune now sees the completed transcript.** A successful run leaves no dangling tool calls, so the prune is a no-op there — pinned by `test_prune_is_noop_on_a_completed_run_transcript`. Cancelled/crashed runs produce no `after_run`, so their checkpoint/prune custody is untouched.
- **`agent_run_end` observers** (and any mid-turn `get_message_history()` reader) see post-run history instead of stale pre-run history — strictly fresher; and since the sites still clobber, any observer that *mutates* history keeps its old post-turn fate.

## Tests

19 contract tests in `tests/agents/test_history_persistence_capability.py`: direct seam contract (persist, pass-through, setter preference, message-less results), the post-run-mutation clobber pin, helper triage (`None`/message-less), real `Agent.run()` end-to-end (single-step, tool-cycle, `CombinedCapability` composition), follow-up seeding wire parity, production wiring through `build_pydantic_agent` (capability-tree membership + end-to-end run), sub-agent-exclusion source pin, no-inline-writebacks-remain source pin, steer-drain interplay (capability + guest), and the prune-no-op divergence pin.

Full suite: green.

## Merge-order note

Touches the main `capabilities=[...]` block in `_builder.py` like most of the series — whichever of the seventeen lands last eats a trivial rebase. Disjoint from #844 (`RunTelemetry`, also `after_run`, main path): different feature, different state; if both merge, the reversed-order onion semantics documented in #845 apply (both are order-insensitive to each other — telemetry reads the result, persistence writes agent state, neither mutates the result).

## Review log

- Pass 1 (code-puppy clone): **REQUEST_CHANGES** — 1 BLOCKING: the identity gate could wrongly skip the sites' historical clobber after a post-`after_run` history mutation; my own test enshrined the bug. Fixed in `d3882019` by removing the gate entirely (and the now-unneeded `agent._history_persistence` stash); sites are unconditional again.
- Pass 2: **APPROVE** — 1 NIT (stale "fallback" wording in the test file), applied in `8cac281b`.
- Pass 3: **APPROVE, zero findings.**
