### PR TITLE
fix: support GPT-5.6 Responses reasoning

### DIFF
--- a/code_puppy/agents/_compaction.py
+++ b/code_puppy/agents/_compaction.py
@@ -263,7 +263,7 @@ async def compact(
 def _strip_empty_thinking_parts(
     messages: List[ModelMessage],
 ) -> Tuple[List[ModelMessage], int]:
-    """Remove empty ThinkingParts; drop messages rendered empty by removal."""
+    """Remove empty ThinkingParts without discarding replay signatures."""
     cleaned: List[ModelMessage] = []
     filtered_count = 0
     for msg in messages:
@@ -272,16 +272,22 @@ def _strip_empty_thinking_parts(
             len(parts) == 1
             and isinstance(parts[0], ThinkingPart)
             and not parts[0].content
+            and not parts[0].signature
         ):
             filtered_count += 1
             continue
-        if any(isinstance(p, ThinkingPart) and not p.content for p in parts):
+        if any(
+            isinstance(p, ThinkingPart) and not p.content and not p.signature
+            for p in parts
+        ):
             msg = dataclasses.replace(
                 msg,
                 parts=[
                     p
                     for p in parts
-                    if not (isinstance(p, ThinkingPart) and not p.content)
+                    if not (
+                        isinstance(p, ThinkingPart) and not p.content and not p.signature
+                    )
                 ],
             )
             if not msg.parts:
@@ -300,7 +306,7 @@ def make_history_processor(agent: Any) -> Callable[..., Any]:
          (preserving the last-message regardless of compacted-hash collisions).
       3. Runs ``compact(...)`` if we're over threshold (or ``/compact`` forced).
       4. Records dropped-message hashes in ``agent._compacted_message_hashes``.
-      5. Strips empty ThinkingParts.
+      5. Strips empty ThinkingParts that carry no replay signature.
       6. Trims trailing ModelResponse messages so history ends with a ModelRequest.
       7. Fires ``on_message_history_processor_end``.
 

--- a/code_puppy/chatgpt_codex_client.py
+++ b/code_puppy/chatgpt_codex_client.py
@@ -25,6 +25,52 @@ import httpx
 logger = logging.getLogger(__name__)
 
 
+def _merge_output_items(
+    envelope_output: list[dict], streamed_items: list[dict]
+) -> list[dict]:
+    """Merge `response.completed` envelope output with streamed item payloads.
+
+    The streamed ``output_item.done`` payloads are richer (they carry
+    reasoning ids and ``encrypted_content`` needed for replay), so they win
+    for any item present in both. Items only the envelope saw (a dropped
+    stream event) keep their envelope position; items only the stream saw
+    (a partial store=false envelope) are inserted before the item that
+    followed them in stream order, preserving reasoning-before-message
+    pairing.
+    """
+    envelope_ids = {item.get("id") for item in envelope_output if item.get("id")}
+    if not envelope_ids:
+        return list(streamed_items)
+
+    streamed_by_id = {item.get("id"): item for item in streamed_items if item.get("id")}
+    if envelope_ids <= streamed_by_id.keys():
+        # Envelope is a subset of the stream: stream order is complete.
+        return list(streamed_items)
+
+    # Rare: the envelope has an item the stream missed. Use the envelope as
+    # the spine, swap in richer streamed twins, and slot stream-only items
+    # ahead of their stream successor (or at the end).
+    pending_before: dict[str, list[dict]] = {}
+    carry: list[dict] = []
+    for item in streamed_items:
+        item_id = item.get("id")
+        if item_id in envelope_ids:
+            if carry:
+                pending_before[item_id] = carry
+                carry = []
+        else:
+            carry.append(item)
+    tail = carry
+
+    merged: list[dict] = []
+    for item in envelope_output:
+        item_id = item.get("id")
+        merged.extend(pending_before.get(item_id, []))
+        merged.append(streamed_by_id.get(item_id, item))
+    merged.extend(tail)
+    return merged
+
+
 def _is_reasoning_model(model_name: str) -> bool:
     """Check if a model supports reasoning parameters."""
     reasoning_models = [
@@ -300,9 +346,13 @@ class ChatGPTCodexAsyncClient(httpx.AsyncClient):
             response_body = dict(final_response_data)
             # The completed envelope may contain a partial output (for example,
             # only the message). Prefer the complete output_item.done payloads,
-            # which preserve reasoning ids and encrypted_content for replay.
+            # which preserve reasoning ids and encrypted_content for replay --
+            # but merge rather than replace, so an item whose done event was
+            # dropped mid-stream is never lost if the envelope still has it.
             if completed_output_items:
-                response_body["output"] = completed_output_items
+                response_body["output"] = _merge_output_items(
+                    response_body.get("output") or [], completed_output_items
+                )
             else:
                 # No items captured either — fall back to text/tool deltas.
                 rebuilt: list[dict] = []

--- a/code_puppy/chatgpt_codex_client.py
+++ b/code_puppy/chatgpt_codex_client.py
@@ -298,10 +298,12 @@ class ChatGPTCodexAsyncClient(httpx.AsyncClient):
         # (empty when store=false) output with the collected output_item.done items.
         if final_response_data:
             response_body = dict(final_response_data)
-            existing_output = response_body.get("output") or []
-            if not existing_output and completed_output_items:
+            # The completed envelope may contain a partial output (for example,
+            # only the message). Prefer the complete output_item.done payloads,
+            # which preserve reasoning ids and encrypted_content for replay.
+            if completed_output_items:
                 response_body["output"] = completed_output_items
-            elif not existing_output:
+            else:
                 # No items captured either — fall back to text/tool deltas.
                 rebuilt: list[dict] = []
                 if collected_text:

--- a/code_puppy/chatgpt_codex_client.py
+++ b/code_puppy/chatgpt_codex_client.py
@@ -153,7 +153,7 @@ class ChatGPTCodexAsyncClient(httpx.AsyncClient):
             forced_stream = True  # Only convert if WE forced streaming
             modified = True
 
-        # Add reasoning settings for reasoning models (gpt-5.2, o-series, etc.)
+        # Add the default reasoning settings for supported reasoning models.
         model = data.get("model", "")
         if "reasoning" not in data and _is_reasoning_model(model):
             data["reasoning"] = {

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -146,9 +146,18 @@ def _thinking_tags_profile(
     from code_puppy.model_utils import get_thinking_tags
 
     tags = get_thinking_tags(model_name, model_config)
-    if tags is None:
-        return None
-    return OpenAIModelProfile(thinking_tags=tags)
+    profile_kwargs: dict[str, Any] = {}
+    if tags is not None:
+        profile_kwargs["thinking_tags"] = tags
+
+    underlying_name = str(model_config.get("name", model_name)).lower()
+    if "gpt-5.6" in underlying_name:
+        profile_kwargs.update(
+            openai_responses_supports_reasoning_mode=True,
+            openai_responses_supports_reasoning_context=True,
+        )
+
+    return OpenAIModelProfile(**profile_kwargs) if profile_kwargs else None
 
 
 def _merge_dotted_key(target: dict, dotted_key: str, value: Any) -> None:
@@ -303,7 +312,9 @@ def make_model_settings(
         # Plain OpenAIChatModelSettings without reasoning params.
         model_settings = OpenAIChatModelSettings(**model_settings_dict)
 
-    elif "gpt-5" in model_name:
+    elif "gpt-5" in model_name or (
+        model_type == "openai" and "gpt-5" in str(model_config.get("name", "")).lower()
+    ):
         # Normalize legacy effort values (minimal->none, ultra->max)
         _EFFORT_ALIAS = {"minimal": "none", "ultra": "max"}
         effort = effective_settings.get("reasoning_effort", "medium")
@@ -313,7 +324,13 @@ def make_model_settings(
         uses_responses_api = (
             model_type == "chatgpt_oauth"
             or model_type == "azure_foundry_openai"
-            or (model_type == "openai" and "codex" in model_name)
+            or (
+                model_type == "openai"
+                and (
+                    "codex" in model_name
+                    or "gpt-5.6" in str(model_config.get("name", "")).lower()
+                )
+            )
             or (
                 model_type in _CUSTOM_OPENAI_MODEL_TYPES
                 and _custom_openai_uses_responses_api(model_name, model_config)
@@ -329,28 +346,12 @@ def make_model_settings(
                     "verbosity", "medium"
                 )
 
-            underlying_name = str(model_config.get("name", "")).lower()
-            is_gpt_5_6 = "gpt-5.6" in model_name.lower() or "gpt-5.6" in underlying_name
-            if is_gpt_5_6:
-                # pydantic-ai 2.31.0 HAS openai_reasoning_mode/context settings,
-                # but they're gated on profile flags
-                # (openai_responses_supports_reasoning_{mode,context}) that
-                # custom-endpoint GPT-5.6 routes don't reliably carry — the
-                # fields would be silently dropped. extra_body delivers the
-                # full reasoning object unconditionally, so keep it (and pop
-                # effort/summary so pydantic-ai's partial doesn't clobber it).
-                reasoning = {
-                    "effort": model_settings_dict.pop("openai_reasoning_effort"),
-                    "summary": model_settings_dict.pop("openai_reasoning_summary"),
-                    "context": effective_settings.get("reasoning_context", "all_turns"),
-                    "mode": effective_settings.get("reasoning_mode", "standard"),
-                }
-                extra_body = dict(model_settings_dict.get("extra_body") or {})
-                extra_body["reasoning"] = reasoning
-                model_settings_dict["extra_body"] = extra_body
-                model_settings_dict.pop("reasoning_context", None)
-                model_settings_dict.pop("reasoning_mode", None)
-
+            model_settings_dict["openai_reasoning_context"] = effective_settings.get(
+                "reasoning_context", "all_turns"
+            )
+            model_settings_dict["openai_reasoning_mode"] = effective_settings.get(
+                "reasoning_mode", "standard"
+            )
             model_settings = OpenAIResponsesModelSettings(**model_settings_dict)
         else:
             # Chat Completions models don't support configurable reasoning summaries.
@@ -710,9 +711,11 @@ class ModelFactory:
                 provider=provider,
                 profile=_thinking_tags_profile(model_name, model_config),
             )
-            if "codex" in model_name:
+            if "codex" in model_name or "gpt-5.6" in model_config["name"].lower():
                 model = OpenAIResponsesModel(
-                    model_name=model_config["name"], provider=provider
+                    model_name=model_config["name"],
+                    provider=provider,
+                    profile=_thinking_tags_profile(model_name, model_config),
                 )
             return model
 

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -155,6 +155,7 @@ def _thinking_tags_profile(
         profile_kwargs.update(
             openai_responses_supports_reasoning_mode=True,
             openai_responses_supports_reasoning_context=True,
+            openai_supports_encrypted_reasoning_content=True,
         )
 
     return OpenAIModelProfile(**profile_kwargs) if profile_kwargs else None

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -313,9 +313,11 @@ def make_model_settings(
         # Plain OpenAIChatModelSettings without reasoning params.
         model_settings = OpenAIChatModelSettings(**model_settings_dict)
 
-    elif "gpt-5" in model_name or (
-        model_type == "openai" and "gpt-5" in str(model_config.get("name", "")).lower()
-    ):
+    elif "gpt-5" in model_name or "gpt-5" in str(model_config.get("name", "")).lower():
+        # Match on the underlying model name as well as the config key:
+        # custom endpoint entries are often keyed by an alias (e.g.
+        # "luna-responses" -> name "gpt-5.6-luna") and would otherwise
+        # silently skip all reasoning configuration.
         # Normalize legacy effort values (minimal->none, ultra->max)
         _EFFORT_ALIAS = {"minimal": "none", "ultra": "max"}
         effort = effective_settings.get("reasoning_effort", "medium")
@@ -712,7 +714,10 @@ class ModelFactory:
                 provider=provider,
                 profile=_thinking_tags_profile(model_name, model_config),
             )
-            if "codex" in model_name or "gpt-5.6" in model_config["name"].lower():
+            if (
+                "codex" in model_name
+                or "gpt-5.6" in str(model_config.get("name", "")).lower()
+            ):
                 model = OpenAIResponsesModel(
                     model_name=model_config["name"],
                     provider=provider,

--- a/tests/test_chatgpt_codex_client.py
+++ b/tests/test_chatgpt_codex_client.py
@@ -341,6 +341,44 @@ class TestConvertStreamToResponse:
         assert body["output"][0]["call_id"] == "call_123"
 
     @pytest.mark.asyncio
+    async def test_preserve_complete_reasoning_output_over_partial_envelope(self):
+        """Retain encrypted reasoning when response.completed is incomplete."""
+        reasoning = {
+            "type": "reasoning",
+            "id": "rs_123",
+            "encrypted_content": "opaque-reasoning-token",
+            "summary": [],
+        }
+        message = {
+            "type": "message",
+            "id": "msg_123",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Hello"}],
+        }
+        sse_lines = [
+            f'data: {json.dumps({"type": "response.output_item.done", "item": reasoning})}',
+            f'data: {json.dumps({"type": "response.output_item.done", "item": message})}',
+            f'data: {json.dumps({"type": "response.completed", "response": {"id": "resp_123", "output": [message]}})}',
+            "data: [DONE]",
+        ]
+
+        async def mock_aiter_lines():
+            for line in sse_lines:
+                yield line
+
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_response.aiter_lines = mock_aiter_lines
+        mock_response.request = Mock()
+
+        result = await ChatGPTCodexAsyncClient()._convert_stream_to_response(mock_response)
+        output = json.loads(result.content)["output"]
+
+        assert output == [reasoning, message]
+        assert output[0]["encrypted_content"] == "opaque-reasoning-token"
+
+    @pytest.mark.asyncio
     async def test_use_response_completed_data(self):
         """Test that response.completed event data is used when available."""
         final_response = {

--- a/tests/test_chatgpt_codex_client.py
+++ b/tests/test_chatgpt_codex_client.py
@@ -356,9 +356,9 @@ class TestConvertStreamToResponse:
             "content": [{"type": "output_text", "text": "Hello"}],
         }
         sse_lines = [
-            f'data: {json.dumps({"type": "response.output_item.done", "item": reasoning})}',
-            f'data: {json.dumps({"type": "response.output_item.done", "item": message})}',
-            f'data: {json.dumps({"type": "response.completed", "response": {"id": "resp_123", "output": [message]}})}',
+            f"data: {json.dumps({'type': 'response.output_item.done', 'item': reasoning})}",
+            f"data: {json.dumps({'type': 'response.output_item.done', 'item': message})}",
+            f"data: {json.dumps({'type': 'response.completed', 'response': {'id': 'resp_123', 'output': [message]}})}",
             "data: [DONE]",
         ]
 
@@ -372,7 +372,9 @@ class TestConvertStreamToResponse:
         mock_response.aiter_lines = mock_aiter_lines
         mock_response.request = Mock()
 
-        result = await ChatGPTCodexAsyncClient()._convert_stream_to_response(mock_response)
+        result = await ChatGPTCodexAsyncClient()._convert_stream_to_response(
+            mock_response
+        )
         output = json.loads(result.content)["output"]
 
         assert output == [reasoning, message]
@@ -891,3 +893,45 @@ class TestEdgeCases:
         body = json.loads(result.content)
         # Only "Hello" should be collected (empty strings are falsy)
         assert body["output"][0]["content"][0]["text"] == "Hello"
+
+
+class TestMergeOutputItems:
+    """Merge semantics for envelope output vs streamed output_item.done."""
+
+    def _items(self):
+        reasoning = {"type": "reasoning", "id": "rs_1", "encrypted_content": "enc"}
+        message = {"type": "message", "id": "msg_1", "role": "assistant"}
+        return reasoning, message
+
+    def test_stream_wins_when_envelope_is_subset(self):
+        from code_puppy.chatgpt_codex_client import _merge_output_items
+
+        reasoning, message = self._items()
+        merged = _merge_output_items([message], [reasoning, message])
+        assert merged == [reasoning, message]
+
+    def test_empty_envelope_returns_stream(self):
+        from code_puppy.chatgpt_codex_client import _merge_output_items
+
+        reasoning, message = self._items()
+        merged = _merge_output_items([], [reasoning, message])
+        assert merged == [reasoning, message]
+
+    def test_dropped_stream_event_recovered_from_envelope(self):
+        from code_puppy.chatgpt_codex_client import _merge_output_items
+
+        reasoning, message = self._items()
+        extra = {"type": "function_call", "id": "fc_1", "call_id": "call_1"}
+        # The stream missed the function_call item; the envelope has it.
+        merged = _merge_output_items([message, extra], [reasoning, message])
+        assert merged == [reasoning, message, extra]
+
+    def test_streamed_twin_replaces_envelope_copy(self):
+        from code_puppy.chatgpt_codex_client import _merge_output_items
+
+        reasoning, message = self._items()
+        stale = {"type": "message", "id": "msg_1", "role": "assistant", "old": True}
+        extra = {"type": "function_call", "id": "fc_1", "call_id": "call_1"}
+        merged = _merge_output_items([stale, extra], [reasoning, message])
+        assert merged == [reasoning, message, extra]
+        assert "old" not in merged[1]

--- a/tests/test_chatgpt_codex_client.py
+++ b/tests/test_chatgpt_codex_client.py
@@ -180,6 +180,21 @@ class TestInjectCodexFields:
         assert result is not None
         data = json.loads(result)
         assert "reasoning" in data
+        assert data["reasoning"] == {
+            "effort": "medium",
+            "summary": "auto",
+        }
+
+    def test_preserve_explicit_reasoning_summary(self):
+        body = json.dumps(
+            {
+                "model": "gpt-5",
+                "reasoning": {"effort": "low", "summary": "auto"},
+            }
+        ).encode()
+        result, _ = ChatGPTCodexAsyncClient._inject_codex_fields(body)
+        data = json.loads(result)
+        assert data["reasoning"] == {"effort": "low", "summary": "auto"}
 
     def test_no_reasoning_for_gpt4(self):
         """Test that reasoning is NOT added for GPT-4 models."""

--- a/tests/test_compaction_reasoning.py
+++ b/tests/test_compaction_reasoning.py
@@ -1,0 +1,23 @@
+from pydantic_ai.messages import ModelResponse, ThinkingPart
+
+from code_puppy.agents._compaction import _strip_empty_thinking_parts
+
+
+def test_preserve_empty_signed_thinking_part():
+    message = ModelResponse(
+        [ThinkingPart(content="", id="rs_1", signature="encrypted")]
+    )
+
+    cleaned, filtered = _strip_empty_thinking_parts([message])
+
+    assert cleaned == [message]
+    assert filtered == 0
+
+
+def test_remove_empty_unsigned_thinking_part():
+    message = ModelResponse([ThinkingPart(content="", id="rs_1")])
+
+    cleaned, filtered = _strip_empty_thinking_parts([message])
+
+    assert cleaned == []
+    assert filtered == 1

--- a/tests/test_model_factory_reasoning.py
+++ b/tests/test_model_factory_reasoning.py
@@ -1,0 +1,48 @@
+from unittest.mock import patch
+
+from code_puppy.model_factory import ModelFactory, make_model_settings
+
+
+def test_openai_gpt5_alias_uses_responses_reasoning_settings():
+    config = {
+        "openai-gpt-5.6-luna": {
+            "type": "openai",
+            "provider": "openai",
+            "name": "gpt-5.6-luna",
+            "context_length": 1_050_000,
+            "supported_settings": [
+                "temperature",
+                "top_p",
+                "reasoning_effort",
+                "verbosity",
+            ],
+        }
+    }
+    with (
+        patch.object(ModelFactory, "load_config", return_value=config),
+        patch(
+            "code_puppy.config.get_custom_model_settings",
+            return_value={},
+        ),
+    ):
+        settings = make_model_settings("openai-gpt-5.6-luna", max_tokens=4096)
+
+    assert settings["openai_reasoning_effort"] == "medium"
+    assert settings["openai_reasoning_summary"] == "auto"
+    assert settings["openai_reasoning_context"] == "all_turns"
+    assert settings["openai_reasoning_mode"] == "standard"
+    assert settings["openai_text_verbosity"] == "medium"
+
+
+def test_gpt56_alias_profile_enables_reasoning_fields():
+    """The exact extra-model alias gets the profile gates it needs."""
+    from code_puppy.model_factory import _thinking_tags_profile
+
+    profile = _thinking_tags_profile(
+        "openai-gpt-5.6-luna",
+        {"name": "gpt-5.6-luna"},
+    )
+
+    assert profile is not None
+    assert profile["openai_responses_supports_reasoning_mode"] is True
+    assert profile["openai_responses_supports_reasoning_context"] is True

--- a/tests/test_model_factory_reasoning.py
+++ b/tests/test_model_factory_reasoning.py
@@ -46,3 +46,4 @@ def test_gpt56_alias_profile_enables_reasoning_fields():
     assert profile is not None
     assert profile["openai_responses_supports_reasoning_mode"] is True
     assert profile["openai_responses_supports_reasoning_context"] is True
+    assert profile["openai_supports_encrypted_reasoning_content"] is True

--- a/tests/test_model_factory_reasoning.py
+++ b/tests/test_model_factory_reasoning.py
@@ -47,3 +47,37 @@ def test_gpt56_alias_profile_enables_reasoning_fields():
     assert profile["openai_responses_supports_reasoning_mode"] is True
     assert profile["openai_responses_supports_reasoning_context"] is True
     assert profile["openai_supports_encrypted_reasoning_content"] is True
+
+
+def test_alias_keyed_custom_responses_model_gets_reasoning_settings():
+    """A config key without "gpt-5" must still match on the underlying name."""
+    config = {
+        "luna-responses": {
+            "type": "custom_openai_responses",
+            "name": "gpt-5.6-luna",
+            "context_length": 1_050_000,
+            "custom_endpoint": {
+                "url": "https://api.openai.com/v1",
+                "api_key": "$OPENAI_API_KEY",
+            },
+            "supported_settings": [
+                "temperature",
+                "top_p",
+                "reasoning_effort",
+                "verbosity",
+            ],
+        }
+    }
+    with (
+        patch.object(ModelFactory, "load_config", return_value=config),
+        patch(
+            "code_puppy.config.get_custom_model_settings",
+            return_value={},
+        ),
+    ):
+        settings = make_model_settings("luna-responses", max_tokens=4096)
+
+    assert settings["openai_reasoning_effort"] == "medium"
+    assert settings["openai_reasoning_summary"] == "auto"
+    assert settings["openai_reasoning_context"] == "all_turns"
+    assert settings["openai_reasoning_mode"] == "standard"


### PR DESCRIPTION
## Summary
- support GPT-5.6 OpenAI aliases through the Responses API
- configure native reasoning mode/context and encrypted reasoning replay
- preserve signed empty reasoning parts needed before tool calls
- preserve complete streamed output items, including encrypted reasoning
- add regression coverage for model settings, compaction, and response reconstruction

Closes #746

## Compatibility note
Existing conversations created before this change may contain incomplete or incompatible Responses API reasoning history. Resuming those conversations may not work reliably; start a fresh conversation if resume fails.

## Testing
- `uv run pytest tests/test_compaction_reasoning.py tests/test_model_factory_reasoning.py tests/test_chatgpt_codex_client.py -q` (61 passed)