### PR TITLE
Keep MCP registry and user-plugin tree in sync with what actually loads

### DIFF
--- a/code_puppy/command_line/mcp/trust_command.py
+++ b/code_puppy/command_line/mcp/trust_command.py
@@ -150,11 +150,14 @@ class TrustCommand(MCPCommandBase):
 
     def _revoke(self, group_id: str) -> None:
         if revoke_project_mcp():
+            try:
+                self.manager.sync_from_config()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Post-revoke registry sync failed: %s", exc)
             emit_info(
                 Text.from_markup(
                     "[green]\u2713 Revoked[/green] trust for this project's MCP "
-                    "config. Its servers will no longer load. Restart or re-sync "
-                    "to drop already-registered ones."
+                    "config. Its servers will no longer load."
                 ),
                 message_group=group_id,
             )

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -595,7 +595,7 @@ def _parse_mcp_servers_mapping(raw_text: str) -> dict:
     return servers
 
 
-def load_mcp_server_configs():
+def load_mcp_server_configs(*, raise_on_error: bool = False):
     """Load MCP server configs, merging user-level and trusted project-level.
 
     Sources, in ascending order of precedence:
@@ -610,6 +610,11 @@ def load_mcp_server_configs():
     Project entries win on name collision, matching how project agents, skills,
     and plugins override their user-level counterparts. Returns an empty dict
     when nothing is configured.
+
+    When *raise_on_error* is true, a parse/IO failure of an existing user-level
+    file (or a failure of the project loader) is re-raised after the error is
+    emitted, so callers that unregister missing names can skip that drop
+    instead of treating ``{}`` as "configure nothing".
     """
     from code_puppy.messaging.message_queue import emit_error
 
@@ -622,6 +627,8 @@ def load_mcp_server_configs():
                 configs.update(_parse_mcp_servers_mapping(f.read()))
     except Exception as e:
         emit_error(f"Failed to load MCP servers - {str(e)}")
+        if raise_on_error:
+            raise
 
     # 2. Project-level config (opt-in, trust-gated). A broken or untrusted
     #    project file must never break user-level loading.
@@ -633,6 +640,8 @@ def load_mcp_server_configs():
             configs.update(project_configs)
     except Exception as e:
         emit_error(f"Failed to load project MCP servers - {str(e)}")
+        if raise_on_error:
+            raise
 
     return configs
 

--- a/code_puppy/mcp_/manager.py
+++ b/code_puppy/mcp_/manager.py
@@ -161,10 +161,7 @@ class MCPManager:
         try:
             from code_puppy.config import load_mcp_server_configs
 
-            configs = load_mcp_server_configs()
-            if not configs:
-                logger.debug("No servers found in mcp_servers.json")
-                return
+            configs = load_mcp_server_configs() or {}
 
             synced_count = 0
             updated_count = 0
@@ -209,9 +206,23 @@ class MCPManager:
                     logger.warning(f"Failed to sync server '{name}' from config: {e}")
                     continue
 
-            if synced_count > 0 or updated_count > 0:
+            configured_names = {
+                name for name, conf in configs.items() if isinstance(conf, dict)
+            }
+            dropped_count = 0
+            for existing in list(self.registry.list_all()):
+                if existing.name not in configured_names:
+                    if self.remove_server(existing.id):
+                        dropped_count += 1
+                        logger.debug(
+                            "Dropped server no longer in mcp_servers.json: %s",
+                            existing.name,
+                        )
+
+            if synced_count > 0 or updated_count > 0 or dropped_count > 0:
                 logger.info(
-                    f"Synced {synced_count} new and updated {updated_count} servers from mcp_servers.json"
+                    f"Synced {synced_count} new, updated {updated_count}, "
+                    f"dropped {dropped_count} servers from mcp_servers.json"
                 )
 
         except Exception as e:

--- a/code_puppy/mcp_/manager.py
+++ b/code_puppy/mcp_/manager.py
@@ -161,7 +161,7 @@ class MCPManager:
         try:
             from code_puppy.config import load_mcp_server_configs
 
