### PR TITLE
fix: drop hardcoded planning-agent ban from GPT-5.6 delegation guard

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -545,7 +545,6 @@ def _build_gpt_5_6_invoke_agent_guard_text() -> str:
         "\n\n## Sub-Agent Delegation (GPT-5.6)\n"
         "Use `invoke_agent` only for focused work that benefits from separate "
         "context or specialized tools. Handle work directly when you can. "
-        "Never invoke `planning-agent`. "
         f"Hard cap: as a GPT-5.6 caller you may only invoke a sub-agent while "
         f"the resulting chain depth stays at or below {limit} "
         f"(main agent = depth 0). Do not attempt deeper chains.\n"


### PR DESCRIPTION
## What

Removes a single hardcoded line from `_build_gpt_5_6_invoke_agent_guard_text()` in `code_puppy/agents/_builder.py`:

```python
"Never invoke \`planning-agent\`. "
```

## Why

This string is appended to the system prompt of **any** agent whose model name contains `gpt-5.6` (substring match via `_is_gpt_5_6_family`). The result is that GPT-5.6 agents refuse to delegate to `planning-agent` and explain the refusal as a *runtime* prohibition.

That explanation is misleading, because no such runtime block exists:

- `_invoke_agent_impl` in `code_puppy/tools/subagent_invocation.py` refuses only on **depth** grounds (`_subagent_recursion_blocked` / `_gpt_5_6_recursion_blocked`). There is no agent-name allow/deny list anywhere in the invocation path.
- `planning-agent` remains registered and visible in `list_agents` output, so users see an agent that is listed, appears invocable, and is nonetheless refused.

The guard text is also appended last — after the system prompt, puppy rules, and the extended-thinking note — which maximises its salience for exactly the models that treat terse imperatives most literally.

Worth noting the inconsistency with its immediate neighbour: the sibling depth cap in the same function is user-tunable via the `subagent_recursion_limit_gpt_5_6` config key and carries a comment explaining why the limit is read at prompt-assembly time. This agent-name ban had no config escape hatch and no stated rationale.

## Scope

One line deleted. The depth cap and the shell-safety overlay are untouched.

## Testing

- `python -m py_compile code_puppy/agents/_builder.py` — passes
- `pytest tests/test_subagent_invocation_usage.py` — 51 passed
- No test in `tests/` asserts on the removed string

## Note for reviewers

If this ban was originally added to work around a specific GPT-5.6 failure mode (for example a planning-agent delegation loop), then removing it outright is the wrong fix and it should instead become a documented, config-gated option. I could not find a comment or commit message stating such a rationale, so this PR takes the straightforward reading. Happy to convert it to a config key if you know the backstory.

Ref: https://jira.walmart.com/browse/PUP-665