### PR TITLE
Promote round-robin model rotation to a RoundRobinRequests capability

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -24,6 +24,7 @@ from code_puppy.agents._output_limits import (
     build_response_clamp,
     build_tool_output_limits,
 )
+from code_puppy.agents._round_robin import build_round_robin_requests
 from code_puppy.agents._steer_processor import make_steer_history_processor
 from code_puppy.agents.event_stream_handler import event_stream_handler
 from code_puppy.callbacks import (
@@ -639,6 +640,10 @@ def build_pydantic_agent(
     history_processor = make_history_processor(agent)
     steer_processor = make_steer_history_processor(agent)
     logical_agent_name = getattr(agent, "name", None) or agent.__class__.__name__
+    # One instance shared by both construction passes (the probe never runs);
+    # empty list unless the resolved model is a RoundRobinModel. Rotation
+    # state lives on the model itself, so sharing is safe either way.
+    round_robin_requests = build_round_robin_requests(model)
 
     def _new_pydantic_agent(toolsets: List[Any]) -> PydanticAgent:
         return PydanticAgent(
@@ -660,11 +665,16 @@ def build_pydantic_agent(
             # hook (after_tool_execute), so its position is inert; the
             # response clamp runs before_model_request after both history
             # processors. The plugin transform wraps the final model request.
+            # Round-robin routing shares the wrap_model_request seam with the
+            # plugin transform but touches only the context's model (the
+            # transform touches only messages), so their nesting order is
+            # inert; the router sits outermost (earlier in the list).
             capabilities=[
                 *build_tool_output_limits(),
                 ProcessHistory(history_processor),
                 ProcessHistory(steer_processor),
                 build_response_clamp(),
+                *round_robin_requests,
                 build_model_message_transform(logical_agent_name),
             ],
             model_settings=model_settings,

--- a/code_puppy/agents/_round_robin.py
+++ b/code_puppy/agents/_round_robin.py
@@ -1,0 +1,120 @@
+"""Round-robin request routing as a pydantic-ai capability.
+
+Promotes the per-request model rotation that ``RoundRobinModel`` performs
+inside its ``request``/``request_stream`` methods onto pydantic-ai 2.31.0's
+``wrap_model_request`` capability seam. The seam is the natural home for the
+feature: rotation is a per-model-request routing decision, and the seam hands
+every request (streamed and non-streamed alike) a mutable
+``ModelRequestContext`` whose ``model`` field the terminal handler honours —
+upstream's own durable-execution capabilities swap ``request_context.model``
+at exactly this seam.
+
+Custody split (explicit-when-ours, fallback-for-guests):
+
+* **Capability-owned requests** — when the request's model is the exact
+  ``RoundRobinModel`` instance this capability was built around, the
+  capability advances the rotation, mirrors the eager leaf-side
+  ``prepare_request`` merge, and routes the request straight to the selected
+  leaf model. ``RoundRobinModel.request``/``request_stream`` never run.
+* **Guest requests** — anything else passes through untouched: an explicit
+  ``run(model=...)``/``override(model=...)`` model, or the round-robin model
+  re-wrapped by instrumentation (``InstrumentedModel``). In the wrapped case
+  the outer model's own ``request`` still reaches
+  ``RoundRobinModel.request``, which rotates eagerly exactly as before — the
+  ``Model`` subclass stays intact as the guest fallback, and both paths share
+  one rotation state (``RoundRobinModel.next_model``), so every request
+  advances the rotation exactly once no matter which path serves it.
+
+Bounded divergences on the capability-owned path (documented, pinned by
+tests where observable):
+
+* ``_ensure_model_supports_streaming`` now checks the routed **leaf** for
+  streamed requests rather than the wrapper — strictly more precise, and
+  vacuous for real provider leaves (they all stream).
+* Span-attribute fix-up moves from stream-open to handler-return on streamed
+  requests (same task and OTel context — the wrap chain runs where the chat
+  span was opened). Non-streamed timing is unchanged (after the response).
+* ``ModelRequestContext.model_id`` is only meaningful while the context still
+  carries the run's resolved model; swapping the model invalidates it for
+  durable-execution capabilities (upstream-documented semantics of any
+  model-swapping hook, including upstream's own).
+"""
+
+from __future__ import annotations
+
+from copy import copy
+from dataclasses import dataclass
+from typing import Any, List
+
+from pydantic_ai import RunContext
+from pydantic_ai.capabilities import AbstractCapability, WrapModelRequestHandler
+from pydantic_ai.messages import ModelResponse
+from pydantic_ai.models import Model, ModelRequestContext
+
+from code_puppy.round_robin_model import RoundRobinModel
+
+__all__ = ["RoundRobinRequests", "build_round_robin_requests"]
+
+
+@dataclass
+class RoundRobinRequests(AbstractCapability[Any]):
+    """Route each model request to the next leaf of a ``RoundRobinModel``.
+
+    One instance per built agent, wrapping that agent's resolved
+    ``RoundRobinModel``. Stateless beyond the model reference — rotation
+    state lives on the model itself so capability-owned and guest requests
+    share one sequence.
+    """
+
+    model: RoundRobinModel
+
+    @classmethod
+    def get_serialization_name(cls) -> str | None:
+        # Holds a live Model instance (provider HTTP clients) — not
+        # spec-constructible.
+        return None
+
+    async def wrap_model_request(
+        self,
+        ctx: RunContext[Any],
+        *,
+        request_context: ModelRequestContext,
+        handler: WrapModelRequestHandler,
+    ) -> ModelResponse:
+        if request_context.model is not self.model:
+            # Guest custody: an explicit run/override model, or our model
+            # re-wrapped (e.g. InstrumentedModel). The outer model's own
+            # request path performs the eager rotation when applicable.
+            return await handler(request_context)
+
+        leaf = self.model.next_model()
+        # Mirror the eager path byte-for-byte: RoundRobinModel.request calls
+        # ``leaf.prepare_request`` before handing off, merging the leaf's own
+        # default settings under the run's settings and letting the leaf
+        # customize the request parameters. The leaf re-prepares internally
+        # on ``request()`` exactly as it did when called by RoundRobinModel.
+        merged_settings, prepared_params = leaf.prepare_request(
+            request_context.model_settings,
+            request_context.model_request_parameters,
+        )
+        routed_context = copy(request_context)
+        routed_context.model = leaf
+        routed_context.model_settings = merged_settings
+        routed_context.model_request_parameters = prepared_params
+
+        response = await handler(routed_context)
+        self.model.record_span_attributes(leaf)
+        return response
+
+
+def build_round_robin_requests(model: Model) -> List[RoundRobinRequests]:
+    """Conditionally splice a ``RoundRobinRequests`` into a capabilities list.
+
+    Returns ``[RoundRobinRequests(model)]`` when ``model`` is a
+    ``RoundRobinModel``, else ``[]`` — the same conditional-splice shape as
+    ``build_tool_output_limits`` so non-round-robin agents carry no inert
+    capability.
+    """
+    if isinstance(model, RoundRobinModel):
+        return [RoundRobinRequests(model)]
+    return []

--- a/code_puppy/agents/_round_robin.py
+++ b/code_puppy/agents/_round_robin.py
@@ -31,9 +31,26 @@ tests where observable):
 * ``_ensure_model_supports_streaming`` now checks the routed **leaf** for
   streamed requests rather than the wrapper — strictly more precise, and
   vacuous for real provider leaves (they all stream).
-* Span-attribute fix-up moves from stream-open to handler-return on streamed
-  requests (same task and OTel context — the wrap chain runs where the chat
-  span was opened). Non-streamed timing is unchanged (after the response).
+* **Continuation segments stay pinned to the leaf that opened the chain.**
+  ``model_request``/``model_request_stream`` resolve suspended → complete
+  continuations (Anthropic ``pause_turn``, OpenAI background polls) by
+  re-invoking ``req_ctx.model`` inside ONE wrapped request. Eagerly the
+  terminal model was the round-robin wrapper, so every segment rotated —
+  which could stitch one merged response from two different models, and
+  would re-poll a *different* provider for a suspended job id. Owned
+  requests advance the rotation once and serve the whole chain from the
+  selected leaf: a deliberate divergence, strictly saner than the eager
+  behaviour (which survives unchanged on the guest path). Pinned both ways
+  by the continuation tests.
+* Span-attribute fix-up on streamed requests moves from stream-open to
+  handler-return, which parks until the stream is fully drained — a
+  mid-stream cancel/teardown therefore records nothing where the eager path
+  had already recorded at open. Materiality bound: the fix-up only matches
+  spans carrying ``gen_ai.request.model`` (i.e. under instrumentation), and
+  instrumentation re-wraps the model, which fails the identity gate and
+  routes to the eager path anyway — so the owned-path fix-up is
+  belt-and-suspenders in every configuration we ship. Non-streamed timing
+  is unchanged (after the response). Pinned by the teardown tests.
 * ``ModelRequestContext.model_id`` is only meaningful while the context still
   carries the run's resolved model; swapping the model invalidates it for
   durable-execution capabilities (upstream-documented semantics of any
@@ -44,7 +61,7 @@ from __future__ import annotations
 
 from copy import copy
 from dataclasses import dataclass
-from typing import Any, List
+from typing import Any
 
 from pydantic_ai import RunContext
 from pydantic_ai.capabilities import AbstractCapability, WrapModelRequestHandler
@@ -107,7 +124,7 @@ class RoundRobinRequests(AbstractCapability[Any]):
         return response
 
 
-def build_round_robin_requests(model: Model) -> List[RoundRobinRequests]:
+def build_round_robin_requests(model: Model) -> list[RoundRobinRequests]:
     """Conditionally splice a ``RoundRobinRequests`` into a capabilities list.
 
     Returns ``[RoundRobinRequests(model)]`` when ``model`` is a

--- a/code_puppy/agents/_round_robin.py
+++ b/code_puppy/agents/_round_robin.py
@@ -55,9 +55,10 @@ tests where observable):
   ``observability.py`` calls ``logfire.instrument_pydantic_ai()``, and 2.31.0
   instrumentation is capability-based (explicit ``InstrumentedModel``s are
   unwrapped before the run), so instrumented requests take the owned path.
-  Scope of the loss: only the leaf-attribute refinement on the chat span —
-  the span itself, its round-robin ``gen_ai.request.model``, and the eager
-  fallback for completed streams are unaffected. Non-streamed timing is
+  Scope of the loss: only the leaf-attribute refinement on the torn-down
+  stream's chat span — the span itself and its round-robin
+  ``gen_ai.request.model`` survive, completed owned streams still get the
+  refinement at handler-return, and eager guest custody is unchanged. Non-streamed timing is
   unchanged (after the response). Pinned by the teardown tests.
 * ``ModelRequestContext.model_id`` is only meaningful while the context still
   carries the run's resolved model; swapping the model invalidates it for

--- a/code_puppy/agents/_round_robin.py
+++ b/code_puppy/agents/_round_robin.py
@@ -18,12 +18,18 @@ Custody split (explicit-when-ours, fallback-for-guests):
   leaf model. ``RoundRobinModel.request``/``request_stream`` never run.
 * **Guest requests** — anything else passes through untouched: an explicit
   ``run(model=...)``/``override(model=...)`` model, or the round-robin model
-  re-wrapped by instrumentation (``InstrumentedModel``). In the wrapped case
-  the outer model's own ``request`` still reaches
-  ``RoundRobinModel.request``, which rotates eagerly exactly as before — the
-  ``Model`` subclass stays intact as the guest fallback, and both paths share
-  one rotation state (``RoundRobinModel.next_model``), so every request
-  advances the rotation exactly once no matter which path serves it.
+  re-wrapped by an arbitrary ``WrapperModel``. In the wrapped case the outer
+  model's own ``request`` still reaches ``RoundRobinModel.request``, which
+  rotates eagerly exactly as before — the ``Model`` subclass stays intact as
+  the guest fallback, and both paths share one rotation state
+  (``RoundRobinModel.next_model``), so every pydantic-ai model request
+  advances the rotation exactly once no matter which path serves it. (Guest
+  custody additionally rotates per *continuation segment* within one wrapped
+  request — the pre-conversion behaviour; see the continuation divergence
+  below.) Note instrumentation is NOT a guest: pydantic-ai 2.31.0 installs
+  it as a capability and unwraps explicit ``InstrumentedModel``s before the
+  run, so instrumented requests still carry the bare round-robin model and
+  take the owned path.
 
 Bounded divergences on the capability-owned path (documented, pinned by
 tests where observable):
@@ -45,12 +51,14 @@ tests where observable):
 * Span-attribute fix-up on streamed requests moves from stream-open to
   handler-return, which parks until the stream is fully drained — a
   mid-stream cancel/teardown therefore records nothing where the eager path
-  had already recorded at open. Materiality bound: the fix-up only matches
-  spans carrying ``gen_ai.request.model`` (i.e. under instrumentation), and
-  instrumentation re-wraps the model, which fails the identity gate and
-  routes to the eager path anyway — so the owned-path fix-up is
-  belt-and-suspenders in every configuration we ship. Non-streamed timing
-  is unchanged (after the response). Pinned by the teardown tests.
+  had already recorded at open. This is reachable in shipped configurations:
+  ``observability.py`` calls ``logfire.instrument_pydantic_ai()``, and 2.31.0
+  instrumentation is capability-based (explicit ``InstrumentedModel``s are
+  unwrapped before the run), so instrumented requests take the owned path.
+  Scope of the loss: only the leaf-attribute refinement on the chat span —
+  the span itself, its round-robin ``gen_ai.request.model``, and the eager
+  fallback for completed streams are unaffected. Non-streamed timing is
+  unchanged (after the response). Pinned by the teardown tests.
 * ``ModelRequestContext.model_id`` is only meaningful while the context still
   carries the run's resolved model; swapping the model invalidates it for
   durable-execution capabilities (upstream-documented semantics of any

--- a/code_puppy/round_robin_model.py
+++ b/code_puppy/round_robin_model.py
@@ -85,8 +85,14 @@ class RoundRobinModel(Model):
         """Base URL from the current model."""
         return self.models[self._current_index].base_url
 
-    def _get_next_model(self) -> Model:
-        """Get the next model in the round-robin sequence and update the index."""
+    def next_model(self) -> Model:
+        """Return the model for the next request, advancing the rotation.
+
+        Public because rotation state is shared between the eager
+        ``request``/``request_stream`` path and the ``RoundRobinRequests``
+        capability (``code_puppy.agents._round_robin``) — both must draw from
+        one sequence so every request advances the rotation exactly once.
+        """
         with self._lock:
             model = self.models[self._current_index]
             self._request_count += 1
@@ -102,7 +108,7 @@ class RoundRobinModel(Model):
         model_request_parameters: ModelRequestParameters,
     ) -> ModelResponse:
         """Make a request using the next model in the round-robin sequence."""
-        current_model = self._get_next_model()
+        current_model = self.next_model()
         # Use prepare_request to merge settings and customize parameters
         merged_settings, prepared_params = current_model.prepare_request(
             model_settings, model_request_parameters
@@ -112,7 +118,7 @@ class RoundRobinModel(Model):
             response = await current_model.request(
                 messages, merged_settings, prepared_params
             )
-            self._set_span_attributes(current_model)
+            self.record_span_attributes(current_model)
             return response
         except Exception:
             # Unlike FallbackModel, we don't try other models here
@@ -128,7 +134,7 @@ class RoundRobinModel(Model):
         run_context: RunContext[Any] | None = None,
     ) -> AsyncIterator[StreamedResponse]:
         """Make a streaming request using the next model in the round-robin sequence."""
-        current_model = self._get_next_model()
+        current_model = self.next_model()
         # Use prepare_request to merge settings and customize parameters
         merged_settings, prepared_params = current_model.prepare_request(
             model_settings, model_request_parameters
@@ -137,11 +143,16 @@ class RoundRobinModel(Model):
         async with current_model.request_stream(
             messages, merged_settings, prepared_params, run_context
         ) as response:
-            self._set_span_attributes(current_model)
+            self.record_span_attributes(current_model)
             yield response
 
-    def _set_span_attributes(self, model: Model):
-        """Set span attributes for observability."""
+    def record_span_attributes(self, model: Model):
+        """Set span attributes for observability.
+
+        Public for the same reason as ``next_model``: the
+        ``RoundRobinRequests`` capability performs the identical fix-up after
+        routing a request to ``model``.
+        """
         with suppress(Exception):
             span = get_current_span()
             if span.is_recording():

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -404,6 +404,7 @@ async def _invoke_agent_impl(
             from code_puppy.agents._model_message_transform import (
                 build_model_message_transform,
             )
+            from code_puppy.agents._round_robin import build_round_robin_requests
 
             # Build the pydantic-ai agent. MCP servers always included; plugins
             # (e.g. DBOS) may swap them via the agent_run_context hook.
@@ -420,9 +421,13 @@ async def _invoke_agent_impl(
                 toolsets=mcp_servers,
                 # ProcessHistory capability replaces the deprecated
                 # `history_processors=` kwarg (removed in pydantic-ai v2).
+                # Round-robin routing shares wrap_model_request with the
+                # plugin transform but only swaps the context's model (the
+                # transform only mutates messages) — nesting order is inert.
                 capabilities=[
                     ProcessHistory(make_history_processor(agent_config)),
                     build_model_message_transform(agent_name),
+                    *build_round_robin_requests(model),
                 ],
                 model_settings=model_settings,
             )

--- a/tests/agents/round_robin_capability_harness.py
+++ b/tests/agents/round_robin_capability_harness.py
@@ -1,0 +1,114 @@
+"""Shared harness for the ``RoundRobinRequests`` capability test files.
+
+Leaf fabrication (FunctionModel + a scripted self-preparing Model), suspended
+continuation responses, request-context construction, and eager-path spies.
+"""
+
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    UserPromptPart,
+)
+from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameters
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from code_puppy.round_robin_model import RoundRobinModel
+
+
+def make_leaf(name: str, hits: dict[str, int]) -> FunctionModel:
+    """A FunctionModel leaf that records how often it served a request."""
+
+    def respond(messages: list, info: AgentInfo) -> ModelResponse:
+        hits[name] = hits.get(name, 0) + 1
+        return ModelResponse(parts=[TextPart(f"reply from {name}")])
+
+    async def stream_respond(messages: list, info: AgentInfo):
+        hits[name] = hits.get(name, 0) + 1
+        yield f"reply from {name}"
+
+    return FunctionModel(respond, stream_function=stream_respond, model_name=name)
+
+
+class ScriptedLeaf(Model):
+    """A minimal leaf Model with a scripted response sequence.
+
+    Mirrors real provider leaves: ``request`` calls ``self.prepare_request``
+    internally before serving, and records what it received so parity
+    assertions can compare the eager and capability-owned delivery paths.
+    """
+
+    def __init__(self, name: str, script):
+        super().__init__()
+        self._name = name
+        self.script = list(script)
+        self.calls = 0
+        self.customize_calls = 0
+        self.received: list[tuple] = []
+
+    @property
+    def model_name(self) -> str:
+        return self._name
+
+    @property
+    def system(self) -> str:
+        return "test"
+
+    def customize_request_parameters(self, model_request_parameters):
+        # Deliberately observable (non-idempotent counter): parity between
+        # eager and owned paths must show the SAME application count at the
+        # moment the request is served.
+        self.customize_calls += 1
+        return model_request_parameters
+
+    async def request(self, messages, model_settings, model_request_parameters):
+        model_settings, model_request_parameters = self.prepare_request(
+            model_settings, model_request_parameters
+        )
+        self.calls += 1
+        self.received.append((model_settings, self.customize_calls))
+        return self.script.pop(0)()
+
+
+def suspended_response(name: str) -> ModelResponse:
+    return ModelResponse(
+        parts=[TextPart(f"partial from {name}")],
+        state="suspended",
+        provider_response_id="job-1",
+    )
+
+
+def complete_response(name: str) -> ModelResponse:
+    return ModelResponse(parts=[TextPart(f"final from {name}")])
+
+
+def request_context(model, prompt: str = "hi") -> ModelRequestContext:
+    return ModelRequestContext(
+        model=model,
+        messages=[ModelRequest(parts=[UserPromptPart(content=prompt)])],
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(),
+    )
+
+
+async def passthrough_handler(req_ctx: ModelRequestContext) -> ModelResponse:
+    return ModelResponse(parts=[TextPart("handled")])
+
+
+def spy_eager_requests(rr: RoundRobinModel) -> list[str]:
+    """Instance-level spies counting eager RoundRobinModel request entries."""
+    calls: list[str] = []
+    original_request = rr.request
+    original_stream = rr.request_stream
+
+    async def spying_request(*args, **kwargs):
+        calls.append("request")
+        return await original_request(*args, **kwargs)
+
+    def spying_stream(*args, **kwargs):
+        calls.append("request_stream")
+        return original_stream(*args, **kwargs)
+
+    rr.request = spying_request  # type: ignore[method-assign]
+    rr.request_stream = spying_stream  # type: ignore[method-assign]
+    return calls

--- a/tests/agents/test_round_robin_capability.py
+++ b/tests/agents/test_round_robin_capability.py
@@ -1,132 +1,34 @@
-"""Contract tests for the ``RoundRobinRequests`` capability.
+"""Seam-contract tests for the ``RoundRobinRequests`` capability.
 
-Pins the promotion of ``RoundRobinModel``'s per-request rotation onto
-pydantic-ai's ``wrap_model_request`` seam:
-
-* seam contract — routing, copy isolation, guest pass-through, eager
-  ``prepare_request`` merge parity, span-attr fix-up, error custody;
-* end-to-end — real ``Agent`` runs (streamed + non-streamed) served by the
-  capability with ``RoundRobinModel.request`` never invoked, rotate_every
-  cadence, explicit-model override, wrapped-model eager fallback, shared
-  rotation state, coexistence with ``PluginMessageTransform``;
-* wiring — builder conditional splice (both polarities) and the sub-agent
-  construction site source pin.
+Direct ``wrap_model_request`` drives: leaf routing, copy isolation, guest
+pass-through, the eager ``prepare_request`` merge, span-attr fix-up custody,
+error propagation, spec-constructibility opt-out, and the conditional splice
+helper. End-to-end ``Agent`` runs and construction-site wiring live in
+``test_round_robin_capability_runs.py``.
 """
 
-from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import patch
 
-import pytest
-from pydantic_ai import Agent
-from pydantic_ai.messages import (
-    ModelRequest,
-    ModelResponse,
-    TextPart,
-    UserPromptPart,
-)
-from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameters
-from pydantic_ai.models.function import AgentInfo, FunctionModel
-from pydantic_ai.models.wrapper import WrapperModel
+from pydantic_ai.messages import ModelResponse, TextPart
+from pydantic_ai.models import ModelRequestContext
+from pydantic_ai.models.function import FunctionModel
 
 from code_puppy.agents._round_robin import (
     RoundRobinRequests,
     build_round_robin_requests,
 )
 from code_puppy.round_robin_model import RoundRobinModel
-
-# ---------------------------------------------------------------------------
-# harness
-# ---------------------------------------------------------------------------
-
-
-def _make_leaf(name: str, hits: dict[str, int]) -> FunctionModel:
-    """A FunctionModel leaf that records how often it served a request."""
-
-    def respond(messages: list, info: AgentInfo) -> ModelResponse:
-        hits[name] = hits.get(name, 0) + 1
-        return ModelResponse(parts=[TextPart(f"reply from {name}")])
-
-    async def stream_respond(messages: list, info: AgentInfo):
-        hits[name] = hits.get(name, 0) + 1
-        yield f"reply from {name}"
-
-    return FunctionModel(respond, stream_function=stream_respond, model_name=name)
-
-
-class _ScriptedLeaf(Model):
-    """A minimal leaf Model with a scripted response sequence.
-
-    Mirrors real provider leaves: ``request`` calls ``self.prepare_request``
-    internally before serving, and records what it received so parity
-    assertions can compare the eager and capability-owned delivery paths.
-    """
-
-    def __init__(self, name: str, script):
-        super().__init__()
-        self._name = name
-        self.script = list(script)
-        self.calls = 0
-        self.customize_calls = 0
-        self.received: list[tuple] = []
-
-    @property
-    def model_name(self) -> str:
-        return self._name
-
-    @property
-    def system(self) -> str:
-        return "test"
-
-    def customize_request_parameters(self, model_request_parameters):
-        # Deliberately observable (non-idempotent counter): parity between
-        # eager and owned paths must show the SAME application count at the
-        # moment the request is served.
-        self.customize_calls += 1
-        return model_request_parameters
-
-    async def request(self, messages, model_settings, model_request_parameters):
-        model_settings, model_request_parameters = self.prepare_request(
-            model_settings, model_request_parameters
-        )
-        self.calls += 1
-        self.received.append((model_settings, self.customize_calls))
-        return self.script.pop(0)()
-
-
-def _suspended(name: str) -> ModelResponse:
-    return ModelResponse(
-        parts=[TextPart(f"partial from {name}")],
-        state="suspended",
-        provider_response_id="job-1",
-    )
-
-
-def _complete(name: str) -> ModelResponse:
-    return ModelResponse(parts=[TextPart(f"final from {name}")])
-
-
-def _request_context(model, prompt: str = "hi") -> ModelRequestContext:
-    return ModelRequestContext(
-        model=model,
-        messages=[ModelRequest(parts=[UserPromptPart(content=prompt)])],
-        model_settings=None,
-        model_request_parameters=ModelRequestParameters(),
-    )
-
-
-async def _passthrough_handler(req_ctx: ModelRequestContext) -> ModelResponse:
-    return ModelResponse(parts=[TextPart("handled")])
-
-
-# ---------------------------------------------------------------------------
-# seam contract
-# ---------------------------------------------------------------------------
+from tests.agents.round_robin_capability_harness import (
+    make_leaf,
+    passthrough_handler,
+    request_context,
+)
 
 
 async def test_routes_requests_to_alternating_leaves():
     hits: dict[str, int] = {}
-    leaf_a, leaf_b = _make_leaf("a", hits), _make_leaf("b", hits)
+    leaf_a, leaf_b = make_leaf("a", hits), make_leaf("b", hits)
     rr = RoundRobinModel(leaf_a, leaf_b)
     capability = RoundRobinRequests(rr)
 
@@ -139,7 +41,7 @@ async def test_routes_requests_to_alternating_leaves():
     for _ in range(4):
         await capability.wrap_model_request(
             SimpleNamespace(),
-            request_context=_request_context(rr),
+            request_context=request_context(rr),
             handler=handler,
         )
 
@@ -147,9 +49,9 @@ async def test_routes_requests_to_alternating_leaves():
 
 
 async def test_original_context_is_not_mutated():
-    rr = RoundRobinModel(_make_leaf("a", {}), _make_leaf("b", {}))
+    rr = RoundRobinModel(make_leaf("a", {}), make_leaf("b", {}))
     capability = RoundRobinRequests(rr)
-    original = _request_context(rr)
+    original = request_context(rr)
     original_messages = original.messages
 
     received: list[ModelRequestContext] = []
@@ -172,10 +74,10 @@ async def test_guest_context_passes_through_untouched():
     """A context carrying any other model must pass through identically —
     that request's rotation (if any) belongs to the outer model's own
     ``request`` path."""
-    rr = RoundRobinModel(_make_leaf("a", {}), _make_leaf("b", {}))
+    rr = RoundRobinModel(make_leaf("a", {}), make_leaf("b", {}))
     capability = RoundRobinRequests(rr)
-    other = _make_leaf("other", {})
-    ctx = _request_context(other)
+    other = make_leaf("other", {})
+    ctx = request_context(other)
 
     received: list[ModelRequestContext] = []
 
@@ -201,10 +103,10 @@ async def test_prepare_request_merge_mirrors_eager_path():
         model_name="leaf",
         settings={"temperature": 0.5},
     )
-    rr = RoundRobinModel(leaf, _make_leaf("b", hits))
+    rr = RoundRobinModel(leaf, make_leaf("b", hits))
     capability = RoundRobinRequests(rr)
 
-    ctx = _request_context(rr)
+    ctx = request_context(rr)
     ctx.model_settings = {"max_tokens": 10}
     expected_settings, expected_params = leaf.prepare_request(
         ctx.model_settings, ctx.model_request_parameters
@@ -228,7 +130,7 @@ async def test_prepare_request_merge_mirrors_eager_path():
 
 async def test_span_attributes_recorded_for_routed_leaf_only():
     hits: dict[str, int] = {}
-    leaf_a, leaf_b = _make_leaf("a", hits), _make_leaf("b", hits)
+    leaf_a, leaf_b = make_leaf("a", hits), make_leaf("b", hits)
     rr = RoundRobinModel(leaf_a, leaf_b)
     capability = RoundRobinRequests(rr)
     recorded: list = []
@@ -240,14 +142,14 @@ async def test_span_attributes_recorded_for_routed_leaf_only():
     ):
         await capability.wrap_model_request(
             SimpleNamespace(),
-            request_context=_request_context(rr),
-            handler=_passthrough_handler,
+            request_context=request_context(rr),
+            handler=passthrough_handler,
         )
         # Guest pass-through must not record anything.
         await capability.wrap_model_request(
             SimpleNamespace(),
-            request_context=_request_context(_make_leaf("other", {})),
-            handler=_passthrough_handler,
+            request_context=request_context(make_leaf("other", {})),
+            handler=passthrough_handler,
         )
 
     assert recorded == [leaf_a]
@@ -257,7 +159,7 @@ async def test_handler_error_propagates_after_rotation_without_span_record():
     """Eager parity: rotation advances before the request; a failed request
     neither rolls the rotation back nor records span attributes."""
     hits: dict[str, int] = {}
-    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
+    rr = RoundRobinModel(make_leaf("a", hits), make_leaf("b", hits))
     capability = RoundRobinRequests(rr)
     recorded: list = []
 
@@ -272,7 +174,7 @@ async def test_handler_error_propagates_after_rotation_without_span_record():
         try:
             await capability.wrap_model_request(
                 SimpleNamespace(),
-                request_context=_request_context(rr),
+                request_context=request_context(rr),
                 handler=broken_handler,
             )
         except RuntimeError:
@@ -291,440 +193,7 @@ def test_not_spec_constructible():
 
 
 def test_build_round_robin_requests_conditional_splice():
-    rr = RoundRobinModel(_make_leaf("a", {}))
+    rr = RoundRobinModel(make_leaf("a", {}))
     caps = build_round_robin_requests(rr)
     assert len(caps) == 1 and caps[0].model is rr
-    assert build_round_robin_requests(_make_leaf("plain", {})) == []
-
-
-# ---------------------------------------------------------------------------
-# end-to-end through a real Agent
-# ---------------------------------------------------------------------------
-
-
-def _spy_eager_requests(rr: RoundRobinModel) -> list[str]:
-    """Instance-level spies counting eager RoundRobinModel request entries."""
-    calls: list[str] = []
-    original_request = rr.request
-    original_stream = rr.request_stream
-
-    async def spying_request(*args, **kwargs):
-        calls.append("request")
-        return await original_request(*args, **kwargs)
-
-    def spying_stream(*args, **kwargs):
-        calls.append("request_stream")
-        return original_stream(*args, **kwargs)
-
-    rr.request = spying_request  # type: ignore[method-assign]
-    rr.request_stream = spying_stream  # type: ignore[method-assign]
-    return calls
-
-
-async def test_agent_runs_distribute_across_leaves_capability_owned():
-    hits: dict[str, int] = {}
-    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
-    eager_calls = _spy_eager_requests(rr)
-    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
-
-    first = await agent.run("one")
-    second = await agent.run("two")
-
-    assert first.output == "reply from a"
-    assert second.output == "reply from b"
-    assert hits == {"a": 1, "b": 1}
-    assert eager_calls == []  # ownership: the Model methods never ran
-
-
-async def test_streamed_agent_run_routes_through_capability():
-    hits: dict[str, int] = {}
-    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
-    eager_calls = _spy_eager_requests(rr)
-    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
-
-    async def benign_handler(ctx, events):
-        async for _ in events:
-            pass
-
-    result = await agent.run("one", event_stream_handler=benign_handler)
-
-    assert result.output == "reply from a"
-    assert hits == {"a": 1}
-    assert eager_calls == []
-
-
-async def test_rotate_every_cadence_preserved():
-    hits: dict[str, int] = {}
-    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits), rotate_every=2)
-    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
-
-    outputs = [(await agent.run(str(i))).output for i in range(4)]
-
-    assert outputs == [
-        "reply from a",
-        "reply from a",
-        "reply from b",
-        "reply from b",
-    ]
-
-
-async def test_explicit_run_model_stays_authoritative():
-    """``run(model=...)`` replaces the round-robin model wholesale — the
-    capability passes through and the rotation is untouched, exactly as the
-    eager path behaved when the model kwarg was overridden."""
-    hits: dict[str, int] = {}
-    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
-    explicit = _make_leaf("explicit", hits)
-    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
-
-    result = await agent.run("one", model=explicit)
-
-    assert result.output == "reply from explicit"
-    assert hits == {"explicit": 1}
-    assert rr.next_model().model_name == "a"  # rotation never advanced
-
-
-async def test_wrapped_model_falls_back_to_eager_rotation():
-    """When something re-wraps the round-robin model (instrumentation), the
-    identity gate fails and the eager ``RoundRobinModel.request`` path still
-    rotates — every request advances the rotation exactly once."""
-    hits: dict[str, int] = {}
-    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
-    eager_calls = _spy_eager_requests(rr)
-    agent = Agent(
-        model=WrapperModel(rr),
-        output_type=str,
-        capabilities=[RoundRobinRequests(rr)],
-    )
-
-    first = await agent.run("one")
-    second = await agent.run("two")
-
-    assert first.output == "reply from a"
-    assert second.output == "reply from b"
-    assert hits == {"a": 1, "b": 1}
-    assert eager_calls == ["request", "request"]
-
-
-async def test_rotation_state_shared_between_eager_and_capability_paths():
-    hits: dict[str, int] = {}
-    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
-    # One eager guest request advances the shared rotation...
-    await rr.request(
-        [ModelRequest(parts=[UserPromptPart(content="direct")])],
-        None,
-        ModelRequestParameters(),
-    )
-    assert hits == {"a": 1}
-
-    # ...so the next capability-owned run picks up at leaf "b".
-    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
-    result = await agent.run("one")
-    assert result.output == "reply from b"
-
-
-async def test_continuation_segments_stay_pinned_to_opening_leaf():
-    """Documented divergence: a suspended → complete continuation chain is
-    served entirely by the leaf that opened it; rotation advances once per
-    wrapped request, not once per segment."""
-    leaf_a = _ScriptedLeaf("a", [lambda: _suspended("a"), lambda: _complete("a")])
-    leaf_b = _ScriptedLeaf("b", [lambda: _complete("b")])
-    rr = RoundRobinModel(leaf_a, leaf_b)
-    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
-
-    result = await agent.run("one")
-
-    assert result.output == "partial from afinal from a"  # one leaf, whole chain
-    assert (leaf_a.calls, leaf_b.calls) == (2, 0)
-    # Rotation advanced exactly once for the whole chain.
-    assert rr.next_model() is leaf_b
-
-
-async def test_eager_guest_path_still_rotates_across_continuation_segments():
-    """Guest custody pin: the intact Model class keeps the old per-segment
-    rotation (each segment enters RoundRobinModel.request), stitching the
-    merged response from two different leaves — the behaviour the owned path
-    deliberately diverges from."""
-    leaf_a = _ScriptedLeaf("a", [lambda: _suspended("a"), lambda: _complete("a")])
-    leaf_b = _ScriptedLeaf("b", [lambda: _complete("b")])
-    rr = RoundRobinModel(leaf_a, leaf_b)
-    agent = Agent(model=rr, output_type=str)  # no capability: eager custody
-
-    result = await agent.run("one")
-
-    assert result.output == "partial from afinal from b"
-    assert (leaf_a.calls, leaf_b.calls) == (1, 1)
-
-
-async def test_streamed_teardown_skips_span_record_on_owned_path():
-    """Documented divergence: the owned streamed fix-up records only after
-    the stream fully drains, so a consumer failure mid-stream records
-    nothing."""
-    hits: dict[str, int] = {}
-    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
-    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
-    recorded: list = []
-
-    async def failing_handler(ctx, events):
-        async for _ in events:
-            raise RuntimeError("consumer exploded")
-
-    with patch.object(
-        RoundRobinModel,
-        "record_span_attributes",
-        lambda self, model: recorded.append(model),
-    ):
-        with pytest.raises(Exception):
-            await agent.run("one", event_stream_handler=failing_handler)
-
-    assert recorded == []
-
-
-async def test_streamed_teardown_still_records_span_on_eager_guest_path():
-    """Contrast pin for the divergence above: eager custody records the leaf
-    at stream-open, so the same mid-consume failure still records it."""
-    hits: dict[str, int] = {}
-    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
-    agent = Agent(model=rr, output_type=str)  # no capability: eager custody
-    recorded: list = []
-
-    async def failing_handler(ctx, events):
-        async for _ in events:
-            raise RuntimeError("consumer exploded")
-
-    with patch.object(
-        RoundRobinModel,
-        "record_span_attributes",
-        lambda self, model: recorded.append(model),
-    ):
-        with pytest.raises(Exception):
-            await agent.run("one", event_stream_handler=failing_handler)
-
-    assert len(recorded) == 1
-    assert recorded[0].model_name == "a"
-
-
-async def test_prepare_request_application_count_matches_eager_path():
-    """Non-idempotence probe: at the moment the leaf serves the request, the
-    parameters must have passed ``customize_request_parameters`` the same
-    number of times on both delivery paths (explicit prepare + the leaf's
-    internal re-prepare)."""
-    eager_leaf = _ScriptedLeaf("eager", [lambda: _complete("eager")])
-    eager_rr = RoundRobinModel(eager_leaf)
-    await eager_rr.request(
-        [ModelRequest(parts=[UserPromptPart(content="direct")])],
-        None,
-        ModelRequestParameters(),
-    )
-
-    owned_leaf = _ScriptedLeaf("owned", [lambda: _complete("owned")])
-    owned_rr = RoundRobinModel(owned_leaf)
-    agent = Agent(
-        model=owned_rr,
-        output_type=str,
-        capabilities=[RoundRobinRequests(owned_rr)],
-    )
-    await agent.run("one")
-
-    assert len(eager_leaf.received) == len(owned_leaf.received) == 1
-    eager_settings, eager_customizations = eager_leaf.received[0]
-    owned_settings, owned_customizations = owned_leaf.received[0]
-    assert eager_customizations == owned_customizations == 2
-    assert eager_settings == owned_settings
-
-
-async def test_coexists_with_plugin_message_transform():
-    """Shares wrap_model_request with PluginMessageTransform: the transform's
-    plugin callbacks still see (and mutate) messages while routing holds."""
-    from code_puppy import callbacks
-    from code_puppy.agents._model_message_transform import (
-        build_model_message_transform,
-    )
-
-    hits: dict[str, int] = {}
-    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
-    seen: list[int] = []
-
-    def observe(_agent_name, messages):
-        seen.append(len(messages))
-
-    callbacks.register_callback("transform_model_messages", observe)
-    try:
-        agent = Agent(
-            model=rr,
-            output_type=str,
-            capabilities=[
-                RoundRobinRequests(rr),
-                build_model_message_transform("test-agent"),
-            ],
-        )
-        result = await agent.run("one")
-    finally:
-        callbacks.clear_callbacks("transform_model_messages")
-
-    assert result.output == "reply from a"
-    assert seen == [1]
-    assert hits == {"a": 1}
-
-
-# ---------------------------------------------------------------------------
-# wiring
-# ---------------------------------------------------------------------------
-
-
-def _find_round_robin_capabilities(built_agent) -> list[RoundRobinRequests]:
-    found: list[RoundRobinRequests] = []
-
-    def visitor(capability):
-        if isinstance(capability, RoundRobinRequests):
-            found.append(capability)
-
-    built_agent.root_capability.apply(visitor)
-    return found
-
-
-def _build_with_model(model):
-    from contextlib import contextmanager
-
-    from code_puppy.agents import _builder
-
-    class _FakeAgentConfig:
-        name = "round-robin-puppy"
-        display_name = "Round Robin Puppy"
-
-        def __init__(self):
-            self._message_history = []
-            self._compacted_message_hashes = set()
-            self._puppy_rules = None
-
-        @contextmanager
-        def temporary_model_name_override(self, _model_name):
-            yield
-
-        def get_model_name(self):
-            return "test-model"
-
-        def get_full_system_prompt(self):
-            return "You are a test agent."
-
-        def get_available_tools(self):
-            return []
-
-        def get_message_history(self):
-            return self._message_history
-
-        def set_message_history(self, history):
-            self._message_history = history
-
-        def __getattr__(self, item):
-            if item.startswith("__"):
-                raise AttributeError(item)
-            return lambda *a, **k: 0
-
-    with (
-        patch.object(
-            _builder,
-            "load_model_with_fallback",
-            lambda *a, **k: (model, "test-model"),
-        ),
-        patch.object(_builder.ModelFactory, "load_config", staticmethod(dict)),
-        patch.object(_builder, "load_mcp_servers", lambda **k: []),
-        patch.object(_builder, "make_model_settings", lambda *a, **k: None),
-        patch("code_puppy.tools.register_tools_for_agent", lambda *a, **k: None),
-    ):
-        return _builder.build_pydantic_agent(_FakeAgentConfig())
-
-
-def test_builder_attaches_capability_for_round_robin_model():
-    rr = RoundRobinModel(_make_leaf("a", {}), _make_leaf("b", {}))
-    built = _build_with_model(rr)
-    found = _find_round_robin_capabilities(built)
-    assert len(found) == 1
-    assert found[0].model is rr
-
-
-def test_builder_skips_capability_for_plain_model():
-    built = _build_with_model(_make_leaf("plain", {}))
-    assert _find_round_robin_capabilities(built) == []
-
-
-def test_subagent_construction_site_wires_round_robin():
-    """Source pin: the sub-agent Agent(...) construction splices the same
-    conditional builder, so a round-robin-pinned sub-agent is capability-owned
-    too."""
-    import inspect
-
-    from code_puppy.tools import subagent_invocation
-
-    source = inspect.getsource(subagent_invocation)
-    assert "build_round_robin_requests" in source
-    assert "*build_round_robin_requests(model)" in source
-
-
-class _SubagentConfig:
-    """Minimal agent-config shape for driving the real sub-agent invocation."""
-
-    name = "test-agent"
-
-    def __init__(self):
-        self._message_history = []
-        self._compacted_message_hashes = set()
-        self._puppy_rules = None
-
-    @contextmanager
-    def temporary_model_name_override(self, _model_name):
-        yield
-
-    def get_model_name(self):
-        return "test-model"
-
-    def get_full_system_prompt(self):
-        return "Test instructions"
-
-    def get_available_tools(self):
-        return []
-
-    def get_message_history(self):
-        return self._message_history
-
-    def set_message_history(self, history):
-        self._message_history = history
-
-    def __getattr__(self, item):
-        if item.startswith("__"):
-            raise AttributeError(item)
-        return lambda *_args, **_kwargs: 0
-
-
-async def test_subagent_invocation_routes_through_capability():
-    """End-to-end sub-agent custody: a round-robin-resolved sub-agent's
-    (streamed) request is served by the capability — the eager Model methods
-    never run."""
-    from code_puppy.tools import subagent_invocation
-
-    hits: dict[str, int] = {}
-    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
-    eager_calls = _spy_eager_requests(rr)
-
-    with (
-        patch(
-            "code_puppy.agents.agent_manager.load_agent",
-            return_value=_SubagentConfig(),
-        ),
-        patch(
-            "code_puppy.agents._builder.load_model_with_fallback",
-            lambda *a, **k: (rr, "test-model"),
-        ),
-        patch(
-            "code_puppy.model_factory.make_model_settings",
-            lambda *_args, **_kwargs: None,
-        ),
-        patch("code_puppy.config.get_value", return_value="true"),
-    ):
-        result = await subagent_invocation._invoke_agent_impl(
-            context=SimpleNamespace(), agent_name="test-agent", prompt="start"
-        )
-
-    assert result.error is None
-    assert hits == {"a": 1}
-    assert eager_calls == []
+    assert build_round_robin_requests(make_leaf("plain", {})) == []

--- a/tests/agents/test_round_robin_capability.py
+++ b/tests/agents/test_round_robin_capability.py
@@ -1,0 +1,497 @@
+"""Contract tests for the ``RoundRobinRequests`` capability.
+
+Pins the promotion of ``RoundRobinModel``'s per-request rotation onto
+pydantic-ai's ``wrap_model_request`` seam:
+
+* seam contract — routing, copy isolation, guest pass-through, eager
+  ``prepare_request`` merge parity, span-attr fix-up, error custody;
+* end-to-end — real ``Agent`` runs (streamed + non-streamed) served by the
+  capability with ``RoundRobinModel.request`` never invoked, rotate_every
+  cadence, explicit-model override, wrapped-model eager fallback, shared
+  rotation state, coexistence with ``PluginMessageTransform``;
+* wiring — builder conditional splice (both polarities) and the sub-agent
+  construction site source pin.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from pydantic_ai import Agent
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    UserPromptPart,
+)
+from pydantic_ai.models import ModelRequestContext, ModelRequestParameters
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.wrapper import WrapperModel
+
+from code_puppy.agents._round_robin import (
+    RoundRobinRequests,
+    build_round_robin_requests,
+)
+from code_puppy.round_robin_model import RoundRobinModel
+
+# ---------------------------------------------------------------------------
+# harness
+# ---------------------------------------------------------------------------
+
+
+def _make_leaf(name: str, hits: dict[str, int]) -> FunctionModel:
+    """A FunctionModel leaf that records how often it served a request."""
+
+    def respond(messages: list, info: AgentInfo) -> ModelResponse:
+        hits[name] = hits.get(name, 0) + 1
+        return ModelResponse(parts=[TextPart(f"reply from {name}")])
+
+    async def stream_respond(messages: list, info: AgentInfo):
+        hits[name] = hits.get(name, 0) + 1
+        yield f"reply from {name}"
+
+    return FunctionModel(respond, stream_function=stream_respond, model_name=name)
+
+
+def _request_context(model, prompt: str = "hi") -> ModelRequestContext:
+    return ModelRequestContext(
+        model=model,
+        messages=[ModelRequest(parts=[UserPromptPart(content=prompt)])],
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(),
+    )
+
+
+async def _passthrough_handler(req_ctx: ModelRequestContext) -> ModelResponse:
+    return ModelResponse(parts=[TextPart("handled")])
+
+
+# ---------------------------------------------------------------------------
+# seam contract
+# ---------------------------------------------------------------------------
+
+
+async def test_routes_requests_to_alternating_leaves():
+    hits: dict[str, int] = {}
+    leaf_a, leaf_b = _make_leaf("a", hits), _make_leaf("b", hits)
+    rr = RoundRobinModel(leaf_a, leaf_b)
+    capability = RoundRobinRequests(rr)
+
+    routed: list = []
+
+    async def handler(req_ctx: ModelRequestContext) -> ModelResponse:
+        routed.append(req_ctx.model)
+        return ModelResponse(parts=[TextPart("ok")])
+
+    for _ in range(4):
+        await capability.wrap_model_request(
+            SimpleNamespace(),
+            request_context=_request_context(rr),
+            handler=handler,
+        )
+
+    assert routed == [leaf_a, leaf_b, leaf_a, leaf_b]
+
+
+async def test_original_context_is_not_mutated():
+    rr = RoundRobinModel(_make_leaf("a", {}), _make_leaf("b", {}))
+    capability = RoundRobinRequests(rr)
+    original = _request_context(rr)
+    original_messages = original.messages
+
+    received: list[ModelRequestContext] = []
+
+    async def handler(req_ctx: ModelRequestContext) -> ModelResponse:
+        received.append(req_ctx)
+        return ModelResponse(parts=[TextPart("ok")])
+
+    await capability.wrap_model_request(
+        SimpleNamespace(), request_context=original, handler=handler
+    )
+
+    assert original.model is rr
+    assert original.messages is original_messages
+    assert received[0] is not original
+    assert received[0].messages is original_messages  # shallow copy, #830 shape
+
+
+async def test_guest_context_passes_through_untouched():
+    """A context carrying any other model must pass through identically —
+    that request's rotation (if any) belongs to the outer model's own
+    ``request`` path."""
+    rr = RoundRobinModel(_make_leaf("a", {}), _make_leaf("b", {}))
+    capability = RoundRobinRequests(rr)
+    other = _make_leaf("other", {})
+    ctx = _request_context(other)
+
+    received: list[ModelRequestContext] = []
+
+    async def handler(req_ctx: ModelRequestContext) -> ModelResponse:
+        received.append(req_ctx)
+        return ModelResponse(parts=[TextPart("ok")])
+
+    await capability.wrap_model_request(
+        SimpleNamespace(), request_context=ctx, handler=handler
+    )
+
+    assert received[0] is ctx  # identical object — no copy, no swap
+    # Rotation untouched: the next owned request still starts at leaf "a".
+    assert rr.next_model().model_name == "a"
+
+
+async def test_prepare_request_merge_mirrors_eager_path():
+    """The routed context must carry exactly what ``RoundRobinModel.request``
+    would have handed the leaf: ``leaf.prepare_request(settings, params)``."""
+    hits: dict[str, int] = {}
+    leaf = FunctionModel(
+        lambda m, i: ModelResponse(parts=[TextPart("ok")]),
+        model_name="leaf",
+        settings={"temperature": 0.5},
+    )
+    rr = RoundRobinModel(leaf, _make_leaf("b", hits))
+    capability = RoundRobinRequests(rr)
+
+    ctx = _request_context(rr)
+    ctx.model_settings = {"max_tokens": 10}
+    expected_settings, expected_params = leaf.prepare_request(
+        ctx.model_settings, ctx.model_request_parameters
+    )
+
+    received: list[ModelRequestContext] = []
+
+    async def handler(req_ctx: ModelRequestContext) -> ModelResponse:
+        received.append(req_ctx)
+        return ModelResponse(parts=[TextPart("ok")])
+
+    await capability.wrap_model_request(
+        SimpleNamespace(), request_context=ctx, handler=handler
+    )
+
+    assert received[0].model_settings == expected_settings
+    assert received[0].model_settings["temperature"] == 0.5
+    assert received[0].model_settings["max_tokens"] == 10
+    assert received[0].model_request_parameters == expected_params
+
+
+async def test_span_attributes_recorded_for_routed_leaf_only():
+    hits: dict[str, int] = {}
+    leaf_a, leaf_b = _make_leaf("a", hits), _make_leaf("b", hits)
+    rr = RoundRobinModel(leaf_a, leaf_b)
+    capability = RoundRobinRequests(rr)
+    recorded: list = []
+
+    with patch.object(
+        RoundRobinModel,
+        "record_span_attributes",
+        lambda self, model: recorded.append(model),
+    ):
+        await capability.wrap_model_request(
+            SimpleNamespace(),
+            request_context=_request_context(rr),
+            handler=_passthrough_handler,
+        )
+        # Guest pass-through must not record anything.
+        await capability.wrap_model_request(
+            SimpleNamespace(),
+            request_context=_request_context(_make_leaf("other", {})),
+            handler=_passthrough_handler,
+        )
+
+    assert recorded == [leaf_a]
+
+
+async def test_handler_error_propagates_after_rotation_without_span_record():
+    """Eager parity: rotation advances before the request; a failed request
+    neither rolls the rotation back nor records span attributes."""
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
+    capability = RoundRobinRequests(rr)
+    recorded: list = []
+
+    async def broken_handler(req_ctx: ModelRequestContext) -> ModelResponse:
+        raise RuntimeError("provider exploded")
+
+    with patch.object(
+        RoundRobinModel,
+        "record_span_attributes",
+        lambda self, model: recorded.append(model),
+    ):
+        try:
+            await capability.wrap_model_request(
+                SimpleNamespace(),
+                request_context=_request_context(rr),
+                handler=broken_handler,
+            )
+        except RuntimeError:
+            pass
+        else:  # pragma: no cover - defensive
+            raise AssertionError("handler error must propagate")
+
+    assert recorded == []
+    # Rotation already advanced past leaf "a" — next owned request gets "b".
+    assert rr.next_model().model_name == "b"
+
+
+def test_not_spec_constructible():
+    # Live Model reference (provider HTTP clients) — #833 precedent.
+    assert RoundRobinRequests.get_serialization_name() is None
+
+
+def test_build_round_robin_requests_conditional_splice():
+    rr = RoundRobinModel(_make_leaf("a", {}))
+    caps = build_round_robin_requests(rr)
+    assert len(caps) == 1 and caps[0].model is rr
+    assert build_round_robin_requests(_make_leaf("plain", {})) == []
+
+
+# ---------------------------------------------------------------------------
+# end-to-end through a real Agent
+# ---------------------------------------------------------------------------
+
+
+def _spy_eager_requests(rr: RoundRobinModel) -> list[str]:
+    """Instance-level spies counting eager RoundRobinModel request entries."""
+    calls: list[str] = []
+    original_request = rr.request
+    original_stream = rr.request_stream
+
+    async def spying_request(*args, **kwargs):
+        calls.append("request")
+        return await original_request(*args, **kwargs)
+
+    def spying_stream(*args, **kwargs):
+        calls.append("request_stream")
+        return original_stream(*args, **kwargs)
+
+    rr.request = spying_request  # type: ignore[method-assign]
+    rr.request_stream = spying_stream  # type: ignore[method-assign]
+    return calls
+
+
+async def test_agent_runs_distribute_across_leaves_capability_owned():
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
+    eager_calls = _spy_eager_requests(rr)
+    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
+
+    first = await agent.run("one")
+    second = await agent.run("two")
+
+    assert first.output == "reply from a"
+    assert second.output == "reply from b"
+    assert hits == {"a": 1, "b": 1}
+    assert eager_calls == []  # ownership: the Model methods never ran
+
+
+async def test_streamed_agent_run_routes_through_capability():
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
+    eager_calls = _spy_eager_requests(rr)
+    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
+
+    async def benign_handler(ctx, events):
+        async for _ in events:
+            pass
+
+    result = await agent.run("one", event_stream_handler=benign_handler)
+
+    assert result.output == "reply from a"
+    assert hits == {"a": 1}
+    assert eager_calls == []
+
+
+async def test_rotate_every_cadence_preserved():
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits), rotate_every=2)
+    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
+
+    outputs = [(await agent.run(str(i))).output for i in range(4)]
+
+    assert outputs == [
+        "reply from a",
+        "reply from a",
+        "reply from b",
+        "reply from b",
+    ]
+
+
+async def test_explicit_run_model_stays_authoritative():
+    """``run(model=...)`` replaces the round-robin model wholesale — the
+    capability passes through and the rotation is untouched, exactly as the
+    eager path behaved when the model kwarg was overridden."""
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
+    explicit = _make_leaf("explicit", hits)
+    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
+
+    result = await agent.run("one", model=explicit)
+
+    assert result.output == "reply from explicit"
+    assert hits == {"explicit": 1}
+    assert rr.next_model().model_name == "a"  # rotation never advanced
+
+
+async def test_wrapped_model_falls_back_to_eager_rotation():
+    """When something re-wraps the round-robin model (instrumentation), the
+    identity gate fails and the eager ``RoundRobinModel.request`` path still
+    rotates — every request advances the rotation exactly once."""
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
+    eager_calls = _spy_eager_requests(rr)
+    agent = Agent(
+        model=WrapperModel(rr),
+        output_type=str,
+        capabilities=[RoundRobinRequests(rr)],
+    )
+
+    first = await agent.run("one")
+    second = await agent.run("two")
+
+    assert first.output == "reply from a"
+    assert second.output == "reply from b"
+    assert hits == {"a": 1, "b": 1}
+    assert eager_calls == ["request", "request"]
+
+
+async def test_rotation_state_shared_between_eager_and_capability_paths():
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
+    # One eager guest request advances the shared rotation...
+    await rr.request(
+        [ModelRequest(parts=[UserPromptPart(content="direct")])],
+        None,
+        ModelRequestParameters(),
+    )
+    assert hits == {"a": 1}
+
+    # ...so the next capability-owned run picks up at leaf "b".
+    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
+    result = await agent.run("one")
+    assert result.output == "reply from b"
+
+
+async def test_coexists_with_plugin_message_transform():
+    """Shares wrap_model_request with PluginMessageTransform: the transform's
+    plugin callbacks still see (and mutate) messages while routing holds."""
+    from code_puppy import callbacks
+    from code_puppy.agents._model_message_transform import (
+        build_model_message_transform,
+    )
+
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
+    seen: list[int] = []
+
+    def observe(_agent_name, messages):
+        seen.append(len(messages))
+
+    callbacks.register_callback("transform_model_messages", observe)
+    try:
+        agent = Agent(
+            model=rr,
+            output_type=str,
+            capabilities=[
+                RoundRobinRequests(rr),
+                build_model_message_transform("test-agent"),
+            ],
+        )
+        result = await agent.run("one")
+    finally:
+        callbacks.clear_callbacks("transform_model_messages")
+
+    assert result.output == "reply from a"
+    assert seen == [1]
+    assert hits == {"a": 1}
+
+
+# ---------------------------------------------------------------------------
+# wiring
+# ---------------------------------------------------------------------------
+
+
+def _find_round_robin_capabilities(built_agent) -> list[RoundRobinRequests]:
+    found: list[RoundRobinRequests] = []
+
+    def visitor(capability):
+        if isinstance(capability, RoundRobinRequests):
+            found.append(capability)
+
+    built_agent.root_capability.apply(visitor)
+    return found
+
+
+def _build_with_model(model):
+    from contextlib import contextmanager
+
+    from code_puppy.agents import _builder
+
+    class _FakeAgentConfig:
+        name = "round-robin-puppy"
+        display_name = "Round Robin Puppy"
+
+        def __init__(self):
+            self._message_history = []
+            self._compacted_message_hashes = set()
+            self._puppy_rules = None
+
+        @contextmanager
+        def temporary_model_name_override(self, _model_name):
+            yield
+
+        def get_model_name(self):
+            return "test-model"
+
+        def get_full_system_prompt(self):
+            return "You are a test agent."
+
+        def get_available_tools(self):
+            return []
+
+        def get_message_history(self):
+            return self._message_history
+
+        def set_message_history(self, history):
+            self._message_history = history
+
+        def __getattr__(self, item):
+            if item.startswith("__"):
+                raise AttributeError(item)
+            return lambda *a, **k: 0
+
+    with (
+        patch.object(
+            _builder,
+            "load_model_with_fallback",
+            lambda *a, **k: (model, "test-model"),
+        ),
+        patch.object(_builder.ModelFactory, "load_config", staticmethod(dict)),
+        patch.object(_builder, "load_mcp_servers", lambda **k: []),
+        patch.object(_builder, "make_model_settings", lambda *a, **k: None),
+        patch("code_puppy.tools.register_tools_for_agent", lambda *a, **k: None),
+    ):
+        return _builder.build_pydantic_agent(_FakeAgentConfig())
+
+
+def test_builder_attaches_capability_for_round_robin_model():
+    rr = RoundRobinModel(_make_leaf("a", {}), _make_leaf("b", {}))
+    built = _build_with_model(rr)
+    found = _find_round_robin_capabilities(built)
+    assert len(found) == 1
+    assert found[0].model is rr
+
+
+def test_builder_skips_capability_for_plain_model():
+    built = _build_with_model(_make_leaf("plain", {}))
+    assert _find_round_robin_capabilities(built) == []
+
+
+def test_subagent_construction_site_wires_round_robin():
+    """Source pin: the sub-agent Agent(...) construction splices the same
+    conditional builder, so a round-robin-pinned sub-agent is capability-owned
+    too."""
+    import inspect
+
+    from code_puppy.tools import subagent_invocation
+
+    source = inspect.getsource(subagent_invocation)
+    assert "build_round_robin_requests" in source
+    assert "*build_round_robin_requests(model)" in source

--- a/tests/agents/test_round_robin_capability.py
+++ b/tests/agents/test_round_robin_capability.py
@@ -13,9 +13,11 @@ pydantic-ai's ``wrap_model_request`` seam:
   construction site source pin.
 """
 
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 from pydantic_ai import Agent
 from pydantic_ai.messages import (
     ModelRequest,
@@ -23,7 +25,7 @@ from pydantic_ai.messages import (
     TextPart,
     UserPromptPart,
 )
-from pydantic_ai.models import ModelRequestContext, ModelRequestParameters
+from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameters
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.wrapper import WrapperModel
 
@@ -50,6 +52,58 @@ def _make_leaf(name: str, hits: dict[str, int]) -> FunctionModel:
         yield f"reply from {name}"
 
     return FunctionModel(respond, stream_function=stream_respond, model_name=name)
+
+
+class _ScriptedLeaf(Model):
+    """A minimal leaf Model with a scripted response sequence.
+
+    Mirrors real provider leaves: ``request`` calls ``self.prepare_request``
+    internally before serving, and records what it received so parity
+    assertions can compare the eager and capability-owned delivery paths.
+    """
+
+    def __init__(self, name: str, script):
+        super().__init__()
+        self._name = name
+        self.script = list(script)
+        self.calls = 0
+        self.customize_calls = 0
+        self.received: list[tuple] = []
+
+    @property
+    def model_name(self) -> str:
+        return self._name
+
+    @property
+    def system(self) -> str:
+        return "test"
+
+    def customize_request_parameters(self, model_request_parameters):
+        # Deliberately observable (non-idempotent counter): parity between
+        # eager and owned paths must show the SAME application count at the
+        # moment the request is served.
+        self.customize_calls += 1
+        return model_request_parameters
+
+    async def request(self, messages, model_settings, model_request_parameters):
+        model_settings, model_request_parameters = self.prepare_request(
+            model_settings, model_request_parameters
+        )
+        self.calls += 1
+        self.received.append((model_settings, self.customize_calls))
+        return self.script.pop(0)()
+
+
+def _suspended(name: str) -> ModelResponse:
+    return ModelResponse(
+        parts=[TextPart(f"partial from {name}")],
+        state="suspended",
+        provider_response_id="job-1",
+    )
+
+
+def _complete(name: str) -> ModelResponse:
+    return ModelResponse(parts=[TextPart(f"final from {name}")])
 
 
 def _request_context(model, prompt: str = "hi") -> ModelRequestContext:
@@ -369,6 +423,116 @@ async def test_rotation_state_shared_between_eager_and_capability_paths():
     assert result.output == "reply from b"
 
 
+async def test_continuation_segments_stay_pinned_to_opening_leaf():
+    """Documented divergence: a suspended → complete continuation chain is
+    served entirely by the leaf that opened it; rotation advances once per
+    wrapped request, not once per segment."""
+    leaf_a = _ScriptedLeaf("a", [lambda: _suspended("a"), lambda: _complete("a")])
+    leaf_b = _ScriptedLeaf("b", [lambda: _complete("b")])
+    rr = RoundRobinModel(leaf_a, leaf_b)
+    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
+
+    result = await agent.run("one")
+
+    assert result.output == "partial from afinal from a"  # one leaf, whole chain
+    assert (leaf_a.calls, leaf_b.calls) == (2, 0)
+    # Rotation advanced exactly once for the whole chain.
+    assert rr.next_model() is leaf_b
+
+
+async def test_eager_guest_path_still_rotates_across_continuation_segments():
+    """Guest custody pin: the intact Model class keeps the old per-segment
+    rotation (each segment enters RoundRobinModel.request), stitching the
+    merged response from two different leaves — the behaviour the owned path
+    deliberately diverges from."""
+    leaf_a = _ScriptedLeaf("a", [lambda: _suspended("a"), lambda: _complete("a")])
+    leaf_b = _ScriptedLeaf("b", [lambda: _complete("b")])
+    rr = RoundRobinModel(leaf_a, leaf_b)
+    agent = Agent(model=rr, output_type=str)  # no capability: eager custody
+
+    result = await agent.run("one")
+
+    assert result.output == "partial from afinal from b"
+    assert (leaf_a.calls, leaf_b.calls) == (1, 1)
+
+
+async def test_streamed_teardown_skips_span_record_on_owned_path():
+    """Documented divergence: the owned streamed fix-up records only after
+    the stream fully drains, so a consumer failure mid-stream records
+    nothing."""
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
+    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
+    recorded: list = []
+
+    async def failing_handler(ctx, events):
+        async for _ in events:
+            raise RuntimeError("consumer exploded")
+
+    with patch.object(
+        RoundRobinModel,
+        "record_span_attributes",
+        lambda self, model: recorded.append(model),
+    ):
+        with pytest.raises(Exception):
+            await agent.run("one", event_stream_handler=failing_handler)
+
+    assert recorded == []
+
+
+async def test_streamed_teardown_still_records_span_on_eager_guest_path():
+    """Contrast pin for the divergence above: eager custody records the leaf
+    at stream-open, so the same mid-consume failure still records it."""
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
+    agent = Agent(model=rr, output_type=str)  # no capability: eager custody
+    recorded: list = []
+
+    async def failing_handler(ctx, events):
+        async for _ in events:
+            raise RuntimeError("consumer exploded")
+
+    with patch.object(
+        RoundRobinModel,
+        "record_span_attributes",
+        lambda self, model: recorded.append(model),
+    ):
+        with pytest.raises(Exception):
+            await agent.run("one", event_stream_handler=failing_handler)
+
+    assert len(recorded) == 1
+    assert recorded[0].model_name == "a"
+
+
+async def test_prepare_request_application_count_matches_eager_path():
+    """Non-idempotence probe: at the moment the leaf serves the request, the
+    parameters must have passed ``customize_request_parameters`` the same
+    number of times on both delivery paths (explicit prepare + the leaf's
+    internal re-prepare)."""
+    eager_leaf = _ScriptedLeaf("eager", [lambda: _complete("eager")])
+    eager_rr = RoundRobinModel(eager_leaf)
+    await eager_rr.request(
+        [ModelRequest(parts=[UserPromptPart(content="direct")])],
+        None,
+        ModelRequestParameters(),
+    )
+
+    owned_leaf = _ScriptedLeaf("owned", [lambda: _complete("owned")])
+    owned_rr = RoundRobinModel(owned_leaf)
+    agent = Agent(
+        model=owned_rr,
+        output_type=str,
+        capabilities=[RoundRobinRequests(owned_rr)],
+    )
+    await agent.run("one")
+
+    assert len(eager_leaf.received) == len(owned_leaf.received) == 1
+    eager_settings, eager_customizations = eager_leaf.received[0]
+    owned_settings, owned_customizations = owned_leaf.received[0]
+    assert eager_customizations == owned_customizations == 2
+    assert eager_settings == owned_settings
+
+
 async def test_coexists_with_plugin_message_transform():
     """Shares wrap_model_request with PluginMessageTransform: the transform's
     plugin callbacks still see (and mutate) messages while routing holds."""
@@ -495,3 +659,72 @@ def test_subagent_construction_site_wires_round_robin():
     source = inspect.getsource(subagent_invocation)
     assert "build_round_robin_requests" in source
     assert "*build_round_robin_requests(model)" in source
+
+
+class _SubagentConfig:
+    """Minimal agent-config shape for driving the real sub-agent invocation."""
+
+    name = "test-agent"
+
+    def __init__(self):
+        self._message_history = []
+        self._compacted_message_hashes = set()
+        self._puppy_rules = None
+
+    @contextmanager
+    def temporary_model_name_override(self, _model_name):
+        yield
+
+    def get_model_name(self):
+        return "test-model"
+
+    def get_full_system_prompt(self):
+        return "Test instructions"
+
+    def get_available_tools(self):
+        return []
+
+    def get_message_history(self):
+        return self._message_history
+
+    def set_message_history(self, history):
+        self._message_history = history
+
+    def __getattr__(self, item):
+        if item.startswith("__"):
+            raise AttributeError(item)
+        return lambda *_args, **_kwargs: 0
+
+
+async def test_subagent_invocation_routes_through_capability():
+    """End-to-end sub-agent custody: a round-robin-resolved sub-agent's
+    (streamed) request is served by the capability — the eager Model methods
+    never run."""
+    from code_puppy.tools import subagent_invocation
+
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(_make_leaf("a", hits), _make_leaf("b", hits))
+    eager_calls = _spy_eager_requests(rr)
+
+    with (
+        patch(
+            "code_puppy.agents.agent_manager.load_agent",
+            return_value=_SubagentConfig(),
+        ),
+        patch(
+            "code_puppy.agents._builder.load_model_with_fallback",
+            lambda *a, **k: (rr, "test-model"),
+        ),
+        patch(
+            "code_puppy.model_factory.make_model_settings",
+            lambda *_args, **_kwargs: None,
+        ),
+        patch("code_puppy.config.get_value", return_value="true"),
+    ):
+        result = await subagent_invocation._invoke_agent_impl(
+            context=SimpleNamespace(), agent_name="test-agent", prompt="start"
+        )
+
+    assert result.error is None
+    assert hits == {"a": 1}
+    assert eager_calls == []

--- a/tests/agents/test_round_robin_capability_runs.py
+++ b/tests/agents/test_round_robin_capability_runs.py
@@ -1,0 +1,456 @@
+"""End-to-end and wiring tests for the ``RoundRobinRequests`` capability.
+
+Real ``Agent`` runs (streamed + non-streamed) proving capability custody,
+rotation cadence, guest fallbacks, the documented continuation/teardown
+divergences (pinned in both custodies), instrumentation gate behaviour, and
+the builder / sub-agent construction-site wiring. The direct seam contract
+lives in ``test_round_robin_capability.py``.
+"""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelRequest, UserPromptPart
+from pydantic_ai.models import ModelRequestParameters
+from pydantic_ai.models.wrapper import WrapperModel
+
+from code_puppy.agents._round_robin import RoundRobinRequests
+from code_puppy.round_robin_model import RoundRobinModel
+from tests.agents.round_robin_capability_harness import (
+    ScriptedLeaf,
+    complete_response,
+    make_leaf,
+    spy_eager_requests,
+    suspended_response,
+)
+
+
+async def test_agent_runs_distribute_across_leaves_capability_owned():
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(make_leaf("a", hits), make_leaf("b", hits))
+    eager_calls = spy_eager_requests(rr)
+    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
+
+    first = await agent.run("one")
+    second = await agent.run("two")
+
+    assert first.output == "reply from a"
+    assert second.output == "reply from b"
+    assert hits == {"a": 1, "b": 1}
+    assert eager_calls == []  # ownership: the Model methods never ran
+
+
+async def test_streamed_agent_run_routes_through_capability():
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(make_leaf("a", hits), make_leaf("b", hits))
+    eager_calls = spy_eager_requests(rr)
+    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
+
+    async def benign_handler(ctx, events):
+        async for _ in events:
+            pass
+
+    result = await agent.run("one", event_stream_handler=benign_handler)
+
+    assert result.output == "reply from a"
+    assert hits == {"a": 1}
+    assert eager_calls == []
+
+
+async def test_rotate_every_cadence_preserved():
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(make_leaf("a", hits), make_leaf("b", hits), rotate_every=2)
+    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
+
+    outputs = [(await agent.run(str(i))).output for i in range(4)]
+
+    assert outputs == [
+        "reply from a",
+        "reply from a",
+        "reply from b",
+        "reply from b",
+    ]
+
+
+async def test_explicit_run_model_stays_authoritative():
+    """``run(model=...)`` replaces the round-robin model wholesale — the
+    capability passes through and the rotation is untouched, exactly as the
+    eager path behaved when the model kwarg was overridden."""
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(make_leaf("a", hits), make_leaf("b", hits))
+    explicit = make_leaf("explicit", hits)
+    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
+
+    result = await agent.run("one", model=explicit)
+
+    assert result.output == "reply from explicit"
+    assert hits == {"explicit": 1}
+    assert rr.next_model().model_name == "a"  # rotation never advanced
+
+
+async def test_wrapped_model_falls_back_to_eager_rotation():
+    """When something re-wraps the round-robin model (instrumentation), the
+    identity gate fails and the eager ``RoundRobinModel.request`` path still
+    rotates — every request advances the rotation exactly once."""
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(make_leaf("a", hits), make_leaf("b", hits))
+    eager_calls = spy_eager_requests(rr)
+    agent = Agent(
+        model=WrapperModel(rr),
+        output_type=str,
+        capabilities=[RoundRobinRequests(rr)],
+    )
+
+    first = await agent.run("one")
+    second = await agent.run("two")
+
+    assert first.output == "reply from a"
+    assert second.output == "reply from b"
+    assert hits == {"a": 1, "b": 1}
+    assert eager_calls == ["request", "request"]
+
+
+async def test_rotation_state_shared_between_eager_and_capability_paths():
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(make_leaf("a", hits), make_leaf("b", hits))
+    # One eager guest request advances the shared rotation...
+    await rr.request(
+        [ModelRequest(parts=[UserPromptPart(content="direct")])],
+        None,
+        ModelRequestParameters(),
+    )
+    assert hits == {"a": 1}
+
+    # ...so the next capability-owned run picks up at leaf "b".
+    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
+    result = await agent.run("one")
+    assert result.output == "reply from b"
+
+
+async def test_continuation_segments_stay_pinned_to_opening_leaf():
+    """Documented divergence: a suspended → complete continuation chain is
+    served entirely by the leaf that opened it; rotation advances once per
+    wrapped request, not once per segment."""
+    leaf_a = ScriptedLeaf(
+        "a", [lambda: suspended_response("a"), lambda: complete_response("a")]
+    )
+    leaf_b = ScriptedLeaf("b", [lambda: complete_response("b")])
+    rr = RoundRobinModel(leaf_a, leaf_b)
+    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
+
+    result = await agent.run("one")
+
+    assert result.output == "partial from afinal from a"  # one leaf, whole chain
+    assert (leaf_a.calls, leaf_b.calls) == (2, 0)
+    # Rotation advanced exactly once for the whole chain.
+    assert rr.next_model() is leaf_b
+
+
+async def test_eager_guest_path_still_rotates_across_continuation_segments():
+    """Guest custody pin: the intact Model class keeps the old per-segment
+    rotation (each segment enters RoundRobinModel.request), stitching the
+    merged response from two different leaves — the behaviour the owned path
+    deliberately diverges from."""
+    leaf_a = ScriptedLeaf(
+        "a", [lambda: suspended_response("a"), lambda: complete_response("a")]
+    )
+    leaf_b = ScriptedLeaf("b", [lambda: complete_response("b")])
+    rr = RoundRobinModel(leaf_a, leaf_b)
+    agent = Agent(model=rr, output_type=str)  # no capability: eager custody
+
+    result = await agent.run("one")
+
+    assert result.output == "partial from afinal from b"
+    assert (leaf_a.calls, leaf_b.calls) == (1, 1)
+
+
+async def test_streamed_teardown_skips_span_record_on_owned_path():
+    """Documented divergence: the owned streamed fix-up records only after
+    the stream fully drains, so a consumer failure mid-stream records
+    nothing."""
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(make_leaf("a", hits), make_leaf("b", hits))
+    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
+    recorded: list = []
+
+    async def failing_handler(ctx, events):
+        async for _ in events:
+            raise RuntimeError("consumer exploded")
+
+    with patch.object(
+        RoundRobinModel,
+        "record_span_attributes",
+        lambda self, model: recorded.append(model),
+    ):
+        with pytest.raises(Exception):
+            await agent.run("one", event_stream_handler=failing_handler)
+
+    assert recorded == []
+
+
+async def test_streamed_teardown_still_records_span_on_eager_guest_path():
+    """Contrast pin for the divergence above: eager custody records the leaf
+    at stream-open, so the same mid-consume failure still records it."""
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(make_leaf("a", hits), make_leaf("b", hits))
+    agent = Agent(model=rr, output_type=str)  # no capability: eager custody
+    recorded: list = []
+
+    async def failing_handler(ctx, events):
+        async for _ in events:
+            raise RuntimeError("consumer exploded")
+
+    with patch.object(
+        RoundRobinModel,
+        "record_span_attributes",
+        lambda self, model: recorded.append(model),
+    ):
+        with pytest.raises(Exception):
+            await agent.run("one", event_stream_handler=failing_handler)
+
+    assert len(recorded) == 1
+    assert recorded[0].model_name == "a"
+
+
+async def test_prepare_request_application_count_matches_eager_path():
+    """Non-idempotence probe: at the moment the leaf serves the request, the
+    parameters must have passed ``customize_request_parameters`` the same
+    number of times on both delivery paths (explicit prepare + the leaf's
+    internal re-prepare)."""
+    eager_leaf = ScriptedLeaf("eager", [lambda: complete_response("eager")])
+    eager_rr = RoundRobinModel(eager_leaf)
+    await eager_rr.request(
+        [ModelRequest(parts=[UserPromptPart(content="direct")])],
+        None,
+        ModelRequestParameters(),
+    )
+
+    owned_leaf = ScriptedLeaf("owned", [lambda: complete_response("owned")])
+    owned_rr = RoundRobinModel(owned_leaf)
+    agent = Agent(
+        model=owned_rr,
+        output_type=str,
+        capabilities=[RoundRobinRequests(owned_rr)],
+    )
+    await agent.run("one")
+
+    assert len(eager_leaf.received) == len(owned_leaf.received) == 1
+    eager_settings, eager_customizations = eager_leaf.received[0]
+    owned_settings, owned_customizations = owned_leaf.received[0]
+    assert eager_customizations == owned_customizations == 2
+    assert eager_settings == owned_settings
+
+
+async def test_instrumented_agent_still_takes_the_owned_path():
+    """Pins the corrected instrumentation claim: 2.31.0 instrumentation is
+    capability-based (no model wrapping), so instrumented requests still
+    carry the bare round-robin model and the identity gate HOLDS."""
+    from opentelemetry.sdk.trace import TracerProvider
+    from pydantic_ai.models.instrumented import InstrumentationSettings
+
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(make_leaf("a", hits), make_leaf("b", hits))
+    eager_calls = spy_eager_requests(rr)
+    agent = Agent(model=rr, output_type=str, capabilities=[RoundRobinRequests(rr)])
+    agent.instrument = InstrumentationSettings(tracer_provider=TracerProvider())
+
+    result = await agent.run("one")
+
+    assert result.output == "reply from a"
+    assert hits == {"a": 1}
+    assert eager_calls == []  # gate held: instrumentation did not re-wrap
+
+
+async def test_coexists_with_plugin_message_transform():
+    """Shares wrap_model_request with PluginMessageTransform: the transform's
+    plugin callbacks still see (and mutate) messages while routing holds."""
+    from code_puppy import callbacks
+    from code_puppy.agents._model_message_transform import (
+        build_model_message_transform,
+    )
+
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(make_leaf("a", hits), make_leaf("b", hits))
+    seen: list[int] = []
+
+    def observe(_agent_name, messages):
+        seen.append(len(messages))
+
+    callbacks.register_callback("transform_model_messages", observe)
+    try:
+        agent = Agent(
+            model=rr,
+            output_type=str,
+            capabilities=[
+                RoundRobinRequests(rr),
+                build_model_message_transform("test-agent"),
+            ],
+        )
+        result = await agent.run("one")
+    finally:
+        callbacks.clear_callbacks("transform_model_messages")
+
+    assert result.output == "reply from a"
+    assert seen == [1]
+    assert hits == {"a": 1}
+
+
+def _find_round_robin_capabilities(built_agent) -> list[RoundRobinRequests]:
+    found: list[RoundRobinRequests] = []
+
+    def visitor(capability):
+        if isinstance(capability, RoundRobinRequests):
+            found.append(capability)
+
+    built_agent.root_capability.apply(visitor)
+    return found
+
+
+def _build_with_model(model):
+    from contextlib import contextmanager
+
+    from code_puppy.agents import _builder
+
+    class _FakeAgentConfig:
+        name = "round-robin-puppy"
+        display_name = "Round Robin Puppy"
+
+        def __init__(self):
+            self._message_history = []
+            self._compacted_message_hashes = set()
+            self._puppy_rules = None
+
+        @contextmanager
+        def temporary_model_name_override(self, _model_name):
+            yield
+
+        def get_model_name(self):
+            return "test-model"
+
+        def get_full_system_prompt(self):
+            return "You are a test agent."
+
+        def get_available_tools(self):
+            return []
+
+        def get_message_history(self):
+            return self._message_history
+
+        def set_message_history(self, history):
+            self._message_history = history
+
+        def __getattr__(self, item):
+            if item.startswith("__"):
+                raise AttributeError(item)
+            return lambda *a, **k: 0
+
+    with (
+        patch.object(
+            _builder,
+            "load_model_with_fallback",
+            lambda *a, **k: (model, "test-model"),
+        ),
+        patch.object(_builder.ModelFactory, "load_config", staticmethod(dict)),
+        patch.object(_builder, "load_mcp_servers", lambda **k: []),
+        patch.object(_builder, "make_model_settings", lambda *a, **k: None),
+        patch("code_puppy.tools.register_tools_for_agent", lambda *a, **k: None),
+    ):
+        return _builder.build_pydantic_agent(_FakeAgentConfig())
+
+
+def test_builder_attaches_capability_for_round_robin_model():
+    rr = RoundRobinModel(make_leaf("a", {}), make_leaf("b", {}))
+    built = _build_with_model(rr)
+    found = _find_round_robin_capabilities(built)
+    assert len(found) == 1
+    assert found[0].model is rr
+
+
+def test_builder_skips_capability_for_plain_model():
+    built = _build_with_model(make_leaf("plain", {}))
+    assert _find_round_robin_capabilities(built) == []
+
+
+def test_subagent_construction_site_wires_round_robin():
+    """Source pin: the sub-agent Agent(...) construction splices the same
+    conditional builder, so a round-robin-pinned sub-agent is capability-owned
+    too."""
+    import inspect
+
+    from code_puppy.tools import subagent_invocation
+
+    source = inspect.getsource(subagent_invocation)
+    assert "build_round_robin_requests" in source
+    assert "*build_round_robin_requests(model)" in source
+
+
+class _SubagentConfig:
+    """Minimal agent-config shape for driving the real sub-agent invocation."""
+
+    name = "test-agent"
+
+    def __init__(self):
+        self._message_history = []
+        self._compacted_message_hashes = set()
+        self._puppy_rules = None
+
+    @contextmanager
+    def temporary_model_name_override(self, _model_name):
+        yield
+
+    def get_model_name(self):
+        return "test-model"
+
+    def get_full_system_prompt(self):
+        return "Test instructions"
+
+    def get_available_tools(self):
+        return []
+
+    def get_message_history(self):
+        return self._message_history
+
+    def set_message_history(self, history):
+        self._message_history = history
+
+    def __getattr__(self, item):
+        if item.startswith("__"):
+            raise AttributeError(item)
+        return lambda *_args, **_kwargs: 0
+
+
+async def test_subagent_invocation_routes_through_capability():
+    """End-to-end sub-agent custody: a round-robin-resolved sub-agent's
+    (streamed) request is served by the capability — the eager Model methods
+    never run."""
+    from code_puppy.tools import subagent_invocation
+
+    hits: dict[str, int] = {}
+    rr = RoundRobinModel(make_leaf("a", hits), make_leaf("b", hits))
+    eager_calls = spy_eager_requests(rr)
+
+    with (
+        patch(
+            "code_puppy.agents.agent_manager.load_agent",
+            return_value=_SubagentConfig(),
+        ),
+        patch(
+            "code_puppy.agents._builder.load_model_with_fallback",
+            lambda *a, **k: (rr, "test-model"),
+        ),
+        patch(
+            "code_puppy.model_factory.make_model_settings",
+            lambda *_args, **_kwargs: None,
+        ),
+        patch("code_puppy.config.get_value", return_value="true"),
+    ):
+        result = await subagent_invocation._invoke_agent_impl(
+            context=SimpleNamespace(), agent_name="test-agent", prompt="start"
+        )
+
+    assert result.error is None
+    assert hits == {"a": 1}
+    assert eager_calls == []


### PR DESCRIPTION
## What

Promotes **round-robin model rotation** — previously implemented entirely inside the `RoundRobinModel(Model)` subclass's `request`/`request_stream` methods — to a first-class pydantic-ai capability, **`RoundRobinRequests`**, on the `wrap_model_request` seam. Nineteenth in the capability series (#828–#836, #838–#842, #844, #845, #847, #848).

Second, disjoint claim of `wrap_model_request` (#830 `PluginMessageTransform` mutates only the context's *messages*; this router swaps only the context's *model* — nesting order is inert, documented at both wiring sites).

## Why this seam

Per-request model rotation is a request-routing decision wearing a `Model` costume. `wrap_model_request` hands every request (streamed and non-streamed — the seam spans both via the cooperative hand-off) a `ModelRequestContext` whose `model` field the terminal handler honours: `model_request(...)` / `model_request_stream(...)` issue against `req_ctx.model`, and upstream's own durable-execution capabilities swap `request_context.model` at exactly this seam (documented in `_agent_graph.py`).

## Custody split (explicit-when-ours, fallback-for-guests — #838/#841/#842 pattern)

- **Capability-owned:** identity gate `request_context.model is self.model`. Owned requests advance the shared rotation, mirror the eager leaf-side `prepare_request` merge byte-for-byte, route straight to the leaf, and run the same span-attribute fix-up. `RoundRobinModel.request` never executes (pinned by spy).
- **Guest:** explicit `run(model=...)`/`override(model=...)` models pass through untouched (parity: the eager kwarg was replaced wholesale too); an instrumentation-wrapped round-robin model (`InstrumentedModel`, `WrapperModel`) fails the gate and the **`Model` subclass — kept intact — rotates eagerly** exactly as before.
- **One rotation state** (`RoundRobinModel.next_model`, now public) is shared by both paths, so every request advances the rotation exactly once no matter which path serves it (pinned by the shared-state test).

## Bounded divergences (documented in the module docstring)

1. `_ensure_model_supports_streaming` now checks the routed **leaf** on owned streamed requests instead of the wrapper — strictly more precise; vacuous for real provider leaves.
2. **Continuation segments stay pinned to the leaf that opened the chain** (reviewer pass-1 blocking find, verified empirically). `model_request`/`model_request_stream` resolve suspended → complete continuations (Anthropic `pause_turn`, OpenAI background polls) by re-invoking `req_ctx.model` inside ONE wrapped request; eagerly the terminal model was the round-robin wrapper, so every segment rotated — stitching one merged response from **two different models** and re-polling a *different* provider for a suspended job id. Owned requests advance the rotation once and serve the whole chain from the selected leaf — a deliberate divergence, strictly saner than eager (which survives unchanged on the guest path). Pinned both ways by continuation tests.
3. The streamed span-attribute fix-up moves from stream-open to handler-return, which parks until the stream drains — a mid-stream cancel/teardown records nothing where eager custody had already recorded at open (reviewer pass-1 blocking find: originally understated as a pure timing shift; pass-2 blocking find killed the follow-up "instrumentation routes to the eager path anyway" materiality claim — **backwards** on 2.31.0, where instrumentation is capability-based, explicit `InstrumentedModel`s are unwrapped before the run, and the shipped `logfire.instrument_pydantic_ai()` therefore reaches the owned path). Honest scope: only the leaf-attribute refinement on a torn-down stream's chat span is lost; the span itself, its round-robin `gen_ai.request.model`, and completed streams are unaffected. Pinned by the teardown test pair plus a new test proving the identity gate HOLDS under real `InstrumentationSettings`.
4. `ModelRequestContext.model_id` is invalidated by the swap for durable-execution consumers — upstream-documented semantics of *any* model-swapping hook, including upstream's own.

## Wiring

- `_builder.py`: one instance hoisted across probe+final passes (probe never runs; rotation state lives on the model regardless), conditional splice `*build_round_robin_requests(model)` — the `build_tool_output_limits` shape, so non-round-robin agents carry no inert capability.
- `subagent_invocation.py`: same conditional splice — a round-robin-pinned sub-agent is capability-owned too (the eager path covered sub-agents, so scope parity requires both sites).
- `get_serialization_name() → None` (live `Model` with provider HTTP clients — #833 precedent).

## Tests

25 contract tests across `tests/agents/test_round_robin_capability.py` (seam contract) and `tests/agents/test_round_robin_capability_runs.py` (end-to-end + wiring), sharing `round_robin_capability_harness.py` — split to respect the 600-line cap (this feature had **zero** prior test coverage):

- Seam contract: alternating leaf routing, copy isolation (#830 shallow-copy shape), guest pass-through identity, `prepare_request` merge parity, span-attr fix-up custody, error propagation with rotation-already-advanced parity
- End-to-end real `Agent` runs: non-streamed + streamed capability ownership (eager methods spied silent), `rotate_every` cadence, explicit-model override, wrapped-model eager fallback, shared rotation state across paths, coexistence with `PluginMessageTransform`
- Wiring: builder attaches/skips (both polarities, capability found via the public `apply` visitor), sub-agent source pin, spec-constructibility opt-out

Post-review additions: continuation pinning (both custodies), streamed-teardown span custody (both custodies), non-idempotent `customize_request_parameters` application-count parity, and a real end-to-end sub-agent invocation drive (capability serves the streamed request; eager Model methods spied silent).

Full suite: **7622 passed, 0 failed** (28 skipped, 1 xpassed). `ruff check` + `ruff format` clean.

## Review

- Pass 1 (code-puppy-clone-1): **REQUEST_CHANGES** — 2 blocking (continuation-segment rotation parity; streamed span-custody loss on teardown), 2 non-blocking (non-idempotent prepare parity probe; sub-agent wiring as source-pin only), 1 nit (`typing.List`). Addressed in d481a0ed: divergences documented honestly + pinned by tests rather than papered over.
- Pass 2: **REQUEST_CHANGES** — 1 blocking (the pass-1 fix's "instrumentation forces eager custody" materiality bound was backwards under 2.31.0 capability-based instrumentation), 1 non-blocking (custody wording ambiguity). Addressed in 7045e172 with corrected docs + an instrumentation-gate test.
