### PR TITLE
Charge image tokens by area instead of digest length (#783)

### DIFF
--- a/code_puppy/agents/_history.py
+++ b/code_puppy/agents/_history.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import dataclasses
 import hashlib
+import io
 import json
 import math
 import re
@@ -80,6 +81,11 @@ def stringify_part(part: Any) -> str:
                 attributes.append(f"content={item}")
             elif isinstance(item, BinaryContent):
                 attributes.append(f"BinaryContent={_digest_bytes(item.data)}")
+            else:
+                # ImageUrl / DocumentUrl / anything pydantic-ai adds later.
+                # Without this arm such items contribute nothing, so two
+                # messages pointing at different URLs hash identically.
+                attributes.append(f"content={repr(item)}")
     else:
         attributes.append(f"content={repr(content)}")
 
@@ -109,6 +115,62 @@ def hash_message(message: Any) -> str:
 def estimate_tokens(text: str) -> int:
     """Dirt-simple tiktoken replacement: ``max(1, floor(len(text) / 2.5))``."""
     return max(1, math.floor(len(text) / 2.5))
+
+
+# Vision models bill images by area, not by the handful of characters our
+# digest happens to occupy. Anthropic documents roughly (width * height) / 750
+# tokens and OpenAI's tile math lands in the same ballpark, so use that.
+_IMAGE_PIXELS_PER_TOKEN = 750
+
+# Charged when dimensions can't be read: a corrupt or unsupported image, or a
+# non-image attachment such as a PDF whose real cost isn't visible from here.
+# Deliberately generous, because undercounting is the failure that silently
+# skips compaction and ends the run on a provider 400.
+_BINARY_CONTENT_FALLBACK_TOKENS = 1500
+
+
+def _image_dimensions(data: bytes) -> Optional[tuple[int, int]]:
+    """``(width, height)`` of an encoded image, or None if it can't be read.
+
+    ``Image.open`` parses only the header; pixel data is loaded lazily and we
+    never touch it, so this stays cheap enough for the estimation path.
+    """
+    try:
+        from PIL import Image
+
+        with Image.open(io.BytesIO(data)) as img:
+            return img.size
+    except Exception:
+        return None
+
+
+def estimate_binary_content_tokens(item: Any) -> int:
+    """Token charge for a single ``BinaryContent`` attachment.
+
+    ``stringify_part`` deliberately reduces binary data to a short digest so
+    hashes stay stable and cheap, which means the digest string tells us
+    nothing about what the image actually costs. Estimate that here instead.
+    """
+    media_type = getattr(item, "media_type", "") or ""
+    data = getattr(item, "data", b"") or b""
+    if media_type.startswith("image/"):
+        dimensions = _image_dimensions(data)
+        if dimensions is not None:
+            width, height = dimensions
+            return max(1, (width * height) // _IMAGE_PIXELS_PER_TOKEN)
+    return _BINARY_CONTENT_FALLBACK_TOKENS
+
+
+def _binary_tokens_in_part(part: Any) -> int:
+    """Total binary-attachment token charge for one message part."""
+    content = getattr(part, "content", None)
+    if not isinstance(content, list):
+        return 0
+    return sum(
+        estimate_binary_content_tokens(item)
+        for item in content
+        if isinstance(item, BinaryContent)
+    )
 
 
 # Models whose tokenizer the char/2.5 heuristic systematically *under*counts;
@@ -155,6 +217,7 @@ def estimate_tokens_for_message(
         part_str = stringify_part(part)
         if part_str:
             total += estimate_tokens(part_str)
+        total += _binary_tokens_in_part(part)
     return _apply_multiplier(max(1, total), model_name)
 
 

--- a/tests/agents/test_history_binary_tokens.py
+++ b/tests/agents/test_history_binary_tokens.py
@@ -1,0 +1,128 @@
+"""Token estimation for binary attachments in code_puppy.agents._history.
+
+The estimator reduces a BinaryContent to a 16-hex-char digest for hashing, so
+without a separate charge a full-page screenshot scores about as much as the
+word "screenshot". That undercount propagates into compact()'s threshold, the
+50k-per-message rule in filter_huge_messages, and the /context badge, so a
+session carrying a handful of images can sail past the real context limit and
+die on a provider 400 with compaction having never run.
+"""
+
+import io
+
+import pytest
+from PIL import Image
+from pydantic_ai import BinaryContent
+from pydantic_ai.messages import ModelRequest, UserPromptPart
+
+from code_puppy.agents._history import (
+    _BINARY_CONTENT_FALLBACK_TOKENS,
+    estimate_binary_content_tokens,
+    estimate_tokens_for_message,
+    hash_message,
+    stringify_part,
+)
+
+
+def _png(width: int, height: int) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), "red").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _image_message(*images: bytes) -> ModelRequest:
+    return ModelRequest(
+        parts=[
+            UserPromptPart(
+                content=[
+                    BinaryContent(data=data, media_type="image/png") for data in images
+                ]
+            )
+        ]
+    )
+
+
+def test_large_image_estimates_in_the_thousands():
+    # A 2048x2048 screenshot is worth thousands of tokens to any vision model.
+    # Before binary charging it scored 16, the length of its digest string.
+    tokens = estimate_tokens_for_message(_image_message(_png(2048, 2048)))
+    assert tokens > 5000
+
+
+def test_image_estimate_scales_with_area():
+    # Compare the binary charge itself. A whole-message comparison would be
+    # muddied by the fixed digest string, which dominates a tiny image.
+    small = estimate_binary_content_tokens(
+        BinaryContent(data=_png(64, 64), media_type="image/png")
+    )
+    large = estimate_binary_content_tokens(
+        BinaryContent(data=_png(1024, 1024), media_type="image/png")
+    )
+    # 256x the pixels. Not exactly 256x the charge: the small image's 5.46
+    # tokens floor to 5, so the ratio comes out a little above 256.
+    assert large > small * 250
+
+
+def test_many_screenshots_accumulate():
+    one = estimate_tokens_for_message(_image_message(_png(1024, 1024)))
+    twenty = estimate_tokens_for_message(_image_message(*[_png(1024, 1024)] * 20))
+    assert twenty > one * 15
+
+
+def test_unreadable_image_falls_back_rather_than_undercounting():
+    item = BinaryContent(data=b"definitely not a png", media_type="image/png")
+    assert estimate_binary_content_tokens(item) == _BINARY_CONTENT_FALLBACK_TOKENS
+
+
+def test_non_image_binary_uses_fallback():
+    item = BinaryContent(data=b"%PDF-1.4 ...", media_type="application/pdf")
+    assert estimate_binary_content_tokens(item) == _BINARY_CONTENT_FALLBACK_TOKENS
+
+
+def test_text_only_message_estimate_is_unchanged():
+    # Guard against the binary charge leaking into ordinary messages.
+    message = ModelRequest(parts=[UserPromptPart(content="hello puppy")])
+    assert estimate_tokens_for_message(message) == 12
+
+
+def test_binary_content_still_hashes_by_digest():
+    # The charge is additive; stringify_part must keep emitting the digest so
+    # existing dedup hashes stay stable.
+    data = _png(32, 32)
+    part = _image_message(data).parts[0]
+    assert "BinaryContent=" in stringify_part(part)
+
+
+def test_differing_images_still_hash_differently():
+    assert hash_message(_image_message(_png(32, 32))) != hash_message(
+        _image_message(_png(64, 64))
+    )
+
+
+class _UnknownItem:
+    """Stands in for ImageUrl / DocumentUrl / whatever pydantic-ai adds next."""
+
+    def __init__(self, url: str):
+        self.url = url
+
+    def __repr__(self) -> str:
+        return f"_UnknownItem(url={self.url!r})"
+
+
+def test_unknown_list_items_do_not_collide():
+    # Without the else arm in stringify_part these both reduced to
+    # "user-prompt" and hashed identically, so distinct pages deduped away.
+    a = ModelRequest(parts=[UserPromptPart(content=[_UnknownItem("https://a/1.png")])])
+    b = ModelRequest(parts=[UserPromptPart(content=[_UnknownItem("https://b/2.png")])])
+    assert stringify_part(a.parts[0]) != stringify_part(b.parts[0])
+    assert hash_message(a) != hash_message(b)
+
+
+@pytest.mark.parametrize("media_type", ["image/png", "image/jpeg", "image/webp"])
+def test_common_image_types_are_measured(media_type):
+    fmt = {"image/png": "PNG", "image/jpeg": "JPEG", "image/webp": "WEBP"}[media_type]
+    buf = io.BytesIO()
+    Image.new("RGB", (800, 600), "blue").save(buf, format=fmt)
+    item = BinaryContent(data=buf.getvalue(), media_type=media_type)
+    # Measured from real dimensions, so distinctly not the blind fallback.
+    assert estimate_binary_content_tokens(item) == (800 * 600) // 750


### PR DESCRIPTION
Fixes #783.

`stringify_part` reduces a `BinaryContent` to a 16-hex-char digest, and `estimate_tokens` then scores that string. So an image costs whatever its digest happens to be long, no matter what is in it. Reproduced on `main`:

```
2048x2048 PNG -> 16 tokens        (a vision model bills ~5,592)
20 screenshots -> 252 tokens      (real cost ~112,000)
```

That undercount flows into `compact()`'s threshold, `filter_huge_messages`' 50k rule, and the `/context` badge, which is why an image-heavy session sails past the real limit and dies on a provider 400 with compaction having never run.

While reproducing it I found a second bug in the same loop. The `for item in content:` arm handles `str` and `BinaryContent` and nothing else, so `ImageUrl` and `DocumentUrl` contribute *nothing*:

```
ImageUrl("https://a.example/1.png")  -> 'user-prompt'
ImageUrl("https://b.example/other.png") -> 'user-prompt'
hashes collide: True
```

Two different images dedup into one.

## What this does

`estimate_tokens_for_message` now adds a per-`BinaryContent` charge from real image dimensions, using `(width * height) / 750` — the ratio Anthropic documents, and close enough to OpenAI's tile math. Dimensions come from Pillow, already a dependency; `Image.open` parses just the header, so no pixel decoding on the estimation path.

Unreadable images and non-image attachments (PDFs and such) take a deliberately generous constant rather than a small one. Overcharging costs an early compaction; undercharging is what kills the run.

`stringify_part` still emits the digest exactly as before, so the charge is purely additive and existing dedup hashes are untouched. There's a test pinning that.

The list loop gets an `else` arm appending `repr(item)`, which fixes both the zero-token contribution and the hash collision.

After:

| | before | after |
|---|---:|---:|
| 2048x2048 image | 16 | 5,608 |
| 20 screenshots | 252 | 112,092 |
| corrupt image / PDF | 16 | 1,516 |
| plain text message | 12 | 12 |
| different ImageUrls collide | yes | no |

## Testing

12 new tests in `tests/agents/test_history_binary_tokens.py`: the 2048x2048 case from the issue, area scaling, accumulation across 20 screenshots, both fallback paths, png/jpeg/webp, the collision fix, and two guards that text-only estimates and digest-based hashing are unchanged.

I checked the tests actually fail when each fix is reverted — dropping the binary charge fails the large-image test, dropping the `else` arm fails the collision test — so they are not passing vacuously.

`tests/agents/` is 415 passed. `ruff check` and `ruff format` clean at 0.15.