### PR TITLE
feat(agents): promote sub-agent recursion guards to a SubagentRecursionGuard capability (wrap_tool_execute seam)

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -20,6 +20,7 @@ from pydantic_ai.capabilities import ProcessHistory
 
 from code_puppy.agents._compaction import make_history_processor
 from code_puppy.agents._model_message_transform import build_model_message_transform
+from code_puppy.agents._subagent_recursion import build_subagent_recursion_guard
 from code_puppy.agents._output_limits import (
     build_response_clamp,
     build_tool_output_limits,
@@ -530,8 +531,9 @@ def _build_gpt_5_6_invoke_agent_guard_text() -> str:
 
     Reading the limit at prompt-assembly time (rather than baking it into a
     module constant) guarantees the model-facing guidance and the runtime
-    enforcement in ``subagent_invocation._gpt_5_6_recursion_blocked`` can
-    never drift out of sync -- they both resolve to
+    enforcement (``subagent_invocation.recursion_guard_error``, applied by
+    the ``SubagentRecursionGuard`` capability and the in-tool guest
+    fallback) can never drift out of sync -- they all resolve to
     ``get_subagent_recursion_limit_gpt_5_6()``.
     """
     # Local import to avoid a top-level ``code_puppy.config`` cycle -- this
@@ -639,6 +641,9 @@ def build_pydantic_agent(
     history_processor = make_history_processor(agent)
     steer_processor = make_steer_history_processor(agent)
     logical_agent_name = getattr(agent, "name", None) or agent.__class__.__name__
+    # Read before ``_new_pydantic_agent`` runs: the closure's capability list
+    # conditions the recursion guard on the agent's declared tool surface.
+    agent_tools = agent.get_available_tools()
 
     def _new_pydantic_agent(toolsets: List[Any]) -> PydanticAgent:
         return PydanticAgent(
@@ -666,6 +671,11 @@ def build_pydantic_agent(
                 ProcessHistory(steer_processor),
                 build_response_clamp(),
                 build_model_message_transform(logical_agent_name),
+                # Sub-agent recursion guards on the wrap_tool_execute seam
+                # (denies invoke_agent calls past the depth caps before the
+                # tool body runs). Sole wrap_tool_execute implementer, so
+                # position is inert.
+                *build_subagent_recursion_guard(agent_tools),
             ],
             model_settings=model_settings,
         )
@@ -673,7 +683,6 @@ def build_pydantic_agent(
     # Pass 1: build with empty toolsets so we can see what pydantic-ai + our
     # tool registry actually produced, and filter MCP to avoid name clashes.
     probe_agent = _new_pydantic_agent(toolsets=[])
-    agent_tools = agent.get_available_tools()
     register_tools_for_agent(
         probe_agent,
         agent_tools,

--- a/code_puppy/agents/_subagent_recursion.py
+++ b/code_puppy/agents/_subagent_recursion.py
@@ -1,0 +1,114 @@
+"""Sub-agent recursion limits as a pydantic-ai capability.
+
+The recursion guards -- the general ``subagent_recursion_limit`` depth cap
+and the GPT-5.6 overlay cap -- historically lived at the top of
+``_invoke_agent_impl``, inside the tool body, invisible to the agent's
+declared wiring. ``wrap_tool_execute`` is pydantic-ai's seam for exactly
+that decision: it fires after plugin ``pre_tool_call`` dispatch and after
+argument validation, and returning without calling ``handler()`` replaces
+the tool result without ever running the tool.
+
+``SubagentRecursionGuard`` denies ``invoke_agent`` /
+``invoke_agent_with_model`` calls that would exceed the configured depth,
+producing the byte-identical denial the in-tool guard produced: same i18n
+error strings, same ``AgentInvokeOutput`` / ``AgentInvokeWithModelOutput``
+shape, same ``emit_error``. ``post_tool_call`` plugin callbacks still see
+the denial as the tool result (the seam sits inside the patched
+``ToolManager.execute_tool_call``), so observability is unchanged.
+
+Custody note (the RoundRobinRequests "guest" doctrine): the in-tool guard
+in ``_invoke_agent_impl`` stays intact as *guest* custody -- direct callers
+and foreign agents that registered the invoke tools without this capability
+keep the old protection. For agents built by code_puppy (both construction
+sites wire this capability) the seam denies first, making the in-tool
+re-check an unreachable no-op; both custodies share
+``recursion_guard_error`` / ``denied_invocation_output``, so their verdicts
+and denial bytes can never drift.
+
+Deliberate precedence pin: ``invoke_agent_with_model`` rejects an *empty*
+``model_name`` before the recursion guard runs (that check lives in the
+tool wrapper, above the impl guard). Blank-model calls therefore pass
+through this capability untouched so the tool's own error keeps winning.
+"""
+
+from __future__ import annotations
+
+from typing import Any, FrozenSet, List
+
+from pydantic_ai.capabilities import AbstractCapability
+
+# Tool names whose execution is gated by the recursion guards.
+GUARDED_TOOL_NAMES: FrozenSet[str] = frozenset(
+    {"invoke_agent", "invoke_agent_with_model"}
+)
+
+
+class SubagentRecursionGuard(AbstractCapability[Any]):
+    """Deny sub-agent invocations that would exceed the recursion limits.
+
+    Stateless: the guards read ambient ``subagent_context`` contextvars and
+    live config at call time, exactly as the in-tool custody does, so the
+    verdict is identical at either layer.
+    """
+
+    async def wrap_tool_execute(
+        self,
+        ctx: Any,
+        *,
+        call: Any,
+        tool_def: Any,
+        args: Any,
+        handler: Any,
+    ) -> Any:
+        if tool_def.name not in GUARDED_TOOL_NAMES:
+            return await handler(args)
+        # Lazy import: this capability is wired from both construction sites
+        # (agents/_builder and tools/subagent_invocation); a top-level import
+        # of the tool module would be circular.
+        from code_puppy.tools.subagent_invocation import (
+            denied_invocation_output,
+            recursion_guard_error,
+        )
+
+        if not isinstance(args, dict):  # pragma: no cover - defensive
+            return await handler(args)
+        agent_name = args.get("agent_name")
+        if not isinstance(agent_name, str):
+            # Malformed args: let the tool's own validation/error path own it.
+            return await handler(args)
+
+        include_usage_metrics = tool_def.name == "invoke_agent_with_model"
+        model_name: str | None = None
+        if include_usage_metrics:
+            raw_model_name = args.get("model_name")
+            model_name = (
+                raw_model_name.strip() if isinstance(raw_model_name, str) else ""
+            )
+            if not model_name:
+                # Empty-model rejection precedes the recursion guard on main;
+                # fall through so the tool's own check answers first.
+                return await handler(args)
+
+        error = recursion_guard_error(agent_name)
+        if error is None:
+            return await handler(args)
+        return denied_invocation_output(
+            agent_name=agent_name,
+            model_name=model_name,
+            include_usage_metrics=include_usage_metrics,
+            error=error,
+        )
+
+
+def build_subagent_recursion_guard(
+    tool_names: Any,
+) -> List[SubagentRecursionGuard]:
+    """Conditional splice: guard only agents that expose the invoke tools.
+
+    Returned as a list so callers can splice it into ``capabilities=[...]``
+    unconditionally (same shape as ``build_tool_output_limits``); agents
+    without ``invoke_agent`` tools keep a byte-identical capability list.
+    """
+    if GUARDED_TOOL_NAMES & set(tool_names or ()):
+        return [SubagentRecursionGuard()]
+    return []

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -112,6 +112,55 @@ def _gpt_5_6_recursion_blocked() -> bool:
     return attempted_depth > get_subagent_recursion_limit_gpt_5_6()
 
 
+def recursion_guard_error(agent_name: str) -> str | None:
+    """Verdict of the recursion guards: the denial message, or None if allowed.
+
+    Single source of truth for both custodies -- the
+    ``SubagentRecursionGuard`` capability (``wrap_tool_execute`` seam, wired
+    at both pydantic-agent construction sites) and the in-tool guest
+    fallback in ``_invoke_agent_impl`` -- so the two verdicts can never
+    drift.
+    """
+    if _subagent_recursion_blocked():
+        return t(
+            "subagent.recursion_limit_reached",
+            limit=get_subagent_recursion_limit(),
+            agent=agent_name,
+        )
+    if _gpt_5_6_recursion_blocked():
+        return t(
+            "subagent.gpt_5_6_recursion_blocked",
+            agent=agent_name,
+            depth=get_subagent_depth() + 1,
+            limit=get_subagent_recursion_limit_gpt_5_6(),
+        )
+    return None
+
+
+def denied_invocation_output(
+    *,
+    agent_name: str,
+    model_name: str | None,
+    include_usage_metrics: bool,
+    error: str,
+) -> AgentInvokeOutput:
+    """Emit the denial and build the model-facing error output.
+
+    Shared by both recursion-guard custodies so the user-visible emit and
+    the model-visible output stay byte-identical regardless of which layer
+    denies. Mirrors the historical blocked path exactly: ``session_id`` is
+    deliberately left ``None`` even when the caller supplied one.
+    """
+    emit_error(error, message_group=generate_group_id("invoke_agent", agent_name))
+    return build_invoke_output(
+        include_usage_metrics=include_usage_metrics,
+        response=None,
+        agent_name=agent_name,
+        model_name=model_name,
+        error=error,
+    )
+
+
 def _subagent_identity_prompt(agent_name: str) -> str:
     """Build explicit nesting context for the child agent's system prompt."""
     depth = get_subagent_depth() + 1
@@ -198,29 +247,17 @@ async def _invoke_agent_impl(
     from code_puppy.agents.agent_manager import load_agent
 
     group_id = generate_group_id("invoke_agent", agent_name)
-    if _subagent_recursion_blocked():
-        error = t(
-            "subagent.recursion_limit_reached",
-            limit=get_subagent_recursion_limit(),
-            agent=agent_name,
-        )
-    elif _gpt_5_6_recursion_blocked():
-        error = t(
-            "subagent.gpt_5_6_recursion_blocked",
-            agent=agent_name,
-            depth=get_subagent_depth() + 1,
-            limit=get_subagent_recursion_limit_gpt_5_6(),
-        )
-    else:
-        error = None
-
+    # Guest custody of the recursion guards: agents built by code_puppy carry
+    # ``SubagentRecursionGuard`` (wrap_tool_execute), which denies before this
+    # body runs, making this re-check an unreachable no-op there. It stays for
+    # direct callers and foreign registrations of the invoke tools. The shared
+    # verdict/denial helpers keep both custodies byte-identical.
+    error = recursion_guard_error(agent_name)
     if error:
-        emit_error(error, message_group=group_id)
-        return build_invoke_output(
-            include_usage_metrics=include_usage_metrics,
-            response=None,
+        return denied_invocation_output(
             agent_name=agent_name,
             model_name=model_name,
+            include_usage_metrics=include_usage_metrics,
             error=error,
         )
 
@@ -401,12 +438,16 @@ async def _invoke_agent_impl(
                 mcp_servers = manager.get_servers_for_agent(agent_name=bound_agent_name)
 
             from code_puppy.agents._compaction import make_history_processor
+            from code_puppy.agents._subagent_recursion import (
+                build_subagent_recursion_guard,
+            )
             from code_puppy.agents._model_message_transform import (
                 build_model_message_transform,
             )
 
             # Build the pydantic-ai agent. MCP servers always included; plugins
             # (e.g. DBOS) may swap them via the agent_run_context hook.
+            agent_tools = agent_config.get_available_tools()
             temp_agent = Agent(
                 model=model,
                 # Explicit name: without it pydantic-ai infers one from the
@@ -423,6 +464,11 @@ async def _invoke_agent_impl(
                 capabilities=[
                     ProcessHistory(make_history_processor(agent_config)),
                     build_model_message_transform(agent_name),
+                    # Recursion guards ride the wrap_tool_execute seam so a
+                    # sub-agent's own invoke_agent calls are denied before
+                    # the tool body runs. Sole wrap_tool_execute implementer,
+                    # so position is inert.
+                    *build_subagent_recursion_guard(agent_tools),
                 ],
                 model_settings=model_settings,
             )
@@ -430,7 +476,6 @@ async def _invoke_agent_impl(
             # Register the tools that the agent needs
             from code_puppy.tools import register_tools_for_agent
 
-            agent_tools = agent_config.get_available_tools()
             register_tools_for_agent(
                 temp_agent, agent_tools, model_name=effective_model_name
             )

--- a/tests/agents/test_subagent_recursion_capability.py
+++ b/tests/agents/test_subagent_recursion_capability.py
@@ -1,0 +1,368 @@
+"""Contract tests for ``SubagentRecursionGuard`` (wrap_tool_execute seam).
+
+The sub-agent recursion guards (general ``subagent_recursion_limit`` depth
+cap + GPT-5.6 overlay) historically ran at the top of
+``_invoke_agent_impl``. They are now delivered as a pydantic-ai capability
+on the ``wrap_tool_execute`` seam, with the in-tool check retained as guest
+custody. These tests pin:
+
+- the seam denies before the tool body runs (impl never entered) with the
+  byte-identical denial output the in-tool guard produced;
+- the GPT-5.6 overlay and the general cap keep their verdict order;
+- ``invoke_agent_with_model`` empty-``model_name`` rejection keeps its
+  historical precedence over the recursion guard;
+- non-guarded tools and under-limit calls pass through untouched;
+- guest custody (agents without the capability) still denies, identically;
+- both construction sites wire the guard, conditionally on the agent's
+  declared tool surface.
+"""
+
+import asyncio
+from typing import Any, List
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.messages import (
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from code_puppy.agents._subagent_recursion import (
+    GUARDED_TOOL_NAMES,
+    SubagentRecursionGuard,
+    build_subagent_recursion_guard,
+)
+from code_puppy.i18n import t
+from code_puppy.tools import subagent_invocation as si
+from code_puppy.tools.agent_tools import (
+    AgentInvokeOutput,
+    AgentInvokeWithModelOutput,
+)
+from code_puppy.tools.subagent_usage_metrics import build_invoke_output
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+def _make_agent(tool_call: ToolCallPart, *, with_capability: bool) -> Agent:
+    """Agent that issues ``tool_call`` once, then finishes."""
+
+    def model_fn(messages: List[Any], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(parts=[tool_call])
+        return ModelResponse(parts=[TextPart("done")])
+
+    agent = Agent(
+        FunctionModel(model_fn),
+        retries=3,
+        capabilities=[SubagentRecursionGuard()] if with_capability else [],
+    )
+    si.register_invoke_agent(agent)
+    si.register_invoke_agent_with_model(agent)
+    return agent
+
+
+def _tool_return(result: Any, tool_name: str) -> Any:
+    """Extract the ToolReturnPart content the model saw for ``tool_name``."""
+    for message in result.all_messages():
+        for part in getattr(message, "parts", []):
+            if isinstance(part, ToolReturnPart) and part.tool_name == tool_name:
+                return part.content
+    raise AssertionError(f"no ToolReturnPart for {tool_name!r}")
+
+
+@pytest.fixture
+def impl_spy(monkeypatch):
+    """Replace ``_invoke_agent_impl`` with a recording stub."""
+    calls: List[dict] = []
+
+    async def _spy(**kwargs: Any) -> AgentInvokeOutput:
+        calls.append(kwargs)
+        return build_invoke_output(
+            include_usage_metrics=kwargs.get("include_usage_metrics", False),
+            response="spy-response",
+            agent_name=kwargs["agent_name"],
+            session_id="spy-session",
+            model_name=kwargs.get("model_name"),
+        )
+
+    monkeypatch.setattr(si, "_invoke_agent_impl", _spy)
+    return calls
+
+
+@pytest.fixture
+def emitted(monkeypatch):
+    """Capture ``emit_error`` calls from the subagent_invocation module."""
+    records: List[str] = []
+    monkeypatch.setattr(
+        si, "emit_error", lambda msg, **kwargs: records.append(str(msg))
+    )
+    return records
+
+
+def _block_general(monkeypatch) -> None:
+    """Depth 0 already meets a limit of 0: every invocation is denied."""
+    monkeypatch.setattr(si, "get_subagent_recursion_limit", lambda: 0)
+
+
+def _block_gpt_5_6(monkeypatch) -> None:
+    """GPT-5.6 caller, overlay cap 0; the general cap stays permissive."""
+    monkeypatch.setattr(si, "get_subagent_recursion_limit", lambda: 10)
+    monkeypatch.setattr(si, "get_subagent_model_name", lambda: "gpt-5.6-codex")
+    monkeypatch.setattr(si, "get_subagent_recursion_limit_gpt_5_6", lambda: 0)
+
+
+_INVOKE_CALL = ToolCallPart(
+    tool_name="invoke_agent",
+    args={"agent_name": "helper", "prompt": "p", "session_id": "keep-me"},
+)
+
+
+# ---------------------------------------------------------------------------
+# Seam denial
+# ---------------------------------------------------------------------------
+
+
+def test_seam_denies_general_depth_limit(monkeypatch, impl_spy, emitted):
+    _block_general(monkeypatch)
+    agent = _make_agent(_INVOKE_CALL, with_capability=True)
+
+    result = asyncio.run(agent.run("go"))
+
+    assert impl_spy == []  # tool body never entered
+    output = _tool_return(result, "invoke_agent")
+    expected_error = t("subagent.recursion_limit_reached", limit=0, agent="helper")
+    assert isinstance(output, AgentInvokeOutput)
+    assert not isinstance(output, AgentInvokeWithModelOutput)
+    assert output.error == expected_error
+    assert output.response is None
+    assert output.agent_name == "helper"
+    # Historical blocked path never echoed the caller's session_id.
+    assert output.session_id is None
+    assert output.model_name is None
+    assert emitted == [expected_error]
+
+
+def test_seam_denies_gpt_5_6_overlay(monkeypatch, impl_spy, emitted):
+    _block_gpt_5_6(monkeypatch)
+    agent = _make_agent(_INVOKE_CALL, with_capability=True)
+
+    result = asyncio.run(agent.run("go"))
+
+    assert impl_spy == []
+    output = _tool_return(result, "invoke_agent")
+    expected_error = t(
+        "subagent.gpt_5_6_recursion_blocked", agent="helper", depth=1, limit=0
+    )
+    assert output.error == expected_error
+    assert emitted == [expected_error]
+
+
+def test_general_cap_precedes_gpt_5_6_overlay(monkeypatch, impl_spy):
+    """Both caps tripped -> the general message wins (historical if/elif order)."""
+    _block_gpt_5_6(monkeypatch)
+    monkeypatch.setattr(si, "get_subagent_recursion_limit", lambda: 0)
+    agent = _make_agent(_INVOKE_CALL, with_capability=True)
+
+    result = asyncio.run(agent.run("go"))
+
+    output = _tool_return(result, "invoke_agent")
+    assert output.error == t(
+        "subagent.recursion_limit_reached", limit=0, agent="helper"
+    )
+
+
+def test_seam_passes_when_under_limit(monkeypatch, impl_spy, emitted):
+    monkeypatch.setattr(si, "get_subagent_recursion_limit", lambda: 10)
+    agent = _make_agent(_INVOKE_CALL, with_capability=True)
+
+    result = asyncio.run(agent.run("go"))
+
+    assert len(impl_spy) == 1
+    assert impl_spy[0]["agent_name"] == "helper"
+    assert impl_spy[0]["session_id"] == "keep-me"
+    output = _tool_return(result, "invoke_agent")
+    assert output.response == "spy-response"
+    assert emitted == []
+
+
+def test_non_gpt_caller_ignores_overlay(monkeypatch, impl_spy):
+    _block_gpt_5_6(monkeypatch)
+    monkeypatch.setattr(si, "get_subagent_model_name", lambda: "claude-sonnet")
+    agent = _make_agent(_INVOKE_CALL, with_capability=True)
+
+    asyncio.run(agent.run("go"))
+
+    assert len(impl_spy) == 1
+
+
+# ---------------------------------------------------------------------------
+# invoke_agent_with_model flavor
+# ---------------------------------------------------------------------------
+
+
+def test_with_model_flavor_denies_with_usage_shape(monkeypatch, impl_spy, emitted):
+    _block_general(monkeypatch)
+    call = ToolCallPart(
+        tool_name="invoke_agent_with_model",
+        args={"agent_name": "helper", "prompt": "p", "model_name": "  m1  "},
+    )
+    agent = _make_agent(call, with_capability=True)
+
+    result = asyncio.run(agent.run("go"))
+
+    assert impl_spy == []
+    output = _tool_return(result, "invoke_agent_with_model")
+    assert isinstance(output, AgentInvokeWithModelOutput)
+    assert output.error == t(
+        "subagent.recursion_limit_reached", limit=0, agent="helper"
+    )
+    # Normalized exactly as the tool wrapper normalizes before the impl guard.
+    assert output.model_name == "m1"
+    assert output.input_tokens is None
+    assert output.num_requests is None
+    assert output.duration_ms is None
+
+
+def test_empty_model_name_precedence_over_guard(monkeypatch, impl_spy, emitted):
+    """Blank model_name is rejected by the tool itself, ahead of the guard."""
+    _block_general(monkeypatch)
+    call = ToolCallPart(
+        tool_name="invoke_agent_with_model",
+        args={"agent_name": "helper", "prompt": "p", "model_name": "   "},
+    )
+    agent = _make_agent(call, with_capability=True)
+
+    result = asyncio.run(agent.run("go"))
+
+    assert impl_spy == []  # wrapper's empty-model check returns before impl
+    output = _tool_return(result, "invoke_agent_with_model")
+    assert output.error == "model_name cannot be empty"
+    assert emitted == ["model_name cannot be empty"]
+
+
+# ---------------------------------------------------------------------------
+# Pass-through and guest custody
+# ---------------------------------------------------------------------------
+
+
+def test_non_guarded_tools_pass_through(monkeypatch, impl_spy):
+    _block_general(monkeypatch)
+    call = ToolCallPart(tool_name="other_tool", args={"q": "hi"})
+    agent = _make_agent(call, with_capability=True)
+
+    async def other_tool(ctx, q: str) -> str:
+        return f"ran-{q}"
+
+    agent._function_toolset.add_function(other_tool, takes_ctx=True, name="other_tool")
+
+    result = asyncio.run(agent.run("go"))
+    assert _tool_return(result, "other_tool") == "ran-hi"
+
+
+def test_guest_custody_denies_identically(monkeypatch, emitted):
+    """Without the capability, the in-tool guard denies with identical bytes."""
+    _block_general(monkeypatch)
+
+    capability_agent = _make_agent(_INVOKE_CALL, with_capability=True)
+    guest_agent = _make_agent(_INVOKE_CALL, with_capability=False)
+
+    seam_output = _tool_return(asyncio.run(capability_agent.run("go")), "invoke_agent")
+    guest_output = _tool_return(asyncio.run(guest_agent.run("go")), "invoke_agent")
+
+    assert seam_output == guest_output
+    assert guest_output.error == t(
+        "subagent.recursion_limit_reached", limit=0, agent="helper"
+    )
+    # One denial emit per custody, same message both times.
+    assert emitted == [guest_output.error, guest_output.error]
+
+
+def test_seam_preempts_in_tool_guard(monkeypatch):
+    """With the capability, the real impl body is never entered when denied."""
+    _block_general(monkeypatch)
+    entered: List[str] = []
+    original_impl = si._invoke_agent_impl
+
+    async def _tracking_impl(**kwargs: Any):
+        entered.append(kwargs["agent_name"])
+        return await original_impl(**kwargs)
+
+    monkeypatch.setattr(si, "_invoke_agent_impl", _tracking_impl)
+    monkeypatch.setattr(si, "emit_error", lambda *a, **k: None)
+    agent = _make_agent(_INVOKE_CALL, with_capability=True)
+
+    asyncio.run(agent.run("go"))
+    assert entered == []
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+
+def test_conditional_splice_shapes():
+    assert build_subagent_recursion_guard(["invoke_agent"]) != []
+    assert build_subagent_recursion_guard(["invoke_agent_with_model", "x"]) != []
+    assert build_subagent_recursion_guard(["read_file"]) == []
+    assert build_subagent_recursion_guard([]) == []
+    assert build_subagent_recursion_guard(None) == []
+    guard = build_subagent_recursion_guard(list(GUARDED_TOOL_NAMES))
+    assert len(guard) == 1 and isinstance(guard[0], SubagentRecursionGuard)
+
+
+def test_capability_visible_in_agent_tree():
+    """The guard is discoverable via the public capability visitor."""
+    agent = Agent(
+        FunctionModel(lambda m, i: ModelResponse(parts=[TextPart("hi")])),
+        capabilities=[*build_subagent_recursion_guard(["invoke_agent"])],
+    )
+    seen: List[Any] = []
+
+    def _visit(cap):
+        if isinstance(cap, SubagentRecursionGuard):
+            seen.append(cap)
+        return cap
+
+    agent.root_capability.apply(_visit)
+    assert len(seen) == 1
+
+
+def test_builder_wires_guard_from_tool_surface():
+    """Source pin: the builder splices the guard from ``agent_tools``."""
+    import inspect
+
+    from code_puppy.agents import _builder
+
+    src = inspect.getsource(_builder.build_pydantic_agent)
+    assert "agent_tools = agent.get_available_tools()" in src
+    cap_block = src[src.find("capabilities=[") :]
+    assert "*build_subagent_recursion_guard(agent_tools)" in cap_block
+    # The tool surface must be read before the closure first runs (probe pass).
+    assert src.find("agent_tools = agent.get_available_tools()") < src.find(
+        "def _new_pydantic_agent"
+    )
+
+
+def test_subagent_site_wires_guard_from_tool_surface():
+    """Source pin: the temp-agent site splices the guard from ``agent_tools``."""
+    import inspect
+
+    src = inspect.getsource(si._invoke_agent_impl)
+    assert "agent_tools = agent_config.get_available_tools()" in src
+    cap_block = src[src.find("capabilities=[") :]
+    assert "*build_subagent_recursion_guard(agent_tools)" in cap_block
+    # Read before construction so the splice sees the declared tool surface.
+    assert src.find("agent_tools = agent_config.get_available_tools()") < src.find(
+        "temp_agent = Agent("
+    )
+
+
+def test_verdict_helper_allows_by_default(monkeypatch):
+    monkeypatch.setattr(si, "get_subagent_recursion_limit", lambda: 10)
+    monkeypatch.setattr(si, "get_subagent_model_name", lambda: None)
+    assert si.recursion_guard_error("helper") is None


### PR DESCRIPTION
## What

Promotes the **sub-agent recursion guards** — the general `subagent_recursion_limit` depth cap and the GPT-5.6 overlay cap — from ad-hoc checks at the top of `_invoke_agent_impl` to a first-class pydantic-ai capability, **`SubagentRecursionGuard`**, on the **`wrap_tool_execute`** seam. Twentieth in the capability series (#828–#836, #838–#842, #844, #845, #847–#849); **first claim of the tool-execute seam family**.

## Why this seam

The guards decide *whether a tool call executes at all* — that is `wrap_tool_execute`'s entire job description: it fires after plugin `pre_tool_call` dispatch and after argument validation, and returning without calling `handler()` replaces the tool result without ever running the tool body. The guards were invisible to nineteen rounds of seam-scouting because they hid *inside* a tool function rather than at a construction/call site.

Verified empirically before writing a line (script in the test file's spiritual lineage):

- Order under the process-global ToolManager patch is `pre_tool_call` (patch) → `wrap_tool_execute` (capability) → tool body — so plugin blocks/rewrites keep their historical precedence, and `post_tool_call` sees the denial as the tool result exactly as it saw the in-tool guard's return.
- A seam denial reaches the model as the same `ToolReturnPart` a tool-body return produces — byte-identical model-visible bytes.
- `args` at the seam is the validated-args dict; `agent_name` / `model_name` are read from it.

## Shape

- **`code_puppy/agents/_subagent_recursion.py`** — `SubagentRecursionGuard` (stateless: reads ambient `subagent_context` contextvars + live config at call time, exactly as the in-tool custody does, so the verdict is identical at either layer) and `build_subagent_recursion_guard(tool_names)`, a conditional splice in the `build_tool_output_limits` shape: agents that don't expose the invoke tools keep a byte-identical capability list.
- **Shared verdict/denial** — `recursion_guard_error` / `denied_invocation_output` in `subagent_invocation`: single source of truth for both custodies. Same i18n keys (`subagent.recursion_limit_reached`, `subagent.gpt_5_6_recursion_blocked`), same `AgentInvokeOutput`/`AgentInvokeWithModelOutput` denial shape (including the historical quirk that `session_id` is `None` on denials even when the caller supplied one — pinned, not "fixed"), same `emit_error`.
- **Both construction sites wire it** — `_builder.build_pydantic_agent` and the sub-agent temp-agent site (sub-agents' own `invoke_agent` calls are precisely where recursion happens). `agent_tools` is read before construction at both sites so the splice sees the declared tool surface.

## Custody (the #849 guest doctrine)

The in-tool guard **stays intact** as guest custody: direct `_invoke_agent_impl` callers and foreign agents that registered the invoke tools without this capability keep the old protection. On agents code_puppy builds, the seam denies first and the in-tool re-check is an unreachable no-op; the shared helpers mean the two custodies cannot drift. Pinned by a cross-custody byte-parity test.

## Deliberate precedence pin

`invoke_agent_with_model` rejects an *empty* `model_name` in the tool wrapper, **before** the impl guard ever ran. The capability preserves that ordering: blank-model calls pass through untouched so the tool's own `"model_name cannot be empty"` keeps winning even when the depth cap is also tripped. Pinned.

## Divergences (all unobservable or pinned)

- Denial `emit_error` uses a fresh message group id instead of the impl's outer one — both are single-use fresh UUIDs; no reader correlates them.
- On owned agents the denial now happens without entering the tool function frame; `pre`/`post_tool_call` plugin callbacks and the model-visible result are unchanged (verified).

## Coverage

The guards had **zero test coverage** on main. Now: 15 contract tests — seam denial for both caps and their verdict order, usage-shape denial with model-name normalization, empty-model precedence, non-guarded pass-through, under-limit pass-through, GPT-overlay non-GPT bypass, cross-custody byte parity, impl-never-entered preemption, conditional-splice shapes, public capability-tree visibility, and wiring pins for both construction sites.

Full suite: **7612 passed, 0 failed**. Ruff clean.

Per standing orders: **do not merge**.
