### PR TITLE
Promote cancellation trace-context capture to a CancellationTraceCapture capability

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 from pydantic_ai import Agent as PydanticAgent
 from pydantic_ai.capabilities import ProcessHistory
 
+from code_puppy.agents._cancellation_trace import CancellationTraceCapture
 from code_puppy.agents._compaction import make_history_processor
 from code_puppy.agents._model_message_transform import build_model_message_transform
 from code_puppy.agents._output_limits import (
@@ -666,6 +667,11 @@ def build_pydantic_agent(
                 ProcessHistory(steer_processor),
                 build_response_clamp(),
                 build_model_message_transform(logical_agent_name),
+                # Sole wrap_run_event_stream implementer, so position is
+                # inert. Resolves per run from the observation _runtime's
+                # _do_run installs; without one it stays seam-less and the
+                # run is not forced into streaming mode.
+                CancellationTraceCapture(),
             ],
             model_settings=model_settings,
         )

--- a/code_puppy/agents/_cancellation_trace.py
+++ b/code_puppy/agents/_cancellation_trace.py
@@ -10,10 +10,16 @@ first-class capability on pydantic-ai's ``wrap_run_event_stream`` seam.
 
 Parity notes:
 
-- The capture fires once per streamed node event stream, synchronously in
-  the same task -- and therefore the same OTel context -- in which the
-  run's ``event_stream_handler`` is invoked, so ``logfire.get_context()``
-  observes the identical value the eager wrapper captured.
+- The capture fires once per streamed node event stream, when the
+  consumer first pulls the wrapped stream -- in the same task, and
+  therefore the same OTel context, in which the run's
+  ``event_stream_handler`` is invoked -- so ``logfire.get_context()``
+  observes the identical value the eager wrapper captured. The eager
+  wrapper captured at handler *invocation*; a handler that defers (or
+  skips) iterating its events defers (or skips) the capture here. The
+  production handler (``StreamingTextDetector`` wrapping the render
+  handler) consumes immediately, so the two moments coincide in
+  practice.
 - The streaming gate is preserved. ``CancellationTraceCapture`` itself
   does NOT override ``wrap_run_event_stream``; only the per-run resolved
   ``_ActiveCancellationTraceCapture`` does. When no observation is

