### PR TITLE
Keep a repeated user prompt when the turn is genuinely new (#781)

### DIFF
--- a/code_puppy/agents/_compaction.py
+++ b/code_puppy/agents/_compaction.py
@@ -331,13 +331,22 @@ def make_history_processor(agent: Any) -> Callable[..., Any]:
         existing_hashes = {hash_message(m) for m in history}
         messages_added = 0
         last_idx = len(messages) - 1
+        # pydantic-ai hands us the history it knows about plus this turn's new
+        # prompt, so being handed more messages than we hold means the last one
+        # is genuinely new. Its hash can still collide: hashes are
+        # timestamp-independent, so a repeated short prompt like "yes" or "1"
+        # hashes identically to the earlier one. Treating that as a duplicate
+        # drops the turn, and the trailing-ModelResponse pop below then removes
+        # the preceding assistant answer too.
+        has_new_turn = len(messages) > len(history)
         for i, msg in enumerate(messages):
             h = hash_message(msg)
-            if h in existing_hashes:
+            is_new_turn = i == last_idx and has_new_turn
+            if h in existing_hashes and not is_new_turn:
                 continue
             # Always keep the newest message even on hash collision — short
             # prompts like "yes"/"1" can collide and get silently dropped.
-            if i == last_idx or h not in compacted_hashes:
+            if is_new_turn or h not in compacted_hashes:
                 history.append(msg)
                 messages_added += 1
 

--- a/tests/agents/test_compaction.py
+++ b/tests/agents/test_compaction.py
@@ -517,6 +517,40 @@ class TestMakeHistoryProcessor:
             await make_history_processor(agent)(_ctx(), [_user_msg("yes")])
         assert len(agent._message_history) == 1
 
+    async def test_repeated_user_prompt_is_not_dropped_as_duplicate(self):
+        """A second "yes" answering a different question must survive.
+
+        Hashes are timestamp-independent, so a repeated short prompt hashes
+        identically to the earlier one. Treating that as a duplicate dropped
+        the turn, and the trailing-ModelResponse pop then removed the previous
+        assistant answer as well, so the model lost both sides of the exchange.
+        """
+        agent = _FakeAgent(model_max=1_000_000)
+        agent._message_history = [_user_msg("yes"), _assistant_text("Deleting it now.")]
+        incoming = [
+            _user_msg("yes"),
+            _assistant_text("Deleting it now."),
+            _user_msg("yes"),
+        ]
+        with patch.object(_compaction, "get_compaction_threshold", return_value=0.95):
+            result = await make_history_processor(agent)(_ctx(), incoming)
+
+        user_turns = [m for m in result if isinstance(m, ModelRequest)]
+        assert len(user_turns) == 2, "the second 'yes' was dropped"
+        assert any(isinstance(m, ModelResponse) for m in result), (
+            "the earlier assistant answer was destroyed by the trailing pop"
+        )
+
+    async def test_resent_history_with_no_new_turn_still_dedupes(self):
+        """Guard the other direction: an identical resend must not grow history."""
+        agent = _FakeAgent(model_max=1_000_000)
+        agent._message_history = [_user_msg("yes"), _assistant_text("done")]
+        with patch.object(_compaction, "get_compaction_threshold", return_value=0.95):
+            await make_history_processor(agent)(
+                _ctx(), [_user_msg("yes"), _assistant_text("done")]
+            )
+        assert len(agent._message_history) == 1  # trailing response popped
+
     async def test_strips_trailing_model_responses(self):
         agent = _FakeAgent(model_max=1_000_000)
         msgs = [_user_msg("q"), _assistant_text("a"), _assistant_text("trailing")]


### PR DESCRIPTION
Fixes #781.

`hash_message` is deliberately timestamp-independent, so answering two different questions with `yes` produces the same hash both times:

```
hash('yes') turn 1: 6f2245e1533438c3
hash('yes') turn 2: 6f2245e1533438c3
identical: True
```

The merge loop skipped the second one as a duplicate. Because that left history ending on a `ModelResponse`, the trailing-response pop below it then removed the earlier assistant answer too. Running the real merge on a two-turn conversation:

```
history before : [USER 'yes'] [ASSIST 'Deleting the branch now.']
incoming       : [USER 'yes'] [ASSIST 'Deleting the branch now.'] [USER 'yes']
messages merged: 0
history after  : [USER 'yes']

user turns the model can see : 1   (expected 2)
prior assistant answer kept  : False (expected True)
```

Three messages in, one out, and it is written back to `agent._message_history` permanently. The model never sees the second question and loses its own previous answer.

Worth noting the comment already sitting above the collision guard:

```python
# Always keep the newest message even on hash collision — short
# prompts like "yes"/"1" can collide and get silently dropped.
```

That is exactly right, but the unconditional `continue` one line earlier meant the guard was only ever reached for messages that were *not* already in `existing_hashes` — so it never protected the case it describes.

## The fix

A hash collision is not the same thing as a duplicate. pydantic-ai passes the history it already knows about plus this turn's new prompt, so when it hands us more messages than we are holding, the last one is a genuinely new turn regardless of what its hash matches.

```python
has_new_turn = len(messages) > len(history)
...
is_new_turn = i == last_idx and has_new_turn
if h in existing_hashes and not is_new_turn:
    continue
```

## Why not the one-liner in the issue

The issue suggests exempting the last index unconditionally (`if h in existing_hashes and i != last_idx`). That breaks `test_dedupes_by_hash`, because an identical resend with no new turn also ends on a colliding last message, and history would grow every time. The message-count check separates the two cases.

I verified all three states rather than assuming:

| variant | result |
|---|---|
| current `main` | new regression test fails (the bug) |
| unconditional last-index exemption | `test_dedupes_by_hash` fails |
| this PR | 27 passed |

## Testing

Two new tests in `tests/agents/test_compaction.py`: one for the repeated prompt, asserting both that the second turn survives and that the earlier assistant answer is not destroyed; and one guarding the opposite direction, that an identical resend with no new turn still dedupes.

`tests/agents/` is 405 passed. `ruff check` and `ruff format` clean at 0.15.