-            configs = load_mcp_server_configs() or {}
+            configs = load_mcp_server_configs(raise_on_error=True) or {}
 
             synced_count = 0
             updated_count = 0

--- a/code_puppy/plugins/__init__.py
+++ b/code_puppy/plugins/__init__.py
@@ -117,6 +117,18 @@ def _install_project_plugin_finder() -> None:
 
 PLUGIN_ENTRY_POINT_GROUP = "code_puppy.plugins"
 
+# shell_safety implements the safety_permission_level threshold. Skip it only
+# when the user opted into high/critical autonomy; the default (medium) must
+# load it or the setting is a no-op.
+_SHELL_SAFETY_SKIP_LEVELS = frozenset({"high", "critical"})
+
+
+def _skip_shell_safety_plugin() -> bool:
+    from code_puppy.config import get_safety_permission_level
+
+    return get_safety_permission_level() in _SHELL_SAFETY_SKIP_LEVELS
+
+
 # Track if plugins have already been loaded to prevent duplicate registration
 _PLUGINS_LOADED = False
 
@@ -135,18 +147,13 @@ def _load_installed_plugins() -> list[str]:
     project plugins, but remain physically independent from the core package.
     Entry points are sorted for deterministic startup and test behavior.
     """
-    from code_puppy.config import get_safety_permission_level
-
     loaded: list[str] = []
     discovered = sorted(
         entry_points(group=PLUGIN_ENTRY_POINT_GROUP), key=lambda item: item.name
     )
     for entry_point in discovered:
         plugin_name = entry_point.name
-        if plugin_name == "shell_safety" and get_safety_permission_level() not in (
-            "none",
-            "low",
-        ):
+        if plugin_name == "shell_safety" and _skip_shell_safety_plugin():
             logger.debug("Skipping shell_safety plugin due to safety permission level")
             continue
         try:
@@ -191,14 +198,12 @@ def _load_builtin_plugins(
                 continue
 
             if callbacks_file.exists():
-                # Skip shell_safety plugin unless safety_permission_level is "low" or "none"
-                if plugin_name == "shell_safety":
-                    safety_level = get_safety_permission_level()
-                    if safety_level not in ("none", "low"):
-                        logger.debug(
-                            f"Skipping shell_safety plugin - safety_permission_level is '{safety_level}' (needs 'low' or 'none')"
-                        )
-                        continue
+                if plugin_name == "shell_safety" and _skip_shell_safety_plugin():
+                    logger.debug(
+                        "Skipping shell_safety plugin - safety_permission_level is %s",
+                        get_safety_permission_level(),
+                    )
+                    continue
 
                 try:
                     module_name = f"code_puppy.plugins.{plugin_name}.register_callbacks"

--- a/code_puppy/session_surrogate_unpickler.py
+++ b/code_puppy/session_surrogate_unpickler.py
@@ -72,9 +72,9 @@ _TZINFO_EQUIVALENTS: Dict[Tuple[str, str], Callable[..., Any]] = {
     ("pydantic_core", "TzInfo"): _tz_from_utc_offset,
 }
 
-# Genuine timezone libraries: unpickle their classes for real when the
-# library is installed; otherwise fall back to surrogates as usual.
-_TZ_LIBRARY_PREFIXES = ("pytz", "dateutil.tz")
+# pytz / dateutil.tz must NOT go through super().find_class: those packages
+# re-export os/sys the same way uuid and collections did. Known tzinfo
+# shapes are rebuilt via _TZINFO_EQUIVALENTS; everything else is a surrogate.
 
 
 class SurrogateBase:
@@ -145,14 +145,6 @@ class SurrogateUnpickler(pickle.Unpickler):
         equivalent = _TZINFO_EQUIVALENTS.get((module, name))
         if equivalent is not None:
             return equivalent
-        if any(
-            module == prefix or module.startswith(prefix + ".")
-            for prefix in _TZ_LIBRARY_PREFIXES
-        ):
-            try:
-                return super().find_class(module, name)
-            except Exception:  # noqa: BLE001 - library absent/renamed
-                pass
         return self._surrogate_for(module, name)
 
     def _tz_tolerant(self, obj: Any) -> Any:

--- a/code_puppy/tools/file_modifications.py
+++ b/code_puppy/tools/file_modifications.py
@@ -46,20 +46,59 @@ from code_puppy.tools.file_permission_state import (
 )
 
 
+def _split_existing(path: Path) -> tuple[Path, tuple[str, ...]]:
+    """Deepest existing ancestor of *path*, plus the missing trailing names."""
+    missing: list[str] = []
+    current = path
+    while True:
+        if current.exists():
+            return current.resolve(), tuple(reversed(missing))
+        parent = current.parent
+        if parent == current:
+            return current, tuple(reversed(missing))
+        missing.append(current.name)
+        current = parent
+
+
+def _casefold_has_prefix(parts: tuple[str, ...], prefix: tuple[str, ...]) -> bool:
+    if len(parts) < len(prefix):
+        return False
+    return all(a.casefold() == b.casefold() for a, b in zip(prefix, parts))
+
+
+def _is_inside_user_plugin_root(target: Path, root: Path) -> bool:
+    """Containment that survives APFS case-folding. ``Path.resolve`` does not."""
+    target_existing, target_rest = _split_existing(target)
+    root_existing, root_rest = _split_existing(root)
+
+    if os.path.samefile(target_existing, root_existing):
+        return _casefold_has_prefix(target_rest, root_rest)
+
+    current = target_existing
+    while True:
+        if os.path.samefile(current, root_existing):
+            return not root_rest
+        parent = current.parent
+        if parent == current:
+            return False
+        current = parent
+
+
 def _is_user_plugin_tree_path(file_path: str) -> bool:
     """True if *file_path* is inside ``~/.code_puppy/plugins``.
 
     That tree is imported at the next process start with no trust ceremony.
     File tools must not plant ``register_callbacks.py`` there.