--- a/code_puppy/agents/_cancellation_trace.py
+++ b/code_puppy/agents/_cancellation_trace.py
@@ -1,0 +1,145 @@
+"""Cancellation trace-context capture as a pydantic-ai capability.
+
+``emit_cancellation`` (``code_puppy/observability.py``) links the
+"Agent run cancelled" Logfire warning to the run's live trace by attaching
+the context captured during the run's most recent streamed model request.
+Previously ``_runtime._do_run`` smuggled that capture into an
+``_observed_event_stream_handler`` closure wrapped around the run's
+``event_stream_handler``. This module promotes the capture to a
+first-class capability on pydantic-ai's ``wrap_run_event_stream`` seam.
+
+Parity notes:
+
+- The capture fires once per streamed node event stream, synchronously in
+  the same task -- and therefore the same OTel context -- in which the
+  run's ``event_stream_handler`` is invoked, so ``logfire.get_context()``
+  observes the identical value the eager wrapper captured.
+- The streaming gate is preserved. ``CancellationTraceCapture`` itself
+  does NOT override ``wrap_run_event_stream``; only the per-run resolved
+  ``_ActiveCancellationTraceCapture`` does. When no observation is
+  installed (direct ``pydantic_agent.run()`` calls outside
+  ``run_with_mcp``) or the observation is disabled (streaming gate off),
+  ``for_run`` returns ``self``, pydantic-ai does not force the run into
+  streaming mode, and no capture happens -- byte-identical to the eager
+  wrapper only existing when ``get_enable_streaming()`` was true.
+- ``clear_agent_context`` (turn-end custody in the task-body ``finally``)
+  and ``emit_cancellation`` (the await-site ``except*`` handlers via
+  ``on_agent_run_cancel``) stay eager: both run outside the run boundary,
+  where no capability seam fires -- a cancelled run never reaches
+  ``after_run``, and the ``CancelledError`` delivered inside the run
+  carries no usable snapshot at the ``wrap_run`` seam.
+
+The observation is installed with a plain ``ContextVar.set`` and never
+reset: ``_do_run`` executes inside the turn's agent task, whose context
+dies with the task, and nested ``run_with_mcp`` turns run in their own
+task where their own install shadows the snapshot inherited at
+``create_task`` time.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any, AsyncIterable, Callable, Optional
+
+from pydantic_ai.capabilities import AbstractCapability
+
+__all__ = [
+    "CancellationTraceCapture",
+    "CancellationTraceObservation",
+    "current_cancellation_trace_observation",
+    "install_cancellation_trace_observation",
+]
+
+
+@dataclass(frozen=True)
+class CancellationTraceObservation:
+    """One turn's capture parameters, installed by ``_runtime._do_run``.
+
+    ``capture`` is an injectable seam for tests; ``None`` resolves to
+    ``code_puppy.observability.capture_agent_context`` at call time so
+    monkeypatching the observability module keeps intercepting.
+    """
+
+    group_id: str
+    enabled: bool
+    capture: Optional[Callable[[str], None]] = None
+
+
+_observation_var: ContextVar[Optional[CancellationTraceObservation]] = ContextVar(
+    "cancellation_trace_observation", default=None
+)
+
+
+def install_cancellation_trace_observation(
+    observation: Optional[CancellationTraceObservation],
+) -> None:
+    """Advertise ``observation`` to ``CancellationTraceCapture.for_run``.
+
+    ``None`` shadows any inherited observation (nested-context hygiene --
+    an explicit "no capture here" must not fall through to an outer
+    turn's group id).
+    """
+    _observation_var.set(observation)
+
+
+def current_cancellation_trace_observation() -> Optional[CancellationTraceObservation]:
+    """Return the observation visible in the current context, if any."""
+    return _observation_var.get()
+
+
+def _resolve_capture(
+    observation: CancellationTraceObservation,
+) -> Callable[[str], None]:
+    if observation.capture is not None:
+        return observation.capture
+    # Late binding: resolved through the module attribute at call time so
+    # test patches on ``code_puppy.observability`` apply.
+    from code_puppy import observability
+
+    return observability.capture_agent_context
+
+
+@dataclass
+class _ActiveCancellationTraceCapture(AbstractCapability[Any]):
+    """Per-run resolved form: pass events through, capture trace context.
+
+    Overriding ``wrap_run_event_stream`` here (and only here) keeps the
+    force-streaming side effect of the seam confined to runs whose
+    observation is enabled -- exactly the runs that already stream.
+    """
+
+    observation: CancellationTraceObservation
+
+    async def wrap_run_event_stream(
+        self,
+        ctx: Any,
+        *,
+        stream: AsyncIterable[Any],
+    ) -> AsyncIterable[Any]:
+        _resolve_capture(self.observation)(self.observation.group_id)
+        try:
+            async for event in stream:
+                yield event
+        finally:
+            # Mirror AbstractCapability.wrap_run_event_stream's base
+            # implementation: propagate closure to the wrapped stream.
+            aclose = getattr(stream, "aclose", None)
+            if aclose is not None:
+                await aclose()
+
+
+@dataclass
+class CancellationTraceCapture(AbstractCapability[Any]):
+    """Static entry registered in the builder's ``capabilities=[...]``.
+
+    Stateless; resolves the turn's observation once per run.
+    """
+
+    async def for_run(self, ctx: Any) -> AbstractCapability[Any]:
+        observation = current_cancellation_trace_observation()
+        if observation is None or not observation.enabled:
+            # No seam override on this class, so returning ``self`` keeps
+            # the run genuinely non-streamed (no forced streaming mode).
+            return self
+        return _ActiveCancellationTraceCapture(observation=observation)

--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -70,6 +70,10 @@ except ImportError:  # pragma: no cover - 3.10 only
 from code_puppy.agent_execution_context import executing_agent_context
 from code_puppy.agents import _history, _key_listeners
 from code_puppy.agents._builder import build_pydantic_agent
+from code_puppy.agents._cancellation_trace import (
+    CancellationTraceObservation,
+    install_cancellation_trace_observation,
+)
 from code_puppy.agents._diagnostics import emit_exception_diagnostics
 from code_puppy.agents._non_streaming_render import (
     StreamingTextDetector,
@@ -726,16 +730,19 @@ async def _run_with_mcp_impl(
         # if no text actually streamed.
         use_streaming = get_enable_streaming()
 
-        async def _observed_event_stream_handler(ctx: Any, events: Any) -> Any:
-            from code_puppy.observability import capture_agent_context
-
-            capture_agent_context(group_id)
-            return await event_stream_handler(ctx, events)
+        # Advertise this turn's runs to CancellationTraceCapture (wired in
+        # _builder's capabilities list): the capability captures the live
+        # trace context at each streamed request for emit_cancellation,
+        # replacing the eager _observed_event_stream_handler wrapper. Plain
+        # set, no reset: this executes inside the turn's agent task, whose
+        # context dies with the task; nested run_with_mcp turns run in their
+        # own task and install their own observation there.
+        install_cancellation_trace_observation(
+            CancellationTraceObservation(group_id=group_id, enabled=use_streaming)
+        )
 
         detector: Optional[StreamingTextDetector] = (
-            StreamingTextDetector(_observed_event_stream_handler)
-            if use_streaming
-            else None
+            StreamingTextDetector(event_stream_handler) if use_streaming else None
         )
         stream_handler = detector if detector is not None else None
         # Plugins (e.g. DBOS) can render their own output and skip the fallback.

--- a/tests/agents/test_cancellation_trace_capability.py
+++ b/tests/agents/test_cancellation_trace_capability.py
@@ -1,0 +1,551 @@
+"""Contract tests for the CancellationTraceCapture capability.
+
+Covers the promotion of the cancellation trace-context capture (the eager
+``_observed_event_stream_handler`` closure in ``_runtime._do_run``) onto
+pydantic-ai's ``wrap_run_event_stream`` seam:
+
+- for_run resolution: no/disabled observation stays seam-less (no forced
+  streaming); enabled observation resolves to the active capture.
+- Capture cadence parity: one capture per event-stream-handler invocation,
+  in the identical OTel span context the handler observes.
+- Streaming-gate parity: gate off means zero captures even when a handler
+  streams.
+- ContextVar custody: None installs shadow, task-local installs die with
+  the task.
+- Wiring: builder registers the capability on the main path only;
+  ``_do_run`` installs the per-turn observation; emit/clear custody stays
+  eager.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelResponse, TextPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.test import TestModel
+
+from code_puppy.agents import _runtime
+from code_puppy.agents._cancellation_trace import (
+    CancellationTraceCapture,
+    CancellationTraceObservation,
+    _ActiveCancellationTraceCapture,
+    current_cancellation_trace_observation,
+    install_cancellation_trace_observation,
+)
+from code_puppy.callbacks import _callbacks, clear_callbacks, register_callback
+
+AGENTS_DIR = Path(_runtime.__file__).parent
+RUNTIME_SOURCE = (AGENTS_DIR / "_runtime.py").read_text()
+BUILDER_SOURCE = (AGENTS_DIR / "_builder.py").read_text()
+SUBAGENT_SOURCE = (AGENTS_DIR.parent / "tools" / "subagent_invocation.py").read_text()
+CALLBACKS_SOURCE = (AGENTS_DIR.parent / "callbacks.py").read_text()
+
+
+@pytest.fixture(autouse=True)
+def isolated_observation():
+    """Shadow any observation leaking in from the surrounding context."""
+    install_cancellation_trace_observation(None)
+    yield
+    install_cancellation_trace_observation(None)
+
+
+def make_stream_model() -> FunctionModel:
+    """A model that ONLY supports streaming: proves a run streamed."""
+
+    async def stream_func(messages: Any, info: AgentInfo):
+        yield "hello "
+        yield "world"
+
+    return FunctionModel(stream_function=stream_func)
+
+
+def make_request_model() -> FunctionModel:
+    """A model that ONLY supports plain requests: proves a run did NOT
+    stream (a streamed request raises UserError)."""
+
+    def func(messages: Any, info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[TextPart("plain")])
+
+    return FunctionModel(function=func)
+
+
+async def consume(_ctx: Any, events: Any) -> None:
+    async for _ in events:
+        pass
+
+
+# --- for_run resolution ------------------------------------------------------
+
+
+async def test_for_run_without_observation_returns_self() -> None:
+    capability = CancellationTraceCapture()
+    resolved = await capability.for_run(None)
+    assert resolved is capability
+    # No seam override on the static class: the run must not be forced
+    # into streaming mode.
+    assert not resolved.has_wrap_run_event_stream
+
+
+async def test_for_run_with_disabled_observation_returns_self() -> None:
+    capability = CancellationTraceCapture()
+    install_cancellation_trace_observation(
+        CancellationTraceObservation(group_id="gid", enabled=False)
+    )
+    resolved = await capability.for_run(None)
+    assert resolved is capability
+    assert not resolved.has_wrap_run_event_stream
+
+
+async def test_for_run_with_enabled_observation_resolves_active() -> None:
+    capability = CancellationTraceCapture()
+    observation = CancellationTraceObservation(group_id="gid", enabled=True)
+    install_cancellation_trace_observation(observation)
+    resolved = await capability.for_run(None)
+    assert isinstance(resolved, _ActiveCancellationTraceCapture)
+    assert resolved.observation is observation
+    assert resolved.has_wrap_run_event_stream
+
+
+# --- ContextVar custody ------------------------------------------------------
+
+
+async def test_none_install_shadows_inherited_observation() -> None:
+    """An explicit None install must hide an outer observation from nested
+    tasks (the #840 stealing lesson): 'no capture here' must not fall
+    through to an outer turn's group id."""
+    outer = CancellationTraceObservation(group_id="outer", enabled=True)
+    install_cancellation_trace_observation(outer)
+
+    async def nested() -> Any:
+        install_cancellation_trace_observation(None)
+        return current_cancellation_trace_observation()
+
+    assert await asyncio.create_task(nested()) is None
+    # The outer context keeps its own observation.
+    assert current_cancellation_trace_observation() is outer
+
+
+async def test_observation_install_dies_with_its_task() -> None:
+    """_do_run installs without reset; that is safe exactly because the
+    turn's task context is discarded when the task completes."""
+
+    async def turn() -> None:
+        install_cancellation_trace_observation(
+            CancellationTraceObservation(group_id="task-local", enabled=True)
+        )
+
+    await asyncio.create_task(turn())
+    assert current_cancellation_trace_observation() is None
+
+
+async def test_nested_task_uses_its_own_observation() -> None:
+    """Nested run_with_mcp turns install their own observation in their own
+    task; captures there must use the nested group id, and the outer turn
+    keeps its own."""
+    captured: list[str] = []
+    outer_obs = CancellationTraceObservation(
+        group_id="outer", enabled=True, capture=captured.append
+    )
+    install_cancellation_trace_observation(outer_obs)
+
+    agent = Agent(make_stream_model(), capabilities=[CancellationTraceCapture()])
+
+    async def nested_turn() -> None:
+        install_cancellation_trace_observation(
+            CancellationTraceObservation(
+                group_id="inner", enabled=True, capture=captured.append
+            )
+        )
+        await agent.run("nested", event_stream_handler=consume)
+
+    await asyncio.create_task(nested_turn())
+    await agent.run("outer", event_stream_handler=consume)
+
+    assert set(captured[: captured.index("outer")]) == {"inner"}
+    assert "inner" in captured and "outer" in captured
+
+
+# --- run behavior ------------------------------------------------------------
+
+
+async def test_inert_path_does_not_force_streaming() -> None:
+    """Streaming-gate parity: with no observation the resolved capability
+    has no wrap_run_event_stream, so a plain run stays non-streamed (the
+    request-only model raises if pydantic-ai tries to stream)."""
+    agent = Agent(make_request_model(), capabilities=[CancellationTraceCapture()])
+    result = await agent.run("hi")
+    assert result.output == "plain"
+
+
+async def test_disabled_observation_never_captures_even_when_streaming() -> None:
+    """Gate parity: streaming may happen (explicit handler) while the gate
+    is off -- e.g. a caller-supplied handler outside run_with_mcp -- and
+    the capture must stay silent, exactly like the eager wrapper that only
+    existed when get_enable_streaming() was true."""
+    captured: list[str] = []
+    install_cancellation_trace_observation(
+        CancellationTraceObservation(
+            group_id="gid", enabled=False, capture=captured.append
+        )
+    )
+    agent = Agent(make_stream_model(), capabilities=[CancellationTraceCapture()])
+    result = await agent.run("hi", event_stream_handler=consume)
+    assert result.output == "hello world"
+    assert captured == []
+
+
+async def test_capture_cadence_matches_handler_invocations() -> None:
+    """The eager wrapper captured once per event_stream_handler invocation;
+    the capability must capture once per wrapped node stream -- the same
+    cadence, pinned by counting both in one run."""
+    captured: list[str] = []
+    handler_calls: list[str] = []
+
+    async def counting_handler(_ctx: Any, events: Any) -> None:
+        handler_calls.append("call")
+        async for _ in events:
+            pass
+
+    install_cancellation_trace_observation(
+        CancellationTraceObservation(
+            group_id="gid", enabled=True, capture=captured.append
+        )
+    )
+    agent = Agent(make_stream_model(), capabilities=[CancellationTraceCapture()])
+    await agent.run("hi", event_stream_handler=counting_handler)
+
+    assert len(captured) == len(handler_calls) > 0
+    assert set(captured) == {"gid"}
+
+
+async def test_capture_works_without_explicit_handler() -> None:
+    """Seam property: an enabled observation auto-enables streaming even
+    without an event_stream_handler. In production enabled is exactly the
+    gate that also supplies the handler, so this only widens coverage for
+    direct run() callers that install an enabled observation."""
+    captured: list[str] = []
+    install_cancellation_trace_observation(
+        CancellationTraceObservation(
+            group_id="gid", enabled=True, capture=captured.append
+        )
+    )
+    agent = Agent(make_stream_model(), capabilities=[CancellationTraceCapture()])
+    result = await agent.run("hi")
+    assert result.output == "hello world"
+    assert captured and set(captured) == {"gid"}
+
+
+async def test_capture_sees_identical_span_context_as_handler() -> None:
+    """The money test: under real OTel instrumentation, the capture runs in
+    the same span context in which the event stream handler is invoked --
+    so logfire.get_context() observes the identical value the eager
+    wrapper captured."""
+    from opentelemetry import trace as otel_trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from pydantic_ai.agent import InstrumentationSettings
+
+    handler_spans: list[int] = []
+    capture_spans: list[int] = []
+
+    def span_capture(_gid: str) -> None:
+        capture_spans.append(otel_trace.get_current_span().get_span_context().span_id)
+
+    async def span_handler(_ctx: Any, events: Any) -> None:
+        handler_spans.append(otel_trace.get_current_span().get_span_context().span_id)
+        async for _ in events:
+            pass
+
+    install_cancellation_trace_observation(
+        CancellationTraceObservation(group_id="gid", enabled=True, capture=span_capture)
+    )
+    agent = Agent(make_stream_model(), capabilities=[CancellationTraceCapture()])
+    agent.instrument = InstrumentationSettings(tracer_provider=TracerProvider())
+    await agent.run("hi", event_stream_handler=span_handler)
+
+    assert handler_spans == capture_spans
+    # Real recording spans, not the default invalid span.
+    assert all(span_id != 0 for span_id in handler_spans)
+
+
+async def test_events_pass_through_unchanged() -> None:
+    """The active capture is a pure observer: the handler must see the
+    exact same event sequence with and without it."""
+
+    def collector(bucket: list[str]):
+        async def handler(_ctx: Any, events: Any) -> None:
+            async for event in events:
+                bucket.append(repr(event))
+
+        return handler
+
+    baseline: list[str] = []
+    agent_plain = Agent(make_stream_model())
+    await agent_plain.run("hi", event_stream_handler=collector(baseline))
+
+    observed: list[str] = []
+    install_cancellation_trace_observation(
+        CancellationTraceObservation(
+            group_id="gid", enabled=True, capture=lambda _: None
+        )
+    )
+    agent_cap = Agent(make_stream_model(), capabilities=[CancellationTraceCapture()])
+    result = await agent_cap.run("hi", event_stream_handler=collector(observed))
+
+    assert observed == baseline
+    assert result.output == "hello world"
+
+
+async def test_sequential_runs_keep_capturing() -> None:
+    """Steer/hook follow-up parity: every run of the turn re-resolves the
+    same observation, so captures keep firing run after run."""
+    captured: list[str] = []
+    install_cancellation_trace_observation(
+        CancellationTraceObservation(
+            group_id="gid", enabled=True, capture=captured.append
+        )
+    )
+    agent = Agent(make_stream_model(), capabilities=[CancellationTraceCapture()])
+    await agent.run("one", event_stream_handler=consume)
+    first_run_captures = len(captured)
+    await agent.run("two", event_stream_handler=consume)
+
+    assert first_run_captures > 0
+    assert len(captured) > first_run_captures
+
+
+async def test_default_capture_late_binds_to_observability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """capture=None resolves through code_puppy.observability at call time,
+    so test/plugin patches on the module keep intercepting."""
+    seen: list[str] = []
+    monkeypatch.setattr("code_puppy.observability.capture_agent_context", seen.append)
+    install_cancellation_trace_observation(
+        CancellationTraceObservation(group_id="gid", enabled=True)
+    )
+    agent = Agent(make_stream_model(), capabilities=[CancellationTraceCapture()])
+    await agent.run("hi", event_stream_handler=consume)
+    assert seen and set(seen) == {"gid"}
+
+
+# --- wiring ------------------------------------------------------------------
+
+
+class _FakeAgentConfig:
+    """Minimal BaseAgent-shaped config for the real build path (mirrors
+    tests/test_agent_span_naming.py)."""
+
+    name = "cancellation-trace-test"
+    display_name = "Cancellation Trace Test"
+
+    def __init__(self) -> None:
+        self._message_history: list[Any] = []
+        self._compacted_message_hashes: set[Any] = set()
+        self._puppy_rules = None
+
+    def get_model_name(self) -> str:
+        return "test-model"
+
+    def get_full_system_prompt(self) -> str:
+        return "You are a test agent."
+
+    def get_available_tools(self) -> list[str]:
+        return []
+
+    def get_message_history(self) -> list[Any]:
+        return self._message_history
+
+    def set_message_history(self, history: list[Any]) -> None:
+        self._message_history = history
+
+    def __getattr__(self, item: str) -> Any:
+        if item.startswith("__"):
+            raise AttributeError(item)
+        return lambda *a, **k: 0
+
+
+def test_builder_wires_cancellation_trace_capture() -> None:
+    from unittest.mock import patch
+
+    from code_puppy.agents import _builder
+
+    cfg = _FakeAgentConfig()
+    with (
+        patch.object(
+            _builder,
+            "load_model_with_fallback",
+            lambda *a, **k: (TestModel(custom_output_text="woof"), "test-model"),
+        ),
+        patch.object(_builder.ModelFactory, "load_config", staticmethod(dict)),
+        patch.object(_builder, "load_mcp_servers", lambda **k: []),
+        patch.object(_builder, "make_model_settings", lambda *a, **k: None),
+        patch("code_puppy.tools.register_tools_for_agent", lambda *a, **k: None),
+    ):
+        built = _builder.build_pydantic_agent(cfg)
+
+    leaves: list[Any] = []
+    built.root_capability.apply(leaves.append)
+    captures = [c for c in leaves if isinstance(c, CancellationTraceCapture)]
+    assert len(captures) == 1
+
+
+def test_subagent_site_excluded() -> None:
+    """The eager capture never covered the sub-agent invoker's temp agents;
+    the capability must not either."""
+    assert "CancellationTraceCapture" not in SUBAGENT_SOURCE
+    assert "install_cancellation_trace_observation" not in SUBAGENT_SOURCE
+
+
+def test_eager_wrapper_retired_and_custody_stays_eager() -> None:
+    """Source pins: the closure-based capture is gone, the runtime installs
+    the observation instead, and the emit/clear custody outside the run
+    boundary is untouched."""
+    assert "async def _observed_event_stream_handler" not in RUNTIME_SOURCE
+    assert "install_cancellation_trace_observation(" in RUNTIME_SOURCE
+    # Turn-end custody and cancellation emission stay eager: no seam fires
+    # on a cancelled run's exit path.
+    assert "clear_agent_context(group_id)" in RUNTIME_SOURCE
+    assert "emit_cancellation(group_id)" in CALLBACKS_SOURCE
+
+
+def test_builder_registers_capability_in_main_list_only() -> None:
+    assert "CancellationTraceCapture()" in BUILDER_SOURCE
+
+
+# --- production-shaped runtime tests ----------------------------------------
+
+
+class DummyResult:
+    def __init__(self, data: str) -> None:
+        self.data = data
+
+    def all_messages(self) -> list[Any]:
+        return []
+
+
+class ScriptedPydanticAgent:
+    def __init__(self, *outcomes: Any) -> None:
+        self._outcomes = list(outcomes)
+        self.calls: list[dict[str, Any]] = []
+
+    async def run(self, prompt: Any, **kwargs: Any) -> Any:
+        self.calls.append({"prompt": prompt, **kwargs})
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
+class DummyAgent:
+    name = "dummy-agent"
+
+    def __init__(self, pydantic_agent: Any) -> None:
+        self._code_generation_agent = pydantic_agent
+        self._message_history: list[Any] = []
+        self._mcp_servers: list[Any] = []
+
+    def get_model_name(self) -> str:
+        return "dummy-model"
+
+    def get_full_system_prompt(self) -> str:
+        return "unused"
+
+
+@pytest.fixture
+def runtime_harness(monkeypatch: pytest.MonkeyPatch):
+    """Isolate callbacks and interactive plumbing, as the runtime suites do."""
+    snapshot = {phase: list(cbs) for phase, cbs in _callbacks.items()}
+    clear_callbacks()
+    monkeypatch.setattr(_runtime, "sigint_fallback_cancels", lambda: True)
+    monkeypatch.setattr(_runtime, "should_render_fallback", lambda *_, **__: False)
+    yield monkeypatch
+    clear_callbacks()
+    for phase, cbs in snapshot.items():
+        _callbacks[phase].extend(cbs)
+
+
+async def test_runtime_installs_observation_with_gate_state(
+    runtime_harness: pytest.MonkeyPatch,
+) -> None:
+    """_do_run must install one observation per turn whose enabled flag is
+    the streaming gate and whose group_id is the turn's group id (the
+    session_id agent_run_start hooks receive)."""
+    installed: list[CancellationTraceObservation | None] = []
+    session_ids: list[str] = []
+
+    runtime_harness.setattr(
+        _runtime, "install_cancellation_trace_observation", installed.append
+    )
+
+    def on_start(agent_name: str, model_name: str, session_id: str = None) -> None:
+        session_ids.append(session_id)
+
+    register_callback("agent_run_start", on_start)
+
+    for gate in (False, True):
+        runtime_harness.setattr(_runtime, "get_enable_streaming", lambda g=gate: g)
+        agent = DummyAgent(ScriptedPydanticAgent(DummyResult("ok")))
+        await _runtime.run_with_mcp(agent, "hello")
+
+    assert [obs.enabled for obs in installed] == [False, True]
+    assert [obs.group_id for obs in installed] == session_ids
+    # Default capture path (late-bound observability), fresh id per turn.
+    assert all(obs.capture is None for obs in installed)
+    assert len({obs.group_id for obs in installed}) == 2
+
+
+async def test_run_with_mcp_end_to_end_capture(
+    runtime_harness: pytest.MonkeyPatch,
+) -> None:
+    """Full production shape: a real pydantic-ai Agent carrying the
+    capability, driven through run_with_mcp with the gate on, captures the
+    turn's group id through the default observability path."""
+    captured: list[str] = []
+    session_ids: list[str] = []
+
+    runtime_harness.setattr(_runtime, "get_enable_streaming", lambda: True)
+    runtime_harness.setattr(_runtime, "event_stream_handler", consume)
+    runtime_harness.setattr(
+        "code_puppy.observability.capture_agent_context", captured.append
+    )
+
+    def on_start(agent_name: str, model_name: str, session_id: str = None) -> None:
+        session_ids.append(session_id)
+
+    register_callback("agent_run_start", on_start)
+
+    pydantic_agent = Agent(
+        make_stream_model(), capabilities=[CancellationTraceCapture()]
+    )
+    agent = DummyAgent(pydantic_agent)
+    result = await _runtime.run_with_mcp(agent, "hello")
+
+    assert result.output == "hello world"
+    assert captured and set(captured) == set(session_ids)
+
+
+async def test_run_with_mcp_gate_off_no_capture(
+    runtime_harness: pytest.MonkeyPatch,
+) -> None:
+    """Gate off through the real runtime: the run stays non-streamed (the
+    request-only model proves it) and nothing is captured."""
+    captured: list[str] = []
+
+    runtime_harness.setattr(_runtime, "get_enable_streaming", lambda: False)
+    runtime_harness.setattr(
+        "code_puppy.observability.capture_agent_context", captured.append
+    )
+
+    pydantic_agent = Agent(
+        make_request_model(), capabilities=[CancellationTraceCapture()]
+    )
+    agent = DummyAgent(pydantic_agent)
+    result = await _runtime.run_with_mcp(agent, "hello")
+
+    assert result.output == "plain"
+    assert captured == []


### PR DESCRIPTION
## What

Eighteenth in the capability-conversion series (#828-#836, #838-#842, #844, #845, #847). Promotes the **cancellation trace-context capture** -- the newest feature on main (#827, "Link cancellation event to agent trace context") -- from an eager `_observed_event_stream_handler` closure in `_runtime._do_run` to a first-class pydantic-ai capability, **`CancellationTraceCapture`**, on the `wrap_run_event_stream` seam.

This is a *disjoint second claim* of the seam (#835 `StreamRendering` claims it for rendering; this claims it for trace capture -- same precedent as #847's second claim of `after_run`). Both are pass-through observers, so order between them is inert.

## Why this feature maps to this seam

`emit_cancellation` links the "Agent run cancelled" Logfire warning to the run's live trace by attaching the context captured during the most recent streamed model request. That capture is per-request, run-path work that main smuggled into the `event_stream_handler` wrapper -- the exact surface `wrap_run_event_stream` formalizes.

The other two thirds of the feature deliberately **stay eager**:
- `clear_agent_context` runs in the turn task's `finally` (must cover cancel/crash exits; a cancelled run never reaches `after_run`).
- `emit_cancellation` fires from the await-site `except*` handlers via `on_agent_run_cancel` (cancellation can land *between* runs of a turn, where no seam is active; and round-15 scouting proved the `CancelledError` at `wrap_run` carries no usable snapshot).

## Design

- **`code_puppy/agents/_cancellation_trace.py`** -- the static entry `CancellationTraceCapture` does NOT override the seam. Its `for_run` resolves a per-turn `CancellationTraceObservation` (`group_id` + streaming gate) from a ContextVar installed by `_do_run`, returning a per-run `_ActiveCancellationTraceCapture` only when enabled. Disabled/absent observations return `self`, so pydantic-ai's "overriding this seam auto-enables streaming" behavior never fires for gated-off runs -- **byte-identical to the eager wrapper existing only when `get_enable_streaming()` was true** (the #835 inert-resolution trick).
- The active capture yields events through unchanged and calls `capture_agent_context(group_id)` once per wrapped node stream -- the same cadence as the old per-handler-invocation capture (pinned by a counting test), in the **identical OTel span context** (pinned under a real SDK `TracerProvider`: capture and handler record the same span id).
- ContextVar custody: plain `set`, no reset -- `_do_run` executes inside the turn's agent task, whose context dies with the task. Nested `run_with_mcp` turns run in their own task and install their own observation (shadowing pinned). `None` installs shadow (the #840 lesson).
- Injectable `capture` seam defaulting to late-bound `code_puppy.observability.capture_agent_context`, so existing module patches keep intercepting (#842's call-time-resolution pattern).
- Sub-agent invoker untouched: the eager capture never covered temp agents (source-pinned).

## Bounded divergences (documented)

1. Capture moment moves from handler-*invocation* to first event *pull* -- one frame apart in the same await chain, same task, same span context; observable only if a cancel lands in that microscopic window, or if a handler never iterates its events (the production handler always does).
2. A direct `pydantic_agent.run()` call issued *inside* a turn's task (bypassing `run_with_mcp`) would inherit the turn's observation and capture under its group id, where the eager wrapper (bound to the kwarg) did not. No such caller exists in the codebase; production installs are turn-task-scoped.
3. Under DBOS durable exec, the capture now rides the workflow-side capability application rather than the per-run kwarg -- the #835 carve-out analysis applies unchanged.

## Tests

21 contract tests in `tests/agents/test_cancellation_trace_capability.py`: for_run resolution, no-forced-streaming (request-only `FunctionModel` proves inertness; stream-only proves streaming -- the #835 asymmetric-model trick), capture cadence == handler invocations, span-context parity under real OTel instrumentation, gate-off silence, event pass-through equality, sequential-run accumulation, ContextVar shadowing/task-death custody, late-binding patches, builder wiring via the public `apply` visitor, production-shaped `run_with_mcp` drives (gate on/off, group id == `agent_run_start` session id), and source pins for the retired wrapper + eager emit/clear custody.

**Full suite: 7618 passed, 0 failed** (28 skipped, 1 xpassed).

## Merge notes

Shares the main `capabilities=[...]` block with the seventeen open siblings -- whichever lands last eats a trivial rebase. Conflicts with #835's `_do_run` changes are mechanical (both touch the handler setup; both preserve `capture_agent_context` semantics).
