### PR TITLE
Port smooth streaming + TUI pickers onto termflow 0.2.1

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -20,6 +20,7 @@ from pydantic_ai.capabilities import ProcessHistory
 
 from code_puppy.agents._compaction import make_history_processor
 from code_puppy.agents._model_message_transform import build_model_message_transform
+from code_puppy.agents._subagent_recursion import build_subagent_recursion_guard
 from code_puppy.agents._output_limits import (
     build_response_clamp,
     build_tool_output_limits,
@@ -530,8 +531,9 @@ def _build_gpt_5_6_invoke_agent_guard_text() -> str:
 
     Reading the limit at prompt-assembly time (rather than baking it into a
     module constant) guarantees the model-facing guidance and the runtime
-    enforcement in ``subagent_invocation._gpt_5_6_recursion_blocked`` can
-    never drift out of sync -- they both resolve to
+    enforcement (``subagent_invocation.recursion_guard_error``, applied by
+    the ``SubagentRecursionGuard`` capability and the in-tool guest
+    fallback) can never drift out of sync -- they all resolve to
     ``get_subagent_recursion_limit_gpt_5_6()``.
     """
     # Local import to avoid a top-level ``code_puppy.config`` cycle -- this
@@ -639,6 +641,9 @@ def build_pydantic_agent(
     history_processor = make_history_processor(agent)
     steer_processor = make_steer_history_processor(agent)
     logical_agent_name = getattr(agent, "name", None) or agent.__class__.__name__
+    # Read before ``_new_pydantic_agent`` runs: the closure's capability list
+    # conditions the recursion guard on the agent's declared tool surface.
+    agent_tools = agent.get_available_tools()
 
     def _new_pydantic_agent(toolsets: List[Any]) -> PydanticAgent:
         return PydanticAgent(
@@ -666,6 +671,11 @@ def build_pydantic_agent(
                 ProcessHistory(steer_processor),
                 build_response_clamp(),
                 build_model_message_transform(logical_agent_name),
+                # Sub-agent recursion guards on the wrap_tool_execute seam
+                # (denies invoke_agent calls past the depth caps before the
+                # tool body runs). Sole wrap_tool_execute implementer, so
+                # position is inert.
+                *build_subagent_recursion_guard(agent_tools),
             ],
             model_settings=model_settings,
         )
@@ -673,7 +683,6 @@ def build_pydantic_agent(
     # Pass 1: build with empty toolsets so we can see what pydantic-ai + our
     # tool registry actually produced, and filter MCP to avoid name clashes.
     probe_agent = _new_pydantic_agent(toolsets=[])
-    agent_tools = agent.get_available_tools()
     register_tools_for_agent(
         probe_agent,
         agent_tools,

--- a/code_puppy/agents/_subagent_recursion.py
+++ b/code_puppy/agents/_subagent_recursion.py
@@ -1,0 +1,114 @@
+"""Sub-agent recursion limits as a pydantic-ai capability.
+
+The recursion guards -- the general ``subagent_recursion_limit`` depth cap
+and the GPT-5.6 overlay cap -- historically lived at the top of
+``_invoke_agent_impl``, inside the tool body, invisible to the agent's
+declared wiring. ``wrap_tool_execute`` is pydantic-ai's seam for exactly
+that decision: it fires after plugin ``pre_tool_call`` dispatch and after
+argument validation, and returning without calling ``handler()`` replaces
+the tool result without ever running the tool.
+
+``SubagentRecursionGuard`` denies ``invoke_agent`` /
+``invoke_agent_with_model`` calls that would exceed the configured depth,
+producing the byte-identical denial the in-tool guard produced: same i18n
+error strings, same ``AgentInvokeOutput`` / ``AgentInvokeWithModelOutput``
+shape, same ``emit_error``. ``post_tool_call`` plugin callbacks still see
+the denial as the tool result (the seam sits inside the patched
+``ToolManager.execute_tool_call``), so observability is unchanged.
+
+Custody note (the RoundRobinRequests "guest" doctrine): the in-tool guard
+in ``_invoke_agent_impl`` stays intact as *guest* custody -- direct callers
+and foreign agents that registered the invoke tools without this capability
+keep the old protection. For agents built by code_puppy (both construction
+sites wire this capability) the seam denies first, making the in-tool
+re-check an unreachable no-op; both custodies share
+``recursion_guard_error`` / ``denied_invocation_output``, so their verdicts
+and denial bytes can never drift.
+
+Deliberate precedence pin: ``invoke_agent_with_model`` rejects an *empty*
+``model_name`` before the recursion guard runs (that check lives in the
+tool wrapper, above the impl guard). Blank-model calls therefore pass
+through this capability untouched so the tool's own error keeps winning.
+"""
+
+from __future__ import annotations
+
+from typing import Any, FrozenSet, List
+
+from pydantic_ai.capabilities import AbstractCapability
+
+# Tool names whose execution is gated by the recursion guards.
+GUARDED_TOOL_NAMES: FrozenSet[str] = frozenset(
+    {"invoke_agent", "invoke_agent_with_model"}
+)
+
+
+class SubagentRecursionGuard(AbstractCapability[Any]):
+    """Deny sub-agent invocations that would exceed the recursion limits.
+
+    Stateless: the guards read ambient ``subagent_context`` contextvars and
+    live config at call time, exactly as the in-tool custody does, so the
+    verdict is identical at either layer.
+    """
+
+    async def wrap_tool_execute(
+        self,
+        ctx: Any,
+        *,
+        call: Any,
+        tool_def: Any,
+        args: Any,
+        handler: Any,
+    ) -> Any:
+        if tool_def.name not in GUARDED_TOOL_NAMES:
+            return await handler(args)
+        # Lazy import: this capability is wired from both construction sites
+        # (agents/_builder and tools/subagent_invocation); a top-level import
+        # of the tool module would be circular.
+        from code_puppy.tools.subagent_invocation import (
+            denied_invocation_output,
+            recursion_guard_error,
+        )
+
+        if not isinstance(args, dict):  # pragma: no cover - defensive
+            return await handler(args)
+        agent_name = args.get("agent_name")
+        if not isinstance(agent_name, str):
+            # Malformed args: let the tool's own validation/error path own it.
+            return await handler(args)
+
+        include_usage_metrics = tool_def.name == "invoke_agent_with_model"
+        model_name: str | None = None
+        if include_usage_metrics:
+            raw_model_name = args.get("model_name")
+            model_name = (
+                raw_model_name.strip() if isinstance(raw_model_name, str) else ""
+            )
+            if not model_name:
+                # Empty-model rejection precedes the recursion guard on main;
+                # fall through so the tool's own check answers first.
+                return await handler(args)
+
+        error = recursion_guard_error(agent_name)
+        if error is None:
+            return await handler(args)
+        return denied_invocation_output(
+            agent_name=agent_name,
+            model_name=model_name,
+            include_usage_metrics=include_usage_metrics,
+            error=error,
+        )
+
+
+def build_subagent_recursion_guard(
+    tool_names: Any,
+) -> List[SubagentRecursionGuard]:
+    """Conditional splice: guard only agents that expose the invoke tools.
+
+    Returned as a list so callers can splice it into ``capabilities=[...]``
+    unconditionally (same shape as ``build_tool_output_limits``); agents
+    without ``invoke_agent`` tools keep a byte-identical capability list.
+    """
+    if GUARDED_TOOL_NAMES & set(tool_names or ()):
+        return [SubagentRecursionGuard()]
+    return []

--- a/code_puppy/agents/smooth_stream.py
+++ b/code_puppy/agents/smooth_stream.py
@@ -1,157 +1,42 @@
-"""Steady-rate streaming helpers for buttery-smooth terminal output.
+"""Code Puppy adapters over termflow's steady-rate streaming engine.
 
-Models emit token deltas in bursts: a big lump, a pause, another lump.
-Printing each delta the instant it lands makes output stutter and jerk.
+The pacing machinery (buffer + adaptive background drain) lives in
+``termflow.stream``; this module just wires it to Code Puppy's Rich
+console styling, pause controller, and config toggles.
 
-This module provides a small ``SteadyDrainer`` base that buffers incoming
-content and releases it to the terminal at an *adaptive, consistent* rate via
-a background task.  Two flavours ride on top of it:
-
-* :class:`ThinkingStreamSmoother` -- drains plain THINKING text (dim) through
-  a Rich console.
-* :class:`SmoothTermflowWriter` -- a file-like proxy that drains pre-rendered
-  ANSI markdown (from termflow) character-by-character, keeping escape
-  sequences atomic so colors never get split mid-code.  This gives the AGENT
-  RESPONSE block a sexy typewriter feel. 😎
-
-Adaptive pacing: each tick we release a slice proportional to the backlog,
-aiming to fully drain it over a short catch-up window.  Latency stays low when
-the model races ahead, while it still feels smooth when it trickles.
+* :class:`ThinkingStreamSmoother` -- drains plain THINKING text (dim)
+  through a Rich console.
+* :class:`SmoothTermflowWriter` -- file-like proxy that drains
+  pre-rendered ANSI markdown (from termflow) with a typewriter feel.
 """
 
 from __future__ import annotations
 
-import asyncio
-import math
 from typing import Optional, TextIO
 
 from rich.console import Console
 from rich.markup import escape
+from termflow.stream import SmoothWriter, StreamSmoother, split_by_visible
 
-# Reuse termflow's battle-tested ANSI matcher so we never split an escape
-# sequence (CSI colors, OSC hyperlinks, etc.) across drain ticks.
-from termflow.ansi.utils import ANSI_ESCAPE_RE
+# Backwards-compatible alias: this helper graduated into termflow.
+_split_by_visible = split_by_visible
 
 
-class SteadyDrainer:
-    """Drive a background task that drains a buffer at an adaptive rate.
+def _pause_controller_is_paused() -> bool:
+    """Best-effort check of the global pause controller.
 
-    Subclasses implement the buffer mechanics via :meth:`_remaining_units`,
-    :meth:`_drain_units`, and :meth:`_flush_all`.  A "unit" is whatever the
-    subclass counts as one step of progress (e.g. a visible character).
+    Injected into termflow's drainers so streamed output never types
+    over the steering prompt.
     """
+    try:
+        from code_puppy.messaging.pause_controller import get_pause_controller
 
-    def __init__(
-        self,
-        *,
-        tick_interval: float = 0.02,
-        catch_up_seconds: float = 0.4,
-        min_units_per_tick: int = 1,
-    ) -> None:
-        self._tick = tick_interval
-        # Ticks over which we aim to drain the current backlog.
-        self._catch_up_ticks = max(1, round(catch_up_seconds / tick_interval))
-        self._min_units = max(1, min_units_per_tick)
-        self._closed = False
-        self._task: Optional[asyncio.Task] = None
-        self._pending = ""
-
-    def start(self) -> None:
-        """Spin up the background drain task (idempotent)."""
-        if self._task is None:
-            self._task = asyncio.create_task(self._run())
-
-    async def close(self) -> None:
-        """Mark the stream finished and wait for the buffer to fully drain."""
-        self._closed = True
-        task, self._task = self._task, None
-        if task is None:
-            return
-        try:
-            await task
-        except asyncio.CancelledError:
-            # We were cancelled while waiting (user interrupt). Make sure
-            # the drain task dies with us and nothing prints afterwards.
-            task.cancel()
-            self._discard_all()
-            raise
-
-    def abort(self) -> None:
-        """Stop immediately and discard buffered content (user interrupt).
-
-        Unlike :meth:`close`, nothing further is printed: the user asked us
-        to stop, so dumping the backlog would just be noise.
-        """
-        self._closed = True
-        self._discard_all()
-        task, self._task = self._task, None
-        if task is not None:
-            task.cancel()
-
-    async def _run(self) -> None:
-        try:
-            was_paused = self._is_paused()
-            while True:
-                if self._is_paused():
-                    if not was_paused:
-                        # Pause just began (user steering): flush the tail in ONE
-                        # atomic write so it lands before the steer prompt and
-                        # close() returns immediately instead of stalling the
-                        # model's HTTP stream (held-open connections get killed
-                        # upstream → RemoteProtocolError next call).
-                        self._flush_all()
-                    was_paused = True
-                    if self._closed and self._remaining_units() <= 0:
-                        return
-                    # Anything fed DURING the pause stays silent until resume
-                    # so we never type over the steering prompt.
-                    await asyncio.sleep(self._tick)
-                    continue
-                was_paused = False
-                remaining = self._remaining_units()
-                if remaining <= 0:
-                    if self._closed:
-                        return
-                    await asyncio.sleep(self._tick)
-                    continue
-                n = max(
-                    self._min_units,
-                    math.ceil(remaining / self._catch_up_ticks),
-                )
-                self._drain_units(n)
-                await asyncio.sleep(self._tick)
-        except asyncio.CancelledError:
-            # Cancellation means interrupt/shutdown: stop typing NOW and
-            # drop the backlog instead of dumping it into the terminal.
-            self._discard_all()
-            raise
-
-    def _discard_all(self) -> None:
-        """Throw away any buffered content without emitting it."""
-        self._pending = ""
-
-    @staticmethod
-    def _is_paused() -> bool:
-        """Best-effort check of the global pause controller."""
-        try:
-            from code_puppy.messaging.pause_controller import get_pause_controller
-
-            return get_pause_controller().is_paused()
-        except Exception:
-            return False
-
-    # ── subclass hooks ─────────────────────────────────────────────────
-    def _remaining_units(self) -> int:  # pragma: no cover - abstract
-        raise NotImplementedError
-
-    def _drain_units(self, n: int) -> None:  # pragma: no cover - abstract
-        raise NotImplementedError
-
-    def _flush_all(self) -> None:  # pragma: no cover - abstract
-        raise NotImplementedError
+        return get_pause_controller().is_paused()
+    except Exception:
+        return False
 
 
-class ThinkingStreamSmoother(SteadyDrainer):
+class ThinkingStreamSmoother(StreamSmoother):
     """Buffer THINKING deltas and print them at a consistent rate."""
 
     def __init__(
@@ -164,42 +49,21 @@ class ThinkingStreamSmoother(SteadyDrainer):
         min_chars_per_tick: int = 2,
     ) -> None:
         super().__init__(
+            self._emit_styled,
             tick_interval=tick_interval,
             catch_up_seconds=catch_up_seconds,
-            min_units_per_tick=min_chars_per_tick,
+            min_chars_per_tick=min_chars_per_tick,
+            is_paused=_pause_controller_is_paused,
         )
         self._console = console
         self._style = style
 
-    def feed(self, text: str) -> None:
-        """Append streamed thinking text to the buffer."""
-        if text:
-            self._pending += text
-
-    def _remaining_units(self) -> int:
-        return len(self._pending)
-
-    def _drain_units(self, n: int) -> None:
-        chunk, self._pending = self._pending[:n], self._pending[n:]
-        self._emit(chunk)
-
-    def _flush_all(self) -> None:
-        if self._pending:
-            self._emit(self._pending)
-            self._pending = ""
-
-    def _emit(self, chunk: str) -> None:
+    def _emit_styled(self, chunk: str) -> None:
         self._console.print(f"[{self._style}]{escape(chunk)}[/{self._style}]", end="")
 
 
-class SmoothTermflowWriter(SteadyDrainer):
-    """File-like proxy that types pre-rendered ANSI text out smoothly.
-
-    termflow's ``Renderer`` writes ANSI-styled markdown to this object; the
-    background drainer then releases it to ``target`` one visible character at
-    a time.  ANSI escape sequences are emitted atomically (and greedily
-    attached to the preceding character) so styling never breaks.
-    """
+class SmoothTermflowWriter(SmoothWriter):
+    """ANSI-atomic typewriter wired to Code Puppy's pause controller."""
 
     def __init__(
         self,
@@ -210,69 +74,12 @@ class SmoothTermflowWriter(SteadyDrainer):
         min_chars_per_tick: int = 1,
     ) -> None:
         super().__init__(
+            target,
             tick_interval=tick_interval,
             catch_up_seconds=catch_up_seconds,
-            min_units_per_tick=min_chars_per_tick,
+            min_chars_per_tick=min_chars_per_tick,
+            is_paused=_pause_controller_is_paused,
         )
-        self._target = target
-
-    # ── file-like interface used by termflow.Renderer ──────────────────
-    def write(self, text: str) -> int:
-        if text:
-            self._pending += text
-        return len(text)
-
-    def flush(self) -> None:
-        # Real flushing is owned by the drain task; termflow flushes eagerly
-        # after every write, but we want to control the cadence ourselves.
-        pass
-
-    # ── drainer hooks ──────────────────────────────────────────────────
-    def _remaining_units(self) -> int:
-        # Count visible chars from the live buffer so escape sequences split
-        # across write() boundaries can't desync a cached counter.
-        return len(ANSI_ESCAPE_RE.sub("", self._pending))
-
-    def _drain_units(self, n: int) -> None:
-        emit, rest, _ = _split_by_visible(self._pending, n)
-        if not emit:
-            return
-        self._pending = rest
-        self._target.write(emit)
-        self._target.flush()
-
-    def _flush_all(self) -> None:
-        if self._pending:
-            self._target.write(self._pending)
-            self._target.flush()
-            self._pending = ""
-
-
-def _split_by_visible(s: str, budget: int) -> tuple[str, str, int]:
-    """Split ``s`` after ``budget`` visible chars, keeping ANSI codes atomic.
-
-    Returns ``(emit, rest, consumed_visible)`` where ``emit`` contains exactly
-    ``consumed_visible`` visible characters plus any ANSI escape sequences that
-    surround them (trailing escapes are greedily attached so style-off codes
-    flush together with their text).
-    """
-    i = 0
-    consumed = 0
-    n = len(s)
-    while i < n and consumed < budget:
-        m = ANSI_ESCAPE_RE.match(s, i)
-        if m:
-            i = m.end()
-        else:
-            i += 1
-            consumed += 1
-    # Greedily attach any trailing escape sequences.
-    while True:
-        m = ANSI_ESCAPE_RE.match(s, i)
-        if not m:
-            break
-        i = m.end()
-    return s[:i], s[i:], consumed
 
 
 def make_thinking_smoother(console: Console) -> Optional[ThinkingStreamSmoother]:
@@ -294,8 +101,8 @@ def make_thinking_smoother(console: Console) -> Optional[ThinkingStreamSmoother]
 def make_smooth_termflow_writer(target: TextIO) -> Optional[SmoothTermflowWriter]:
     """Build a smooth termflow writer honoring the user's config toggle.
 
-    Returns ``None`` when response smoothing is disabled, so callers fall back
-    to writing straight to ``target``.
+    Returns ``None`` when response smoothing is disabled, so callers fall
+    back to writing straight to ``target``.
     """
     try:
         from code_puppy.config import get_smooth_response_stream

--- a/code_puppy/command_line/agent_menu.py
+++ b/code_puppy/command_line/agent_menu.py
@@ -1,19 +1,19 @@
 """Interactive terminal UI for selecting agents.
 
-Provides a split-panel interface for browsing and selecting agents
-with live preview of agent details.
+Provides a split-panel interface (termflow MenuBuilder) for browsing and
+selecting agents with live preview of agent details.
+
+Keys: up/down navigate, left/right page, Enter select, P pin model,
+B bind MCP servers, C clone, D delete clone, Esc/Ctrl+C cancel.
 """
 
 import asyncio
-import sys
 import unicodedata
 from typing import List, Optional, Tuple
 
-from prompt_toolkit.application import Application
-from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.layout import Dimension, Layout, VSplit, Window
-from prompt_toolkit.layout.controls import FormattedTextControl
-from prompt_toolkit.widgets import Frame
+from termflow.ansi.codes import BOLD_ON, DIM_ON, RESET
+from termflow.tui import MenuBuilder, MenuItem
+from termflow.tui.menu import MenuResult
 
 from code_puppy.agents import (
     clone_agent,
@@ -29,12 +29,6 @@ from code_puppy.command_line.model_picker_completion import (
     ModelSelectionMenu,
     load_model_names,
 )
-from code_puppy.command_line.pagination import (
-    ensure_visible_page,
-    get_page_bounds,
-    get_page_for_index,
-    get_total_pages,
-)
 from code_puppy.config import (
     clear_agent_pinned_model,
     get_agent_pinned_model,
@@ -42,7 +36,6 @@ from code_puppy.config import (
 )
 from code_puppy.messaging import emit_info, emit_success, emit_warning
 from code_puppy.tools.command_runner import set_awaiting_user_input
-from code_puppy.callbacks import on_prompt_toolkit_style
 
 PAGE_SIZE = 10  # Agents per page
 
@@ -88,7 +81,7 @@ def _sanitize_display_text(text: str) -> str:
         text: Text that may contain emojis or wide characters
 
     Returns:
-        Sanitized text safe for prompt_toolkit rendering
+        Sanitized text safe for terminal rendering
     """
     # Keep only characters that render cleanly in terminals
     # Be aggressive about stripping anything that could cause width issues
@@ -271,184 +264,128 @@ def _get_agent_entries() -> List[Tuple[str, str, str]]:
     return entries
 
 
-def _render_menu_panel(
-    entries: List[Tuple[str, str, str]],
-    page: int,
-    selected_idx: int,
-    current_agent_name: str,
-) -> List:
-    """Render the left menu panel with pagination.
-
-    Args:
-        entries: List of (name, display_name, description) tuples
-        page: Current page number (0-indexed)
-        selected_idx: Currently selected index (global)
-        current_agent_name: Name of the current active agent
-
-    Returns:
-        List of (style, text) tuples for FormattedTextControl
-    """
-    lines = []
-    total_pages = get_total_pages(len(entries), PAGE_SIZE)
-    start_idx, end_idx = get_page_bounds(page, len(entries), PAGE_SIZE)
-
-    lines.append(("class:tui.header", "Agents"))
-    lines.append(("class:tui.muted", f" (Page {page + 1}/{total_pages})"))
-    lines.append(("", "\n\n"))
-
-    if not entries:
-        lines.append(("class:tui.warning", "  No agents found."))
-        lines.append(("", "\n\n"))
-    else:
-        # Show agents for current page
-        for i in range(start_idx, end_idx):
-            name, display_name, _ = entries[i]
-            is_selected = i == selected_idx
-            is_current = name == current_agent_name
-            pinned_model = _get_pinned_model(name)
-
-            # Sanitize display name to avoid emoji rendering issues
-            safe_display_name = _sanitize_display_text(display_name)
-
-            # Build the line
-            if is_selected:
-                lines.append(("class:tui.selected", f"▶ {safe_display_name}"))
+def _wrap(text: str, width: int) -> List[str]:
+    """Simple word wrap for the preview description."""
+    out: List[str] = []
+    for raw_line in text.split("\n"):
+        line = ""
+        for word in raw_line.split():
+            if len(line) + len(word) + 1 > width and line:
+                out.append(line)
+                line = word
             else:
-                lines.append(("class:tui.body", f"  {safe_display_name}"))
-
-            if pinned_model:
-                safe_pinned_model = _sanitize_display_text(pinned_model)
-                lines.append(("class:tui.label", f" → {safe_pinned_model}"))
-
-            # Add current marker
-            if is_current:
-                lines.append(("class:tui.success", " ← current"))
-
-            lines.append(("", "\n"))
-
-    # Navigation hints
-    lines.append(("", "\n"))
-    lines.append(("class:tui.help-key", "  ↑↓ "))
-    lines.append(("class:tui.help", "Navigate\n"))
-    lines.append(("class:tui.help-key", "  ←→ "))
-    lines.append(("class:tui.help", "Page\n"))
-    lines.append(("class:tui.help-key", "  Enter  "))
-    lines.append(("class:tui.help", "Select\n"))
-    lines.append(("class:tui.help-key", "  P "))
-    lines.append(("class:tui.help", "Pin model\n"))
-    lines.append(("class:tui.help-key", "  B "))
-    lines.append(("class:tui.help", "Bind MCP servers\n"))
-    lines.append(("class:tui.help-key", "  C "))
-    lines.append(("class:tui.help", "Clone\n"))
-    lines.append(("class:tui.help-key", "  D "))
-    lines.append(("class:tui.help", "Delete clone\n"))
-    lines.append(("class:tui.help-key", "  Ctrl+C "))
-    lines.append(("class:tui.help", "Cancel"))
-
-    return lines
+                line = word if not line else f"{line} {word}"
+        if line.strip():
+            out.append(line)
+    return out
 
 
-def _render_preview_panel(
-    entry: Optional[Tuple[str, str, str]],
-    current_agent_name: str,
-) -> List:
-    """Render the right preview panel with agent details.
-
-    Args:
-        entry: Tuple of (name, display_name, description) or None
-        current_agent_name: Name of the current active agent
-
-    Returns:
-        List of (style, text) tuples for FormattedTextControl
-    """
-    lines = []
-
-    lines.append(("class:tui.title", " AGENT DETAILS"))
-    lines.append(("", "\n\n"))
-
-    if not entry:
-        lines.append(("class:tui.warning", "  No agent selected."))
-        lines.append(("", "\n"))
-        return lines
-
+def _render_agent_details(entry: Tuple[str, str, str], current_agent_name: str) -> str:
+    """ANSI preview pane for the highlighted agent."""
     name, display_name, description = entry
     is_current = name == current_agent_name
     pinned_model = _get_pinned_model(name)
 
-    # Sanitize text to avoid emoji rendering issues
-    safe_display_name = _sanitize_display_text(display_name)
-    safe_description = _sanitize_display_text(description)
+    lines = [f"{BOLD_ON}AGENT DETAILS{RESET}", ""]
+    lines.append(f"{DIM_ON}Name:{RESET}          {name}")
+    lines.append(
+        f"{DIM_ON}Display Name:{RESET}  {_sanitize_display_text(display_name)}"
+    )
+    pinned = _sanitize_display_text(pinned_model) if pinned_model else "default"
+    lines.append(f"{DIM_ON}Pinned Model:{RESET}  {pinned}")
 
-    # Agent name (identifier)
-    lines.append(("class:tui.label", "Name: "))
-    lines.append(("", name))
-    lines.append(("", "\n\n"))
-
-    # Display name
-    lines.append(("class:tui.label", "Display Name: "))
-    lines.append(("class:tui.body", safe_display_name))
-    lines.append(("", "\n\n"))
-
-    # Pinned model
-    lines.append(("class:tui.label", "Pinned Model: "))
-    if pinned_model:
-        safe_pinned_model = _sanitize_display_text(pinned_model)
-        lines.append(("class:tui.body", safe_pinned_model))
-    else:
-        lines.append(("class:tui.muted", "default"))
-    lines.append(("", "\n\n"))
-
-    # MCP bindings summary
     try:
         bound = get_bound_servers(name)
     except Exception:
         bound = {}
-    lines.append(("class:tui.label", "MCP Servers: "))
     if bound:
         auto_count = sum(1 for opts in bound.values() if opts.get("auto_start"))
         summary = f"{len(bound)} bound"
         if auto_count:
             summary += f" ({auto_count} auto-start)"
-        lines.append(("class:tui.success", summary))
     else:
-        lines.append(("class:tui.muted", "none bound (strict opt-in)"))
-    lines.append(("", "\n\n"))
+        summary = "none bound (strict opt-in)"
+    lines.append(f"{DIM_ON}MCP Servers:{RESET}   {summary}")
+    lines.append("")
+    lines.append(f"{DIM_ON}Description:{RESET}")
+    lines.extend(_wrap(_sanitize_display_text(description), 55))
+    lines.append("")
+    status = "Currently Active" if is_current else "Not active"
+    lines.append(f"{DIM_ON}Status:{RESET} {status}")
+    return "\n".join(lines)
 
-    # Description
-    lines.append(("class:tui.label", "Description:"))
-    lines.append(("", "\n"))
 
-    # Wrap description to fit panel
-    desc_lines = safe_description.split("\n")
-    for desc_line in desc_lines:
-        # Word wrap long lines
-        words = desc_line.split()
-        current_line = ""
-        for word in words:
-            if len(current_line) + len(word) + 1 > 55:
-                lines.append(("class:tui.body", current_line))
-                lines.append(("", "\n"))
-                current_line = word
-            else:
-                if current_line == "":
-                    current_line = word
-                else:
-                    current_line += " " + word
-        if current_line.strip():
-            lines.append(("class:tui.body", current_line))
-            lines.append(("", "\n"))
+def _agent_items(
+    entries: List[Tuple[str, str, str]], current_agent_name: str
+) -> List[MenuItem]:
+    items = []
+    for name, display_name, _description in entries:
+        pinned = _get_pinned_model(name)
+        marks = []
+        if pinned:
+            marks.append(f"-> {_sanitize_display_text(pinned)}")
+        if name == current_agent_name:
+            marks.append("(current)")
+        items.append(
+            MenuItem(
+                _sanitize_display_text(display_name),
+                value=name,
+                description="  ".join(marks),
+            )
+        )
+    return items
 
-    lines.append(("", "\n"))
 
-    # Current status
-    lines.append(("class:tui.label", "  Status: "))
-    if is_current:
-        lines.append(("class:tui.success", "✓ Currently Active"))
-    else:
-        lines.append(("class:tui.muted", "Not active"))
-    lines.append(("", "\n"))
+def build_agent_menu(
+    entries: List[Tuple[str, str, str]],
+    current_agent_name: str,
+    pending_action: dict,
+    initial_index: int = 0,
+    **overrides,
+):
+    """Build the agent picker menu (overrides allow headless test driving)."""
+    entry_by_name = {name: entry for entry in entries for name in [entry[0]]}
 
-    return lines
+    def _action(action: str):
+        def handler(_menu, item: MenuItem) -> MenuResult:
+            pending_action["action"] = action
+            return MenuResult(item=item)
+
+        return handler
+
+    def _page_left(menu, _item: MenuItem) -> None:
+        menu.page_up()
+        return None
+
+    def _page_right(menu, _item: MenuItem) -> None:
+        menu.page_down()
+        return None
+
+    builder = (
+        MenuBuilder("Agents")
+        .items(_agent_items(entries, current_agent_name))
+        .page_size(PAGE_SIZE)
+        .list_width(45)
+        .initial_index(initial_index)
+        .preview(
+            lambda item: _render_agent_details(
+                entry_by_name[item.value], current_agent_name
+            )
+        )
+        .on_key("p", _action("pin"))
+        .on_key("b", _action("bind"))
+        .on_key("c", _action("clone"))
+        .on_key("d", _action("delete"))
+        .on_key("left", _page_left)
+        .on_key("right", _page_right)
+        .footer_hint(
+            "Up/Down navigate - Left/Right page - Enter select - P pin model - "
+            "B bind MCP - C clone - D delete clone - Esc cancel"
+        )
+    )
+    for name, value in overrides.items():
+        getattr(builder, name)(value)
+    return builder.build()
 
 
 async def interactive_agent_picker() -> Optional[str]:
@@ -465,228 +402,62 @@ async def interactive_agent_picker() -> Optional[str]:
         emit_info("No agents found.")
         return None
 
-    # State
-    selected_idx = [0]  # Current selection (global index)
-    current_page = [0]  # Current page
-    result = [None]  # Selected agent name
-    pending_action = [None]  # 'pin', 'clone', 'delete', or None
+    selected_index = 0
+    result: Optional[str] = None
 
-    total_pages = [get_total_pages(len(entries), PAGE_SIZE)]
-
-    def get_current_entry() -> Optional[Tuple[str, str, str]]:
-        if 0 <= selected_idx[0] < len(entries):
-            return entries[selected_idx[0]]
-        return None
-
-    def refresh_entries(selected_name: Optional[str] = None) -> None:
-        nonlocal entries
-
-        entries = _get_agent_entries()
-        total_pages[0] = get_total_pages(len(entries), PAGE_SIZE)
-
-        if not entries:
-            selected_idx[0] = 0
-            current_page[0] = 0
-            return
-
-        if selected_name:
-            for idx, (name, _, _) in enumerate(entries):
-                if name == selected_name:
-                    selected_idx[0] = idx
-                    break
-            else:
-                selected_idx[0] = min(selected_idx[0], len(entries) - 1)
-        else:
-            selected_idx[0] = min(selected_idx[0], len(entries) - 1)
-
-        current_page[0] = get_page_for_index(selected_idx[0], PAGE_SIZE)
-
-    # Build UI
-    menu_control = FormattedTextControl(text="")
-    preview_control = FormattedTextControl(text="")
-
-    def update_display():
-        """Update both panels."""
-        menu_control.text = _render_menu_panel(
-            entries, current_page[0], selected_idx[0], current_agent_name
-        )
-        preview_control.text = _render_preview_panel(
-            get_current_entry(), current_agent_name
-        )
-
-    menu_window = Window(
-        content=menu_control, wrap_lines=False, width=Dimension(weight=35)
-    )
-    preview_window = Window(
-        content=preview_control, wrap_lines=False, width=Dimension(weight=65)
-    )
-
-    menu_frame = Frame(menu_window, width=Dimension(weight=35), title="Agents")
-    preview_frame = Frame(preview_window, width=Dimension(weight=65), title="Preview")
-
-    root_container = VSplit(
-        [
-            menu_frame,
-            preview_frame,
-        ]
-    )
-
-    # Key bindings
-    kb = KeyBindings()
-
-    @kb.add("up")
-    def _(event):
-        if selected_idx[0] > 0:
-            selected_idx[0] -= 1
-            current_page[0] = ensure_visible_page(
-                selected_idx[0],
-                current_page[0],
-                len(entries),
-                PAGE_SIZE,
-            )
-            update_display()
-
-    @kb.add("down")
-    def _(event):
-        if selected_idx[0] < len(entries) - 1:
-            selected_idx[0] += 1
-            current_page[0] = ensure_visible_page(
-                selected_idx[0],
-                current_page[0],
-                len(entries),
-                PAGE_SIZE,
-            )
-            update_display()
-
-    @kb.add("left")
-    def _(event):
-        if current_page[0] > 0:
-            current_page[0] -= 1
-            selected_idx[0] = current_page[0] * PAGE_SIZE
-            update_display()
-
-    @kb.add("right")
-    def _(event):
-        if current_page[0] < total_pages[0] - 1:
-            current_page[0] += 1
-            selected_idx[0] = current_page[0] * PAGE_SIZE
-            update_display()
-
-    @kb.add("p")
-    def _(event):
-        if get_current_entry():
-            pending_action[0] = "pin"
-            event.app.exit()
-
-    @kb.add("b")
-    def _(event):
-        if get_current_entry():
-            pending_action[0] = "bind"
-            event.app.exit()
-
-    @kb.add("c")
-    def _(event):
-        if get_current_entry():
-            pending_action[0] = "clone"
-            event.app.exit()
-
-    @kb.add("d")
-    def _(event):
-        if get_current_entry():
-            pending_action[0] = "delete"
-            event.app.exit()
-
-    @kb.add("enter")
-    def _(event):
-        entry = get_current_entry()
-        if entry:
-            result[0] = entry[0]  # Store agent name
-        event.app.exit()
-
-    @kb.add("c-c")
-    def _(event):
-        result[0] = None
-        event.app.exit()
-
-    layout = Layout(root_container)
-    app = Application(
-        layout=layout,
-        key_bindings=kb,
-        full_screen=False,
-        mouse_support=False,
-        style=on_prompt_toolkit_style(),
-    )
+    def _index_of(agent_name: Optional[str]) -> int:
+        for idx, (name, _, _) in enumerate(entries):
+            if name == agent_name:
+                return idx
+        return min(selected_index, max(len(entries) - 1, 0))
 
     set_awaiting_user_input(True)
-
-    # Enter alternate screen buffer once for entire session
-    sys.stdout.write("\033[?1049h")  # Enter alternate buffer
-    sys.stdout.write("\033[2J\033[H")  # Clear and home
-    sys.stdout.flush()
-    await asyncio.sleep(0.05)
-
     try:
         while True:
-            pending_action[0] = None
-            result[0] = None
-            update_display()
+            pending_action: dict = {"action": None}
+            menu = build_agent_menu(
+                entries, current_agent_name, pending_action, selected_index
+            )
+            menu_result = await asyncio.to_thread(menu.run)
 
-            # Clear the current buffer
-            sys.stdout.write("\033[2J\033[H")
-            sys.stdout.flush()
+            highlighted = menu_result.item.value if menu_result.item else None
+            selected_index = _index_of(highlighted)
+            action = pending_action["action"]
 
-            # Run application
-            await app.run_async()
-
-            if pending_action[0] == "pin":
-                entry = get_current_entry()
-                if entry:
-                    selected_model = await _select_pinned_model(entry[0])
-                    if selected_model:
-                        _apply_pinned_model(entry[0], selected_model)
+            if action == "pin" and highlighted:
+                selected_model = await _select_pinned_model(highlighted)
+                if selected_model:
+                    _apply_pinned_model(highlighted, selected_model)
                 continue
 
-            if pending_action[0] == "bind":
-                entry = get_current_entry()
-                if entry:
-                    await interactive_mcp_binding_menu(entry[0])
+            if action == "bind" and highlighted:
+                await interactive_mcp_binding_menu(highlighted)
                 continue
 
-            if pending_action[0] == "clone":
-                entry = get_current_entry()
-                selected_name = None
-                if entry:
-                    cloned_name = clone_agent(entry[0])
-                    selected_name = cloned_name or entry[0]
-                refresh_entries(selected_name=selected_name)
+            if action == "clone" and highlighted:
+                cloned_name = clone_agent(highlighted)
+                entries = _get_agent_entries()
+                selected_index = _index_of(cloned_name or highlighted)
                 continue
 
-            if pending_action[0] == "delete":
-                entry = get_current_entry()
-                selected_name = None
-                if entry:
-                    agent_name = entry[0]
-                    selected_name = agent_name
-                    if not is_clone_agent_name(agent_name):
-                        emit_warning("Only cloned agents can be deleted.")
-                    elif agent_name == current_agent_name:
-                        emit_warning("Cannot delete the active agent. Switch first.")
-                    else:
-                        if delete_clone_agent(agent_name):
-                            selected_name = None
-                refresh_entries(selected_name=selected_name)
+            if action == "delete" and highlighted:
+                if not is_clone_agent_name(highlighted):
+                    emit_warning("Only cloned agents can be deleted.")
+                elif highlighted == current_agent_name:
+                    emit_warning("Cannot delete the active agent. Switch first.")
+                elif delete_clone_agent(highlighted):
+                    selected_index = 0
+                entries = _get_agent_entries()
+                if not entries:
+                    break
+                selected_index = min(selected_index, len(entries) - 1)
                 continue
 
+            if not menu_result.cancelled and highlighted:
+                result = highlighted
             break
-
     finally:
-        # Exit alternate screen buffer once at end
-        sys.stdout.write("\033[?1049l")  # Exit alternate buffer
-        sys.stdout.flush()
-        # Reset awaiting input flag
         set_awaiting_user_input(False)
 
-    # Clear exit message
-    emit_info("✓ Exited agent picker")
-
-    return result[0]
+    emit_info("Exited agent picker")
+    return result

--- a/code_puppy/command_line/mcp_binding_menu.py
+++ b/code_puppy/command_line/mcp_binding_menu.py
@@ -3,26 +3,25 @@
 Launched from :mod:`code_puppy.command_line.agent_menu` (and reused by the
 post-install flow in :mod:`code_puppy.command_line.mcp.install_command`).
 
-UI:
+Built on termflow's MenuBuilder:
 
-* Left panel — every MCP server known to the manager. Each row shows
-  ``[x]`` / ``[ ]`` for bound/unbound and ``⚡`` if auto-start is on.
-* Right panel — server details (id, type, current state).
-* Keys: ``↑↓`` navigate, ``space`` toggle binding, ``a`` toggle auto-start,
-  ``enter``/``q`` close, ``Ctrl+C`` cancel.
+* Rows show ``[x]`` / ``[ ]`` for bound/unbound plus an auto-start marker.
+* Right panel shows server details for the highlighted row.
+* Keys: up/down navigate, ``space`` toggle binding, ``a`` toggle
+  auto-start, ``enter``/``q`` close, ``esc``/``ctrl-c`` cancel.
+
+Toggles mutate the bindings file immediately (no save/cancel split), so
+"close" and "cancel" are equivalent exits.
 """
 
 from __future__ import annotations
 
 import asyncio
-import sys
 from typing import List, Tuple
 
-from prompt_toolkit.application import Application
-from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.layout import Dimension, Layout, VSplit, Window
-from prompt_toolkit.layout.controls import FormattedTextControl
-from prompt_toolkit.widgets import Frame
+from termflow.ansi.codes import BOLD_ON, DIM_ON, RESET
+from termflow.tui import MenuBuilder, MenuItem
+from termflow.tui.menu import MenuResult
 
 from code_puppy.mcp_ import get_mcp_manager
 from code_puppy.mcp_.agent_bindings import (
@@ -34,7 +33,8 @@ from code_puppy.mcp_.agent_bindings import (
 )
 from code_puppy.messaging import emit_info, emit_warning
 from code_puppy.tools.command_runner import set_awaiting_user_input
-from code_puppy.callbacks import on_prompt_toolkit_style
+
+_AUTO_MARKER = " \u26a1auto"
 
 
 def _list_servers() -> List[Tuple[str, str, str]]:
@@ -52,98 +52,90 @@ def _list_servers() -> List[Tuple[str, str, str]]:
     return rows
 
 
-def _render_menu(
-    agent_name: str,
-    servers: List[Tuple[str, str, str]],
-    selected_idx: int,
-) -> List:
-    """Format the left binding panel."""
+def _binding_label(agent_name: str, server_name: str) -> str:
+    """Checkbox + auto marker + server name for one row."""
     bindings = get_bound_servers(agent_name)
-    lines: List = []
-    lines.append(("class:tui.label", "MCP bindings for agent: "))
-    lines.append(("class:tui.title", agent_name))
-    lines.append(("", "\n\n"))
-
-    if not servers:
-        lines.append(("class:tui.warning", "  No MCP servers installed yet.\n"))
-        lines.append(("class:tui.help", "  Run /mcp install to add some.\n"))
-    else:
-        for i, (name, _type, _state) in enumerate(servers):
-            bound = name in bindings
-            auto = bool(bindings.get(name, {}).get("auto_start"))
-            checkbox = "[x]" if bound else "[ ]"
-            auto_marker = " ⚡auto" if auto else ""
-            prefix = "▶ " if i == selected_idx else "  "
-            style_prefix = "class:tui.selected" if i == selected_idx else ""
-            style_box = "class:tui.success" if bound else "class:tui.muted"
-            lines.append((style_prefix, prefix))
-            lines.append((style_box, f"{checkbox} "))
-            lines.append((style_prefix or "", name))
-            if auto_marker:
-                lines.append(("class:tui.warning", auto_marker))
-            lines.append(("", "\n"))
-
-    lines.append(("", "\n"))
-    lines.append(("class:tui.help-key", "  ↑↓ "))
-    lines.append(("", "Navigate\n"))
-    lines.append(("class:tui.help-key", "  Space "))
-    lines.append(("", "Toggle bind\n"))
-    lines.append(("class:tui.help-key", "  A "))
-    lines.append(("", "Toggle auto-start\n"))
-    lines.append(("class:tui.help-key", "  Enter / Q "))
-    lines.append(("", "Done\n"))
-    lines.append(("class:tui.help-key", "  Ctrl+C "))
-    lines.append(("", "Cancel"))
-    return lines
+    bound = server_name in bindings
+    auto = bool(bindings.get(server_name, {}).get("auto_start"))
+    checkbox = "[x]" if bound else "[ ]"
+    return f"{checkbox} {server_name}{_AUTO_MARKER if auto else ''}"
 
 
-def _render_preview(
-    agent_name: str,
-    servers: List[Tuple[str, str, str]],
-    selected_idx: int,
-) -> List:
-    """Format the right detail panel."""
-    lines: List = []
-    lines.append(("class:tui.title", " SERVER DETAILS"))
-    lines.append(("", "\n\n"))
-    if not servers or not (0 <= selected_idx < len(servers)):
-        lines.append(("class:tui.muted", "  Nothing to preview.\n"))
-        return lines
+def _server_items(
+    agent_name: str, servers: List[Tuple[str, str, str]]
+) -> list[MenuItem]:
+    return [
+        MenuItem(_binding_label(agent_name, name), value=name)
+        for name, _type, _state in servers
+    ]
 
-    name, type_, state = servers[selected_idx]
+
+def _render_details(
+    agent_name: str, servers: List[Tuple[str, str, str]], server_name: str
+) -> str:
+    """ANSI detail pane for the highlighted server."""
+    row = next((r for r in servers if r[0] == server_name), None)
+    if row is None:
+        return f"{DIM_ON}Nothing to preview.{RESET}"
+    name, type_, state = row
     bindings = get_bound_servers(agent_name)
     bound = name in bindings
     auto = bool(bindings.get(name, {}).get("auto_start"))
+    yn = lambda flag: "yes" if flag else "no"  # noqa: E731 - tiny local formatter
+    return "\n".join(
+        [
+            f"{BOLD_ON}SERVER DETAILS{RESET}",
+            "",
+            f"{DIM_ON}Name:{RESET}       {name}",
+            f"{DIM_ON}Type:{RESET}       {type_}",
+            f"{DIM_ON}State:{RESET}      {state}",
+            f"{DIM_ON}Bound:{RESET}      {yn(bound)}",
+            f"{DIM_ON}Auto-start:{RESET} {yn(auto)}",
+        ]
+    )
 
-    lines.append(("class:tui.label", "Name: "))
-    lines.append(("class:tui.body", name))
-    lines.append(("", "\n\n"))
-    lines.append(("class:tui.label", "Type: "))
-    lines.append(("", type_))
-    lines.append(("", "\n\n"))
-    lines.append(("class:tui.label", "State: "))
-    lines.append(
-        ("class:tui.success" if state == "running" else "class:tui.muted", state)
+
+def build_binding_menu(
+    agent_name: str, servers: List[Tuple[str, str, str]], **overrides
+):
+    """Build the termflow menu for per-agent MCP bindings (testable headless)."""
+
+    def _toggle(menu, item: MenuItem) -> MenuResult | None:
+        toggle_binding(agent_name, item.value)
+        menu.replace_items(_server_items(agent_name, servers))
+        return None
+
+    def _toggle_auto(menu, item: MenuItem) -> MenuResult | None:
+        if toggle_auto_start(agent_name, item.value) is None:
+            # Not bound yet -- bind first, then turn auto_start on.
+            set_binding(agent_name, item.value, auto_start=True)
+        menu.replace_items(_server_items(agent_name, servers))
+        return None
+
+    def _done(_menu, item: MenuItem) -> MenuResult:
+        return MenuResult(item=item)
+
+    builder = (
+        MenuBuilder(f"MCP bindings for agent: {agent_name}")
+        .items(_server_items(agent_name, servers))
+        .preview(lambda item: _render_details(agent_name, servers, item.value))
+        .on_key(" ", _toggle)
+        .on_key("a", _toggle_auto)
+        .on_key("q", _done)
+        .footer_hint(
+            "Up/Down navigate - Space toggle bind - A auto-start - Enter/Q done - Esc cancel"
+        )
     )
-    lines.append(("", "\n\n"))
-    lines.append(("class:tui.label", "Bound: "))
-    lines.append(
-        ("class:tui.success" if bound else "class:tui.muted", "yes" if bound else "no"),
-    )
-    lines.append(("", "\n\n"))
-    lines.append(("class:tui.label", "Auto-start: "))
-    lines.append(
-        ("class:tui.warning" if auto else "class:tui.muted", "yes" if auto else "no"),
-    )
-    lines.append(("", "\n"))
-    return lines
+    for name, value in overrides.items():
+        getattr(builder, name)(value)
+    return builder.build()
 
 
 async def interactive_mcp_binding_menu(agent_name: str) -> None:
     """Open the MCP-binding sub-menu for ``agent_name``.
 
-    Returns when the user hits Enter / Q / Ctrl+C. Mutates the bindings file
-    immediately on each toggle (no save/cancel split).
+    Returns when the user hits Enter / Q / Esc / Ctrl+C. Mutates the
+    bindings file immediately on each toggle (no save/cancel split).
     """
     servers = _list_servers()
     if not servers:
@@ -153,248 +145,79 @@ async def interactive_mcp_binding_menu(agent_name: str) -> None:
         )
         return
 
-    selected_idx = [0]
-    menu_control = FormattedTextControl(text="")
-    preview_control = FormattedTextControl(text="")
-
-    def refresh() -> None:
-        menu_control.text = _render_menu(agent_name, servers, selected_idx[0])
-        preview_control.text = _render_preview(agent_name, servers, selected_idx[0])
-
-    refresh()
-
-    menu_window = Window(content=menu_control, wrap_lines=False)
-    preview_window = Window(content=preview_control, wrap_lines=False)
-    menu_frame = Frame(menu_window, width=Dimension(weight=55), title="MCP Servers")
-    preview_frame = Frame(preview_window, width=Dimension(weight=45), title="Details")
-    root = VSplit([menu_frame, preview_frame])
-
-    kb = KeyBindings()
-
-    @kb.add("up")
-    def _(event):
-        if selected_idx[0] > 0:
-            selected_idx[0] -= 1
-            refresh()
-
-    @kb.add("down")
-    def _(event):
-        if selected_idx[0] < len(servers) - 1:
-            selected_idx[0] += 1
-            refresh()
-
-    @kb.add("space")
-    def _(event):
-        name = servers[selected_idx[0]][0]
-        toggle_binding(agent_name, name)
-        refresh()
-
-    @kb.add("a")
-    def _(event):
-        name = servers[selected_idx[0]][0]
-        result = toggle_auto_start(agent_name, name)
-        if result is None:
-            # Not bound yet — bind first, then turn auto_start on.
-            set_binding(agent_name, name, auto_start=True)
-        refresh()
-
-    @kb.add("enter")
-    @kb.add("q")
-    def _(event):
-        event.app.exit()
-
-    @kb.add("c-c")
-    def _(event):
-        event.app.exit()
-
-    app = Application(
-        layout=Layout(root),
-        key_bindings=kb,
-        full_screen=False,
-        mouse_support=False,
-        style=on_prompt_toolkit_style(),
-    )
-
     set_awaiting_user_input(True)
-    sys.stdout.write("\033[?1049h\033[2J\033[H")
-    sys.stdout.flush()
-    await asyncio.sleep(0.05)
     try:
-        await app.run_async()
+        await asyncio.to_thread(build_binding_menu(agent_name, servers).run)
     finally:
-        sys.stdout.write("\033[?1049l")
-        sys.stdout.flush()
         set_awaiting_user_input(False)
 
     bindings = get_bound_servers(agent_name)
     emit_info(
-        f"✓ Saved MCP bindings for '{agent_name}': {len(bindings)} server(s) bound."
+        f"Saved MCP bindings for '{agent_name}': {len(bindings)} server(s) bound."
     )
 
 
 # ---------- post-install bind helper -----------------------------------------
 
 
+def _agent_label(agent: str, server_name: str) -> str:
+    from code_puppy.mcp_.agent_bindings import get_auto_start
+
+    bound = is_bound(agent, server_name)
+    auto = get_auto_start(agent, server_name) if bound else False
+    checkbox = "[x]" if bound else "[ ]"
+    return f"{checkbox} {agent}{_AUTO_MARKER if auto else ''}"
+
+
+def build_post_install_menu(server_name: str, agents: List[str], **overrides):
+    """Build the inverted menu (one server, many agents) after an install."""
+
+    def _items() -> list[MenuItem]:
+        return [MenuItem(_agent_label(a, server_name), value=a) for a in agents]
+
+    def _toggle(menu, item: MenuItem) -> MenuResult | None:
+        toggle_binding(item.value, server_name)
+        menu.replace_items(_items())
+        return None
+
+    def _toggle_auto(menu, item: MenuItem) -> MenuResult | None:
+        if toggle_auto_start(item.value, server_name) is None:
+            set_binding(item.value, server_name, auto_start=True)
+        menu.replace_items(_items())
+        return None
+
+    def _done(_menu, item: MenuItem) -> MenuResult:
+        return MenuResult(item=item)
+
+    builder = (
+        MenuBuilder(f"Bind '{server_name}' to which agents?")
+        .items(_items())
+        .on_key(" ", _toggle)
+        .on_key("a", _toggle_auto)
+        .on_key("q", _done)
+        .footer_hint("Space toggle bind - A auto-start - Enter/Q done - Esc skip")
+    )
+    for name, value in overrides.items():
+        getattr(builder, name)(value)
+    return builder.build()
+
+
 async def prompt_bind_after_install(server_name: str) -> None:
     """After a fresh install, ask the user which agents to bind the server to.
 
-    Walks every registered agent and lets the user toggle binding + auto-start
-    for the *new* server. Reuses the same TUI shape as the per-agent menu but
-    inverted (one server, many agents).
+    Walks every registered agent and lets the user toggle binding +
+    auto-start for the *new* server. Same TUI shape as the per-agent menu
+    but inverted (one server, many agents).
     """
     from code_puppy.agents import get_available_agents
-    from code_puppy.mcp_.agent_bindings import (
-        get_auto_start,
-        toggle_binding,
-    )
 
     available = get_available_agents()
     if not available:
         return
     agents = sorted(available.keys(), key=str.lower)
 
-    selected_idx = [0]
-    menu_control = FormattedTextControl(text="")
-
-    def render() -> List:
-        lines: List = []
-        lines.append(("class:tui.label", "Bind '"))
-        lines.append(("class:tui.title", server_name))
-        lines.append(("class:tui.label", "' to which agents?"))
-        lines.append(("", "\n\n"))
-        for i, agent in enumerate(agents):
-            bound = is_bound(agent, server_name)
-            auto = get_auto_start(agent, server_name) if bound else False
-            checkbox = "[x]" if bound else "[ ]"
-            prefix = "▶ " if i == selected_idx[0] else "  "
-            style_prefix = "class:tui.selected" if i == selected_idx[0] else ""
-            style_box = "class:tui.success" if bound else "class:tui.muted"
-            lines.append((style_prefix, prefix))
-            lines.append((style_box, f"{checkbox} "))
-            lines.append((style_prefix or "", agent))
-            if auto:
-                lines.append(("class:tui.warning", " \u26a1auto"))
-            lines.append(("", "\n"))
-        lines.append(("", "\n"))
-        lines.append(("class:tui.help-key", "  Space "))
-        lines.append(("", "Toggle bind   "))
-        lines.append(("class:tui.help-key", "A "))
-        lines.append(("", "Toggle auto-start\n"))
-        lines.append(("class:tui.help-key", "  Enter / Q "))
-        lines.append(("", "Done   "))
-        lines.append(("class:tui.help-key", "Ctrl+C "))
-        lines.append(("", "Skip"))
-        return lines
-
-    def refresh() -> None:
-        menu_control.text = render()
-
-    refresh()
-
-    kb = KeyBindings()
-
-    @kb.add("up")
-    def _(event):
-        if selected_idx[0] > 0:
-            selected_idx[0] -= 1
-            refresh()
-
-    @kb.add("down")
-    def _(event):
-        if selected_idx[0] < len(agents) - 1:
-            selected_idx[0] += 1
-            refresh()
-
-    @kb.add("space")
-    def _(event):
-        toggle_binding(agents[selected_idx[0]], server_name)
-        refresh()
-
-    @kb.add("a")
-    def _(event):
-        agent = agents[selected_idx[0]]
-        result = toggle_auto_start(agent, server_name)
-        if result is None:
-            set_binding(agent, server_name, auto_start=True)
-        refresh()
-
-    @kb.add("enter")
-    @kb.add("q")
-    @kb.add("c-c")
-    def _(event):
-        event.app.exit()
-
-    window = Window(content=menu_control, wrap_lines=False)
-    frame = Frame(window, title=f"Bind {server_name}")
-    app = Application(
-        layout=Layout(frame),
-        key_bindings=kb,
-        full_screen=False,
-        mouse_support=False,
-        style=on_prompt_toolkit_style(),
-    )
-
     set_awaiting_user_input(True)
-    sys.stdout.write("\033[?1049h\033[2J\033[H")
-    sys.stdout.flush()
-    await asyncio.sleep(0.05)
     try:
-        await app.run_async()
+        await asyncio.to_thread(build_post_install_menu(server_name, agents).run)
     finally:
-        sys.stdout.write("\033[?1049l")
-        sys.stdout.flush()
         set_awaiting_user_input(False)
-
-    bound_agents = [a for a in agents if is_bound(a, server_name)]
-    if bound_agents:
-        emit_info(f"✓ '{server_name}' is now bound to: {', '.join(bound_agents)}")
-    else:
-        emit_info(
-            f"'{server_name}' was installed but isn't bound to any agent yet. "
-            "Use /agents → B to bind it later."
-        )
-
-
-def prompt_bind_after_install_sync(server_name: str) -> None:
-    """Sync entrypoint for the post-install bind flow.
-
-    Asks the user (via a normal text prompt) whether to launch the binding
-    TUI right now. If they decline, prints a hint about ``/agents → B`` and
-    returns without opening any full-screen menu.
-
-    Mirrors the threading pattern used by ``/agents`` in ``core_commands.py``
-    so we don't fight the outer CLI event loop.
-    """
-    import concurrent.futures
-
-    emit_info(
-        "\nMCP servers are bound per-agent (strict opt-in). "
-        f"Right now, '{server_name}' is installed but not visible to any agent."
-    )
-    emit_info(
-        "You can bind it now via a quick menu, or skip and bind later from /agents → B."
-    )
-
-    # safe_input (not emit_prompt) so the answer appears inline after the
-    # question, matching the wizard's [y/N]: style (emit_prompt adds a ">>> "
-    # line).
-    from code_puppy.command_line.utils import safe_input
-
-    try:
-        answer = safe_input("Configure bindings for this server now? [Y/n]: ")
-    except (KeyboardInterrupt, EOFError):
-        emit_info("Skipped binding. Use /agents → B to bind later.")
-        return
-
-    if answer.strip().lower().startswith("n"):
-        emit_info("Skipped binding. Use /agents → B to bind later.")
-        return
-
-    try:
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            future = executor.submit(
-                lambda: asyncio.run(prompt_bind_after_install(server_name))
-            )
-            future.result(timeout=300)
-    except Exception as exc:
-        emit_warning(f"Could not show bind prompt: {exc}")

--- a/code_puppy/command_line/model_picker_completion.py
+++ b/code_puppy/command_line/model_picker_completion.py
@@ -1,23 +1,16 @@
+import asyncio
 import logging
 import os
-import sys
 from typing import Iterable, Optional
 
-from prompt_toolkit import Application, PromptSession
+from prompt_toolkit import PromptSession
 from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.document import Document
 from prompt_toolkit.history import FileHistory
-from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.layout import Layout, Window
-from prompt_toolkit.layout.controls import FormattedTextControl
+from termflow.tui import MenuBuilder, MenuItem
+from termflow.tui.menu import MenuResult
 
 from code_puppy.callbacks import on_prompt_toolkit_style
-from code_puppy.command_line.pagination import (
-    ensure_visible_page,
-    get_page_bounds,
-    get_page_for_index,
-    get_total_pages,
-)
 from code_puppy.command_line.utils import safe_input
 from code_puppy.config import get_global_model_name
 from code_puppy.list_filtering import query_matches_text
@@ -246,182 +239,75 @@ def update_model_in_input(text: str) -> Optional[str]:
 
 
 class ModelSelectionMenu:
-    """Paginated interactive model picker for the /model command."""
+    """Paginated interactive model picker for the /model command.
+
+    Built on termflow's MenuBuilder: type-to-filter (fuzzy, via
+    ``query_matches_text``), pagination, Ctrl+E credential editing.
+    """
 
     def __init__(self, model_names: Optional[list[str]] = None):
         self.model_names = (
             list(model_names) if model_names is not None else load_model_names()
         )
         self.current_model = get_active_model()
-        self.filter_text = ""
-        self.selected_index = 0
-        self.page = 0
-        self.page_size = MODEL_PICKER_PAGE_SIZE
         self.result: Optional[str] = None
         self.pending_credentials_edit: Optional[str] = None
 
-        if self.current_model in self.visible_model_names:
-            self.selected_index = self.visible_model_names.index(self.current_model)
-            self.page = get_page_for_index(self.selected_index, self.page_size)
-
-    @property
-    def total_pages(self) -> int:
-        return get_total_pages(len(self.visible_model_names), self.page_size)
-
-    @property
-    def page_start(self) -> int:
-        start, _ = get_page_bounds(
-            self.page, len(self.visible_model_names), self.page_size
-        )
-        return start
-
-    @property
-    def page_end(self) -> int:
-        _, end = get_page_bounds(
-            self.page, len(self.visible_model_names), self.page_size
-        )
-        return end
-
-    @property
-    def models_on_page(self) -> list[str]:
-        return self.visible_model_names[self.page_start : self.page_end]
-
-    @property
-    def visible_model_names(self) -> list[str]:
-        if not self.filter_text:
-            return self.model_names
+    def _items(self) -> list[MenuItem]:
         return [
-            model_name
-            for model_name in self.model_names
-            if query_matches_text(self.filter_text, model_name)
+            MenuItem(
+                name,
+                description="(active)" if name == self.current_model else "",
+            )
+            for name in self.model_names
         ]
 
-    def _get_selected_model_name(self) -> Optional[str]:
-        if 0 <= self.selected_index < len(self.visible_model_names):
-            return self.visible_model_names[self.selected_index]
-        return None
+    def build_menu(self, **overrides):
+        """Build the termflow menu (overrides allow headless test driving)."""
 
-    def _ensure_selection_visible(self) -> None:
-        self.page = ensure_visible_page(
-            self.selected_index,
-            self.page,
-            len(self.visible_model_names),
-            self.page_size,
+        def _edit_credentials(_menu, item: MenuItem) -> Optional[MenuResult]:
+            if not required_env_var_for_model(item.value):
+                logger.debug("No env var required for model: %s", item.value)
+                return None
+            logger.info("User requested credential edit for model: %s", item.value)
+            self.pending_credentials_edit = item.value
+            return MenuResult(item=item)
+
+        def _clear_filter(menu, _item: MenuItem) -> None:
+            menu.clear_search()
+            return None
+
+        def _page_left(menu, _item: MenuItem) -> None:
+            menu.page_up()
+            return None
+
+        def _page_right(menu, _item: MenuItem) -> None:
+            menu.page_down()
+            return None
+
+        initial = 0
+        if self.current_model in self.model_names:
+            initial = self.model_names.index(self.current_model)
+
+        builder = (
+            MenuBuilder(f"Select Active Model  (current: {self.current_model})")
+            .items(self._items())
+            .searchable()
+            .page_size(MODEL_PICKER_PAGE_SIZE)
+            .initial_index(initial)
+            .filter_fn(lambda query, item: query_matches_text(query, item.label))
+            .on_key("ctrl-e", _edit_credentials)
+            .on_key("ctrl-u", _clear_filter)
+            .on_key("left", _page_left)
+            .on_key("right", _page_right)
+            .footer_hint(
+                "Up/Down navigate - PgUp/PgDn page - type to filter - "
+                "Ctrl+U clear - Ctrl+E credentials - Enter select - Esc cancel"
+            )
         )
-
-    def _set_filter_text(self, value: str) -> None:
-        selected_model = self._get_selected_model_name()
-        self.filter_text = value
-        visible_models = self.visible_model_names
-        if not visible_models:
-            self.selected_index = 0
-            self.page = 0
-            return
-
-        if selected_model and selected_model in visible_models:
-            self.selected_index = visible_models.index(selected_model)
-        elif self.current_model in visible_models:
-            self.selected_index = visible_models.index(self.current_model)
-        else:
-            self.selected_index = 0
-        self._ensure_selection_visible()
-
-    def _append_filter_char(self, value: str) -> None:
-        self._set_filter_text(self.filter_text + value)
-
-    def _delete_filter_char(self) -> None:
-        if self.filter_text:
-            self._set_filter_text(self.filter_text[:-1])
-
-    def _accept_selection(self) -> bool:
-        """Store the currently selected visible model if one is available."""
-        selected_model = self._get_selected_model_name()
-        if selected_model is None:
-            return False
-        self.result = selected_model
-        return True
-
-    def _move_up(self) -> None:
-        if self.selected_index > 0:
-            self.selected_index -= 1
-            self._ensure_selection_visible()
-
-    def _move_down(self) -> None:
-        if self.selected_index < len(self.visible_model_names) - 1:
-            self.selected_index += 1
-            self._ensure_selection_visible()
-
-    def _page_up(self) -> None:
-        if self.page > 0:
-            self.page -= 1
-            self.selected_index = self.page_start
-
-    def _page_down(self) -> None:
-        if self.page < self.total_pages - 1:
-            self.page += 1
-            self.selected_index = self.page_start
-
-    def _render(self):
-        lines = [("class:tui.header", " 🤖 Select Active Model")]
-        filter_label = self.filter_text or "type to filter"
-        lines.append(("class:tui.muted", f"\n  Filter: {filter_label}"))
-        if self.total_pages > 1:
-            lines.append(
-                ("class:tui.muted", f"  (Page {self.page + 1}/{self.total_pages})")
-            )
-        lines.append(("", "\n"))
-
-        if not self.visible_model_names:
-            empty_message = (
-                "No models match the current filter."
-                if self.filter_text
-                else "No models available."
-            )
-            lines.append(("class:tui.warning", f"\n  {empty_message}\n"))
-            lines.append(("class:tui.help-key", "  Type  "))
-            lines.append(("class:tui.help", "Adjust filter\n"))
-            lines.append(("class:tui.help-key", "  Backspace  "))
-            lines.append(("class:tui.help", "Delete filter char\n"))
-            if self.filter_text:
-                lines.append(("class:tui.help-key", "  Ctrl+U  "))
-                lines.append(("class:tui.help", "Clear filter\n"))
-            lines.append(("class:tui.help-key", "  Esc  "))
-            lines.append(("class:tui.help", "Exit\n"))
-            return lines
-
-        lines.append(("class:tui.muted", f"\n  Current: {self.current_model}\n\n"))
-
-        for offset, model_name in enumerate(self.models_on_page):
-            absolute_index = self.page_start + offset
-            is_selected = absolute_index == self.selected_index
-            is_current = model_name == self.current_model
-
-            prefix = " › " if is_selected else "   "
-            style = "class:tui.selected" if is_selected else "class:tui.body"
-            lines.append((style, f"{prefix}{model_name}"))
-            if is_current:
-                lines.append(("class:tui.success", " (active)"))
-            lines.append(("", "\n"))
-
-        lines.append(("", "\n"))
-        lines.append(("class:tui.help-key", "  ↑/↓  "))
-        lines.append(("class:tui.help", "Navigate\n"))
-        if self.total_pages > 1:
-            lines.append(("class:tui.help-key", "  PgUp/PgDn  "))
-            lines.append(("class:tui.help", "Change page\n"))
-        lines.append(("class:tui.help-key", "  Type  "))
-        lines.append(("class:tui.help", "Filter models\n"))
-        lines.append(("class:tui.help-key", "  Backspace  "))
-        lines.append(("class:tui.help", "Delete filter char\n"))
-        lines.append(("class:tui.help-key", "  Ctrl+U  "))
-        lines.append(("class:tui.help", "Clear filter\n"))
-        lines.append(("class:tui.help-key", "  Enter  "))
-        lines.append(("class:tui.help", "Select model\n"))
-        lines.append(("class:tui.help-key", "  Ctrl+E  "))
-        lines.append(("class:tui.help", "Edit credentials\n"))
-        lines.append(("class:tui.help-key", "  Esc  "))
-        lines.append(("class:tui.help", "Cancel\n"))
-        return lines
+        for name, value in overrides.items():
+            getattr(builder, name)(value)
+        return builder.build()
 
     def _edit_credentials_for_model(self, model_name: str) -> None:
         """Prompt user to edit the credential for a specific model.
@@ -441,134 +327,36 @@ class ModelSelectionMenu:
             model_name,
             status,
         )
-        print(f"\n🔑 {model_name} credential: {env_var} ({status})")
+        print(f"\n{model_name} credential: {env_var} ({status})")
         if hint:
             print(f"   {hint}")
         try:
             value = safe_input("   New value (or Enter to skip): ")
             if value:
                 save_credential(env_var, value)
-                print(f"✅ Saved {env_var}")
+                print(f"Saved {env_var}")
                 logger.info("Saved credential %s for model %s", env_var, model_name)
         except (KeyboardInterrupt, EOFError):
             logger.info("Credential editing cancelled by user")
-            print("\n⚠️ Credential editing cancelled")
+            print("\nCredential editing cancelled")
 
     async def run_async(self) -> Optional[str]:
-        control = FormattedTextControl(lambda: self._render())
-        kb = KeyBindings()
-
-        def refresh() -> None:
-            control.text = self._render()
-
-        @kb.add("up")
-        @kb.add("c-p")
-        def _(event):
-            self._move_up()
-            refresh()
-            event.app.invalidate()
-
-        @kb.add("down")
-        @kb.add("c-n")
-        def _(event):
-            self._move_down()
-            refresh()
-            event.app.invalidate()
-
-        @kb.add("pageup")
-        @kb.add("left")
-        def _(event):
-            self._page_up()
-            refresh()
-            event.app.invalidate()
-
-        @kb.add("pagedown")
-        @kb.add("right")
-        def _(event):
-            self._page_down()
-            refresh()
-            event.app.invalidate()
-
-        @kb.add("backspace")
-        def _(event):
-            if not self.filter_text:
-                return
-            self._delete_filter_char()
-            refresh()
-            event.app.invalidate()
-
-        @kb.add("c-u")
-        def _(event):
-            if not self.filter_text:
-                return
-            self._set_filter_text("")
-            refresh()
-            event.app.invalidate()
-
-        @kb.add("c-e")
-        def _(event):
-            """Edit credentials for the selected model."""
-            selected = self._get_selected_model_name()
-            if not selected:
-                logger.debug("No model selected for credential editing")
-                return
-            env_var = required_env_var_for_model(selected)
-            if not env_var:
-                logger.debug("No env var required for model: %s", selected)
-                return
-            logger.info("User requested credential edit for model: %s", selected)
-            self.pending_credentials_edit = selected
-            event.app.exit()
-
-        @kb.add("<any>")
-        def _(event):
-            if not event.data or not event.data.isprintable():
-                return
-            self._append_filter_char(event.data)
-            refresh()
-            event.app.invalidate()
-
-        @kb.add("enter")
-        def _(event):
-            if not self._accept_selection():
-                return
-            event.app.exit()
-
-        @kb.add("escape")
-        @kb.add("c-c")
-        def _(event):
-            self.result = None
-            event.app.exit()
-
         while True:
-            # Enter alternate screen buffer for this session
-            sys.stdout.write("\033[?1049h")  # Enter alternate buffer
-            sys.stdout.write("\033[2J\033[H")  # Clear and home
-            sys.stdout.flush()
+            menu_result = await asyncio.to_thread(self.build_menu().run)
 
-            # Create a fresh Application each iteration — reusing a
-            # prompt_toolkit Application after exit() is unreliable
-            app = Application(
-                layout=Layout(Window(content=control, wrap_lines=True)),
-                key_bindings=kb,
-                full_screen=False,
-                style=on_prompt_toolkit_style(),
-            )
-            await app.run_async()
-
-            # Exit alternate screen buffer
-            sys.stdout.write("\033[?1049l")  # Exit alternate buffer
-            sys.stdout.flush()
-
-            # Handle credential editing outside the event loop
+            # Handle credential editing outside the menu loop, then reopen.
             if self.pending_credentials_edit:
                 model_name = self.pending_credentials_edit
                 self.pending_credentials_edit = None
                 logger.info("Editing credentials for model: %s", model_name)
                 self._edit_credentials_for_model(model_name)
-                logger.info("Credential edit completed, restarting application")
-                continue  # Restart the application
+                logger.info("Credential edit completed, restarting menu")
+                continue
 
+            if menu_result.cancelled or menu_result.item is None:
+                self.result = None
+            else:
+                self.result = menu_result.item.value
             return self.result
 
 

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -112,6 +112,55 @@ def _gpt_5_6_recursion_blocked() -> bool:
     return attempted_depth > get_subagent_recursion_limit_gpt_5_6()
 
 
+def recursion_guard_error(agent_name: str) -> str | None:
+    """Verdict of the recursion guards: the denial message, or None if allowed.
+
+    Single source of truth for both custodies -- the
+    ``SubagentRecursionGuard`` capability (``wrap_tool_execute`` seam, wired
+    at both pydantic-agent construction sites) and the in-tool guest
+    fallback in ``_invoke_agent_impl`` -- so the two verdicts can never
+    drift.
+    """
+    if _subagent_recursion_blocked():
+        return t(
+            "subagent.recursion_limit_reached",
+            limit=get_subagent_recursion_limit(),
+            agent=agent_name,
+        )
+    if _gpt_5_6_recursion_blocked():
+        return t(
+            "subagent.gpt_5_6_recursion_blocked",
+            agent=agent_name,
+            depth=get_subagent_depth() + 1,
+            limit=get_subagent_recursion_limit_gpt_5_6(),
+        )
+    return None
+
+
+def denied_invocation_output(
+    *,
+    agent_name: str,
+    model_name: str | None,
+    include_usage_metrics: bool,
+    error: str,
+) -> AgentInvokeOutput:
+    """Emit the denial and build the model-facing error output.
+
+    Shared by both recursion-guard custodies so the user-visible emit and
+    the model-visible output stay byte-identical regardless of which layer
+    denies. Mirrors the historical blocked path exactly: ``session_id`` is
+    deliberately left ``None`` even when the caller supplied one.
+    """
+    emit_error(error, message_group=generate_group_id("invoke_agent", agent_name))
+    return build_invoke_output(
+        include_usage_metrics=include_usage_metrics,
+        response=None,
+        agent_name=agent_name,
+        model_name=model_name,
+        error=error,
+    )
+
+
 def _subagent_identity_prompt(agent_name: str) -> str:
     """Build explicit nesting context for the child agent's system prompt."""
     depth = get_subagent_depth() + 1
@@ -198,29 +247,17 @@ async def _invoke_agent_impl(
     from code_puppy.agents.agent_manager import load_agent
 
     group_id = generate_group_id("invoke_agent", agent_name)
-    if _subagent_recursion_blocked():
-        error = t(
-            "subagent.recursion_limit_reached",
-            limit=get_subagent_recursion_limit(),
-            agent=agent_name,
-        )
-    elif _gpt_5_6_recursion_blocked():
-        error = t(
-            "subagent.gpt_5_6_recursion_blocked",
-            agent=agent_name,
-            depth=get_subagent_depth() + 1,
-            limit=get_subagent_recursion_limit_gpt_5_6(),
-        )
-    else:
-        error = None
-
+    # Guest custody of the recursion guards: agents built by code_puppy carry
+    # ``SubagentRecursionGuard`` (wrap_tool_execute), which denies before this
+    # body runs, making this re-check an unreachable no-op there. It stays for
+    # direct callers and foreign registrations of the invoke tools. The shared
+    # verdict/denial helpers keep both custodies byte-identical.
+    error = recursion_guard_error(agent_name)
     if error:
-        emit_error(error, message_group=group_id)
-        return build_invoke_output(
-            include_usage_metrics=include_usage_metrics,
-            response=None,
+        return denied_invocation_output(
             agent_name=agent_name,
             model_name=model_name,
+            include_usage_metrics=include_usage_metrics,
             error=error,
         )
 
@@ -401,12 +438,16 @@ async def _invoke_agent_impl(
                 mcp_servers = manager.get_servers_for_agent(agent_name=bound_agent_name)
 
             from code_puppy.agents._compaction import make_history_processor
+            from code_puppy.agents._subagent_recursion import (
+                build_subagent_recursion_guard,
+            )
             from code_puppy.agents._model_message_transform import (
                 build_model_message_transform,
             )
 
             # Build the pydantic-ai agent. MCP servers always included; plugins
             # (e.g. DBOS) may swap them via the agent_run_context hook.
+            agent_tools = agent_config.get_available_tools()
             temp_agent = Agent(
                 model=model,
                 # Explicit name: without it pydantic-ai infers one from the
@@ -423,6 +464,11 @@ async def _invoke_agent_impl(
                 capabilities=[
                     ProcessHistory(make_history_processor(agent_config)),
                     build_model_message_transform(agent_name),
+                    # Recursion guards ride the wrap_tool_execute seam so a
+                    # sub-agent's own invoke_agent calls are denied before
+                    # the tool body runs. Sole wrap_tool_execute implementer,
+                    # so position is inert.
+                    *build_subagent_recursion_guard(agent_tools),
                 ],
                 model_settings=model_settings,
             )
@@ -430,7 +476,6 @@ async def _invoke_agent_impl(
             # Register the tools that the agent needs
             from code_puppy.tools import register_tools_for_agent
 
-            agent_tools = agent_config.get_available_tools()
             register_tools_for_agent(
                 temp_agent, agent_tools, model_name=effective_model_name
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "openai>=2.45.0",
     "ripgrep==14.1.0; sys_platform != 'android'",
     "playwright>=1.40.0; sys_platform != 'android'",
-    "termflow-md>=0.1.11",
+    "termflow-md>=0.2.1",
     "Pillow>=10.0.0",
     "azure-identity>=1.15.0",
     "anthropic>=0.108.0,<1",

--- a/tests/agents/test_subagent_recursion_capability.py
+++ b/tests/agents/test_subagent_recursion_capability.py
@@ -1,0 +1,368 @@
+"""Contract tests for ``SubagentRecursionGuard`` (wrap_tool_execute seam).
+
+The sub-agent recursion guards (general ``subagent_recursion_limit`` depth
+cap + GPT-5.6 overlay) historically ran at the top of
+``_invoke_agent_impl``. They are now delivered as a pydantic-ai capability
+on the ``wrap_tool_execute`` seam, with the in-tool check retained as guest
+custody. These tests pin:
+
+- the seam denies before the tool body runs (impl never entered) with the
+  byte-identical denial output the in-tool guard produced;
+- the GPT-5.6 overlay and the general cap keep their verdict order;
+- ``invoke_agent_with_model`` empty-``model_name`` rejection keeps its
+  historical precedence over the recursion guard;
+- non-guarded tools and under-limit calls pass through untouched;
+- guest custody (agents without the capability) still denies, identically;
+- both construction sites wire the guard, conditionally on the agent's
+  declared tool surface.
+"""
+
+import asyncio
+from typing import Any, List
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.messages import (
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from code_puppy.agents._subagent_recursion import (
+    GUARDED_TOOL_NAMES,
+    SubagentRecursionGuard,
+    build_subagent_recursion_guard,
+)
+from code_puppy.i18n import t
+from code_puppy.tools import subagent_invocation as si
+from code_puppy.tools.agent_tools import (
+    AgentInvokeOutput,
+    AgentInvokeWithModelOutput,
+)
+from code_puppy.tools.subagent_usage_metrics import build_invoke_output
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+def _make_agent(tool_call: ToolCallPart, *, with_capability: bool) -> Agent:
+    """Agent that issues ``tool_call`` once, then finishes."""
+
+    def model_fn(messages: List[Any], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(parts=[tool_call])
+        return ModelResponse(parts=[TextPart("done")])
+
+    agent = Agent(
+        FunctionModel(model_fn),
+        retries=3,
+        capabilities=[SubagentRecursionGuard()] if with_capability else [],
+    )
+    si.register_invoke_agent(agent)
+    si.register_invoke_agent_with_model(agent)
+    return agent
+
+
+def _tool_return(result: Any, tool_name: str) -> Any:
+    """Extract the ToolReturnPart content the model saw for ``tool_name``."""
+    for message in result.all_messages():
+        for part in getattr(message, "parts", []):
+            if isinstance(part, ToolReturnPart) and part.tool_name == tool_name:
+                return part.content
+    raise AssertionError(f"no ToolReturnPart for {tool_name!r}")
+
+
+@pytest.fixture
+def impl_spy(monkeypatch):
+    """Replace ``_invoke_agent_impl`` with a recording stub."""
+    calls: List[dict] = []
+
+    async def _spy(**kwargs: Any) -> AgentInvokeOutput:
+        calls.append(kwargs)
+        return build_invoke_output(
+            include_usage_metrics=kwargs.get("include_usage_metrics", False),
+            response="spy-response",
+            agent_name=kwargs["agent_name"],
+            session_id="spy-session",
+            model_name=kwargs.get("model_name"),
+        )
+
+    monkeypatch.setattr(si, "_invoke_agent_impl", _spy)
+    return calls
+
+
+@pytest.fixture
+def emitted(monkeypatch):
+    """Capture ``emit_error`` calls from the subagent_invocation module."""
+    records: List[str] = []
+    monkeypatch.setattr(
+        si, "emit_error", lambda msg, **kwargs: records.append(str(msg))
+    )
+    return records
+
+
+def _block_general(monkeypatch) -> None:
+    """Depth 0 already meets a limit of 0: every invocation is denied."""
+    monkeypatch.setattr(si, "get_subagent_recursion_limit", lambda: 0)
+
+
+def _block_gpt_5_6(monkeypatch) -> None:
+    """GPT-5.6 caller, overlay cap 0; the general cap stays permissive."""
+    monkeypatch.setattr(si, "get_subagent_recursion_limit", lambda: 10)
+    monkeypatch.setattr(si, "get_subagent_model_name", lambda: "gpt-5.6-codex")
+    monkeypatch.setattr(si, "get_subagent_recursion_limit_gpt_5_6", lambda: 0)
+
+
+_INVOKE_CALL = ToolCallPart(
+    tool_name="invoke_agent",
+    args={"agent_name": "helper", "prompt": "p", "session_id": "keep-me"},
+)
+
+
+# ---------------------------------------------------------------------------
+# Seam denial
+# ---------------------------------------------------------------------------
+
+
+def test_seam_denies_general_depth_limit(monkeypatch, impl_spy, emitted):
+    _block_general(monkeypatch)
+    agent = _make_agent(_INVOKE_CALL, with_capability=True)
+
+    result = asyncio.run(agent.run("go"))
+
+    assert impl_spy == []  # tool body never entered
+    output = _tool_return(result, "invoke_agent")
+    expected_error = t("subagent.recursion_limit_reached", limit=0, agent="helper")
+    assert isinstance(output, AgentInvokeOutput)
+    assert not isinstance(output, AgentInvokeWithModelOutput)
+    assert output.error == expected_error
+    assert output.response is None
+    assert output.agent_name == "helper"
+    # Historical blocked path never echoed the caller's session_id.
+    assert output.session_id is None
+    assert output.model_name is None
+    assert emitted == [expected_error]
+
+
+def test_seam_denies_gpt_5_6_overlay(monkeypatch, impl_spy, emitted):
+    _block_gpt_5_6(monkeypatch)
+    agent = _make_agent(_INVOKE_CALL, with_capability=True)
+
+    result = asyncio.run(agent.run("go"))
+
+    assert impl_spy == []
+    output = _tool_return(result, "invoke_agent")
+    expected_error = t(
+        "subagent.gpt_5_6_recursion_blocked", agent="helper", depth=1, limit=0
+    )
+    assert output.error == expected_error
+    assert emitted == [expected_error]
+
+
+def test_general_cap_precedes_gpt_5_6_overlay(monkeypatch, impl_spy):
+    """Both caps tripped -> the general message wins (historical if/elif order)."""
+    _block_gpt_5_6(monkeypatch)
+    monkeypatch.setattr(si, "get_subagent_recursion_limit", lambda: 0)
+    agent = _make_agent(_INVOKE_CALL, with_capability=True)
+
+    result = asyncio.run(agent.run("go"))
+
+    output = _tool_return(result, "invoke_agent")
+    assert output.error == t(
+        "subagent.recursion_limit_reached", limit=0, agent="helper"
+    )
+
+
+def test_seam_passes_when_under_limit(monkeypatch, impl_spy, emitted):
+    monkeypatch.setattr(si, "get_subagent_recursion_limit", lambda: 10)
+    agent = _make_agent(_INVOKE_CALL, with_capability=True)
+
+    result = asyncio.run(agent.run("go"))
+
+    assert len(impl_spy) == 1
+    assert impl_spy[0]["agent_name"] == "helper"
+    assert impl_spy[0]["session_id"] == "keep-me"
+    output = _tool_return(result, "invoke_agent")
+    assert output.response == "spy-response"
+    assert emitted == []
+
+
+def test_non_gpt_caller_ignores_overlay(monkeypatch, impl_spy):
+    _block_gpt_5_6(monkeypatch)
+    monkeypatch.setattr(si, "get_subagent_model_name", lambda: "claude-sonnet")
+    agent = _make_agent(_INVOKE_CALL, with_capability=True)
+
+    asyncio.run(agent.run("go"))
+
+    assert len(impl_spy) == 1
+
+
+# ---------------------------------------------------------------------------
+# invoke_agent_with_model flavor
+# ---------------------------------------------------------------------------
+
+
+def test_with_model_flavor_denies_with_usage_shape(monkeypatch, impl_spy, emitted):
+    _block_general(monkeypatch)
+    call = ToolCallPart(
+        tool_name="invoke_agent_with_model",
+        args={"agent_name": "helper", "prompt": "p", "model_name": "  m1  "},
+    )
+    agent = _make_agent(call, with_capability=True)
+
+    result = asyncio.run(agent.run("go"))
+
+    assert impl_spy == []
+    output = _tool_return(result, "invoke_agent_with_model")
+    assert isinstance(output, AgentInvokeWithModelOutput)
+    assert output.error == t(
+        "subagent.recursion_limit_reached", limit=0, agent="helper"
+    )
+    # Normalized exactly as the tool wrapper normalizes before the impl guard.
+    assert output.model_name == "m1"
+    assert output.input_tokens is None
+    assert output.num_requests is None
+    assert output.duration_ms is None
+
+
+def test_empty_model_name_precedence_over_guard(monkeypatch, impl_spy, emitted):
+    """Blank model_name is rejected by the tool itself, ahead of the guard."""
+    _block_general(monkeypatch)
+    call = ToolCallPart(
+        tool_name="invoke_agent_with_model",
+        args={"agent_name": "helper", "prompt": "p", "model_name": "   "},
+    )
+    agent = _make_agent(call, with_capability=True)
+
+    result = asyncio.run(agent.run("go"))
+
+    assert impl_spy == []  # wrapper's empty-model check returns before impl
+    output = _tool_return(result, "invoke_agent_with_model")
+    assert output.error == "model_name cannot be empty"
+    assert emitted == ["model_name cannot be empty"]
+
+
+# ---------------------------------------------------------------------------
+# Pass-through and guest custody
+# ---------------------------------------------------------------------------
+
+
+def test_non_guarded_tools_pass_through(monkeypatch, impl_spy):
+    _block_general(monkeypatch)
+    call = ToolCallPart(tool_name="other_tool", args={"q": "hi"})
+    agent = _make_agent(call, with_capability=True)
+
+    async def other_tool(ctx, q: str) -> str:
+        return f"ran-{q}"
+
+    agent._function_toolset.add_function(other_tool, takes_ctx=True, name="other_tool")
+
+    result = asyncio.run(agent.run("go"))
+    assert _tool_return(result, "other_tool") == "ran-hi"
+
+
+def test_guest_custody_denies_identically(monkeypatch, emitted):
+    """Without the capability, the in-tool guard denies with identical bytes."""
+    _block_general(monkeypatch)
+
+    capability_agent = _make_agent(_INVOKE_CALL, with_capability=True)
+    guest_agent = _make_agent(_INVOKE_CALL, with_capability=False)
+
+    seam_output = _tool_return(asyncio.run(capability_agent.run("go")), "invoke_agent")
+    guest_output = _tool_return(asyncio.run(guest_agent.run("go")), "invoke_agent")
+
+    assert seam_output == guest_output
+    assert guest_output.error == t(
+        "subagent.recursion_limit_reached", limit=0, agent="helper"
+    )
+    # One denial emit per custody, same message both times.
+    assert emitted == [guest_output.error, guest_output.error]
+
+
+def test_seam_preempts_in_tool_guard(monkeypatch):
+    """With the capability, the real impl body is never entered when denied."""
+    _block_general(monkeypatch)
+    entered: List[str] = []
+    original_impl = si._invoke_agent_impl
+
+    async def _tracking_impl(**kwargs: Any):
+        entered.append(kwargs["agent_name"])
+        return await original_impl(**kwargs)
+
+    monkeypatch.setattr(si, "_invoke_agent_impl", _tracking_impl)
+    monkeypatch.setattr(si, "emit_error", lambda *a, **k: None)
+    agent = _make_agent(_INVOKE_CALL, with_capability=True)
+
+    asyncio.run(agent.run("go"))
+    assert entered == []
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+
+def test_conditional_splice_shapes():
+    assert build_subagent_recursion_guard(["invoke_agent"]) != []
+    assert build_subagent_recursion_guard(["invoke_agent_with_model", "x"]) != []
+    assert build_subagent_recursion_guard(["read_file"]) == []
+    assert build_subagent_recursion_guard([]) == []
+    assert build_subagent_recursion_guard(None) == []
+    guard = build_subagent_recursion_guard(list(GUARDED_TOOL_NAMES))
+    assert len(guard) == 1 and isinstance(guard[0], SubagentRecursionGuard)
+
+
+def test_capability_visible_in_agent_tree():
+    """The guard is discoverable via the public capability visitor."""
+    agent = Agent(
+        FunctionModel(lambda m, i: ModelResponse(parts=[TextPart("hi")])),
+        capabilities=[*build_subagent_recursion_guard(["invoke_agent"])],
+    )
+    seen: List[Any] = []
+
+    def _visit(cap):
+        if isinstance(cap, SubagentRecursionGuard):
+            seen.append(cap)
+        return cap
+
+    agent.root_capability.apply(_visit)
+    assert len(seen) == 1
+
+
+def test_builder_wires_guard_from_tool_surface():
+    """Source pin: the builder splices the guard from ``agent_tools``."""
+    import inspect
+
+    from code_puppy.agents import _builder
+
+    src = inspect.getsource(_builder.build_pydantic_agent)
+    assert "agent_tools = agent.get_available_tools()" in src
+    cap_block = src[src.find("capabilities=[") :]
+    assert "*build_subagent_recursion_guard(agent_tools)" in cap_block
+    # The tool surface must be read before the closure first runs (probe pass).
+    assert src.find("agent_tools = agent.get_available_tools()") < src.find(
+        "def _new_pydantic_agent"
+    )
+
+
+def test_subagent_site_wires_guard_from_tool_surface():
+    """Source pin: the temp-agent site splices the guard from ``agent_tools``."""
+    import inspect
+
+    src = inspect.getsource(si._invoke_agent_impl)
+    assert "agent_tools = agent_config.get_available_tools()" in src
+    cap_block = src[src.find("capabilities=[") :]
+    assert "*build_subagent_recursion_guard(agent_tools)" in cap_block
+    # Read before construction so the splice sees the declared tool surface.
+    assert src.find("agent_tools = agent_config.get_available_tools()") < src.find(
+        "temp_agent = Agent("
+    )
+
+
+def test_verdict_helper_allows_by_default(monkeypatch):
+    monkeypatch.setattr(si, "get_subagent_recursion_limit", lambda: 10)
+    monkeypatch.setattr(si, "get_subagent_model_name", lambda: None)
+    assert si.recursion_guard_error("helper") is None

--- a/tests/command_line/mcp/test_mcp_binding_menu.py
+++ b/tests/command_line/mcp/test_mcp_binding_menu.py
@@ -1,40 +1,76 @@
-"""Semantic rendering tests for the MCP binding menus."""
+"""Behavioral tests for the termflow-based MCP binding menus."""
 
+from io import StringIO
 from unittest.mock import patch
 
-from code_puppy.command_line.mcp_binding_menu import _render_menu, _render_preview
+from code_puppy.command_line.mcp_binding_menu import (
+    _binding_label,
+    _render_details,
+    build_binding_menu,
+)
 
 MODULE = "code_puppy.command_line.mcp_binding_menu"
 
+SERVERS = [("alpha", "stdio", "running"), ("beta", "sse", "stopped")]
 
-def test_binding_menu_uses_semantic_selection_and_status_roles():
-    bindings = {"alpha": {"auto_start": True}}
 
+def _drive(keys, bindings):
+    """Run the binding menu headlessly with a scripted key sequence."""
+    script = iter(keys)
+    out = StringIO()
     with patch(f"{MODULE}.get_bound_servers", return_value=bindings):
-        lines = _render_menu("code-puppy", [("alpha", "stdio", "running")], 0)
+        menu = build_binding_menu(
+            "code-puppy",
+            SERVERS,
+            key_source=lambda: next(script),
+            output=out,
+            size=lambda: (100, 30),
+            alt_screen=False,
+        )
+        result = menu.run()
+    return result, out.getvalue()
 
-    styles = {style for style, _text in lines if style}
-    assert {
-        "class:tui.selected",
-        "class:tui.success",
-        "class:tui.warning",
-        "class:tui.help-key",
-    } <= styles
-    assert not any("fg:" in style or "ansi" in style for style in styles)
 
-
-def test_binding_preview_uses_semantic_detail_roles():
+def test_binding_label_shows_checkbox_and_auto_marker():
     bindings = {"alpha": {"auto_start": True}}
-
     with patch(f"{MODULE}.get_bound_servers", return_value=bindings):
-        lines = _render_preview("code-puppy", [("alpha", "stdio", "running")], 0)
+        assert _binding_label("code-puppy", "alpha") == "[x] alpha \u26a1auto"
+        assert _binding_label("code-puppy", "beta") == "[ ] beta"
 
-    styles = {style for style, _text in lines if style}
-    assert {
-        "class:tui.title",
-        "class:tui.label",
-        "class:tui.body",
-        "class:tui.success",
-        "class:tui.warning",
-    } <= styles
-    assert not any("fg:" in style or "ansi" in style for style in styles)
+
+def test_details_pane_reflects_binding_state():
+    bindings = {"alpha": {"auto_start": True}}
+    with patch(f"{MODULE}.get_bound_servers", return_value=bindings):
+        details = _render_details("code-puppy", SERVERS, "alpha")
+    assert "alpha" in details
+    assert "stdio" in details
+    assert "running" in details
+    assert "Bound:" in details and "yes" in details
+    assert "Auto-start:" in details
+
+
+def test_space_toggles_binding():
+    with patch(f"{MODULE}.toggle_binding") as mock_toggle:
+        result, _ = _drive([" ", "enter"], bindings={})
+    mock_toggle.assert_called_once_with("code-puppy", "alpha")
+    assert not result.cancelled
+
+
+def test_a_binds_then_enables_auto_start_when_unbound():
+    with (
+        patch(f"{MODULE}.toggle_auto_start", return_value=None) as mock_auto,
+        patch(f"{MODULE}.set_binding") as mock_set,
+    ):
+        _drive(["down", "a", "enter"], bindings={})
+    mock_auto.assert_called_once_with("code-puppy", "beta")
+    mock_set.assert_called_once_with("code-puppy", "beta", auto_start=True)
+
+
+def test_q_exits_like_enter():
+    result, _ = _drive(["q"], bindings={})
+    assert not result.cancelled
+
+
+def test_escape_exits():
+    result, _ = _drive(["escape"], bindings={})
+    assert result.cancelled

--- a/tests/command_line/test_agent_menu.py
+++ b/tests/command_line/test_agent_menu.py
@@ -10,19 +10,11 @@ import pytest
 
 from code_puppy.command_line.agent_menu import (
     PAGE_SIZE,
+    _agent_items,
     _get_agent_entries,
-    _render_menu_panel,
-    _render_preview_panel,
+    _render_agent_details,
+    build_agent_menu,
 )
-
-
-def _get_text_from_formatted(result):
-    """Extract plain text from formatted text control output.
-
-    The render functions return List[(style, text)] tuples.
-    This helper extracts just the text content for easier assertions.
-    """
-    return "".join(text for _, text in result)
 
 
 class TestPageSizeConstant:
@@ -161,329 +153,146 @@ class TestGetAgentEntries:
             assert f"agent_{i:02d}" in agent_names
 
 
-class TestRenderMenuPanel:
-    """Test the _render_menu_panel function."""
+class TestAgentItems:
+    """Test the _agent_items row builder."""
 
-    def test_renders_empty_list(self):
-        """Test rendering when no agents are available."""
-        result = _render_menu_panel([], page=0, selected_idx=0, current_agent_name="")
-
-        text = _get_text_from_formatted(result)
-        assert "No agents found" in text
-        # Should show page 1 of 1 even for empty list
-        assert "Page 1/1" in text
-
-    def test_renders_single_agent(self):
-        """Test rendering a single agent.
-
-        Note: Emojis are stripped from display names for clean terminal rendering.
-        """
-        entries = [("code_puppy", "Code Puppy 🐶", "A friendly assistant.")]
-
-        result = _render_menu_panel(
-            entries, page=0, selected_idx=0, current_agent_name=""
-        )
-
-        text = _get_text_from_formatted(result)
-        # Emojis are sanitized for clean terminal rendering
-        assert "Code Puppy" in text
-        assert "Page 1/1" in text
-
-    @pytest.mark.parametrize(
-        ("current", "frag"),
-        [("", "▶"), ("agent2", "current")],
-        ids=["highlights_selected_agent", "marks_current_agent"],
-    )
-    def test_selection_and_current_marker(self, current, frag):
-        """Test that the selected agent is highlighted and current agent marked."""
+    @patch("code_puppy.command_line.agent_menu._get_pinned_model")
+    def test_labels_and_markers(self, mock_pinned):
+        mock_pinned.return_value = None
         entries = [
-            ("agent1", "Agent One", "Description 1"),
-            ("agent2", "Agent Two", "Description 2"),
+            ("agent1", "Agent One", "First"),
+            ("agent2", "Agent Two", "Second"),
         ]
+        items = _agent_items(entries, current_agent_name="agent2")
 
-        result = _render_menu_panel(
-            entries, page=0, selected_idx=0, current_agent_name=current
-        )
+        assert [it.value for it in items] == ["agent1", "agent2"]
+        assert items[0].label == "Agent One"
+        assert items[0].description == ""
+        assert "(current)" in items[1].description
 
-        text = _get_text_from_formatted(result)
-        assert frag in text
+    @patch("code_puppy.command_line.agent_menu._get_pinned_model")
+    def test_pinned_model_marker(self, mock_pinned):
+        mock_pinned.return_value = "gpt-5"
+        items = _agent_items([("a", "A", "desc")], current_agent_name="")
+        assert "-> gpt-5" in items[0].description
 
-    @patch("code_puppy.command_line.agent_menu.get_agent_pinned_model")
-    def test_shows_pinned_model_marker(self, mock_pinned_model):
-        """Test that pinned models are displayed in the menu."""
-        mock_pinned_model.return_value = "gpt-4"
-        entries = [("agent1", "Agent One", "Description 1")]
+    @patch("code_puppy.command_line.agent_menu._get_pinned_model")
+    def test_display_names_are_sanitized(self, mock_pinned):
+        mock_pinned.return_value = None
+        items = _agent_items([("a", "Agent \U0001f436 One", "d")], "")
+        assert items[0].label == "Agent One"
 
-        result = _render_menu_panel(
-            entries, page=0, selected_idx=0, current_agent_name=""
-        )
 
-        text = _get_text_from_formatted(result)
-        assert "gpt-4" in text
+class TestRenderAgentDetails:
+    """Test the ANSI preview pane."""
 
-    @patch("code_puppy.command_line.agent_menu.get_agent_pinned_model")
-    def test_unpinned_model_shows_no_marker(self, mock_pinned_model):
-        """Test that unpinned agents show no pinned model marker."""
-        mock_pinned_model.return_value = None
-        entries = [("agent1", "Agent One", "Description 1")]
+    @patch("code_puppy.command_line.agent_menu.get_bound_servers")
+    @patch("code_puppy.command_line.agent_menu._get_pinned_model")
+    def test_renders_core_fields(self, mock_pinned, mock_bound):
+        mock_pinned.return_value = None
+        mock_bound.return_value = {}
+        details = _render_agent_details(("a1", "Agent One", "Does things."), "a1")
 
-        result = _render_menu_panel(
-            entries, page=0, selected_idx=0, current_agent_name=""
-        )
+        assert "AGENT DETAILS" in details
+        assert "a1" in details
+        assert "Agent One" in details
+        assert "default" in details  # unpinned model
+        assert "none bound (strict opt-in)" in details
+        assert "Does things." in details
+        assert "Currently Active" in details
 
-        text = _get_text_from_formatted(result)
-        # Should not show any model name after the agent name
-        assert "Agent One\n" in text or result[-3][1] == "Agent One"
-        # Verify no arrow/pinned indicator
-        lines = text.split("\n")
-        agent_line = [line for line in lines if "Agent One" in line]
-        assert len(agent_line) == 1
-        assert "→" not in agent_line[0]
+    @patch("code_puppy.command_line.agent_menu.get_bound_servers")
+    @patch("code_puppy.command_line.agent_menu._get_pinned_model")
+    def test_renders_pinned_and_bindings(self, mock_pinned, mock_bound):
+        mock_pinned.return_value = "gpt-5"
+        mock_bound.return_value = {
+            "srv1": {"auto_start": True},
+            "srv2": {},
+        }
+        details = _render_agent_details(("a1", "Agent One", "d"), "other")
+
+        assert "gpt-5" in details
+        assert "2 bound (1 auto-start)" in details
+        assert "Not active" in details
+
+    @patch("code_puppy.command_line.agent_menu.get_bound_servers")
+    @patch("code_puppy.command_line.agent_menu._get_pinned_model")
+    def test_long_description_is_wrapped(self, mock_pinned, mock_bound):
+        mock_pinned.return_value = None
+        mock_bound.return_value = {}
+        long_desc = "word " * 40
+        details = _render_agent_details(("a1", "A", long_desc), "")
+        assert all(len(line) <= 60 for line in details.splitlines() if "word" in line)
+
+
+class TestBuildAgentMenu:
+    """Drive the termflow menu headlessly with scripted keys."""
+
+    def _drive(self, keys, entries, current="", initial=0):
+        from io import StringIO
+
+        script = iter(keys)
+        out = StringIO()
+        pending = {"action": None}
+        with (
+            patch(
+                "code_puppy.command_line.agent_menu._get_pinned_model",
+                return_value=None,
+            ),
+            patch(
+                "code_puppy.command_line.agent_menu.get_bound_servers",
+                return_value={},
+            ),
+        ):
+            menu = build_agent_menu(
+                entries,
+                current,
+                pending,
+                initial,
+                key_source=lambda: next(script),
+                output=out,
+                size=lambda: (120, 40),
+                alt_screen=False,
+            )
+            result = menu.run()
+        return result, pending, out.getvalue()
+
+    ENTRIES = [
+        ("agent1", "Agent One", "First agent"),
+        ("agent2", "Agent Two", "Second agent"),
+        ("agent3", "Agent Three", "Third agent"),
+    ]
+
+    def test_enter_selects_highlighted(self):
+        result, pending, _ = self._drive(["down", "enter"], self.ENTRIES)
+        assert result.item.value == "agent2"
+        assert pending["action"] is None
+
+    def test_escape_cancels(self):
+        result, _, _ = self._drive(["escape"], self.ENTRIES)
+        assert result.cancelled
+
+    def test_initial_index_preselects(self):
+        result, _, _ = self._drive(["enter"], self.ENTRIES, initial=2)
+        assert result.item.value == "agent3"
 
     @pytest.mark.parametrize(
-        ("n_entries", "page", "selected_idx", "frag1", "frag2"),
-        [
-            (25, 0, 0, "Page 1/3", "Agent 00"),
-            (25, 1, 10, "Page 2/3", "Agent 10"),
-            (15, 1, 12, "▶", "Agent 12"),
-            (15, 0, 9, "▶", "Agent 09"),
-        ],
-        ids=[
-            "pagination_page_zero",
-            "pagination_page_one",
-            "selected_agent_on_second_page",
-            "menu_panel_last_item_on_page_selected",
-        ],
+        "key,action", [("p", "pin"), ("b", "bind"), ("c", "clone"), ("d", "delete")]
     )
-    def test_pagination(self, n_entries, page, selected_idx, frag1, frag2):
-        """Test pagination info and selection highlighting."""
-        entries = [
-            (f"agent_{i:02d}", f"Agent {i:02d}", f"Desc {i:02d}")
-            for i in range(n_entries)
-        ]
+    def test_action_keys_exit_with_pending_action(self, key, action):
+        result, pending, _ = self._drive([key], self.ENTRIES)
+        assert pending["action"] == action
+        assert result.item.value == "agent1"
 
-        result = _render_menu_panel(
-            entries, page=page, selected_idx=selected_idx, current_agent_name=""
-        )
+    def test_current_agent_marked(self):
+        _, _, screen = self._drive(["escape"], self.ENTRIES, current="agent2")
+        assert "(current)" in screen
 
-        text = _get_text_from_formatted(result)
-        assert frag1 in text
-        assert frag2 in text
+    def test_pagination_hides_offpage_agents(self):
+        entries = [(f"agent{i:02d}", f"Agent {i:02d}", "d") for i in range(25)]
+        _, _, screen = self._drive(["escape"], entries)
+        from termflow.ansi.utils import visible
 
-    def test_pagination_last_page(self):
-        """Test pagination shows correct info for last page."""
-        entries = [
-            (f"agent_{i:02d}", f"Agent {i:02d}", f"Desc {i:02d}") for i in range(25)
-        ]
-
-        result = _render_menu_panel(
-            entries, page=2, selected_idx=20, current_agent_name=""
-        )
-
-        text = _get_text_from_formatted(result)
-        # Should show page 3 of 3
-        assert "Page 3/3" in text
-
-    def test_shows_navigation_hints(self):
-        """Test that navigation hints are displayed."""
-        result = _render_menu_panel([], page=0, selected_idx=0, current_agent_name="")
-
-        text = _get_text_from_formatted(result)
-        assert "↑↓" in text
-        assert "←→" in text
-        assert "Enter" in text
-        assert "P" in text
-        assert "Pin model" in text
-        assert "C" in text
-        assert "Clone" in text
-        assert "D" in text
-        assert "Delete clone" in text
-        assert "Ctrl+C" in text
-        assert "Navigate" in text
-        assert "Page" in text
-        assert "Select" in text
-        assert "Cancel" in text
-
-    def test_shows_agents_header(self):
-        """Test that Agents header is displayed."""
-        result = _render_menu_panel([], page=0, selected_idx=0, current_agent_name="")
-
-        text = _get_text_from_formatted(result)
-        assert "Agents" in text
-
-    def test_current_agent_indicator_with_selection(self):
-        """Test that both selection and current markers can appear."""
-        entries = [
-            ("agent1", "Agent One", "Description 1"),
-            ("agent2", "Agent Two", "Description 2"),
-        ]
-
-        # Select agent2 which is also the current agent
-        result = _render_menu_panel(
-            entries, page=0, selected_idx=1, current_agent_name="agent2"
-        )
-
-        text = _get_text_from_formatted(result)
-        assert "▶" in text  # Selection
-        assert "current" in text  # Current marker
-
-
-class TestRenderPreviewPanel:
-    """Test the _render_preview_panel function."""
-
-    def test_renders_no_selection(self):
-        """Test rendering when no agent is selected."""
-        result = _render_preview_panel(entry=None, current_agent_name="")
-
-        text = _get_text_from_formatted(result)
-        assert "No agent selected" in text
-        assert "AGENT DETAILS" in text
-
-    @pytest.mark.parametrize(
-        ("entry", "current", "frag1", "frag2"),
-        [
-            (
-                ("code_puppy", "Code Puppy ", "A friendly assistant."),
-                "",
-                "Name:",
-                "code_puppy",
-            ),
-            (
-                ("code_puppy", "Code Puppy ", "A friendly assistant."),
-                "",
-                "Display Name:",
-                "Code Puppy",
-            ),
-            (
-                ("code_puppy", "Code Puppy ", "A friendly coding assistant dog."),
-                "",
-                "Description:",
-                "friendly",
-            ),
-            (
-                ("code_puppy", "Code Puppy ", "A friendly assistant."),
-                "other_agent",
-                "Status:",
-                "Not active",
-            ),
-        ],
-        ids=[
-            "renders_agent_name",
-            "renders_display_name",
-            "renders_description",
-            "renders_status_not_active",
-        ],
-    )
-    def test_renders_preview_fields(self, entry, current, frag1, frag2):
-        """Test that core preview fields are displayed."""
-        result = _render_preview_panel(entry, current_agent_name=current)
-
-        text = _get_text_from_formatted(result)
-        assert frag1 in text
-        assert frag2 in text
-
-    @pytest.mark.parametrize(
-        ("pinned", "frag"),
-        [("gpt-4", "gpt-4"), (None, "default")],
-        ids=["renders_pinned_model", "renders_unpinned_model_shows_default"],
-    )
-    @patch("code_puppy.command_line.agent_menu.get_agent_pinned_model")
-    def test_renders_pinned_model(self, mock_pinned_model, pinned, frag):
-        """Test that pinned model (or default) is shown in the preview panel."""
-        mock_pinned_model.return_value = pinned
-        entry = ("code_puppy", "Code Puppy ", "A friendly assistant.")
-
-        result = _render_preview_panel(entry, current_agent_name="")
-
-        text = _get_text_from_formatted(result)
-        assert "Pinned Model:" in text
-        assert frag in text
-
-    @pytest.mark.parametrize(
-        ("entry", "current", "frag1", "frag2", "frag3"),
-        [
-            (
-                ("code_puppy", "Code Puppy ", "A friendly assistant."),
-                "code_puppy",
-                "Status:",
-                "Currently Active",
-                "",
-            ),
-            (
-                (
-                    "test_agent",
-                    "Test Agent",
-                    "First line of description.\nSecond line of description.\nThird line.",
-                ),
-                "",
-                "First line",
-                "Second line",
-                "Third line",
-            ),
-            (
-                ("test_agent", "Test Agent", ""),
-                "",
-                "Name:",
-                "test_agent",
-                "Display Name:",
-            ),
-        ],
-        ids=[
-            "renders_status_currently_active",
-            "handles_multiline_description",
-            "handles_empty_description",
-        ],
-    )
-    def test_renders_status_and_description(self, entry, current, frag1, frag2, frag3):
-        """Test status marker and multi-line/empty description rendering."""
-        result = _render_preview_panel(entry, current_agent_name=current)
-
-        text = _get_text_from_formatted(result)
-        assert frag1 in text
-        assert frag2 in text
-        assert frag3 in text
-
-    def test_handles_long_description(self):
-        """Test handling of very long descriptions that need word wrapping."""
-        long_description = (
-            "This is a very long description that should be wrapped appropriately "
-            "to fit within the preview panel boundaries without causing display issues."
-        )
-        entry = ("test_agent", "Test Agent", long_description)
-
-        result = _render_preview_panel(entry, current_agent_name="")
-
-        text = _get_text_from_formatted(result)
-        # Should contain parts of the description
-        assert "very long description" in text
-        assert "wrapped" in text
-
-    @pytest.mark.parametrize(
-        ("entry", "frag"),
-        [
-            (("agent1", "Agent One", "Description"), "AGENT DETAILS"),
-            (
-                (
-                    "emoji_agent",
-                    "Emoji Agent ",
-                    "An agent with emojis  and special chars: <>&",
-                ),
-                "Emoji Agent",
-            ),
-            (
-                ("minimal_agent", "Minimal Agent", "No description available"),
-                "No description available",
-            ),
-        ],
-        ids=[
-            "renders_header",
-            "handles_description_with_special_characters",
-            "preview_panel_with_no_description_default",
-        ],
-    )
-    def test_renders_preview_fragment(self, entry, frag):
-        """Test assorted preview panel fragments render correctly."""
-        result = _render_preview_panel(entry, current_agent_name="")
-
-        text = _get_text_from_formatted(result)
-        assert frag in text
+        text = visible(screen)
+        assert "Agent 00" in text
+        assert "Agent 15" not in text

--- a/tests/command_line/test_model_picker_completion.py
+++ b/tests/command_line/test_model_picker_completion.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 from prompt_toolkit.document import Document
 
+from code_puppy.command_line.model_picker_completion import ModelSelectionMenu
+
 
 class TestLoadModelNames:
     def test_returns_model_list(self):
@@ -280,231 +282,142 @@ class TestUpdateModelInInput:
 
 
 class TestModelSelectionMenu:
-    def test_preselects_active_model_page(self):
-        from code_puppy.command_line.model_picker_completion import (
-            MODEL_PICKER_PAGE_SIZE,
-            ModelSelectionMenu,
-        )
+    """Drive the termflow-backed picker headlessly with scripted keys."""
 
-        models = [f"model-{i}" for i in range(MODEL_PICKER_PAGE_SIZE + 5)]
-        active_model = models[-1]
+    MODELS = [f"model-{i:02d}" for i in range(40)]
 
+    def _drive(self, keys, models=None, active="model-00"):
+        from io import StringIO
+
+        script = iter(keys)
+        out = StringIO()
         with patch(
             "code_puppy.command_line.model_picker_completion.get_active_model",
-            return_value=active_model,
+            return_value=active,
         ):
-            menu = ModelSelectionMenu(models)
-
-        assert menu.selected_index == len(models) - 1
-        assert menu.page == 1
-        assert active_model in menu.models_on_page
-
-    def test_page_navigation_moves_selection_to_page_start(self):
-        from code_puppy.command_line.model_picker_completion import (
-            MODEL_PICKER_PAGE_SIZE,
-            ModelSelectionMenu,
-        )
-
-        models = [f"model-{i}" for i in range(MODEL_PICKER_PAGE_SIZE * 2 + 1)]
-
-        with patch(
-            "code_puppy.command_line.model_picker_completion.get_active_model",
-            return_value="missing-model",
-        ):
-            menu = ModelSelectionMenu(models)
-
-        menu._page_down()
-        assert menu.page == 1
-        assert menu.selected_index == MODEL_PICKER_PAGE_SIZE
-
-        menu._page_up()
-        assert menu.page == 0
-        assert menu.selected_index == 0
-
-    def test_move_down_keeps_selection_visible(self):
-        from code_puppy.command_line.model_picker_completion import (
-            MODEL_PICKER_PAGE_SIZE,
-            ModelSelectionMenu,
-        )
-
-        models = [f"model-{i}" for i in range(MODEL_PICKER_PAGE_SIZE + 1)]
-
-        with patch(
-            "code_puppy.command_line.model_picker_completion.get_active_model",
-            return_value="missing-model",
-        ):
-            menu = ModelSelectionMenu(models)
-
-        menu.selected_index = MODEL_PICKER_PAGE_SIZE - 1
-        menu.page = 0
-        menu._move_down()
-
-        assert menu.selected_index == MODEL_PICKER_PAGE_SIZE
-        assert menu.page == 1
-
-    def test_filter_keeps_current_model_selected_when_visible(self):
-        from code_puppy.command_line.model_picker_completion import ModelSelectionMenu
-
-        with patch(
-            "code_puppy.command_line.model_picker_completion.get_active_model",
-            return_value="claude-3-sonnet",
-        ):
-            menu = ModelSelectionMenu(
-                ["gpt-5-mini", "claude-3-sonnet", "claude-3-opus"]
+            menu_obj = ModelSelectionMenu(model_names=models or self.MODELS)
+            menu = menu_obj.build_menu(
+                key_source=lambda: next(script),
+                output=out,
+                size=lambda: (100, 40),
+                alt_screen=False,
             )
+            result = menu.run()
+        return menu_obj, result, out.getvalue()
 
-        menu._set_filter_text("claude")
+    def test_preselects_active_model(self):
+        _, result, _ = self._drive(["enter"], active="model-17")
+        assert result.item.value == "model-17"
 
-        assert menu.visible_model_names == ["claude-3-sonnet", "claude-3-opus"]
-        assert menu.selected_index == 0
+    def test_active_model_marked(self):
+        _, _, screen = self._drive(["escape"], active="model-01")
+        assert "(active)" in screen
 
-    def test_filter_resets_to_first_visible_match_when_selection_disappears(self):
-        from code_puppy.command_line.model_picker_completion import ModelSelectionMenu
+    def test_page_navigation_moves_selection(self):
+        _, result, _ = self._drive(["page-down", "enter"], active="model-00")
+        assert result.item.value == "model-15"  # MODEL_PICKER_PAGE_SIZE == 15
 
-        with patch(
-            "code_puppy.command_line.model_picker_completion.get_active_model",
-            return_value="gpt-5-mini",
-        ):
-            menu = ModelSelectionMenu(
-                ["gpt-5-mini", "claude-3-sonnet", "claude-3-opus"]
-            )
+    def test_left_right_page_via_bound_keys(self):
+        _, result, _ = self._drive(["right", "enter"], active="model-00")
+        assert result.item.value == "model-15"
+        _, result, _ = self._drive(["right", "left", "enter"], active="model-00")
+        assert result.item.value == "model-00"
 
-        menu._set_filter_text("opus")
+    def test_filter_narrows_matches(self):
+        _, result, _ = self._drive(["3", "9", "enter"])
+        assert result.item.value == "model-39"
 
-        assert menu.visible_model_names == ["claude-3-opus"]
-        assert menu.selected_index == 0
+    def test_ctrl_u_clears_filter(self):
+        _, result, _ = self._drive(["3", "9", "ctrl-u", "enter"])
+        # Filter cleared: cursor clamps back into the full list.
+        assert result.item.value in self.MODELS
 
-    def test_accept_selection_returns_false_when_filter_has_no_matches(self):
-        from code_puppy.command_line.model_picker_completion import ModelSelectionMenu
+    def test_enter_ignored_when_filter_has_no_matches(self):
+        _, result, _ = self._drive(["z", "z", "enter", "escape"])
+        assert result.cancelled
 
-        with patch(
-            "code_puppy.command_line.model_picker_completion.get_active_model",
-            return_value="missing-model",
-        ):
-            menu = ModelSelectionMenu(["gpt-5-mini", "claude-3-sonnet"])
+    def test_no_matches_renders_hint(self):
+        from termflow.ansi.utils import visible
 
-        menu._set_filter_text("nope")
+        _, _, screen = self._drive(["z", "escape"])
+        assert "(no matches)" in visible(screen)
 
-        assert menu._accept_selection() is False
-        assert menu.result is None
-
-    def test_accept_selection_guards_invalid_selected_index(self):
-        from code_puppy.command_line.model_picker_completion import ModelSelectionMenu
-
-        with patch(
-            "code_puppy.command_line.model_picker_completion.get_active_model",
-            return_value="missing-model",
-        ):
-            menu = ModelSelectionMenu(["gpt-5-mini"])
-
-        menu.selected_index = 99
-
-        assert menu._accept_selection() is False
-        assert menu.result is None
-
-    def test_render_no_matches_mentions_filter_and_clear_shortcut(self):
-        from code_puppy.command_line.model_picker_completion import ModelSelectionMenu
-
-        with patch(
-            "code_puppy.command_line.model_picker_completion.get_active_model",
-            return_value="missing-model",
-        ):
-            menu = ModelSelectionMenu(["gpt-5-mini", "claude-3-sonnet"])
-
-        menu._set_filter_text("nope")
-
-        rendered = "".join(text for _, text in menu._render())
-
-        assert "No models match the current filter." in rendered
-        assert "Clear filter" in rendered
-
-
-def _key_tuple(binding) -> tuple:
-    """Normalise a prompt_toolkit binding's keys into plain strings.
-
-    Control keys / special keys are ``Keys`` enum members whose ``.value`` is
-    the canonical string ('c-e', '<any>', ...); literal characters are plain
-    strings already.
-    """
-    return tuple(getattr(k, "value", k) for k in binding.keys)
-
-
-async def _capture_key_bindings(menu):
-    """Run the menu with the prompt_toolkit Application stubbed out and return
-    the KeyBindings object the menu registered.
-
-    The real bindings are built *inside* ``run_async`` and handed to a fresh
-    ``Application``; we intercept that Application so nothing interactive ever
-    launches.
-    """
-    from code_puppy.command_line import model_picker_completion
-
-    captured = {}
-
-    class _FakeApp:
-        def __init__(self, *args, **kwargs):
-            captured["kb"] = kwargs.get("key_bindings")
-
-        async def run_async(self):  # no-op: exit immediately, result stays None
-            return None
-
-        def exit(self, *args, **kwargs):
-            pass
-
-        def invalidate(self):
-            pass
-
-    with patch.object(model_picker_completion, "Application", _FakeApp):
-        await menu.run_async()
-
-    return captured["kb"]
+    def test_escape_cancels(self):
+        menu_obj, result, _ = self._drive(["escape"])
+        assert result.cancelled
+        assert menu_obj.pending_credentials_edit is None
 
 
 class TestModelSelectionMenuKeybindings:
-    """Footgun guard: editing credentials must NOT shadow type-to-filter.
+    def test_edit_credentials_bound_to_ctrl_e(self):
+        from io import StringIO
 
-    The edit-credentials action should live on Ctrl+E ('c-e'). If plain 'e' is
-    bound to it, the more-specific binding wins over the '<any>' filter handler
-    and you can never type the letter 'e' to filter models (deepseek,
-    claude-code, byteplus, ... all contain 'e').
-    """
+        script = iter(["ctrl-e"])
+        with (
+            patch(
+                "code_puppy.command_line.model_picker_completion.get_active_model",
+                return_value="m1",
+            ),
+            patch(
+                "code_puppy.command_line.model_picker_completion.required_env_var_for_model",
+                return_value="API_KEY",
+            ),
+        ):
+            menu_obj = ModelSelectionMenu(model_names=["m1", "m2"])
+            menu = menu_obj.build_menu(
+                key_source=lambda: next(script),
+                output=StringIO(),
+                size=lambda: (100, 30),
+                alt_screen=False,
+            )
+            result = menu.run()
+        assert menu_obj.pending_credentials_edit == "m1"
+        assert result.item.value == "m1"
 
-    @pytest.mark.asyncio
-    async def test_edit_credentials_bound_to_ctrl_e(self):
-        from code_puppy.command_line.model_picker_completion import ModelSelectionMenu
+    def test_ctrl_e_without_env_var_stays_in_menu(self):
+        from io import StringIO
 
+        script = iter(["ctrl-e", "escape"])
+        with (
+            patch(
+                "code_puppy.command_line.model_picker_completion.get_active_model",
+                return_value="m1",
+            ),
+            patch(
+                "code_puppy.command_line.model_picker_completion.required_env_var_for_model",
+                return_value=None,
+            ),
+        ):
+            menu_obj = ModelSelectionMenu(model_names=["m1"])
+            menu = menu_obj.build_menu(
+                key_source=lambda: next(script),
+                output=StringIO(),
+                size=lambda: (100, 30),
+                alt_screen=False,
+            )
+            result = menu.run()
+        assert menu_obj.pending_credentials_edit is None
+        assert result.cancelled
+
+    def test_plain_e_reaches_filter(self):
+        from io import StringIO
+
+        script = iter(["e", "escape"])
         with patch(
             "code_puppy.command_line.model_picker_completion.get_active_model",
-            return_value="missing-model",
+            return_value="alpha",
         ):
-            menu = ModelSelectionMenu(["deepseek", "claude-code", "byteplus"])
-
-        kb = await _capture_key_bindings(menu)
-        all_keys = [_key_tuple(b) for b in kb.bindings]
-
-        assert ("c-e",) in all_keys, (
-            f"edit-credentials must be bound to Ctrl+E; bound keys: {all_keys}"
-        )
-
-    @pytest.mark.asyncio
-    async def test_plain_e_not_bound_so_it_reaches_filter(self):
-        from code_puppy.command_line.model_picker_completion import ModelSelectionMenu
-
-        with patch(
-            "code_puppy.command_line.model_picker_completion.get_active_model",
-            return_value="missing-model",
-        ):
-            menu = ModelSelectionMenu(["deepseek", "claude-code", "byteplus"])
-
-        kb = await _capture_key_bindings(menu)
-        all_keys = [_key_tuple(b) for b in kb.bindings]
-
-        # The '<any>' handler must still be present to do the filtering.
-        assert ("<any>",) in all_keys, f"missing type-to-filter handler: {all_keys}"
-        # Plain 'e' must NOT be bound, or it shadows '<any>' and breaks filtering.
-        assert ("e",) not in all_keys, (
-            f"plain 'e' is bound and shadows type-to-filter; bound keys: {all_keys}"
-        )
+            menu_obj = ModelSelectionMenu(model_names=["alpha", "beta"])
+            menu = menu_obj.build_menu(
+                key_source=lambda: next(script),
+                output=(out := StringIO()),
+                size=lambda: (100, 30),
+                alt_screen=False,
+            )
+            menu.run()
+        # "e" became search text, not a credential action.
+        assert menu_obj.pending_credentials_edit is None
+        assert "search: " in out.getvalue() or "e" in out.getvalue()
 
 
 class TestInteractiveModelPicker:

--- a/tests/command_line/test_tui_keybindings.py
+++ b/tests/command_line/test_tui_keybindings.py
@@ -326,16 +326,42 @@ def test_model_settings_keybindings():
 
 
 def test_agent_menu_keybindings():
-    from code_puppy.command_line.agent_menu import interactive_agent_picker
+    import code_puppy.command_line.agent_menu as am
+    from io import StringIO
 
     # Create enough entries for multiple pages (PAGE_SIZE=10)
     entries = [(f"agent{i}", f"Agent {i}", "builtin") for i in range(25)]
+
+    # One shared script spanning the picker's sequential menu runs:
+    #   run 1: navigate + page both directions, then "p" (pin action)
+    #   run 2: "c" (clone action)
+    #   run 3: "d" (delete action)
+    #   run 4: enter (select highlighted)
+    script = iter(["down", "up", "right", "left", "p", "c", "d", "enter"])
+
+    real_build = am.build_agent_menu
+
+    def headless_build(entries_arg, current, pending, idx, **_overrides):
+        return real_build(
+            entries_arg,
+            current,
+            pending,
+            idx,
+            key_source=lambda: next(script),
+            output=StringIO(),
+            size=lambda: (120, 40),
+            alt_screen=False,
+        )
+
     with (
         patch(
             "code_puppy.command_line.agent_menu._get_agent_entries",
             return_value=entries,
         ),
-        patch("code_puppy.command_line.agent_menu.Application") as mock_app_cls,
+        patch(
+            "code_puppy.command_line.agent_menu.build_agent_menu",
+            side_effect=headless_build,
+        ),
         patch("code_puppy.command_line.agent_menu.set_awaiting_user_input"),
         patch(
             "code_puppy.command_line.agent_menu._select_pinned_model",
@@ -349,38 +375,21 @@ def test_agent_menu_keybindings():
         patch(
             "code_puppy.command_line.agent_menu.delete_clone_agent", return_value=True
         ),
+        patch(
+            "code_puppy.command_line.agent_menu.get_current_agent", return_value=None
+        ),
+        patch(
+            "code_puppy.command_line.agent_menu._get_pinned_model", return_value=None
+        ),
+        patch("code_puppy.command_line.agent_menu.get_bound_servers", return_value={}),
         patch("code_puppy.command_line.agent_menu.emit_warning"),
-        patch("sys.stdout"),
-        patch("asyncio.sleep", new_callable=AsyncMock),
+        patch("code_puppy.command_line.agent_menu.emit_info"),
     ):
-        mock_app = AsyncMock()
-        mock_app_cls.return_value = mock_app
+        result = asyncio.run(am.interactive_agent_picker())
 
-        call_count = [0]
-
-        async def run_and_capture():
-            call_count[0] += 1
-            kb = _extract_kb(mock_app_cls)
-            if kb:
-                if call_count[0] == 1:
-                    # First call: navigate down then up to cover both bodies
-                    _fire(kb, {"down"})  # selected_idx: 0->1
-                    _fire(kb, {"up"})  # selected_idx: 1->0 (covers up body)
-                    # Navigate to next page and back
-                    _fire(kb, {"right"})  # page 0->1
-                    _fire(kb, {"left"})  # page 1->0
-                    _fire(kb, {"p"})  # pin action
-                elif call_count[0] == 2:
-                    _fire(kb, {"c"})  # clone action
-                elif call_count[0] == 3:
-                    _fire(kb, {"d"})  # delete action
-                elif call_count[0] == 4:
-                    _fire(kb, {"c-m"})  # enter/select
-                else:
-                    _fire(kb, {"c-c"})
-
-        mock_app.run_async = run_and_capture
-        _run_coro(interactive_agent_picker())
+    # After pin/clone/delete detours, the final Enter selects the
+    # highlighted agent (delete resets the cursor to the top).
+    assert result == "agent0"
 
 
 # ============================================================

--- a/uv.lock
+++ b/uv.lock
@@ -489,7 +489,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.28.0" },
     { name = "rich", specifier = ">=13.4.2" },
     { name = "ripgrep", marker = "sys_platform != 'android'", specifier = "==14.1.0" },
-    { name = "termflow-md", specifier = ">=0.1.11" },
+    { name = "termflow-md", specifier = ">=0.2.1" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
 provides-extras = ["bedrock", "durable", "computer-use"]
@@ -2757,15 +2757,15 @@ wheels = [
 
 [[package]]
 name = "termflow-md"
-version = "0.1.11"
+version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pygments" },
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/9d/85297bbe0277905c45428422335454ce4131a72d98b7c613d0b3ec0fb7b7/termflow_md-0.1.11.tar.gz", hash = "sha256:8e18f937ca136801160dddd4b837499e028c6573aebb4da7aa74ec1fa57cc87f", size = 115509, upload-time = "2026-04-18T17:05:25.217Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/8b/6e7217d293cd9eb637faa0f90471faa31f8e4da976dcece3710a6c7671a2/termflow_md-0.2.1.tar.gz", hash = "sha256:5fafe8cf501b2abd1d825aeef2777e459c1f0586c9840282d23f586e5aeb54b1", size = 136511, upload-time = "2026-08-22T20:08:12.705Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/49/0fa8324879351c59ceb169f443c578fd6f8272ee3e71268f0b9140589614/termflow_md-0.1.11-py3-none-any.whl", hash = "sha256:4fd6f375b4a06aa06987dfc80d2910fed2b27e9576c50d49c7f3903c67195b2a", size = 58710, upload-time = "2026-04-18T17:05:23.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/65/6591b5fadf0bd9394176642324ccb7eb4919e20a2c70a86863b89c13feb0/termflow_md-0.2.1-py3-none-any.whl", hash = "sha256:86df260f3d436b8fad63480ace8dd524ab5b152668527a7039923fdebf37bba0", size = 77097, upload-time = "2026-08-22T20:08:11.605Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

First wave of the termflow consolidation: the streaming smoother and three interactive pickers now ride on `termflow.stream` / `termflow.tui` instead of bespoke prompt_toolkit machinery.

| Module | Before | After |
|---|---|---|
| `agents/smooth_stream.py` | 310-line engine | ~110-line adapter (engine lives in termflow.stream) |
| `command_line/mcp_binding_menu.py` | prompt_toolkit Application x2 | MenuBuilder with on_key toggles |
| `command_line/model_picker_completion.py` | 325-line Application class | MenuBuilder + credential-edit loop |
| `command_line/agent_menu.py` | Application + manual pagination | MenuBuilder + action-key dispatch loop |

## Behavior preserved

- Pin/bind/clone/delete action keys and the deferred pin-reload queue (worker-loop deadlock avoidance) in the agent picker
- Ctrl+E credential editing loop in the model picker (menu closes, edits, reopens)
- Fuzzy filtering via `query_matches_text` (injected through `filter_fn`)
- Immediate-mutation semantics of MCP binding toggles

## Tests

Menus are now driven headlessly (scripted `key_source`, captured output) instead of firing prompt_toolkit binding closures. Full suite: **7605 passed / 0 failed**, ruff clean.

## Notes

- `termflow-md>=0.2.1` (published; MenuBuilder grew `on_key`/`initial_index`/`list_width`/`filter_fn` for exactly these ports)
- Companion PR in code_puppy_core_plugins ports the theme plugin (palettes/OSC/picker)
- Remaining prompt_toolkit menus (colors, set, diff, uc, autosave, add_model, model_settings, ask_user_question) follow the same recipe in subsequent PRs