+    Canonicalization errors fail closed (treated as inside).
     """
     from code_puppy.plugins import USER_PLUGINS_DIR
 
     try:
         resolved = Path(resolve_path(file_path)).resolve()
         root = Path(USER_PLUGINS_DIR).expanduser().resolve()
+        return _is_inside_user_plugin_root(resolved, root)
     except (OSError, RuntimeError, ValueError):
-        return False
-    return resolved == root or root in resolved.parents
+        return True
 
 
 def _refuse_user_plugin_tree(file_path: str) -> Dict[str, Any] | None:

--- a/code_puppy/tools/file_modifications.py
+++ b/code_puppy/tools/file_modifications.py
@@ -14,6 +14,7 @@ import difflib
 import json
 import os
 import traceback
+from pathlib import Path
 from code_puppy.undo_manager import UndoManager
 import warnings
 from typing import Annotated, Any, Dict, List, Union
@@ -43,6 +44,36 @@ from code_puppy.tools.file_permission_state import (
     get_last_user_feedback,
     was_diff_already_shown,
 )
+
+
+def _is_user_plugin_tree_path(file_path: str) -> bool:
+    """True if *file_path* is inside ``~/.code_puppy/plugins``.
+
+    That tree is imported at the next process start with no trust ceremony.
+    File tools must not plant ``register_callbacks.py`` there.
+    """
+    from code_puppy.plugins import USER_PLUGINS_DIR
+
+    try:
+        resolved = Path(resolve_path(file_path)).resolve()
+        root = Path(USER_PLUGINS_DIR).expanduser().resolve()
+    except (OSError, RuntimeError, ValueError):
+        return False
+    return resolved == root or root in resolved.parents
+
+
+def _refuse_user_plugin_tree(file_path: str) -> Dict[str, Any] | None:
+    if not _is_user_plugin_tree_path(file_path):
+        return None
+    return {
+        "success": False,
+        "path": file_path,
+        "message": (
+            "Refused: file tools cannot modify ~/.code_puppy/plugins. "
+            "That directory is imported at startup."
+        ),
+        "changed": False,
+    }
 
 
 def _permission_denied(permission_results: List[Any]) -> bool:
@@ -424,6 +455,9 @@ def _write_to_file(
 def delete_snippet_from_file(
     context: RunContext, file_path: str, snippet: str, message_group: str | None = None
 ) -> Dict[str, Any]:
+    refused = _refuse_user_plugin_tree(file_path)
+    if refused is not None:
+        return refused
     # Use the plugin system for permission handling with operation data
     from code_puppy.callbacks import on_file_permission
 
@@ -452,6 +486,9 @@ def write_to_file(
     overwrite: bool,
     message_group: str | None = None,
 ) -> Dict[str, Any]:
+    refused = _refuse_user_plugin_tree(path)
+    if refused is not None:
+        return refused
     # Use the plugin system for permission handling with operation data
     from code_puppy.callbacks import on_file_permission
 
@@ -481,6 +518,9 @@ def replace_in_file(
     replacements: List[Dict[str, str]],
     message_group: str | None = None,
 ) -> Dict[str, Any]:
+    refused = _refuse_user_plugin_tree(path)
+    if refused is not None:
+        return refused
     # Use the plugin system for permission handling with operation data
     from code_puppy.callbacks import on_file_permission
 
@@ -504,6 +544,9 @@ async def delete_snippet_from_file_async(
     context: RunContext, file_path: str, snippet: str, message_group: str | None = None
 ) -> Dict[str, Any]:
     """Async permission-aware variant of ``delete_snippet_from_file``."""
+    refused = _refuse_user_plugin_tree(file_path)
+    if refused is not None:
+        return refused
     from code_puppy.callbacks import on_file_permission_async
 
     operation_data = {"snippet": snippet}
@@ -530,6 +573,9 @@ async def write_to_file_async(
     message_group: str | None = None,
 ) -> Dict[str, Any]:
     """Async permission-aware variant of ``write_to_file``."""
+    refused = _refuse_user_plugin_tree(path)
+    if refused is not None:
+        return refused
     from code_puppy.callbacks import on_file_permission_async
 
     operation_data = {"content": content, "overwrite": overwrite}
@@ -556,6 +602,9 @@ async def replace_in_file_async(
     message_group: str | None = None,
 ) -> Dict[str, Any]:
     """Async permission-aware variant of ``replace_in_file``."""
+    refused = _refuse_user_plugin_tree(path)
+    if refused is not None:
+        return refused
     from code_puppy.callbacks import on_file_permission_async
 
     operation_data = {"replacements": replacements}
@@ -726,6 +775,9 @@ async def _edit_file_async(
 def _delete_file(
     context: RunContext, file_path: str, message_group: str | None = None
 ) -> Dict[str, Any]:
+    refused = _refuse_user_plugin_tree(file_path)
+    if refused is not None:
+        return refused
     UndoManager().record_change(file_path, "delete_file")
     file_path = resolve_path(file_path)
 
@@ -786,6 +838,9 @@ async def _delete_file_async(
     context: RunContext, file_path: str, message_group: str | None = None
 ) -> Dict[str, Any]:
     """Async permission-aware variant of ``_delete_file``."""
+    refused = _refuse_user_plugin_tree(file_path)
+    if refused is not None:
+        return refused
     file_path = resolve_path(file_path)
 
     from code_puppy.callbacks import on_file_permission_async

--- a/tests/mcp/test_manager_extended.py
+++ b/tests/mcp/test_manager_extended.py
@@ -646,11 +646,21 @@ class TestMCPManagerExtended:
         with patch("code_puppy.mcp_.manager.ServerRegistry") as mock_registry_class:
             mock_registry = Mock()
             mock_registry.list_all.return_value = configs
+            mock_registry.get_by_name.side_effect = lambda name: next(
+                (c for c in configs if c.name == name), None
+            )
             mock_registry_class.return_value = mock_registry
 
             with (
                 patch("code_puppy.mcp_.manager.ManagedMCPServer") as mock_managed_class,
                 patch("code_puppy.mcp_.manager.ServerStatusTracker"),
+                patch(
+                    "code_puppy.config.load_mcp_server_configs",
+                    return_value={
+                        "server1": {"type": "stdio", "command": "echo"},
+                        "server2": {"type": "sse", "url": "http://localhost:8080"},
+                    },
+                ),
             ):
                 manager = MCPManager()
 
@@ -687,6 +697,9 @@ class TestMCPManagerExtended:
         with patch("code_puppy.mcp_.manager.ServerRegistry") as mock_registry_class:
             mock_registry = Mock()
             mock_registry.list_all.return_value = configs
+            mock_registry.get_by_name.side_effect = lambda name: next(
+                (c for c in configs if c.name == name), None
+            )
             mock_registry_class.return_value = mock_registry
 
             # Make second server creation fail
@@ -702,6 +715,13 @@ class TestMCPManagerExtended:
                 patch(
                     "code_puppy.mcp_.manager.ServerStatusTracker"
                 ) as mock_tracker_class,
+                patch(
+                    "code_puppy.config.load_mcp_server_configs",
+                    return_value={
+                        "good-server": {"type": "stdio", "command": "echo"},
+                        "bad-server": {"type": "stdio", "command": "bad"},
+                    },
+                ),
             ):
                 mock_tracker = Mock()
                 mock_tracker_class.return_value = mock_tracker

--- a/tests/mcp/test_registry_sync_drops_unconfigured.py
+++ b/tests/mcp/test_registry_sync_drops_unconfigured.py
@@ -1,5 +1,6 @@
 """sync_from_config drops registry entries that left mcp_servers.json."""
 
+import json
 from unittest.mock import patch
 
 from code_puppy.mcp_.manager import MCPManager
@@ -21,3 +22,24 @@ def test_sync_from_config_drops_servers_absent_from_json(tmp_path, monkeypatch):
         manager.sync_from_config()
 
     assert manager.registry.get_by_name("proj-stdio") is None
+
+
+def test_sync_from_config_keeps_registry_when_json_unreadable(tmp_path, monkeypatch):
+    monkeypatch.setattr("code_puppy.config.DATA_DIR", str(tmp_path))
+    servers_file = tmp_path / "mcp_servers.json"
+    monkeypatch.setattr("code_puppy.config.MCP_SERVERS_FILE", str(servers_file))
+    monkeypatch.setattr(
+        "code_puppy.mcp_.project_config.load_project_mcp_server_configs",
+        lambda *args, **kwargs: {},
+    )
+
+    present = {"keepme": {"type": "stdio", "command": "/usr/bin/true", "enabled": True}}
+    servers_file.write_text(json.dumps({"mcp_servers": present}))
+
+    manager = MCPManager()
+    assert manager.registry.get_by_name("keepme") is not None
+
+    servers_file.write_text("{not json")
+    manager.sync_from_config()
+
+    assert manager.registry.get_by_name("keepme") is not None

--- a/tests/mcp/test_registry_sync_drops_unconfigured.py
+++ b/tests/mcp/test_registry_sync_drops_unconfigured.py
@@ -1,0 +1,23 @@
+"""sync_from_config drops registry entries that left mcp_servers.json."""
+
+from unittest.mock import patch
+
+from code_puppy.mcp_.manager import MCPManager
+
+
+def test_sync_from_config_drops_servers_absent_from_json(tmp_path, monkeypatch):
+    monkeypatch.setattr("code_puppy.config.DATA_DIR", str(tmp_path))
+
+    present = {
+        "proj-stdio": {"type": "stdio", "command": "/usr/bin/true", "enabled": True}
+    }
+
+    with patch("code_puppy.config.load_mcp_server_configs", return_value=present):
+        manager = MCPManager()
+
+    assert manager.registry.get_by_name("proj-stdio") is not None
+
+    with patch("code_puppy.config.load_mcp_server_configs", return_value={}):
+        manager.sync_from_config()
+
+    assert manager.registry.get_by_name("proj-stdio") is None

--- a/tests/test_config_full_coverage.py
+++ b/tests/test_config_full_coverage.py
@@ -662,6 +662,14 @@ class TestMCPServerConfigs:
                 result = cp_config.load_mcp_server_configs()
                 assert result == {}
 
+    def test_bad_json_raise_on_error(self, tmp_path):
+        f = tmp_path / "mcp_servers.json"
+        f.write_text("not json")
+        with patch.object(cp_config, "MCP_SERVERS_FILE", str(f)):
+            with patch("code_puppy.messaging.message_queue.emit_error"):
+                with pytest.raises(json.JSONDecodeError):
+                    cp_config.load_mcp_server_configs(raise_on_error=True)
+
 
 # ---------------------------------------------------------------------------
 # Config keys

--- a/tests/test_installed_plugins.py
+++ b/tests/test_installed_plugins.py
@@ -50,6 +50,28 @@ def test_installed_plugin_failures_are_isolated(caplog):
     assert "broken" in caplog.text
 
 
+def test_shell_safety_loads_at_default_medium():
+    events = []
+    points = [FakeEntryPoint("shell_safety", lambda: events.append("loaded"))]
+    with (
+        patch.object(plugins, "entry_points", return_value=points),
+        patch("code_puppy.config.get_safety_permission_level", return_value="medium"),
+    ):
+        assert plugins._load_installed_plugins() == ["shell_safety"]
+    assert events == ["loaded"]
+
+
+def test_shell_safety_skipped_at_high():
+    events = []
+    points = [FakeEntryPoint("shell_safety", lambda: events.append("loaded"))]
+    with (
+        patch.object(plugins, "entry_points", return_value=points),
+        patch("code_puppy.config.get_safety_permission_level", return_value="high"),
+    ):
+        assert plugins._load_installed_plugins() == []
+    assert events == []
+
+
 def test_legacy_loader_skips_installed_duplicate(tmp_path):
     duplicate = tmp_path / "duplicate"
     duplicate.mkdir()

--- a/tests/test_session_pickle_loading_safety.py
+++ b/tests/test_session_pickle_loading_safety.py
@@ -102,6 +102,21 @@ def test_build_into_module_namespace_is_refused():
     assert not hasattr(sys, "_cp_pwn")
 
 
+def test_dateutil_tz_reexports_are_surrogates():
+    """dateutil.tz re-exports os/sys; those names must not resolve live."""
+    import io
+    import os
+    import sys
+
+    from code_puppy.session_surrogate_unpickler import SurrogateBase, SurrogateUnpickler
+
+    unpickler = SurrogateUnpickler(io.BytesIO(b""))
+    for name, real in (("os", os), ("sys", sys)):
+        resolved = unpickler.find_class("dateutil.tz", name)
+        assert resolved is not real, name
+        assert issubclass(resolved, SurrogateBase), name
+
+
 def test_exit_quit_help_do_not_resolve_to_real_callables():
     """builtins.exit/quit/help must resolve to surrogates, not the real callables.
 

--- a/tests/tools/test_user_plugin_path_guard.py
+++ b/tests/tools/test_user_plugin_path_guard.py
@@ -1,0 +1,46 @@
+"""File tools refuse writes under ~/.code_puppy/plugins."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from code_puppy.tools.file_modifications import (
+    _is_user_plugin_tree_path,
+    write_to_file,
+)
+
+
+def test_detects_user_plugin_tree(tmp_path, monkeypatch):
+    plugins_root = tmp_path / "plugins"
+    plugins_root.mkdir()
+    monkeypatch.setattr("code_puppy.plugins.USER_PLUGINS_DIR", plugins_root)
+
+    target = plugins_root / "evil" / "register_callbacks.py"
+    assert _is_user_plugin_tree_path(str(target)) is True
+    assert _is_user_plugin_tree_path(str(tmp_path / "other.py")) is False
+
+
+def test_write_to_file_refuses_user_plugin_tree(tmp_path, monkeypatch):
+    plugins_root = tmp_path / "plugins"
+    plugins_root.mkdir()
+    monkeypatch.setattr("code_puppy.plugins.USER_PLUGINS_DIR", plugins_root)
+
+    target = plugins_root / "evil" / "register_callbacks.py"
+    result = write_to_file(MagicMock(), str(target), "print('hi')\n", overwrite=True)
+
+    assert result["success"] is False
+    assert result["changed"] is False
+    assert "cannot modify" in result["message"]
+    assert not target.exists()
+
+
+def test_write_to_file_allows_project_path(tmp_path, monkeypatch):
+    plugins_root = tmp_path / "plugins"
+    plugins_root.mkdir()
+    monkeypatch.setattr("code_puppy.plugins.USER_PLUGINS_DIR", plugins_root)
+
+    target = tmp_path / "src" / "app.py"
+    target.parent.mkdir()
+    result = write_to_file(MagicMock(), str(target), "ok\n", overwrite=True)
+
+    assert result.get("success") is True
+    assert Path(target).read_text() == "ok\n"

--- a/tests/tools/test_user_plugin_path_guard.py
+++ b/tests/tools/test_user_plugin_path_guard.py
@@ -1,12 +1,25 @@
 """File tools refuse writes under ~/.code_puppy/plugins."""
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock
+
+import pytest
 
 from code_puppy.tools.file_modifications import (
     _is_user_plugin_tree_path,
     write_to_file,
 )
+
+
+def _fs_is_case_insensitive(path: Path) -> bool:
+    probe = path / "CaseGuardProbe"
+    probe.mkdir()
+    try:
+        folded = path / "caseguardprobe"
+        return folded.exists() and os.path.samefile(probe, folded)
+    finally:
+        probe.rmdir()
 
 
 def test_detects_user_plugin_tree(tmp_path, monkeypatch):
@@ -44,3 +57,24 @@ def test_write_to_file_allows_project_path(tmp_path, monkeypatch):
 
     assert result.get("success") is True
     assert Path(target).read_text() == "ok\n"
+
+
+def test_write_to_file_refuses_case_variant_plugin_tree(tmp_path, monkeypatch):
+    plugins_root = tmp_path / "plugins"
+    plugins_root.mkdir()
+    if not _fs_is_case_insensitive(tmp_path):
+        pytest.skip("filesystem is case-sensitive")
+
+    monkeypatch.setattr("code_puppy.plugins.USER_PLUGINS_DIR", plugins_root)
+
+    mixed_root = plugins_root.parent / (
+        "PLUGINS" if plugins_root.name != "PLUGINS" else "plugins"
+    )
+    target = mixed_root / "evil" / "register_callbacks.py"
+    assert _is_user_plugin_tree_path(str(target)) is True
+
+    result = write_to_file(MagicMock(), str(target), "print('hi')\n", overwrite=True)
+
+    assert result["success"] is False
+    assert result["changed"] is False
+    assert not (plugins_root / "evil" / "register_callbacks.py").exists()


### PR DESCRIPTION
> This pull request was posted by Grok Build using grok-4.6 on behalf of David.

Fixes #866.

`sync_from_config` now unregisters registry entries whose names are no longer in the merged `mcp_servers.json`. `/mcp trust revoke` runs that sync instead of asking the user to restart.

File-tool write/replace/delete refuse paths inside `~/.code_puppy/plugins` (imported at startup, no trust hash).

`shell_safety` loads at the default `safety_permission_level=medium` (still skipped at `high`/`critical`). `SurrogateUnpickler` no longer resolves `dateutil.tz` / `pytz` names through `find_class`.