### PR TITLE
feat(editing): Anthropic native text-editor adapter with exact-match-safe replace engine (Phases 1-3)

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -757,7 +757,15 @@ def build_tool_probe_for_agent(agent: Any) -> Optional[Any]:
             toolsets=[],
         )
         register_tools_for_agent(
-            probe, agent.get_available_tools(), model_name=resolved_model_name
+            probe,
+            agent.get_available_tools(),
+            model_name=resolved_model_name,
+            # Thread the same fresh `models_config` used to resolve the
+            # model above, so this probe can't briefly disagree with the
+            # real agent build about the Anthropic-native-editor capability
+            # decision (see register_tools_for_agent's own docstring on why
+            # this parameter exists).
+            models_config=models_config,
         )
     except Exception:
         return None

--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -688,6 +688,7 @@ def build_pydantic_agent(
         agent_tools,
         model_name=resolved_model_name,
         agent_name=logical_agent_name,
+        models_config=models_config,
     )
 
     existing_tool_names: Set[str] = set(getattr(probe_agent, "_tools", {}) or {})
@@ -703,6 +704,7 @@ def build_pydantic_agent(
         agent_tools,
         model_name=resolved_model_name,
         agent_name=logical_agent_name,
+        models_config=models_config,
     )
 
     agent.cur_model = model

--- a/code_puppy/agents/run_stats.py
+++ b/code_puppy/agents/run_stats.py
@@ -50,6 +50,7 @@ from pydantic_ai.messages import (
     ToolCallPartDelta,
 )
 
+from code_puppy.model_capabilities import NATIVE_EDITOR_TOOL_NAME
 from code_puppy.tools.subagent_context import is_subagent
 
 
@@ -335,6 +336,7 @@ _TOOLS_WITH_RENDERER = frozenset(
         "delete_file",
         "delete_snippet",
         "edit_file",
+        NATIVE_EDITOR_TOOL_NAME,
         "agent_run_shell_command",
         "ask_user_question",
         "activate_skill",

--- a/code_puppy/anthropic_native_editor_model.py
+++ b/code_puppy/anthropic_native_editor_model.py
@@ -1,0 +1,69 @@
+"""The Phase 3 model-layer seam: substitute Anthropic's native, client-executed
+text-editor tool declaration for one specific pydantic-ai tool, leaving every
+other tool's request/response handling completely unmodified.
+
+Why a subclass and not a generic HTTP body rewrite (per the plan's Phase 3
+step 1): pydantic-ai's public ``native_tools`` surface has no text-editor
+tool class (verified against the installed ``pydantic-ai-slim`` 2.31.0 -- see
+``.context/plan/anthropic-editor-adapter.md``, Phase 3 step 0), so there is
+no supported public API to prefer. This overrides exactly one well-defined,
+private-but-stable extension point (``_map_tool_definition``, the single
+place a ``ToolDefinition`` becomes the wire-level tool param) rather than
+reimplementing request construction.
+
+The inbound side needs no changes at all: we still register
+``str_replace_based_edit_tool`` as an ordinary pydantic-ai function tool (see
+``code_puppy/tools/anthropic_editor_tool.py``). Claude's ``tool_use`` blocks
+for this tool carry the same command-shaped JSON regardless of which wire
+declaration triggered them, and pydantic-ai's normal FunctionToolset dispatch
+already validates that JSON against our function's own parameter model. Only
+the *outbound* declaration -- what we tell Anthropic this tool looks like --
+needs to differ from the generic ``{name, description, input_schema}`` shape.
+Because history is stored as ordinary ``ToolCallPart``/``ToolReturnPart``
+entries (not an Anthropic-specific block type), switching models mid-session
+also needs no special normalization here -- see `History and model
+switching` in the plan.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.tools import ToolDefinition
+
+from code_puppy.model_capabilities import (
+    NATIVE_EDITOR_TOOL_NAME,
+    NATIVE_EDITOR_TOOL_TYPE,
+)
+
+
+class AnthropicNativeEditorModel(AnthropicModel):
+    """``AnthropicModel`` that declares the native text-editor tool natively.
+
+    Every other tool continues through the base class's normal JSON-schema
+    tool-definition path unchanged.
+    """
+
+    def _map_tool_definition(
+        self,
+        f: ToolDefinition,
+        model_settings: Any,
+        *,
+        visibility: Any,
+    ) -> Any:
+        if f.name != NATIVE_EDITOR_TOOL_NAME:
+            return super()._map_tool_definition(
+                f, model_settings, visibility=visibility
+            )
+
+        # Anthropic's client-executed editor tool: the API already knows this
+        # tool's input shape from training, so -- unlike a normal custom
+        # tool -- no `input_schema`/`description` travels on the wire at all.
+        tool_param: dict[str, Any] = {
+            "name": NATIVE_EDITOR_TOOL_NAME,
+            "type": NATIVE_EDITOR_TOOL_TYPE,
+        }
+        if visibility == "deferred":
+            tool_param["defer_loading"] = True
+        return tool_param

--- a/code_puppy/command_line/set_menu_catalog.py
+++ b/code_puppy/command_line/set_menu_catalog.py
@@ -22,6 +22,7 @@ from code_puppy.command_line.set_menu_shims import (
     get_goal_max_iterations_effective,
     get_max_pause_seconds_effective,
 )
+from code_puppy.model_capabilities import get_anthropic_native_editor_enabled
 from code_puppy.config import (
     get_allow_recursion,
     get_auto_save_session,
@@ -307,6 +308,21 @@ _FEATURES = SettingsCategory(
             description="Allow agents to dynamically create custom tools at runtime.",
             type_hint="bool",
             effective_getter=get_universal_constructor_enabled,
+        ),
+        Setting(
+            key="enable_anthropic_native_editor",
+            display_name="Anthropic Native Editor",
+            description=(
+                "Opt-in: swap the portable read_file/replace_in_file/"
+                "create_file tools for Anthropic's client-executed "
+                "text-editor tool on direct-Anthropic routes only (not "
+                "OpenAI-compatible gateways). Off by default; Phase 4 of "
+                "the anthropic-editor-adapter plan decides the eventual "
+                "default. delete_snippet/delete_file stay available either "
+                "way."
+            ),
+            type_hint="bool",
+            effective_getter=get_anthropic_native_editor_enabled,
         ),
         Setting(
             key="enable_dbos",

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -499,6 +499,9 @@ def get_config_keys():
     default_keys.append("enable_streaming")
     # Opt-in Logfire observability (see code_puppy/observability.py)
     default_keys.append("enable_logfire")
+    # Opt-in Anthropic native client-executed text-editor tool (Phase 3,
+    # see code_puppy/model_capabilities.py); off by default.
+    default_keys.append("enable_anthropic_native_editor")
     # Add suppress directory listing key
     default_keys.append("suppress_directory_listing")
     # Add cancel agent key configuration

--- a/code_puppy/hook_engine/aliases.py
+++ b/code_puppy/hook_engine/aliases.py
@@ -57,6 +57,26 @@ CLAUDE_CODE_ALIASES: Dict[str, str] = {
 
 
 # ---------------------------------------------------------------------------
+# Anthropic native text-editor facade (Phase 3 of the
+# anthropic-editor-adapter plan). ``str_replace_based_edit_tool`` is a
+# single tool name multiplexing four commands (view/str_replace/create/
+# insert) behind one ``command`` argument -- unlike every other entry in
+# this file, it has no clean 1:1 provider-tool -> internal-tool mapping.
+# Without an entry here, existing hooks written against "Edit"/"Write"/
+# "replace_in_file"/"create_file" silently stop firing the moment an agent
+# is switched onto the native-editor profile -- a policy/audit hook going
+# dark with no error is worse than one that never existed. Mapped to
+# "replace_in_file" (the closest single canonical mutation tool) so those
+# matchers keep firing; the known tradeoff is that a hook scoped only to
+# mutations will also match the tool's read-only "view" command, since the
+# matcher only ever sees the tool name, not which command was invoked.
+# ---------------------------------------------------------------------------
+ANTHROPIC_NATIVE_EDITOR_ALIASES: Dict[str, str] = {
+    "str_replace_based_edit_tool": "replace_in_file",
+}
+
+
+# ---------------------------------------------------------------------------
 # Gemini  (Google)
 # TODO: populate once Gemini MCP tool names are verified.
 # Run `gemini mcp serve` (or equivalent) and inspect the tools/list response,
@@ -92,6 +112,7 @@ SWARM_ALIASES: Dict[str, str] = {
 # ---------------------------------------------------------------------------
 PROVIDER_ALIASES: Dict[str, Dict[str, str]] = {
     "claude": CLAUDE_CODE_ALIASES,
+    "anthropic_native_editor": ANTHROPIC_NATIVE_EDITOR_ALIASES,
     "gemini": GEMINI_ALIASES,  # placeholder — empty until populated
     "codex": CODEX_ALIASES,  # placeholder — empty until populated
     "swarm": SWARM_ALIASES,  # placeholder — empty until populated

--- a/code_puppy/hook_engine/aliases.py
+++ b/code_puppy/hook_engine/aliases.py
@@ -67,9 +67,23 @@ CLAUDE_CODE_ALIASES: Dict[str, str] = {
 # is switched onto the native-editor profile -- a policy/audit hook going
 # dark with no error is worse than one that never existed. Mapped to
 # "replace_in_file" (the closest single canonical mutation tool) so those
-# matchers keep firing; the known tradeoff is that a hook scoped only to
-# mutations will also match the tool's read-only "view" command, since the
-# matcher only ever sees the tool name, not which command was invoked.
+# matchers keep firing.
+#
+# This mapping is deliberately 1:1 and CANNOT simply be widened to also
+# list create_file/read_file. ``_build_lookup`` groups by internal name and
+# unions every provider name that maps to it, so a second mapping would
+# transitively merge the create_file and replace_in_file groups -- making
+# ``matches("Write", "Edit")`` return True and collapsing two distinct
+# hook scopes into one. (The symmetry invariant in tests/hook_engine/
+# test_aliases.py catches exactly this.) Widening it properly needs a
+# command-aware matcher, not a bigger alias table.
+#
+# Two known gaps follow from the 1:1 choice, both accepted for now:
+#   * Hooks scoped only to mutations ALSO fire for the read-only "view"
+#     command -- the matcher sees only the tool name, never ``command``.
+#   * Hooks scoped exclusively to "Write"/"create_file" do NOT fire for
+#     this tool's "create" command. Scope such hooks to "Edit"/
+#     "replace_in_file" as well when running the native-editor profile.
 # ---------------------------------------------------------------------------
 ANTHROPIC_NATIVE_EDITOR_ALIASES: Dict[str, str] = {
     "str_replace_based_edit_tool": "replace_in_file",

--- a/code_puppy/model_capabilities.py
+++ b/code_puppy/model_capabilities.py
@@ -89,8 +89,10 @@ def get_anthropic_native_editor_enabled() -> bool:
 
     Off by default -- per the Phase 3 plan and acceptance criteria, the
     native path must not become the default at merge. Set
-    ``enable_anthropic_native_editor = true`` in config (or the matching env
-    var Code Puppy already maps onto config values) to turn it on.
+    ``enable_anthropic_native_editor = true`` in config to turn it on.
+    ``get_value``/``get_truthy_bool_value`` read only the config file today
+    (no environment-variable fallback exists for this or any other flag),
+    so there is no separate env-var knob to document here.
     """
     return get_truthy_bool_value("enable_anthropic_native_editor", False)
 

--- a/code_puppy/model_capabilities.py
+++ b/code_puppy/model_capabilities.py
@@ -1,0 +1,140 @@
+"""Anthropic-native-editor capability resolution (Phase 3 of the Anthropic
+editor adapter plan, see ``.context/plan/anthropic-editor-adapter.md``).
+
+Decides, from known configuration data (never from a failed provider call),
+whether a given model is eligible for Anthropic's client-executed text-editor
+tool (``str_replace_based_edit_tool``). The decision is made once, up front,
+at tool-registration and model-construction time -- never discovered by
+retrying after a provider rejection.
+
+Two independent gates must both pass:
+
+1. **Feature flag** -- ``enable_anthropic_native_editor`` (default off). This
+   keeps the native path opt-in at merge time; Phase 4 decides the default.
+2. **Route** -- the resolved model's ``type`` in ``models.json`` must be the
+   direct Anthropic API (``"anthropic"``). Deliberately conservative:
+   ``custom_anthropic`` (an arbitrary Anthropic-compatible base URL) and
+   ``claude_code`` (OAuth via a separate plugin-owned transport) are not
+   assumed compatible without dedicated verification, and Claude reached
+   through an OpenAI-compatible gateway (``type: "openai"``, e.g. OpenRouter)
+   is excluded by construction -- this checks the declared route, never a
+   model-name substring.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from code_puppy.command_line.completion_cache import TTLCache
+from code_puppy.config import get_truthy_bool_value
+
+# Anthropic's client-executed text-editor tool. Both the 2025-04-29 and
+# 2025-07-28 tool *versions* (the ``type`` value) advertise this same tool
+# ``name``; we target the newer, currently-documented version for Claude 4.x
+# models. Verified in the installed ``anthropic`` SDK: no ``undo_edit`` command
+# exists for this tool family (only the retired ``text_editor_20241022``
+# had one), so it is intentionally not offered -- see the dispatcher in
+# ``code_puppy/tools/anthropic_editor_tool.py``.
+NATIVE_EDITOR_TOOL_NAME = "str_replace_based_edit_tool"
+NATIVE_EDITOR_TOOL_TYPE = "text_editor_20250728"
+
+# model_config["type"] values confirmed (in model_factory.py) to route
+# directly to Anthropic's own API via the real ``anthropic`` SDK client.
+_DIRECT_ANTHROPIC_MODEL_TYPES = frozenset({"anthropic"})
+
+# Generic tools with a direct native-editor equivalent. Hidden from the tool
+# list only when the native editor is actually offered in their place.
+# delete_snippet/delete_file are deliberately NOT here: the native editor has
+# no delete command, so hiding them would remove a capability, not
+# deduplicate one.
+OVERLAPPING_PORTABLE_TOOLS = frozenset({"read_file", "replace_in_file", "create_file"})
+
+# The subset of OVERLAPPING_PORTABLE_TOOLS that actually grants write access.
+# The native editor is a single monolithic tool offering create+str_replace+
+# insert together -- it cannot be partially granted. So the swap must only
+# fire for an agent that already carries *all* of these (the full portable
+# write surface), never just one:
+#   - An agent with only `create_file` (e.g. agent_model_judge: `create_file`
+#     but no `replace_in_file`) must not gain `str_replace`/`insert` access
+#     to arbitrary *existing* files it could never touch before.
+#   - An agent with only `replace_in_file` must not gain the native `create`
+#     command's always-overwrite whole-file write it could never do before.
+# Least-privilege triggers on "did this agent ask for the full mutation
+# surface", not "does the agent's toolset overlap the native editor at all"
+# or "did it ask for any one mutation tool".
+NATIVE_EDITOR_MUTATION_TOOLS = frozenset({"replace_in_file", "create_file"})
+
+
+def has_full_native_editor_mutation_surface(tool_names) -> bool:
+    """True only when ``tool_names`` already contains every tool the native
+    editor's write commands collectively replace -- see
+    ``NATIVE_EDITOR_MUTATION_TOOLS`` for why partial overlap must not
+    trigger the swap.
+    """
+    names = set(tool_names)
+    return NATIVE_EDITOR_MUTATION_TOOLS.issubset(names)
+
+
+_model_config_cache: TTLCache[Dict[str, Any]] = TTLCache()
+
+
+def _load_models_config() -> Dict[str, Any]:
+    from code_puppy.model_factory import ModelFactory
+
+    return ModelFactory.load_config()
+
+
+def get_anthropic_native_editor_enabled() -> bool:
+    """Feature flag: opt-in rollout switch for the Anthropic native editor.
+
+    Off by default -- per the Phase 3 plan and acceptance criteria, the
+    native path must not become the default at merge. Set
+    ``enable_anthropic_native_editor = true`` in config (or the matching env
+    var Code Puppy already maps onto config values) to turn it on.
+    """
+    return get_truthy_bool_value("enable_anthropic_native_editor", False)
+
+
+def get_model_config(
+    model_name: Optional[str], models_config: Optional[Dict[str, Any]] = None
+) -> Optional[Dict[str, Any]]:
+    """Look up one model's config dict, loading/caching the full config if needed.
+
+    Cached briefly (see ``TTLCache``) because ``register_tools_for_agent`` is
+    called twice per agent build (probe + final pass) and this resolution
+    must not add a full config reload+merge to each call.
+    """
+    if not model_name:
+        return None
+    config = (
+        models_config
+        if models_config is not None
+        else _model_config_cache.get(_load_models_config)
+    )
+    model_config = config.get(model_name)
+    return model_config if isinstance(model_config, dict) else None
+
+
+def is_direct_anthropic_route(model_config: Optional[Dict[str, Any]]) -> bool:
+    """Return True when ``model_config`` routes directly to Anthropic's API.
+
+    Based solely on the declared ``type``, never a model-name guess.
+    """
+    if not model_config:
+        return False
+    return model_config.get("type") in _DIRECT_ANTHROPIC_MODEL_TYPES
+
+
+def supports_anthropic_native_editor(
+    model_name: Optional[str], models_config: Optional[Dict[str, Any]] = None
+) -> bool:
+    """Return True when ``model_name`` should receive the native editor tool.
+
+    Both the feature flag and a confirmed direct-Anthropic route are
+    required; an unsupported or ambiguous route falls back to the portable
+    tool profile chosen up front, not discovered by retrying.
+    """
+    if not get_anthropic_native_editor_enabled():
+        return False
+    model_config = get_model_config(model_name, models_config)
+    return is_direct_anthropic_route(model_config)

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -26,6 +26,8 @@ from . import callbacks
 from .claude_cache_client import ClaudeCacheAsyncClient
 from .config import EXTRA_MODELS_FILE, get_value, get_yolo_mode
 from .http_utils import create_async_client, get_cert_bundle_path, get_http2
+from .anthropic_native_editor_model import AnthropicNativeEditorModel
+from .model_capabilities import supports_anthropic_native_editor
 from .provider_identity import (
     make_anthropic_provider,
     make_openai_provider,
@@ -55,6 +57,20 @@ def _load_plugin_model_providers():
 
 # Load plugin model providers at module initialization
 _load_plugin_model_providers()
+
+
+def _resolve_anthropic_model_class(
+    model_name: str, model_config: Dict[str, Any]
+) -> type:
+    """Pick the plain vs. native-editor Anthropic model class.
+
+    Decided once, up front, from known config (feature flag + declared
+    direct-Anthropic route) -- never by trying the native tool and falling
+    back after a provider rejection. See ``model_capabilities.py``.
+    """
+    if supports_anthropic_native_editor(model_name, {model_name: model_config}):
+        return AnthropicNativeEditorModel
+    return AnthropicModel
 
 
 # Anthropic beta header required for 1M context window support.
@@ -797,7 +813,12 @@ class ModelFactory:
             provider = make_anthropic_provider(
                 provider_identity, anthropic_client=anthropic_client
             )
-            return AnthropicModel(model_name=model_config["name"], provider=provider)
+            anthropic_model_cls = _resolve_anthropic_model_class(
+                model_name, model_config
+            )
+            return anthropic_model_cls(
+                model_name=model_config["name"], provider=provider
+            )
 
         elif model_type == "custom_anthropic":
             url, headers, verify, api_key, timeout = get_custom_config(model_config)

--- a/code_puppy/tools/__init__.py
+++ b/code_puppy/tools/__init__.py
@@ -290,6 +290,24 @@ def register_tools_for_agent(
             emit_warning(f"Warning: Unknown tool '{tool_name}' requested, skipping...")
             continue
 
+        # Defense in depth for the Anthropic native editor: the capability
+        # gate above only ever ADDS this tool, it never blocks an explicit
+        # request for it by name (e.g. a JSON agent config, or a plugin's
+        # register_agent_tools extra). Re-check the same predicate here so
+        # naming the tool directly can never bypass the feature flag or the
+        # direct-Anthropic-route requirement -- see model_capabilities.py's
+        # module docstring: this decision must never be discoverable by
+        # simply asking for the tool.
+        if tool_name == NATIVE_EDITOR_TOOL_NAME and not supports_anthropic_native_editor(
+            model_name
+        ):
+            emit_warning(
+                f"Warning: '{tool_name}' requires the Anthropic native editor "
+                "capability (feature flag + direct-Anthropic model route); "
+                "skipping..."
+            )
+            continue
+
         # Check if Universal Constructor is disabled
         if (
             tool_name == "universal_constructor"

--- a/code_puppy/tools/__init__.py
+++ b/code_puppy/tools/__init__.py
@@ -29,8 +29,17 @@ from code_puppy.tools.file_operations import (
     register_list_files,
     register_read_file,
 )
+from code_puppy.tools.anthropic_editor_tool import (
+    register_str_replace_based_edit_tool,
+)
 from code_puppy.tools.image_tools import register_load_image
 from code_puppy.tools.model_tools import register_list_available_models
+from code_puppy.model_capabilities import (
+    NATIVE_EDITOR_TOOL_NAME,
+    OVERLAPPING_PORTABLE_TOOLS,
+    has_full_native_editor_mutation_surface,
+    supports_anthropic_native_editor,
+)
 
 # Map of tool names to their individual registration functions
 TOOL_REGISTRY = {
@@ -49,6 +58,9 @@ TOOL_REGISTRY = {
     "replace_in_file": register_replace_in_file,
     "delete_snippet": register_delete_snippet,
     "delete_file": register_delete_file,
+    # Anthropic native client-executed text editor (Phase 3, opt-in via
+    # capability + feature flag -- see code_puppy/model_capabilities.py)
+    NATIVE_EDITOR_TOOL_NAME: register_str_replace_based_edit_tool,
     # Command Runner
     "agent_run_shell_command": register_agent_run_shell_command,
     "agent_share_your_reasoning": register_agent_share_your_reasoning,
@@ -239,6 +251,26 @@ def register_tools_for_agent(
                 expanded_tools.append(tool_name)
                 seen.add(tool_name)
     tool_names = expanded_tools
+
+    # Anthropic native editor swap (Phase 3): trigger only when the agent's
+    # own tool list already carries the FULL portable mutation surface the
+    # native editor collectively replaces (create_file AND replace_in_file --
+    # see has_full_native_editor_mutation_surface). Partial overlap must not
+    # trigger it: an agent with only create_file (e.g. agent_model_judge)
+    # would otherwise silently gain str_replace/insert access to arbitrary
+    # *existing* files it could never touch before, and an agent with only
+    # replace_in_file would gain the native `create` command's always-
+    # overwrite whole-file write. Once triggered, the whole overlap set
+    # (including read_file) is swapped together, since `view` is
+    # `read_file`'s native-editor equivalent.
+    if has_full_native_editor_mutation_surface(tool_names) and (
+        supports_anthropic_native_editor(model_name)
+    ):
+        tool_names = [
+            name for name in tool_names if name not in OVERLAPPING_PORTABLE_TOOLS
+        ]
+        if NATIVE_EDITOR_TOOL_NAME not in tool_names:
+            tool_names.append(NATIVE_EDITOR_TOOL_NAME)
 
     for tool_name in tool_names:
         # Handle UC tools (prefixed with "uc:")

--- a/code_puppy/tools/__init__.py
+++ b/code_puppy/tools/__init__.py
@@ -262,9 +262,16 @@ def register_tools_for_agent(
     # replace_in_file would gain the native `create` command's always-
     # overwrite whole-file write. Once triggered, the whole overlap set
     # (including read_file) is swapped together, since `view` is
-    # `read_file`'s native-editor equivalent.
-    if has_full_native_editor_mutation_surface(tool_names) and (
-        supports_anthropic_native_editor(model_name)
+    # `read_file`'s native-editor equivalent -- but that equivalence is only
+    # true, and only least-privilege-safe, for an agent that ALREADY has
+    # read_file. An agent configured with the full write surface but no
+    # read_file (unusual, but not impossible for a deliberately write-only
+    # JSON agent) must not gain `view`'s brand-new read capability just by
+    # having both mutation tools -- gate on read_file's presence too.
+    if (
+        "read_file" in tool_names
+        and has_full_native_editor_mutation_surface(tool_names)
+        and supports_anthropic_native_editor(model_name)
     ):
         tool_names = [
             name for name in tool_names if name not in OVERLAPPING_PORTABLE_TOOLS

--- a/code_puppy/tools/__init__.py
+++ b/code_puppy/tools/__init__.py
@@ -261,6 +261,17 @@ def register_tools_for_agent(
                 seen.add(tool_name)
     tool_names = expanded_tools
 
+    # Computed once and reused below: `supports_anthropic_native_editor()`
+    # re-reads the live feature flag (never cached) each call, so evaluating
+    # it twice in this one synchronous pass (once for the swap trigger, once
+    # for the defense-in-depth re-check further down) could theoretically
+    # observe two different answers if config changes mid-call. One snapshot
+    # keeps both checks consistent with each other, not just individually
+    # correct.
+    native_editor_supported = supports_anthropic_native_editor(
+        model_name, models_config
+    )
+
     # Anthropic native editor swap (Phase 3): trigger only when the agent's
     # own tool list already carries the FULL portable mutation surface the
     # native editor collectively replaces (create_file AND replace_in_file --
@@ -286,7 +297,7 @@ def register_tools_for_agent(
         "read_file" in tool_names
         and "list_files" in tool_names
         and has_full_native_editor_mutation_surface(tool_names)
-        and supports_anthropic_native_editor(model_name, models_config)
+        and native_editor_supported
     ):
         tool_names = [
             name for name in tool_names if name not in OVERLAPPING_PORTABLE_TOOLS
@@ -320,10 +331,7 @@ def register_tools_for_agent(
         # direct-Anthropic-route requirement -- see model_capabilities.py's
         # module docstring: this decision must never be discoverable by
         # simply asking for the tool.
-        if (
-            tool_name == NATIVE_EDITOR_TOOL_NAME
-            and not supports_anthropic_native_editor(model_name, models_config)
-        ):
+        if tool_name == NATIVE_EDITOR_TOOL_NAME and not native_editor_supported:
             emit_warning(
                 f"Warning: '{tool_name}' requires the Anthropic native editor "
                 "capability (feature flag + direct-Anthropic model route); "

--- a/code_puppy/tools/__init__.py
+++ b/code_puppy/tools/__init__.py
@@ -195,6 +195,7 @@ def register_tools_for_agent(
     tool_names: list[str],
     model_name: str | None = None,
     agent_name: str | None = None,
+    models_config: dict | None = None,
 ):
     """Register specific tools for an agent based on tool names.
 
@@ -207,6 +208,14 @@ def register_tools_for_agent(
         agent_name: Optional logical agent name (e.g. ``"code-puppy"``).
             Passed to the ``register_agent_tools`` callback so plugins can
             advertise tools per-agent if they want.
+        models_config: Optional pre-loaded model config, threaded through to
+            ``supports_anthropic_native_editor``. Without this, that check
+            falls back to its own independently-TTL-cached config load,
+            which can very briefly disagree with the fresh config a caller
+            (e.g. the agent builder) already used to pick the model class
+            itself -- passing the same config both places removes that
+            two-source-of-truth window entirely. Purely additive: callers
+            that have no config handy keep the prior cached-lookup behavior.
     """
     from code_puppy.config import get_universal_constructor_enabled
 
@@ -268,10 +277,16 @@ def register_tools_for_agent(
     # read_file (unusual, but not impossible for a deliberately write-only
     # JSON agent) must not gain `view`'s brand-new read capability just by
     # having both mutation tools -- gate on read_file's presence too.
+    # Same reasoning applies to `list_files`: `view` on a directory path
+    # returns a directory listing, which is `list_files`'s equivalent
+    # capability, not read_file's -- an agent with the full mutation
+    # surface and read_file but no list_files must not gain directory
+    # discovery purely as a side effect of the swap.
     if (
         "read_file" in tool_names
+        and "list_files" in tool_names
         and has_full_native_editor_mutation_surface(tool_names)
-        and supports_anthropic_native_editor(model_name)
+        and supports_anthropic_native_editor(model_name, models_config)
     ):
         tool_names = [
             name for name in tool_names if name not in OVERLAPPING_PORTABLE_TOOLS
@@ -307,7 +322,7 @@ def register_tools_for_agent(
         # simply asking for the tool.
         if (
             tool_name == NATIVE_EDITOR_TOOL_NAME
-            and not supports_anthropic_native_editor(model_name)
+            and not supports_anthropic_native_editor(model_name, models_config)
         ):
             emit_warning(
                 f"Warning: '{tool_name}' requires the Anthropic native editor "

--- a/code_puppy/tools/__init__.py
+++ b/code_puppy/tools/__init__.py
@@ -305,8 +305,9 @@ def register_tools_for_agent(
         # direct-Anthropic-route requirement -- see model_capabilities.py's
         # module docstring: this decision must never be discoverable by
         # simply asking for the tool.
-        if tool_name == NATIVE_EDITOR_TOOL_NAME and not supports_anthropic_native_editor(
-            model_name
+        if (
+            tool_name == NATIVE_EDITOR_TOOL_NAME
+            and not supports_anthropic_native_editor(model_name)
         ):
             emit_warning(
                 f"Warning: '{tool_name}' requires the Anthropic native editor "

--- a/code_puppy/tools/anthropic_editor_tool.py
+++ b/code_puppy/tools/anthropic_editor_tool.py
@@ -319,6 +319,27 @@ def _view_file(path: str, view_range: Optional[List[int]]) -> Dict[str, Any]:
         f"{idx:6d}\t{line}" for idx, line in enumerate(selected, start=start)
     )
 
+    # Backstop against per-line gutter overhead: the `f"{idx:6d}\t"` gutter
+    # adds a fixed 7 chars/line on top of raw content, which is invisible to
+    # the raw-content check above when lines are short -- thousands of
+    # short/blank lines can pass the raw budget by a wide margin yet still
+    # explode once every line gets its own gutter (e.g. 40,000 blank lines
+    # is ~10 KB raw but ~280 KB numbered). Bounded at 2x the raw budget
+    # rather than a hard line-count limit: generous enough that the
+    # narrow-line regression test above (5,000 one-char lines) still
+    # succeeds, but it puts an absolute ceiling on what actually reaches
+    # the model regardless of how that size was reached.
+    if len(numbered) // 4 > _MAX_VIEW_TOKENS * 2:
+        return {
+            "error": "content_too_large",
+            "path": file_path,
+            "total_lines": total_lines,
+            "message": (
+                "The requested range is too large to view in one call; "
+                "narrow view_range and retry."
+            ),
+        }
+
     # Matches read_file's UI contract: the raw (unnumbered) slice goes to
     # the message bus for display/telemetry; the line-numbered rendering
     # below is what actually goes back to the model. Without this, `view`
@@ -427,6 +448,12 @@ async def _insert_into_file(
         lines[-1] = lines[-1] + style
 
     new_content = "".join(lines[:insert_line] + [inserted] + lines[insert_line:])
+    # Built once and reused across every remaining return in this function
+    # (success, rejection, or race-detected) so the callback below always
+    # sees what was actually attempted -- matching str_replace/create,
+    # whose single engine call routes every outcome (not just success)
+    # through the same callback with the same payload shape.
+    payload = ContentPayload(file_path=file_path, content=new_content, overwrite=True)
 
     group_id = generate_group_id("str_replace_based_edit_tool", path)
     permission_results = await on_file_permission_async(
@@ -438,7 +465,9 @@ async def _insert_into_file(
         {"content": new_content, "overwrite": True},
     )
     if _permission_denied(permission_results):
-        return _create_rejection_response(file_path)
+        return _apply_edit_callback(
+            context, _create_rejection_response(file_path), payload
+        )
 
     # Close the approval-wait race described in this function's docstring:
     # re-read now and compare byte-for-byte against the snapshot the
@@ -456,15 +485,19 @@ async def _insert_into_file(
             "path": file_path,
         }
     if current != original:
-        return {
-            "error": "concurrent_modification",
-            "path": file_path,
-            "message": (
-                "The file changed after permission was requested and "
-                "before the insert was applied; view the file again and "
-                "retry with an up-to-date insert_line."
-            ),
-        }
+        return _apply_edit_callback(
+            context,
+            {
+                "error": "concurrent_modification",
+                "path": file_path,
+                "message": (
+                    "The file changed after permission was requested and "
+                    "before the insert was applied; view the file again and "
+                    "retry with an up-to-date insert_line."
+                ),
+            },
+            payload,
+        )
 
     result = _write_to_file(
         context, file_path, new_content, overwrite=True, message_group=group_id
@@ -472,7 +505,6 @@ async def _insert_into_file(
     diff = result.pop("diff", "")
     if diff:
         _emit_diff_message(file_path, "modify", diff, new_content=new_content)
-    payload = ContentPayload(file_path=file_path, content=new_content, overwrite=True)
     return _apply_edit_callback(context, result, payload)
 
 

--- a/code_puppy/tools/anthropic_editor_tool.py
+++ b/code_puppy/tools/anthropic_editor_tool.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic_ai import RunContext
 
-from code_puppy.callbacks import on_edit_file
+from code_puppy.callbacks import on_edit_file, on_file_permission_async
 from code_puppy.messaging import FileContentMessage, get_message_bus
 from code_puppy.tools import fs_access
 from code_puppy.tools.common import generate_group_id, resolve_path
@@ -29,6 +29,10 @@ from code_puppy.tools.file_modifications import (
     ContentPayload,
     Replacement,
     ReplacementsPayload,
+    _create_rejection_response,
+    _emit_diff_message,
+    _permission_denied,
+    _write_to_file,
     replace_in_file_async,
     write_to_file_async,
 )
@@ -299,11 +303,17 @@ async def _insert_into_file(
     """Insert ``new_str`` after ``insert_line`` (0 = start of file).
 
     No generic-tool equivalent exists to delegate to, so this computes the
-    resulting full-file content itself and then hands the actual write off
-    to ``write_to_file_async`` -- the same permission-check, undo-capture,
-    and diff-emission path every other mutation uses. (The permission audit
-    label reads "write" rather than "insert" as a result; the operation data
-    still carries the real inserted text.)
+    resulting full-file content itself from a snapshot read at the top of
+    this function. Unlike str_replace/create -- whose engine functions run
+    permission check then read/validate/write as one call, so there is
+    nothing to go stale -- insert's snapshot is taken *before* the
+    permission prompt, and a human approval pause can be arbitrarily long.
+    So after approval, and before writing, this re-reads the file and
+    refuses to proceed if it no longer matches the snapshot the approved
+    preview was built from, rather than silently splicing into content the
+    approver never actually saw. (The permission audit label reads "write"
+    rather than "insert" as a result; the operation data still carries the
+    real inserted text.)
     """
     file_path = resolve_path(path)
 
@@ -366,10 +376,48 @@ async def _insert_into_file(
     new_content = "".join(lines[:insert_line] + [inserted] + lines[insert_line:])
 
     group_id = generate_group_id("str_replace_based_edit_tool", path)
-    result = await write_to_file_async(
-        context, path, new_content, overwrite=True, message_group=group_id
+    permission_results = await on_file_permission_async(
+        context,
+        file_path,
+        "write",
+        None,
+        group_id,
+        {"content": new_content, "overwrite": True},
     )
-    result.pop("diff", None)
+    if _permission_denied(permission_results):
+        return _create_rejection_response(file_path)
+
+    # Close the approval-wait race described in this function's docstring:
+    # re-read now and compare byte-for-byte against the snapshot the
+    # approved preview above was computed from. Any difference means the
+    # file moved out from under us; fail closed rather than overwrite
+    # content the approver never saw (the same "never silently guess"
+    # philosophy the Phase 2 exact-match engine applies to ambiguous text
+    # matches, applied here to a stale file snapshot instead).
+    try:
+        current = _sanitize_surrogates(fs_access.read_text(file_path))
+    except OSError as exc:
+        return {
+            "error": f"Failed to read file '{file_path}': {exc}",
+            "path": file_path,
+        }
+    if current != original:
+        return {
+            "error": "concurrent_modification",
+            "path": file_path,
+            "message": (
+                "The file changed after permission was requested and "
+                "before the insert was applied; view the file again and "
+                "retry with an up-to-date insert_line."
+            ),
+        }
+
+    result = _write_to_file(
+        context, file_path, new_content, overwrite=True, message_group=group_id
+    )
+    diff = result.pop("diff", "")
+    if diff:
+        _emit_diff_message(file_path, "modify", diff, new_content=new_content)
     payload = ContentPayload(file_path=file_path, content=new_content, overwrite=True)
     return _apply_edit_callback(context, result, payload)
 

--- a/code_puppy/tools/anthropic_editor_tool.py
+++ b/code_puppy/tools/anthropic_editor_tool.py
@@ -31,6 +31,7 @@ from code_puppy.tools.file_modifications import (
     ReplacementsPayload,
     _create_rejection_response,
     _emit_diff_message,
+    _log_error,
     _permission_denied,
     _write_to_file,
     replace_in_file_async,
@@ -159,17 +160,35 @@ async def dispatch_editor_command(
     if command == "create":
         if file_text is None:
             return _missing_field_error(command, "file_text")
-        # overwrite=True is deliberate spec conformance, not an oversight:
         # Anthropic's documented `create` command always (over)writes the
         # full file at `path`, unlike the portable `create_file` tool (which
-        # defaults to refusing an existing file). The permission gate below
-        # still applies, so an overwrite still requires approval.
+        # defaults to refusing an existing file) -- deliberate spec
+        # conformance, not an oversight. The permission gate below still
+        # applies, so an overwrite still requires approval.
+        #
+        # `overwrite` is derived from whether the file already exists
+        # (rather than hardcoded True) purely so write_to_file_async's own
+        # `"modify" if overwrite else "create"` diff-operation label comes
+        # out correct -- a brand-new file must not be reported to the UI as
+        # a "modify". Behavior is unchanged either way: `create` always
+        # succeeds and always writes the full content, since `_write_to_file`
+        # only refuses on `exists and not overwrite`, which never happens
+        # here (the two always agree). The existence check has the same
+        # narrow TOCTOU window as `_write_to_file`'s own equivalent check;
+        # accepted for the same reason.
+        already_existed = fs_access.exists(resolve_path(path))
         group_id = generate_group_id("str_replace_based_edit_tool", path)
         result = await write_to_file_async(
-            context, path, file_text, overwrite=True, message_group=group_id
+            context,
+            path,
+            file_text,
+            overwrite=already_existed,
+            message_group=group_id,
         )
         result.pop("diff", None)
-        payload = ContentPayload(file_path=path, content=file_text, overwrite=True)
+        payload = ContentPayload(
+            file_path=path, content=file_text, overwrite=already_existed
+        )
         return _apply_edit_callback(context, result, payload)
 
     if command == "insert":
@@ -192,7 +211,12 @@ def _view_file(path: str, view_range: Optional[List[int]]) -> Dict[str, Any]:
     if fs_access.is_dir(file_path):
         try:
             entries = fs_access.list_dir(file_path)
-        except OSError as exc:
+        except Exception as exc:
+            # Broad on purpose: fs_access can be backed by a non-local
+            # FileSystemBackend (e.g. an ACP host) that raises whatever its
+            # transport raises, not just OSError -- matches the posture
+            # _read_file already takes on its own backend-read path in
+            # file_operations.py.
             return {"error": f"Failed to list directory '{file_path}': {exc}"}
         names = sorted((f"{e.name}/" if e.is_dir else e.name) for e in entries)
         # Same intent as _MAX_VIEW_TOKENS below: an unbounded directory
@@ -214,7 +238,8 @@ def _view_file(path: str, view_range: Optional[List[int]]) -> Dict[str, Any]:
 
     try:
         content = fs_access.read_text(file_path)
-    except OSError as exc:
+    except Exception as exc:
+        # Broad for the same reason as the directory-listing branch above.
         return {"error": f"Failed to read file '{file_path}': {exc}"}
 
     content = _sanitize_surrogates(content)
@@ -322,7 +347,8 @@ async def _insert_into_file(
 
     try:
         original = fs_access.read_text(file_path)
-    except OSError as exc:
+    except Exception as exc:
+        # Broad on purpose -- see the matching comment on _view_file's read.
         return {"error": f"Failed to read file '{file_path}': {exc}"}
 
     original = _sanitize_surrogates(original)
@@ -396,7 +422,8 @@ async def _insert_into_file(
     # matches, applied here to a stale file snapshot instead).
     try:
         current = _sanitize_surrogates(fs_access.read_text(file_path))
-    except OSError as exc:
+    except Exception as exc:
+        # Broad on purpose -- see the matching comment on _view_file's read.
         return {
             "error": f"Failed to read file '{file_path}': {exc}",
             "path": file_path,
@@ -448,13 +475,28 @@ def register_str_replace_based_edit_tool(agent) -> None:
         file), str_replace (path, old_str, new_str), create (path,
         file_text), insert (path, insert_line, new_str).
         """
-        return await dispatch_editor_command(
-            context,
-            command,
-            path,
-            old_str=old_str,
-            new_str=new_str,
-            file_text=file_text,
-            insert_line=insert_line,
-            view_range=view_range,
-        )
+        try:
+            return await dispatch_editor_command(
+                context,
+                command,
+                path,
+                old_str=old_str,
+                new_str=new_str,
+                file_text=file_text,
+                insert_line=insert_line,
+                view_range=view_range,
+            )
+        except Exception as exc:
+            # Last line of defense -- never let this tool crash the agent
+            # run, matching the try/except every portable file-modification
+            # tool wraps its own body in (see file_modifications.py).
+            _log_error(
+                "Unhandled exception in str_replace_based_edit_tool",
+                exc,
+                message_group=None,
+            )
+            return {
+                "error": f"str_replace_based_edit_tool failed: {exc}",
+                "command": command,
+                "path": path,
+            }

--- a/code_puppy/tools/anthropic_editor_tool.py
+++ b/code_puppy/tools/anthropic_editor_tool.py
@@ -32,7 +32,7 @@ from code_puppy.tools.file_modifications import (
     replace_in_file_async,
     write_to_file_async,
 )
-from code_puppy.tools.line_endings import detect_dominant, to_style
+from code_puppy.tools.line_endings import detect_dominant, split_lines, to_style
 
 # Claude's older ``text_editor_20241022`` tool had an ``undo_edit`` command;
 # the versions this façade targets (2025-04-29 / 2025-07-28) do not -- see
@@ -45,6 +45,10 @@ _SUPPORTED_COMMANDS = frozenset({"view", "str_replace", "create", "insert"})
 # Reuse the same file-size guard the portable read_file tool applies, so
 # `view` can't dump an unbounded file into context either.
 _MAX_VIEW_TOKENS = 10_000
+
+# Same intent for the directory-listing branch of `view`, which has no
+# equivalent token-based guard of its own to piggyback on.
+_MAX_VIEW_ENTRIES = 1_000
 
 
 def _unsupported_command_error(command: str) -> Dict[str, Any]:
@@ -187,7 +191,22 @@ def _view_file(path: str, view_range: Optional[List[int]]) -> Dict[str, Any]:
         except OSError as exc:
             return {"error": f"Failed to list directory '{file_path}': {exc}"}
         names = sorted((f"{e.name}/" if e.is_dir else e.name) for e in entries)
-        return {"path": file_path, "is_directory": True, "entries": names}
+        # Same intent as _MAX_VIEW_TOKENS below: an unbounded directory
+        # listing (e.g. node_modules, .git) would blow past the very
+        # context budget the file-view branch already enforces.
+        truncated = len(names) > _MAX_VIEW_ENTRIES
+        result: Dict[str, Any] = {
+            "path": file_path,
+            "is_directory": True,
+            "entries": names[:_MAX_VIEW_ENTRIES],
+            "total_entries": len(names),
+        }
+        if truncated:
+            result["truncated"] = True
+        return result
+
+    if not fs_access.is_file(file_path):
+        return {"error": "not_a_regular_file", "path": file_path}
 
     try:
         content = fs_access.read_text(file_path)
@@ -195,15 +214,17 @@ def _view_file(path: str, view_range: Optional[List[int]]) -> Dict[str, Any]:
         return {"error": f"Failed to read file '{file_path}': {exc}"}
 
     content = _sanitize_surrogates(content)
-    lines = content.splitlines()
+    lines = split_lines(content)
     total_lines = len(lines)
     start, end = 1, total_lines
 
     if view_range is not None:
-        if len(view_range) != 2:
+        if len(view_range) != 2 or not all(
+            isinstance(v, int) and not isinstance(v, bool) for v in view_range
+        ):
             return {
                 "error": "invalid_view_range",
-                "message": "view_range must be exactly [start_line, end_line].",
+                "message": "view_range must be exactly [start_line, end_line], both integers.",
             }
         start, end = view_range
         if end == -1:
@@ -295,8 +316,15 @@ async def _insert_into_file(
         return {"error": f"Failed to read file '{file_path}': {exc}"}
 
     original = _sanitize_surrogates(original)
-    lines = original.splitlines(keepends=True) if original else []
+    lines = split_lines(original, keepends=True) if original else []
     line_count = len(lines)
+
+    if not isinstance(insert_line, int) or isinstance(insert_line, bool):
+        return {
+            "error": "invalid_insert_line",
+            "path": file_path,
+            "message": f"insert_line must be an integer; got {insert_line!r}.",
+        }
 
     if insert_line < 0 or insert_line > line_count:
         return {
@@ -311,7 +339,22 @@ async def _insert_into_file(
 
     style = detect_dominant(original) if original else "\n"
     inserted = to_style(new_str, style)
-    if inserted and not inserted.endswith(style):
+
+    if not inserted:
+        # An empty new_str (after style conversion, which never turns a
+        # non-empty string empty) is a genuine no-op. Return here, BEFORE
+        # touching `lines`, so nothing below mutates the file's last line
+        # just to attach a terminator to text we are not actually going to
+        # insert -- that previously produced a false "changed: true" write
+        # on any file whose last line lacked a trailing newline.
+        return {
+            "success": False,
+            "path": file_path,
+            "changed": False,
+            "message": "No change: the inserted text was empty.",
+        }
+
+    if not inserted.endswith(style):
         inserted += style
 
     # If we're inserting after the current last line and that line is
@@ -320,20 +363,7 @@ async def _insert_into_file(
     if insert_line == line_count and lines and not lines[-1].endswith(("\n", "\r")):
         lines[-1] = lines[-1] + style
 
-    new_lines = lines[:insert_line] + [inserted] + lines[insert_line:]
-    new_content = "".join(new_lines)
-
-    if new_content == original:
-        # An empty new_str (after style conversion) is a genuine no-op --
-        # report it as such rather than pushing a write/undo entry for a
-        # byte-identical file (the same no-op contract _replace_in_file
-        # honors; see file_modifications.py).
-        return {
-            "success": False,
-            "path": file_path,
-            "changed": False,
-            "message": "No change: the inserted text was empty.",
-        }
+    new_content = "".join(lines[:insert_line] + [inserted] + lines[insert_line:])
 
     group_id = generate_group_id("str_replace_based_edit_tool", path)
     result = await write_to_file_async(

--- a/code_puppy/tools/anthropic_editor_tool.py
+++ b/code_puppy/tools/anthropic_editor_tool.py
@@ -44,6 +44,7 @@ from code_puppy.tools.file_modifications import (
     _emit_diff_message,
     _log_error,
     _permission_denied,
+    _refuse_user_plugin_tree,
     _write_to_file,
     replace_in_file_async,
     write_to_file_async,
@@ -438,6 +439,10 @@ async def _insert_into_file(
     real inserted text.)
     """
     file_path = resolve_path(path)
+
+    refused = _refuse_user_plugin_tree(path)
+    if refused is not None:
+        return refused
 
     if not fs_access.exists(file_path) or not fs_access.is_file(file_path):
         return {"error": "not_found", "path": file_path}

--- a/code_puppy/tools/anthropic_editor_tool.py
+++ b/code_puppy/tools/anthropic_editor_tool.py
@@ -17,14 +17,25 @@ errors, not silent no-ops.
 
 from __future__ import annotations
 
+import os
 from typing import Any, Dict, List, Optional
 
 from pydantic_ai import RunContext
 
 from code_puppy.callbacks import on_edit_file, on_file_permission_async
-from code_puppy.messaging import FileContentMessage, get_message_bus
+from code_puppy.messaging import (
+    FileContentMessage,
+    FileEntry,
+    FileListingMessage,
+    get_message_bus,
+)
 from code_puppy.tools import fs_access
-from code_puppy.tools.common import generate_group_id, resolve_path
+from code_puppy.tools.common import (
+    generate_group_id,
+    resolve_path,
+    should_ignore_dir_path,
+    should_ignore_path,
+)
 from code_puppy.tools.file_modifications import (
     ContentPayload,
     Replacement,
@@ -232,7 +243,21 @@ def _view_file(path: str, view_range: Optional[List[int]]) -> Dict[str, Any]:
             # _read_file already takes on its own backend-read path in
             # file_operations.py.
             return {"error": f"Failed to list directory '{file_path}': {exc}"}
-        names = sorted((f"{e.name}/" if e.is_dir else e.name) for e in entries)
+        # `view` is `list_files`'s native-editor equivalent (see the swap
+        # gate in tools/__init__.py), so it must not be able to see more
+        # than list_files does -- without this filter, view on a directory
+        # freely enumerated .git/, node_modules/, and .env, all of which
+        # list_files's default (recursive) call hides via DIR_IGNORE_PATTERNS.
+        # Filtered by full path, matching should_ignore_path/
+        # should_ignore_dir_path's own contract.
+        visible = [
+            e
+            for e in entries
+            if not (should_ignore_dir_path if e.is_dir else should_ignore_path)(
+                os.path.join(file_path, e.name)
+            )
+        ]
+        names = sorted((f"{e.name}/" if e.is_dir else e.name) for e in visible)
         # Same intent as _MAX_VIEW_TOKENS below: an unbounded directory
         # listing (e.g. node_modules, .git) would blow past the very
         # context budget the file-view branch already enforces.
@@ -245,6 +270,30 @@ def _view_file(path: str, view_range: Optional[List[int]]) -> Dict[str, Any]:
         }
         if truncated:
             result["truncated"] = True
+
+        # Matches the file branch below: without this, a directory `view`
+        # is invisible to the user/run_stats (NATIVE_EDITOR_TOOL_NAME is in
+        # run_stats._TOOLS_WITH_RENDERER, which suppresses the fallback body
+        # render on the assumption a message bus event already showed it).
+        listed = visible[:_MAX_VIEW_ENTRIES]
+        get_message_bus().emit(
+            FileListingMessage(
+                directory=file_path,
+                files=[
+                    FileEntry(
+                        path=e.name,
+                        type="dir" if e.is_dir else "file",
+                        size=0 if e.is_dir else e.size,
+                        depth=0,
+                    )
+                    for e in listed
+                ],
+                recursive=False,
+                total_size=sum(e.size for e in listed if not e.is_dir),
+                dir_count=sum(1 for e in listed if e.is_dir),
+                file_count=sum(1 for e in listed if not e.is_dir),
+            )
+        )
         return result
 
     if not fs_access.is_file(file_path):

--- a/code_puppy/tools/anthropic_editor_tool.py
+++ b/code_puppy/tools/anthropic_editor_tool.py
@@ -291,19 +291,33 @@ def _view_file(path: str, view_range: Optional[List[int]]) -> Dict[str, Any]:
         start, end = 0, 0
 
     selected = lines[start - 1 : end] if total_lines else []
-    numbered = "\n".join(
-        f"{idx:6d}\t{line}" for idx, line in enumerate(selected, start=start)
-    )
+    raw_selected = "\n".join(selected)
 
-    if len(numbered) // 4 > _MAX_VIEW_TOKENS:
+    # Budget against the RAW slice, not the line-numbered rendering. The
+    # `f"{idx:6d}\t"` gutter adds a fixed 7 characters per line, which on
+    # narrow-line files dominates the measurement: a 5,000-line file of
+    # one-character lines is 10 KB of real content (2.5k tokens, which
+    # portable `read_file` accepts) but 40 KB once numbered, so the old
+    # check rejected it as `content_too_large`. That made `view` refuse
+    # files `read_file` happily returns -- and since the native-editor
+    # profile REPLACES read_file, that was a hard capability regression
+    # with no fallback tool to reach for. Measuring the raw slice keeps
+    # the two tools' limits equivalent (same 10k-token budget over the
+    # same bytes), which is exactly the parity the swap assumes.
+    if len(raw_selected) // 4 > _MAX_VIEW_TOKENS:
         return {
             "error": "content_too_large",
             "path": file_path,
+            "total_lines": total_lines,
             "message": (
                 "The requested range is too large to view in one call; "
                 "narrow view_range and retry."
             ),
         }
+
+    numbered = "\n".join(
+        f"{idx:6d}\t{line}" for idx, line in enumerate(selected, start=start)
+    )
 
     # Matches read_file's UI contract: the raw (unnumbered) slice goes to
     # the message bus for display/telemetry; the line-numbered rendering
@@ -313,7 +327,6 @@ def _view_file(path: str, view_range: Optional[List[int]]) -> Dict[str, Any]:
     # FileContentMessage requires num_lines >= 1, so an empty file (or the
     # unranged whole-file case, which read_file's own contract also reports
     # as start_line=None) must fall back to None rather than 0.
-    raw_selected = "\n".join(selected)
     get_message_bus().emit(
         FileContentMessage(
             path=file_path,

--- a/code_puppy/tools/anthropic_editor_tool.py
+++ b/code_puppy/tools/anthropic_editor_tool.py
@@ -176,7 +176,21 @@ async def dispatch_editor_command(
         # here (the two always agree). The existence check has the same
         # narrow TOCTOU window as `_write_to_file`'s own equivalent check;
         # accepted for the same reason.
-        already_existed = fs_access.exists(resolve_path(path))
+        resolved_path = resolve_path(path)
+        if fs_access.exists(resolved_path) and fs_access.is_dir(resolved_path):
+            # `_write_to_file` has no directory guard of its own -- without
+            # this check the write attempt falls through to a bare
+            # `except Exception` and leaks a raw `[Errno 21] Is a
+            # directory: ...` string, violating this module's own
+            # "fail loudly and specifically" contract (see module
+            # docstring). `view`/`insert` already guard this; `create`
+            # didn't.
+            return {
+                "error": "not_a_regular_file",
+                "path": resolved_path,
+                "message": f"Cannot create a file at '{resolved_path}': it is a directory.",
+            }
+        already_existed = fs_access.exists(resolved_path)
         group_id = generate_group_id("str_replace_based_edit_tool", path)
         result = await write_to_file_async(
             context,

--- a/code_puppy/tools/anthropic_editor_tool.py
+++ b/code_puppy/tools/anthropic_editor_tool.py
@@ -1,0 +1,382 @@
+"""Canonical command dispatch for Anthropic's native text-editor tool.
+
+Phase 3 of the Anthropic editor adapter plan
+(``.context/plan/anthropic-editor-adapter.md``). Maps the fixed
+``view``/``str_replace``/``create``/``insert`` command shape Claude was
+trained on directly onto the same hardened engine the portable
+``read_file``/``replace_in_file``/``create_file`` tools use --
+``str_replace`` and ``create`` are thin dispatches into the exact-match-safe,
+permission-checked, undo-tracked helpers in ``file_modifications.py`` (no
+duplicated safety logic); ``view`` and ``insert`` are the two commands with
+no existing generic-tool equivalent, implemented here.
+
+Every branch fails loudly and specifically: unknown commands, missing
+required fields, and out-of-range locations are all external-input parsing
+errors, not silent no-ops.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic_ai import RunContext
+
+from code_puppy.callbacks import on_edit_file
+from code_puppy.messaging import FileContentMessage, get_message_bus
+from code_puppy.tools import fs_access
+from code_puppy.tools.common import generate_group_id, resolve_path
+from code_puppy.tools.file_modifications import (
+    ContentPayload,
+    Replacement,
+    ReplacementsPayload,
+    replace_in_file_async,
+    write_to_file_async,
+)
+from code_puppy.tools.line_endings import detect_dominant, to_style
+
+# Claude's older ``text_editor_20241022`` tool had an ``undo_edit`` command;
+# the versions this façade targets (2025-04-29 / 2025-07-28) do not -- see
+# ``model_capabilities.py``'s module docstring for the verification. Rejected
+# by name, not silently ignored, in case a model trained on the older tool
+# still emits it.
+_UNSUPPORTED_COMMANDS = frozenset({"undo_edit"})
+_SUPPORTED_COMMANDS = frozenset({"view", "str_replace", "create", "insert"})
+
+# Reuse the same file-size guard the portable read_file tool applies, so
+# `view` can't dump an unbounded file into context either.
+_MAX_VIEW_TOKENS = 10_000
+
+
+def _unsupported_command_error(command: str) -> Dict[str, Any]:
+    if command in _UNSUPPORTED_COMMANDS:
+        return {
+            "error": "unsupported_command",
+            "command": command,
+            "message": (
+                f"'{command}' is not supported by this tool version. There is "
+                "no per-command undo stack; make a corrective str_replace or "
+                "create call instead, or use the shell/undo tooling."
+            ),
+        }
+    return {
+        "error": "unknown_command",
+        "command": command,
+        "supported_commands": sorted(_SUPPORTED_COMMANDS),
+        "message": f"Unknown command '{command}'. Supported: {sorted(_SUPPORTED_COMMANDS)}.",
+    }
+
+
+def _missing_field_error(command: str, field: str) -> Dict[str, Any]:
+    return {
+        "error": "missing_field",
+        "command": command,
+        "field": field,
+        "message": f"command '{command}' requires '{field}'.",
+    }
+
+
+def _sanitize_surrogates(text: str) -> str:
+    """Strip lone Unicode surrogates from file content read off disk.
+
+    Same technique ``_replace_in_file``/``_finalize_read_output`` already
+    apply (see ``file_modifications.py``/``file_operations.py``) -- a raw
+    non-UTF-8 byte survives ``fs_access.read_text`` as a surrogate
+    codepoint, which then raises an untyped ``UnicodeEncodeError`` deep
+    inside the eventual write/JSON-serialization path instead of failing
+    at this parsing boundary. Kept as its own tiny helper here (a third
+    copy) rather than added to ``tools/common.py``/``file_modifications.py``,
+    which the plan already flags as over the 600-line limit.
+    """
+    try:
+        return text.encode("utf-8", errors="surrogatepass").decode(
+            "utf-8", errors="replace"
+        )
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        return "".join(
+            ch if not (0xD800 <= ord(ch) <= 0xDFFF) else "\ufffd" for ch in text
+        )
+
+
+def _apply_edit_callback(
+    context: RunContext, result: Dict[str, Any], payload: Any
+) -> Dict[str, Any]:
+    """Run the same ``on_edit_file`` enhancement hook the portable
+    ``create_file``/``replace_in_file`` tools fire after a write, so a
+    plugin listening for edit results (e.g. rejection-detail enrichment)
+    sees native-editor writes too -- native and portable edits share the
+    write engine but must not silently diverge in what fires afterward.
+    """
+    enhanced_results = on_edit_file(context, result, payload)
+    if enhanced_results:
+        for enhanced_result in enhanced_results:
+            if enhanced_result is not None:
+                return enhanced_result
+    return result
+
+
+async def dispatch_editor_command(
+    context: RunContext,
+    command: str,
+    path: str,
+    *,
+    old_str: Optional[str] = None,
+    new_str: Optional[str] = None,
+    file_text: Optional[str] = None,
+    insert_line: Optional[int] = None,
+    view_range: Optional[List[int]] = None,
+) -> Dict[str, Any]:
+    """Route one native-editor command to the canonical engine."""
+    if command == "view":
+        return _view_file(path, view_range)
+
+    if command == "str_replace":
+        if old_str is None:
+            return _missing_field_error(command, "old_str")
+        if new_str is None:
+            return _missing_field_error(command, "new_str")
+        group_id = generate_group_id("str_replace_based_edit_tool", path)
+        result = await replace_in_file_async(
+            context,
+            path,
+            [{"old_str": old_str, "new_str": new_str}],
+            message_group=group_id,
+        )
+        result.pop("diff", None)
+        payload = ReplacementsPayload(
+            file_path=path,
+            replacements=[Replacement(old_str=old_str, new_str=new_str)],
+        )
+        return _apply_edit_callback(context, result, payload)
+
+    if command == "create":
+        if file_text is None:
+            return _missing_field_error(command, "file_text")
+        # overwrite=True is deliberate spec conformance, not an oversight:
+        # Anthropic's documented `create` command always (over)writes the
+        # full file at `path`, unlike the portable `create_file` tool (which
+        # defaults to refusing an existing file). The permission gate below
+        # still applies, so an overwrite still requires approval.
+        group_id = generate_group_id("str_replace_based_edit_tool", path)
+        result = await write_to_file_async(
+            context, path, file_text, overwrite=True, message_group=group_id
+        )
+        result.pop("diff", None)
+        payload = ContentPayload(file_path=path, content=file_text, overwrite=True)
+        return _apply_edit_callback(context, result, payload)
+
+    if command == "insert":
+        if insert_line is None:
+            return _missing_field_error(command, "insert_line")
+        if new_str is None:
+            return _missing_field_error(command, "new_str")
+        return await _insert_into_file(context, path, insert_line, new_str)
+
+    return _unsupported_command_error(command)
+
+
+def _view_file(path: str, view_range: Optional[List[int]]) -> Dict[str, Any]:
+    """Read-only view, no permission gate (matches the portable read_file tool)."""
+    file_path = resolve_path(path)
+
+    if not fs_access.exists(file_path):
+        return {"error": "not_found", "path": file_path}
+
+    if fs_access.is_dir(file_path):
+        try:
+            entries = fs_access.list_dir(file_path)
+        except OSError as exc:
+            return {"error": f"Failed to list directory '{file_path}': {exc}"}
+        names = sorted((f"{e.name}/" if e.is_dir else e.name) for e in entries)
+        return {"path": file_path, "is_directory": True, "entries": names}
+
+    try:
+        content = fs_access.read_text(file_path)
+    except OSError as exc:
+        return {"error": f"Failed to read file '{file_path}': {exc}"}
+
+    content = _sanitize_surrogates(content)
+    lines = content.splitlines()
+    total_lines = len(lines)
+    start, end = 1, total_lines
+
+    if view_range is not None:
+        if len(view_range) != 2:
+            return {
+                "error": "invalid_view_range",
+                "message": "view_range must be exactly [start_line, end_line].",
+            }
+        start, end = view_range
+        if end == -1:
+            end = total_lines
+        if start < 1 or start > max(total_lines, 1) or end < start:
+            return {
+                "error": "invalid_view_range",
+                "path": file_path,
+                "total_lines": total_lines,
+                "message": f"view_range {view_range} is out of bounds for a {total_lines}-line file.",
+            }
+        end = min(end, total_lines)
+
+    if total_lines == 0:
+        # Degenerate case: an empty file has no valid non-zero line range.
+        # Normalize both the ranged and unranged paths to the same (0, 0)
+        # shape instead of leaving `end` at the range-validation fallout of
+        # 0 (view_range case) or `total_lines` (unranged case, also 0) --
+        # either way `start` must not stay at its 1-based default when
+        # there is nothing to number starting from line 1.
+        start, end = 0, 0
+
+    selected = lines[start - 1 : end] if total_lines else []
+    numbered = "\n".join(
+        f"{idx:6d}\t{line}" for idx, line in enumerate(selected, start=start)
+    )
+
+    if len(numbered) // 4 > _MAX_VIEW_TOKENS:
+        return {
+            "error": "content_too_large",
+            "path": file_path,
+            "message": (
+                "The requested range is too large to view in one call; "
+                "narrow view_range and retry."
+            ),
+        }
+
+    # Matches read_file's UI contract: the raw (unnumbered) slice goes to
+    # the message bus for display/telemetry; the line-numbered rendering
+    # below is what actually goes back to the model. Without this, `view`
+    # is invisible to the user/run_stats even though it is a real read.
+    # Metadata is only meaningful for a real ranged, non-empty selection --
+    # FileContentMessage requires num_lines >= 1, so an empty file (or the
+    # unranged whole-file case, which read_file's own contract also reports
+    # as start_line=None) must fall back to None rather than 0.
+    raw_selected = "\n".join(selected)
+    get_message_bus().emit(
+        FileContentMessage(
+            path=file_path,
+            content=raw_selected,
+            start_line=start if (view_range is not None and total_lines) else None,
+            num_lines=(end - start + 1)
+            if (view_range is not None and total_lines)
+            else None,
+            total_lines=total_lines,
+            num_tokens=len(numbered) // 4,
+        )
+    )
+
+    return {
+        "path": file_path,
+        "start_line": start,
+        "end_line": end,
+        "total_lines": total_lines,
+        "content": numbered,
+    }
+
+
+async def _insert_into_file(
+    context: RunContext, path: str, insert_line: int, new_str: str
+) -> Dict[str, Any]:
+    """Insert ``new_str`` after ``insert_line`` (0 = start of file).
+
+    No generic-tool equivalent exists to delegate to, so this computes the
+    resulting full-file content itself and then hands the actual write off
+    to ``write_to_file_async`` -- the same permission-check, undo-capture,
+    and diff-emission path every other mutation uses. (The permission audit
+    label reads "write" rather than "insert" as a result; the operation data
+    still carries the real inserted text.)
+    """
+    file_path = resolve_path(path)
+
+    if not fs_access.exists(file_path) or not fs_access.is_file(file_path):
+        return {"error": "not_found", "path": file_path}
+
+    try:
+        original = fs_access.read_text(file_path)
+    except OSError as exc:
+        return {"error": f"Failed to read file '{file_path}': {exc}"}
+
+    original = _sanitize_surrogates(original)
+    lines = original.splitlines(keepends=True) if original else []
+    line_count = len(lines)
+
+    if insert_line < 0 or insert_line > line_count:
+        return {
+            "error": "invalid_insert_line",
+            "path": file_path,
+            "line_count": line_count,
+            "message": (
+                f"insert_line must be between 0 and {line_count} "
+                f"(the file's current line count); got {insert_line}."
+            ),
+        }
+
+    style = detect_dominant(original) if original else "\n"
+    inserted = to_style(new_str, style)
+    if inserted and not inserted.endswith(style):
+        inserted += style
+
+    # If we're inserting after the current last line and that line is
+    # missing its own terminator, add one so the insertion doesn't fuse onto
+    # the previous line's text.
+    if insert_line == line_count and lines and not lines[-1].endswith(("\n", "\r")):
+        lines[-1] = lines[-1] + style
+
+    new_lines = lines[:insert_line] + [inserted] + lines[insert_line:]
+    new_content = "".join(new_lines)
+
+    if new_content == original:
+        # An empty new_str (after style conversion) is a genuine no-op --
+        # report it as such rather than pushing a write/undo entry for a
+        # byte-identical file (the same no-op contract _replace_in_file
+        # honors; see file_modifications.py).
+        return {
+            "success": False,
+            "path": file_path,
+            "changed": False,
+            "message": "No change: the inserted text was empty.",
+        }
+
+    group_id = generate_group_id("str_replace_based_edit_tool", path)
+    result = await write_to_file_async(
+        context, path, new_content, overwrite=True, message_group=group_id
+    )
+    result.pop("diff", None)
+    payload = ContentPayload(file_path=file_path, content=new_content, overwrite=True)
+    return _apply_edit_callback(context, result, payload)
+
+
+def register_str_replace_based_edit_tool(agent) -> None:
+    """Register Anthropic's native text-editor tool on ``agent``.
+
+    Declared here as an ordinary pydantic-ai function tool; the wire-level
+    substitution that makes Anthropic treat it as the client-executed
+    editor (instead of a generic JSON-schema tool) happens in
+    ``AnthropicNativeEditorModel``, not here.
+    """
+
+    @agent.tool
+    async def str_replace_based_edit_tool(
+        context: RunContext,
+        command: str,
+        path: str,
+        old_str: Optional[str] = None,
+        new_str: Optional[str] = None,
+        file_text: Optional[str] = None,
+        insert_line: Optional[int] = None,
+        view_range: Optional[List[int]] = None,
+    ) -> Dict[str, Any]:
+        """Anthropic's native client-executed text-editor tool.
+
+        Commands: view (path, optional view_range=[start,end], -1=end of
+        file), str_replace (path, old_str, new_str), create (path,
+        file_text), insert (path, insert_line, new_str).
+        """
+        return await dispatch_editor_command(
+            context,
+            command,
+            path,
+            old_str=old_str,
+            new_str=new_str,
+            file_text=file_text,
+            insert_line=insert_line,
+            view_range=view_range,
+        )

--- a/code_puppy/tools/common.py
+++ b/code_puppy/tools/common.py
@@ -1220,7 +1220,7 @@ def atomic_write_text(
 
     fd, tmp = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
     try:
-        with os.fdopen(fd, "w", encoding=encoding) as f:
+        with os.fdopen(fd, "w", encoding=encoding, newline="") as f:
             f.write(content)
             f.flush()
             os.fsync(f.fileno())

--- a/code_puppy/tools/file_modifications.py
+++ b/code_puppy/tools/file_modifications.py
@@ -976,7 +976,6 @@ def _delete_file(
     refused = _refuse_user_plugin_tree(file_path)
     if refused is not None:
         return refused
-    UndoManager().record_change(file_path, "delete_file")
     file_path = resolve_path(file_path)
 
     # Use the plugin system for permission handling with operation data

--- a/code_puppy/tools/file_modifications.py
+++ b/code_puppy/tools/file_modifications.py
@@ -37,7 +37,7 @@ from code_puppy.tools.common import (
     resolve_path,
     write_project_file,
 )
-from code_puppy.tools.line_endings import resolve_pattern, to_style
+from code_puppy.tools.line_endings import find_logical_matches, to_style
 from code_puppy.tools.file_permission_state import (
     clear_diff_shown_flag,
     clear_user_feedback,
@@ -236,14 +236,28 @@ def _delete_snippet_from_file(
         except (UnicodeEncodeError, UnicodeDecodeError):
             pass
         # Reconcile the model's \n-terminated snippet against the file's
-        # actual line endings (see tools/line_endings.py).
-        effective_snippet, snippet_count, _style = resolve_pattern(original, snippet)
-        if not snippet_count:
+        # actual line endings (see tools/line_endings.py). find_logical_matches
+        # aggregates every equivalent LF/CRLF/CR occurrence before we decide
+        # anything is unique.
+        matches = find_logical_matches(original, snippet)
+        if not matches:
             return {
                 "error": f"Snippet not found in file '{file_path}'.",
                 "diff": diff_text,
             }
-        modified = original.replace(effective_snippet, "", 1)
+        if len(matches) > 1:
+            return {
+                "error": "ambiguous_match",
+                "path": file_path,
+                "match_count": len(matches),
+                "message": (
+                    f"snippet matched {len(matches)} locations; make it unique "
+                    "before retrying."
+                ),
+                "diff": diff_text,
+            }
+        match = matches[0]
+        modified = original[: match.start] + original[match.end :]
         from code_puppy.config import get_diff_context_lines
 
         diff_text = "".join(
@@ -255,8 +269,9 @@ def _delete_snippet_from_file(
                 n=get_diff_context_lines(),
             )
         )
-        UndoManager().record_change(file_path, "delete_snippet")
+        pending_change = UndoManager().capture_change(file_path, "delete_snippet")
         write_project_file(file_path, modified)
+        UndoManager().commit_change(pending_change)
         return {
             "success": True,
             "path": file_path,
@@ -265,7 +280,7 @@ def _delete_snippet_from_file(
             "diff": diff_text,
         }
     except Exception as exc:
-        return {"error": str(exc), "diff": diff_text}
+        return {"error": str(exc), "diff": ""}
 
 
 def _bounded_suggestion(
@@ -351,13 +366,19 @@ def _replace_in_file(
 
         # Models emit \n even when the file uses \r\n; reconcile the pattern
         # to the file's actual bytes instead of rewriting the file's endings.
-        effective_old, match_count, style = resolve_pattern(modified, old_snippet)
+        # find_logical_matches aggregates every equivalent LF/CRLF/CR
+        # occurrence (and every overlapping one) before uniqueness is decided,
+        # so an ambiguous edit can never be silently narrowed to "the first
+        # one that happened to match verbatim".
+        matches = find_logical_matches(modified, old_snippet)
+        match_count = len(matches)
 
         if match_count == 1:
-            # Convert the replacement to the surrounding style so the edit
-            # doesn't leave a mixed-terminator island behind.
-            effective_new = to_style(new_snippet, style)
-            modified = modified.replace(effective_old, effective_new, 1)
+            match = matches[0]
+            # Convert the replacement to the matched span's own style so the
+            # edit doesn't leave a mixed-terminator island behind.
+            effective_new = to_style(new_snippet, match.style)
+            modified = modified[: match.start] + effective_new + modified[match.end :]
             continue
 
         if match_count == 0:
@@ -412,26 +433,26 @@ def _replace_in_file(
     )
 
     # Snapshot pre-write state for undo now that every replacement has been
-    # validated -- record_change reads current on-disk content, so it must
-    # run immediately before the write, never after (after the write it
-    # would snapshot the NEW content, turning undo into a no-op).
-    UndoManager().record_change(path, "replace_in_file")
+    # validated. capture_change reads current on-disk content but does NOT
+    # append to history yet -- it's only committed below once the write has
+    # actually succeeded, so a failed write can never poison undo history and
+    # no unsafe pop-the-most-recent-entry rollback is needed.
+    pending_change = UndoManager().capture_change(path, "replace_in_file")
     try:
         write_project_file(file_path, modified)
     except OSError as exc:
-        UndoManager().pop_change()
         return {
             "error": f"Failed to write file '{file_path}': {exc}",
-            "diff": diff_text,
+            "diff": "",
         }
     except Exception as exc:  # pragma: no cover - genuinely unexpected write failure
-        UndoManager().pop_change()
         _log_error(
             f"Unexpected error writing '{file_path}' during replace_in_file",
             exc,
             message_group=message_group,
         )
-        return {"error": f"Unexpected write failure: {exc}", "diff": diff_text}
+        return {"error": f"Unexpected write failure: {exc}", "diff": ""}
+    UndoManager().commit_change(pending_change)
 
     return {
         "success": True,
@@ -489,10 +510,12 @@ def _write_to_file(
         # manages its own topology.
         fs_access.make_dirs(os.path.dirname(file_path) or ".")
         # Snapshot pre-write state (None if the file doesn't exist yet, so
-        # undo knows to delete rather than restore) immediately before the
-        # write -- never after, which would snapshot the new content instead.
-        UndoManager().record_change(path, "write_to_file")
+        # undo knows to delete rather than restore). Committed only after the
+        # write below actually succeeds, so a failed write never poisons undo
+        # history with a phantom entry for a mutation that never happened.
+        pending_change = UndoManager().capture_change(path, "write_to_file")
         write_project_file(file_path, content)
+        UndoManager().commit_change(pending_change)
 
         action = "overwritten" if exists else "created"
         return {
@@ -809,6 +832,56 @@ async def _edit_file_async(
         }
 
 
+def _delete_file_after_permission(
+    file_path: str, message_group: str | None = None
+) -> Dict[str, Any]:
+    """Delete an already-permission-approved file, recording undo correctly.
+
+    Shared by both the sync and async delete tools so undo behavior (and any
+    future fix to it) can never drift between the two paths again.
+    """
+    try:
+        if not fs_access.exists(file_path) or not fs_access.is_file(file_path):
+            return {"error": f"File '{file_path}' does not exist.", "diff": ""}
+
+        original = fs_access.read_text(file_path)
+        # Sanitize any surrogate characters from reading
+        try:
+            original = original.encode("utf-8", errors="surrogatepass").decode(
+                "utf-8", errors="replace"
+            )
+        except (UnicodeEncodeError, UnicodeDecodeError):
+            pass
+        from code_puppy.config import get_diff_context_lines
+
+        diff_text = "".join(
+            difflib.unified_diff(
+                original.splitlines(keepends=True),
+                [],
+                fromfile=f"a/{os.path.basename(file_path)}",
+                tofile=f"b/{os.path.basename(file_path)}",
+                n=get_diff_context_lines(),
+            )
+        )
+        # Snapshot BEFORE deleting -- once the file is gone, its content
+        # cannot be recovered for undo to restore. Committed only after the
+        # delete below actually succeeds, so a failed delete never poisons
+        # undo history with a phantom entry.
+        pending_change = UndoManager().capture_change(file_path, "delete_file")
+        fs_access.delete_file(file_path)
+        UndoManager().commit_change(pending_change)
+        return {
+            "success": True,
+            "path": file_path,
+            "message": f"File '{file_path}' deleted successfully.",
+            "changed": True,
+            "diff": diff_text,
+        }
+    except Exception as exc:
+        _log_error("Unhandled exception in delete_file", exc)
+        return {"error": str(exc), "diff": ""}
+
+
 def _delete_file(
     context: RunContext, file_path: str, message_group: str | None = None
 ) -> Dict[str, Any]:
@@ -826,44 +899,7 @@ def _delete_file(
     if _permission_denied(permission_results):
         return _create_rejection_response(file_path)
 
-    try:
-        if not fs_access.exists(file_path) or not fs_access.is_file(file_path):
-            res = {"error": f"File '{file_path}' does not exist.", "diff": ""}
-        else:
-            original = fs_access.read_text(file_path)
-            # Sanitize any surrogate characters from reading
-            try:
-                original = original.encode("utf-8", errors="surrogatepass").decode(
-                    "utf-8", errors="replace"
-                )
-            except (UnicodeEncodeError, UnicodeDecodeError):
-                pass
-            from code_puppy.config import get_diff_context_lines
-
-            diff_text = "".join(
-                difflib.unified_diff(
-                    original.splitlines(keepends=True),
-                    [],
-                    fromfile=f"a/{os.path.basename(file_path)}",
-                    tofile=f"b/{os.path.basename(file_path)}",
-                    n=get_diff_context_lines(),
-                )
-            )
-            # Snapshot BEFORE deleting -- once the file is gone, its content
-            # cannot be recovered for undo to restore.
-            UndoManager().record_change(file_path, "delete_file")
-            fs_access.delete_file(file_path)
-            res = {
-                "success": True,
-                "path": file_path,
-                "message": f"File '{file_path}' deleted successfully.",
-                "changed": True,
-                "diff": diff_text,
-            }
-    except Exception as exc:
-        _log_error("Unhandled exception in delete_file", exc)
-        res = {"error": str(exc), "diff": ""}
-
+    res = _delete_file_after_permission(file_path, message_group)
     diff = res.get("diff", "")
     if diff:
         _emit_diff_message(file_path, "delete", diff)
@@ -885,40 +921,7 @@ async def _delete_file_async(
     if _permission_denied(permission_results):
         return _create_rejection_response(file_path)
 
-    try:
-        if not fs_access.exists(file_path) or not fs_access.is_file(file_path):
-            res = {"error": f"File '{file_path}' does not exist.", "diff": ""}
-        else:
-            original = fs_access.read_text(file_path)
-            try:
-                original = original.encode("utf-8", errors="surrogatepass").decode(
-                    "utf-8", errors="replace"
-                )
-            except (UnicodeEncodeError, UnicodeDecodeError):
-                pass
-            from code_puppy.config import get_diff_context_lines
-
-            diff_text = "".join(
-                difflib.unified_diff(
-                    original.splitlines(keepends=True),
-                    [],
-                    fromfile=f"a/{os.path.basename(file_path)}",
-                    tofile=f"b/{os.path.basename(file_path)}",
-                    n=get_diff_context_lines(),
-                )
-            )
-            fs_access.delete_file(file_path)
-            res = {
-                "success": True,
-                "path": file_path,
-                "message": f"File '{file_path}' deleted successfully.",
-                "changed": True,
-                "diff": diff_text,
-            }
-    except Exception as exc:
-        _log_error("Unhandled exception in delete_file", exc)
-        res = {"error": str(exc), "diff": ""}
-
+    res = _delete_file_after_permission(file_path, message_group)
     diff = res.get("diff", "")
     if diff:
         _emit_diff_message(file_path, "delete", diff)

--- a/code_puppy/tools/file_modifications.py
+++ b/code_puppy/tools/file_modifications.py
@@ -37,6 +37,7 @@ from code_puppy.tools.common import (
     resolve_path,
     write_project_file,
 )
+from code_puppy.tools.line_endings import resolve_pattern, to_style
 from code_puppy.tools.file_permission_state import (
     clear_diff_shown_flag,
     clear_user_feedback,
@@ -221,7 +222,6 @@ def _delete_snippet_from_file(
     snippet: str,
     message_group: str | None = None,
 ) -> Dict[str, Any]:
-    UndoManager().record_change(file_path, "delete_snippet")
     file_path = resolve_path(file_path)
     diff_text = ""
     try:
@@ -235,12 +235,15 @@ def _delete_snippet_from_file(
             )
         except (UnicodeEncodeError, UnicodeDecodeError):
             pass
-        if snippet not in original:
+        # Reconcile the model's \n-terminated snippet against the file's
+        # actual line endings (see tools/line_endings.py).
+        effective_snippet, snippet_count, _style = resolve_pattern(original, snippet)
+        if not snippet_count:
             return {
                 "error": f"Snippet not found in file '{file_path}'.",
                 "diff": diff_text,
             }
-        modified = original.replace(snippet, "", 1)
+        modified = original.replace(effective_snippet, "", 1)
         from code_puppy.config import get_diff_context_lines
 
         diff_text = "".join(
@@ -252,6 +255,7 @@ def _delete_snippet_from_file(
                 n=get_diff_context_lines(),
             )
         )
+        UndoManager().record_change(file_path, "delete_snippet")
         write_project_file(file_path, modified)
         return {
             "success": True,
@@ -264,98 +268,178 @@ def _delete_snippet_from_file(
         return {"error": str(exc), "diff": diff_text}
 
 
+def _bounded_suggestion(
+    haystack_lines: List[str],
+    needle: str,
+    max_lines: int = 6,
+    max_chars: int = 400,
+) -> Dict[str, Any] | None:
+    """Build a whole-line-aligned, size-bounded, line-numbered hint of nearby
+    text for a failed exact match. Never used to select a mutation target --
+    read-only diagnostic output only. Bounding to whole lines (never a
+    mid-line truncation) means a model can copy this text into an exact
+    retry without the suggestion itself guaranteeing a second failure.
+    """
+    if not haystack_lines:
+        return None
+    loc, score = _find_best_window(haystack_lines, needle)
+    if loc is not None:
+        start, end = loc
+    else:
+        start, end = 0, min(len(haystack_lines), max(1, len(needle.splitlines()) or 1))
+    if end - start > max_lines:
+        end = start + max_lines
+    end = min(end, len(haystack_lines))
+    numbered = [f"{i + 1}: {haystack_lines[i]}" for i in range(start, end)]
+    text = "\n".join(numbered)
+    if len(text) > max_chars:
+        text = text[:max_chars].rstrip() + " \u2026(truncated)"
+    return {
+        "suggested_current_text": text,
+        "jw_score": score,
+        "start_line": start + 1,
+        "end_line": end,
+    }
+
+
 def _replace_in_file(
     context: RunContext | None,
     path: str,
     replacements: List[Dict[str, str]],
     message_group: str | None = None,
 ) -> Dict[str, Any]:
-    UndoManager().record_change(path, "replace_in_file")
-    """Robust replacement engine with explicit edge‑case reporting."""
+    """Strict exact-match replacement engine.
+
+    Contract: an empty ``old_str`` is rejected outright, zero exact matches
+    and multiple (ambiguous) exact matches both fail closed without writing,
+    fuzzy matching is used only to build a bounded suggestion for a failed
+    match (never to select a mutation target), and every replacement in the
+    batch is validated in memory before a single atomic write. Undo is
+    recorded once, only immediately before that write actually happens --
+    never on a validation failure or a no-op.
+    """
     file_path = resolve_path(path)
-    diff_text = ""
+
+    if not fs_access.exists(file_path) or not fs_access.is_file(file_path):
+        return {"error": f"File '{file_path}' does not exist.", "diff": ""}
+
     try:
-        if not fs_access.exists(file_path) or not fs_access.is_file(file_path):
-            return {"error": f"File '{file_path}' does not exist.", "diff": diff_text}
-
         original = fs_access.read_text(file_path)
+    except OSError as exc:
+        return {"error": f"Failed to read file '{file_path}': {exc}", "diff": ""}
 
-        # Sanitize any surrogate characters from reading
-        try:
-            original = original.encode("utf-8", errors="surrogatepass").decode(
-                "utf-8", errors="replace"
-            )
-        except (UnicodeEncodeError, UnicodeDecodeError):
-            pass
+    # Sanitize any surrogate characters from reading
+    try:
+        original = original.encode("utf-8", errors="surrogatepass").decode(
+            "utf-8", errors="replace"
+        )
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        pass
 
-        modified = original
-        for rep in replacements:
-            old_snippet = rep.get("old_str", "")
-            new_snippet = rep.get("new_str", "")
+    modified = original
+    for rep in replacements:
+        old_snippet = rep.get("old_str", "")
+        new_snippet = rep.get("new_str", "")
 
-            if old_snippet and old_snippet in modified:
-                modified = modified.replace(old_snippet, new_snippet, 1)
-                continue
-
-            had_trailing_newline = modified.endswith("\n")
-            orig_lines = modified.splitlines()
-            loc, score = _find_best_window(orig_lines, old_snippet)
-
-            if score < 0.95 or loc is None:
-                return {
-                    "error": "No suitable match in file (JW < 0.95)",
-                    "jw_score": score,
-                    "received": old_snippet,
-                    "diff": "",
-                }
-
-            start, end = loc
-            prefix = "\n".join(orig_lines[:start])
-            suffix = "\n".join(orig_lines[end:])
-            parts = []
-            if prefix:
-                parts.append(prefix)
-            parts.append(new_snippet.rstrip("\n"))
-            if suffix:
-                parts.append(suffix)
-            modified = "\n".join(parts)
-            if had_trailing_newline and not modified.endswith("\n"):
-                modified += "\n"
-
-        if modified == original:
-            emit_warning(
-                "No changes to apply – proposed content is identical.",
-                message_group=message_group,
-            )
+        if old_snippet == "":
             return {
-                "success": False,
+                "error": "empty_old_str",
                 "path": file_path,
-                "message": "No changes to apply.",
-                "changed": False,
+                "message": "old_str must not be empty; an empty pattern is not a valid replacement target.",
                 "diff": "",
             }
 
-        from code_puppy.config import get_diff_context_lines
+        # Models emit \n even when the file uses \r\n; reconcile the pattern
+        # to the file's actual bytes instead of rewriting the file's endings.
+        effective_old, match_count, style = resolve_pattern(modified, old_snippet)
 
-        diff_text = "".join(
-            difflib.unified_diff(
-                original.splitlines(keepends=True),
-                modified.splitlines(keepends=True),
-                fromfile=f"a/{os.path.basename(file_path)}",
-                tofile=f"b/{os.path.basename(file_path)}",
-                n=get_diff_context_lines(),
-            )
-        )
-        write_project_file(file_path, modified)
+        if match_count == 1:
+            # Convert the replacement to the surrounding style so the edit
+            # doesn't leave a mixed-terminator island behind.
+            effective_new = to_style(new_snippet, style)
+            modified = modified.replace(effective_old, effective_new, 1)
+            continue
+
+        if match_count == 0:
+            suggestion = _bounded_suggestion(modified.splitlines(), old_snippet)
+            result: Dict[str, Any] = {
+                "error": "match_not_found",
+                "path": file_path,
+                "match_count": 0,
+                "received": old_snippet,
+                "diff": "",
+            }
+            if suggestion is not None:
+                result.update(suggestion)
+            return result
+
+        # match_count > 1: ambiguous, do not guess which occurrence was meant.
         return {
-            "success": True,
+            "error": "ambiguous_match",
             "path": file_path,
-            "message": "Replacements applied.",
-            "changed": True,
+            "match_count": match_count,
+            "message": (
+                f"'old_str' matched {match_count} locations; make it unique "
+                "(e.g. include more surrounding context) before retrying."
+            ),
+            "received": old_snippet,
+            "diff": "",
+        }
+
+    if modified == original:
+        emit_warning(
+            "No changes to apply – proposed content is identical.",
+            message_group=message_group,
+        )
+        return {
+            "success": False,
+            "path": file_path,
+            "message": "No changes to apply.",
+            "changed": False,
+            "diff": "",
+        }
+
+    from code_puppy.config import get_diff_context_lines
+
+    diff_text = "".join(
+        difflib.unified_diff(
+            original.splitlines(keepends=True),
+            modified.splitlines(keepends=True),
+            fromfile=f"a/{os.path.basename(file_path)}",
+            tofile=f"b/{os.path.basename(file_path)}",
+            n=get_diff_context_lines(),
+        )
+    )
+
+    # Snapshot pre-write state for undo now that every replacement has been
+    # validated -- record_change reads current on-disk content, so it must
+    # run immediately before the write, never after (after the write it
+    # would snapshot the NEW content, turning undo into a no-op).
+    UndoManager().record_change(path, "replace_in_file")
+    try:
+        write_project_file(file_path, modified)
+    except OSError as exc:
+        UndoManager().pop_change()
+        return {
+            "error": f"Failed to write file '{file_path}': {exc}",
             "diff": diff_text,
         }
-    except Exception as exc:
-        return {"error": str(exc), "diff": diff_text}
+    except Exception as exc:  # pragma: no cover - genuinely unexpected write failure
+        UndoManager().pop_change()
+        _log_error(
+            f"Unexpected error writing '{file_path}' during replace_in_file",
+            exc,
+            message_group=message_group,
+        )
+        return {"error": f"Unexpected write failure: {exc}", "diff": diff_text}
+
+    return {
+        "success": True,
+        "path": file_path,
+        "message": "Replacements applied.",
+        "changed": True,
+        "diff": diff_text,
+    }
 
 
 def _write_to_file(
@@ -365,7 +449,6 @@ def _write_to_file(
     overwrite: bool = False,
     message_group: str | None = None,
 ) -> Dict[str, Any]:
-    UndoManager().record_change(path, "write_to_file")
     file_path = resolve_path(path)
 
     try:
@@ -405,6 +488,10 @@ def _write_to_file(
         # Create local dirs only for local writes; a FS backend (e.g. ACP host)
         # manages its own topology.
         fs_access.make_dirs(os.path.dirname(file_path) or ".")
+        # Snapshot pre-write state (None if the file doesn't exist yet, so
+        # undo knows to delete rather than restore) immediately before the
+        # write -- never after, which would snapshot the new content instead.
+        UndoManager().record_change(path, "write_to_file")
         write_project_file(file_path, content)
 
         action = "overwritten" if exists else "created"
@@ -575,7 +662,6 @@ async def replace_in_file_async(
 def _edit_file(
     context: RunContext, payload: EditFilePayload, group_id: str | None = None
 ) -> Dict[str, Any]:
-    UndoManager().record_change(payload.file_path, "edit_file")
     """
     High-level implementation of the *edit_file* behaviour.
 
@@ -726,7 +812,6 @@ async def _edit_file_async(
 def _delete_file(
     context: RunContext, file_path: str, message_group: str | None = None
 ) -> Dict[str, Any]:
-    UndoManager().record_change(file_path, "delete_file")
     file_path = resolve_path(file_path)
 
     # Use the plugin system for permission handling with operation data
@@ -764,6 +849,9 @@ def _delete_file(
                     n=get_diff_context_lines(),
                 )
             )
+            # Snapshot BEFORE deleting -- once the file is gone, its content
+            # cannot be recovered for undo to restore.
+            UndoManager().record_change(file_path, "delete_file")
             fs_access.delete_file(file_path)
             res = {
                 "success": True,

--- a/code_puppy/tools/fs_access.py
+++ b/code_puppy/tools/fs_access.py
@@ -103,7 +103,9 @@ def read_text(
     backend = get_filesystem_backend()
     if backend is not None:
         return backend.read_text_file(path, line=line, limit=limit)
-    with open(path, "r", encoding="utf-8", errors="surrogateescape") as f:
+    with open(
+        path, "r", encoding="utf-8", errors="surrogateescape", newline=""
+    ) as f:
         if line is None or limit is None:
             return f.read()
         # 1-based line slice, mirroring the backend contract.
@@ -129,7 +131,7 @@ def write_text(path: str, content: str) -> None:
     if backend is not None:
         backend.write_text_file(path, content)
         return
-    with open(path, "w", encoding="utf-8") as f:
+    with open(path, "w", encoding="utf-8", newline="") as f:
         f.write(content)
 
 

--- a/code_puppy/tools/fs_access.py
+++ b/code_puppy/tools/fs_access.py
@@ -103,9 +103,7 @@ def read_text(
     backend = get_filesystem_backend()
     if backend is not None:
         return backend.read_text_file(path, line=line, limit=limit)
-    with open(
-        path, "r", encoding="utf-8", errors="surrogateescape", newline=""
-    ) as f:
+    with open(path, "r", encoding="utf-8", errors="surrogateescape", newline="") as f:
         if line is None or limit is None:
             return f.read()
         # 1-based line slice, mirroring the backend contract.

--- a/code_puppy/tools/line_endings.py
+++ b/code_puppy/tools/line_endings.py
@@ -95,6 +95,38 @@ def _local_style(text: str, start: int, end: int) -> str:
     return LF
 
 
+def split_lines(text: str, *, keepends: bool = False) -> list[str]:
+    """Split ``text`` into lines using only CRLF/CR/LF as terminators.
+
+    Deliberately narrower than ``str.splitlines()``, which also breaks on
+    form feed, vertical tab, ``\\x1c``-``\\x1e``, ``\\u2028``, and
+    ``\\u2029`` -- characters that occur in ordinary source/text files
+    without meaning "new line" there. Every caller that needs to agree on
+    line numbers (e.g. the Anthropic editor's ``view``/``insert``
+    commands, which hand a line number computed by one back to the other)
+    must use this instead of ``str.splitlines()`` so they can never
+    disagree about what a line is.
+    """
+    lines: list[str] = []
+    start = 0
+    index = 0
+    length = len(text)
+    while index < length:
+        if text.startswith(CRLF, index):
+            term_end = index + 2
+        elif text[index] == CR or text[index] == LF:
+            term_end = index + 1
+        else:
+            index += 1
+            continue
+        lines.append(text[start:term_end] if keepends else text[start:index])
+        start = term_end
+        index = term_end
+    if start < length:
+        lines.append(text[start:length])
+    return lines
+
+
 def find_logical_matches(haystack: str, pattern: str) -> tuple[PatternMatch, ...]:
     """Find every logical match, including overlaps and mixed-EOL equivalents.
 

--- a/code_puppy/tools/line_endings.py
+++ b/code_puppy/tools/line_endings.py
@@ -1,0 +1,97 @@
+"""Line-ending reconciliation for the file-editing engine.
+
+Why this exists
+---------------
+``fs_access`` reads and writes files with ``newline=""`` so bytes round-trip
+faithfully -- a file's existing CRLF/LF/CR terminators are never silently
+rewritten just because the file was edited. That is correct at the I/O layer,
+but it pushes one problem up to the editing layer: **models always emit
+``\\n``** in an ``old_str``/snippet, even when the target file uses ``\\r\\n``.
+Matching a model-supplied ``\\n`` pattern against raw CRLF content fails on
+every multi-line edit.
+
+The strategy here is to translate the *pattern* into the *file's* line-ending
+style, rather than normalizing the whole file to the model's style. Every byte
+the model did not target stays untouched -- including in files with mixed
+terminators, which stay mixed everywhere except the edited region.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+CRLF = "\r\n"
+LF = "\n"
+CR = "\r"
+
+# CRLF must be probed before CR/LF so its two-character sequence isn't shadowed.
+_STYLES = (CRLF, LF, CR)
+
+
+def detect_dominant(text: str) -> str:
+    """Return the most common line terminator in ``text``.
+
+    Falls back to ``"\\n"`` when ``text`` has no terminators at all (empty or
+    single-line content), which makes every conversion below a no-op.
+    """
+    crlf = text.count(CRLF)
+    # Each CRLF contains a CR and an LF; discount them from the solo tallies.
+    cr_only = text.count(CR) - crlf
+    lf_only = text.count(LF) - crlf
+
+    if crlf and crlf >= lf_only and crlf >= cr_only:
+        return CRLF
+    if cr_only and cr_only > lf_only:
+        return CR
+    return LF
+
+
+def to_lf(text: str) -> str:
+    """Normalize every terminator style in ``text`` to a bare ``\\n``."""
+    return text.replace(CRLF, LF).replace(CR, LF)
+
+
+def to_style(text: str, style: str) -> str:
+    """Rewrite every terminator in ``text`` to ``style``."""
+    normalized = to_lf(text)
+    if style == LF:
+        return normalized
+    return normalized.replace(LF, style)
+
+
+def resolve_pattern(haystack: str, pattern: str) -> Tuple[Optional[str], int, str]:
+    """Find the form of ``pattern`` that actually occurs in ``haystack``.
+
+    Returns ``(effective_pattern, occurrence_count, style)``. ``style`` is the
+    terminator the matched form uses, so the caller can convert its
+    replacement text to match the surrounding file.
+
+    The pattern is tried verbatim first, so a caller that already supplied
+    exact bytes is never second-guessed. Then the file's dominant style, then
+    the remaining styles -- which is what makes mixed-terminator files work.
+    When nothing matches, returns ``(None, 0, <dominant style>)`` so the
+    caller can still report a sensible style in its error path.
+    """
+    dominant = detect_dominant(haystack)
+
+    if pattern == "":
+        return None, 0, dominant
+
+    # Single-line patterns contain no terminators; no reconciliation applies.
+    if LF not in pattern and CR not in pattern:
+        return pattern, haystack.count(pattern), dominant
+
+    count = haystack.count(pattern)
+    if count:
+        return pattern, count, detect_dominant(pattern)
+
+    ordered = (dominant,) + tuple(s for s in _STYLES if s != dominant)
+    for style in ordered:
+        candidate = to_style(pattern, style)
+        if candidate == pattern:
+            continue  # already tried verbatim above
+        count = haystack.count(candidate)
+        if count:
+            return candidate, count, style
+
+    return None, 0, dominant

--- a/code_puppy/tools/line_endings.py
+++ b/code_puppy/tools/line_endings.py
@@ -1,41 +1,34 @@
-"""Line-ending reconciliation for the file-editing engine.
+"""Byte-faithful line-ending reconciliation for text edits.
 
-Why this exists
----------------
-``fs_access`` reads and writes files with ``newline=""`` so bytes round-trip
-faithfully -- a file's existing CRLF/LF/CR terminators are never silently
-rewritten just because the file was edited. That is correct at the I/O layer,
-but it pushes one problem up to the editing layer: **models always emit
-``\\n``** in an ``old_str``/snippet, even when the target file uses ``\\r\\n``.
-Matching a model-supplied ``\\n`` pattern against raw CRLF content fails on
-every multi-line edit.
-
-The strategy here is to translate the *pattern* into the *file's* line-ending
-style, rather than normalizing the whole file to the model's style. Every byte
-the model did not target stays untouched -- including in files with mixed
-terminators, which stay mixed everywhere except the edited region.
+The filesystem layer reads/writes with ``newline=""`` so untouched bytes are
+never normalized. Models, however, emit ``\\n`` regardless of a target file's
+terminators. Matching therefore happens against an LF-normalized *view* while
+every returned match maps back to exact offsets in the original text -- so
+ambiguity checks (including overlaps and cross-style duplicates) operate on
+the same logical matches that the mutation itself will use.
 """
 
 from __future__ import annotations
 
-from typing import Optional, Tuple
+from dataclasses import dataclass
 
 CRLF = "\r\n"
 LF = "\n"
 CR = "\r"
 
-# CRLF must be probed before CR/LF so its two-character sequence isn't shadowed.
-_STYLES = (CRLF, LF, CR)
+
+@dataclass(frozen=True)
+class PatternMatch:
+    """One logical match, mapped to exact offsets in the original text."""
+
+    start: int
+    end: int
+    style: str
 
 
 def detect_dominant(text: str) -> str:
-    """Return the most common line terminator in ``text``.
-
-    Falls back to ``"\\n"`` when ``text`` has no terminators at all (empty or
-    single-line content), which makes every conversion below a no-op.
-    """
+    """Return the most common terminator, defaulting to LF for no-newline text."""
     crlf = text.count(CRLF)
-    # Each CRLF contains a CR and an LF; discount them from the solo tallies.
     cr_only = text.count(CR) - crlf
     lf_only = text.count(LF) - crlf
 
@@ -47,51 +40,94 @@ def detect_dominant(text: str) -> str:
 
 
 def to_lf(text: str) -> str:
-    """Normalize every terminator style in ``text`` to a bare ``\\n``."""
+    """Normalize every terminator style in ``text`` to LF."""
     return text.replace(CRLF, LF).replace(CR, LF)
 
 
 def to_style(text: str, style: str) -> str:
     """Rewrite every terminator in ``text`` to ``style``."""
     normalized = to_lf(text)
-    if style == LF:
-        return normalized
-    return normalized.replace(LF, style)
+    return normalized if style == LF else normalized.replace(LF, style)
 
 
-def resolve_pattern(haystack: str, pattern: str) -> Tuple[Optional[str], int, str]:
-    """Find the form of ``pattern`` that actually occurs in ``haystack``.
+def _normalized_view(text: str) -> tuple[str, list[int]]:
+    """Return an LF-normalized view plus a normalized->original offset map."""
+    normalized: list[str] = []
+    boundaries = [0]
+    index = 0
+    while index < len(text):
+        if text.startswith(CRLF, index):
+            normalized.append(LF)
+            index += 2
+        elif text[index] == CR:
+            normalized.append(LF)
+            index += 1
+        else:
+            normalized.append(text[index])
+            index += 1
+        boundaries.append(index)
+    return "".join(normalized), boundaries
 
-    Returns ``(effective_pattern, occurrence_count, style)``. ``style`` is the
-    terminator the matched form uses, so the caller can convert its
-    replacement text to match the surrounding file.
 
-    The pattern is tried verbatim first, so a caller that already supplied
-    exact bytes is never second-guessed. Then the file's dominant style, then
-    the remaining styles -- which is what makes mixed-terminator files work.
-    When nothing matches, returns ``(None, 0, <dominant style>)`` so the
-    caller can still report a sensible style in its error path.
+def _local_style(text: str, start: int, end: int) -> str:
+    """Style for a matched span: its own terminators, else its line's."""
+    matched = text[start:end]
+    if CR in matched or LF in matched:
+        return detect_dominant(matched)
+
+    index = end
+    while index < len(text):
+        if text.startswith(CRLF, index):
+            return CRLF
+        if text[index] == CR:
+            return CR
+        if text[index] == LF:
+            return LF
+        index += 1
+
+    index = start - 1
+    while index >= 0:
+        if text[index] == LF:
+            return CRLF if index > 0 and text[index - 1] == CR else LF
+        if text[index] == CR:
+            return CR
+        index -= 1
+    return LF
+
+
+def find_logical_matches(haystack: str, pattern: str) -> tuple[PatternMatch, ...]:
+    """Find every logical match, including overlaps and mixed-EOL equivalents.
+
+    Both strings are compared through LF-normalized views, so an ``old_str``
+    written with plain ``\\n`` matches a CRLF span, and two occurrences that
+    only differ by terminator style are both counted -- neither can be
+    silently treated as the unique target. The search advances one character
+    at a time so overlapping occurrences (e.g. ``"ana"`` in ``"banana"``) are
+    never undercounted by non-overlapping primitives like ``str.count``.
     """
-    dominant = detect_dominant(haystack)
+    if not pattern:
+        return ()
 
-    if pattern == "":
-        return None, 0, dominant
+    normalized_haystack, boundaries = _normalized_view(haystack)
+    normalized_pattern = to_lf(pattern)
+    if not normalized_pattern:
+        return ()
 
-    # Single-line patterns contain no terminators; no reconciliation applies.
-    if LF not in pattern and CR not in pattern:
-        return pattern, haystack.count(pattern), dominant
-
-    count = haystack.count(pattern)
-    if count:
-        return pattern, count, detect_dominant(pattern)
-
-    ordered = (dominant,) + tuple(s for s in _STYLES if s != dominant)
-    for style in ordered:
-        candidate = to_style(pattern, style)
-        if candidate == pattern:
-            continue  # already tried verbatim above
-        count = haystack.count(candidate)
-        if count:
-            return candidate, count, style
-
-    return None, 0, dominant
+    matches: list[PatternMatch] = []
+    cursor = 0
+    while True:
+        start = normalized_haystack.find(normalized_pattern, cursor)
+        if start < 0:
+            break
+        normalized_end = start + len(normalized_pattern)
+        original_start = boundaries[start]
+        original_end = boundaries[normalized_end]
+        matches.append(
+            PatternMatch(
+                start=original_start,
+                end=original_end,
+                style=_local_style(haystack, original_start, original_end),
+            )
+        )
+        cursor = start + 1
+    return tuple(matches)

--- a/code_puppy/tools/line_endings.py
+++ b/code_puppy/tools/line_endings.py
@@ -10,11 +10,16 @@ the same logical matches that the mutation itself will use.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
 CRLF = "\r\n"
 LF = "\n"
 CR = "\r"
+
+# Matches exactly the three terminators split_lines() recognizes, longest
+# (CRLF) first so a CRLF pair is never split into a dangling CR + LF.
+_LINE_TERMINATOR_RE = re.compile(r"\r\n|\r|\n")
 
 
 @dataclass(frozen=True)
@@ -107,23 +112,23 @@ def split_lines(text: str, *, keepends: bool = False) -> list[str]:
     must use this instead of ``str.splitlines()`` so they can never
     disagree about what a line is.
     """
+    if not text:
+        return []
     lines: list[str] = []
     start = 0
-    index = 0
-    length = len(text)
-    while index < length:
-        if text.startswith(CRLF, index):
-            term_end = index + 2
-        elif text[index] == CR or text[index] == LF:
-            term_end = index + 1
-        else:
-            index += 1
-            continue
-        lines.append(text[start:term_end] if keepends else text[start:index])
-        start = term_end
-        index = term_end
-    if start < length:
-        lines.append(text[start:length])
+    # Regex `finditer` over the whole string is ~9x faster than the
+    # previous char-at-a-time scan (which called `str.startswith`/indexed
+    # every character) -- a real difference on multi-MB files, since
+    # `view`/`insert` both call this on the full file content before any
+    # size limit is applied. Verified byte-for-byte equivalent to the old
+    # loop, including keepends, empty input, and every CR/LF/CRLF
+    # combination (see tests/tools/test_line_endings.py).
+    for match in _LINE_TERMINATOR_RE.finditer(text):
+        end = match.end() if keepends else match.start()
+        lines.append(text[start:end])
+        start = match.end()
+    if start < len(text):
+        lines.append(text[start:])
     return lines
 
 

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -477,7 +477,14 @@ async def _invoke_agent_impl(
             from code_puppy.tools import register_tools_for_agent
 
             register_tools_for_agent(
-                temp_agent, agent_tools, model_name=effective_model_name
+                temp_agent,
+                agent_tools,
+                model_name=effective_model_name,
+                # `models_config` was already loaded fresh above to resolve
+                # the model itself; threading it through here closes the
+                # same two-source-of-truth window fixed for the main agent
+                # builder (register_tools_for_agent's docstring explains why).
+                models_config=models_config,
             )
 
             # Allow plugins to wrap the agent (e.g. DBOS durable-exec wrapper).

--- a/code_puppy/undo_manager.py
+++ b/code_puppy/undo_manager.py
@@ -22,7 +22,14 @@ class UndoManager:
         if not hasattr(self, "history"):
             self.history: List[FileChange] = []
 
-    def record_change(self, file_path: str, action: str):
+    def capture_change(self, file_path: str, action: str) -> FileChange:
+        """Snapshot pre-mutation state WITHOUT touching undo history.
+
+        Callers must pass the result to ``commit_change`` only after their
+        filesystem mutation actually succeeds. This keeps a failed mutation
+        from ever entering history, and avoids needing an LIFO ``pop_change``
+        rollback (which can drop a different, concurrently-succeeded edit).
+        """
         # Route via the fs facade + resolve_path so undo matches whatever
         # filesystem the tools wrote to (local disk or an installed backend).
         from code_puppy.tools import fs_access
@@ -35,11 +42,20 @@ class UndoManager:
                 original_content = fs_access.read_text(file_path)
             except Exception:
                 pass  # Ignore binary files or unreadable files for now
-        self.history.append(
-            FileChange(
-                file_path=file_path, original_content=original_content, action=action
-            )
+        return FileChange(
+            file_path=file_path, original_content=original_content, action=action
         )
+
+    def commit_change(self, change: FileChange) -> None:
+        """Publish a snapshot from ``capture_change`` after a successful mutation."""
+        self.history.append(change)
+
+    def record_change(self, file_path: str, action: str) -> None:
+        """Immediate capture+commit. Kept for callers with no failure path to
+        guard against; new mutation code should prefer capture_change/
+        commit_change so a failed write can never poison undo history.
+        """
+        self.commit_change(self.capture_change(file_path, action))
 
     def pop_change(self) -> Optional[FileChange]:
         if self.history:

--- a/tests/command_line/test_set_menu.py
+++ b/tests/command_line/test_set_menu.py
@@ -55,6 +55,17 @@ def test_dbos_effective_value_uses_plugin_capability():
     capability.assert_called_once_with("dbos_durable_exec")
 
 
+def test_anthropic_native_editor_is_discoverable_and_off_by_default():
+    """Regression: the Phase 3 native-editor flag was wired into
+    model_capabilities.py/config.py's /set autocompletion but had no entry
+    in the curated /set picker, so a user browsing Features would never
+    find it. It must resolve through the real getter and read as False
+    with no config override present."""
+    setting = find_setting("enable_anthropic_native_editor")
+    assert setting.type_hint == "bool"
+    assert setting.effective_getter() is False
+
+
 # ---------------------------------------------------------------------------
 # apply_setting validation
 # ---------------------------------------------------------------------------

--- a/tests/hook_engine/test_matcher.py
+++ b/tests/hook_engine/test_matcher.py
@@ -41,6 +41,14 @@ _MATCH_CASES = [
     ("Edit && .py || Bash", "Edit", {"file_path": "app.py"}, True),
     ("Edit && .py || Bash", "Bash", {}, True),
     ("Edit && .py || Bash", "Edit", {"file_path": "app.js"}, False),
+    # Anthropic native-editor facade tool: without an alias entry, hooks
+    # written against Edit/Write/replace_in_file/create_file silently stop
+    # firing when an agent runs the native-editor profile, since the wire
+    # tool name (str_replace_based_edit_tool) shares nothing textually with
+    # any of those names. See hook_engine/aliases.py's
+    # ANTHROPIC_NATIVE_EDITOR_ALIASES for the mapping this exercises.
+    ("Edit", "str_replace_based_edit_tool", {"path": "app.py"}, True),
+    ("replace_in_file", "str_replace_based_edit_tool", {"path": "app.py"}, True),
 ]
 
 

--- a/tests/hook_engine/test_matcher.py
+++ b/tests/hook_engine/test_matcher.py
@@ -81,3 +81,24 @@ class TestExtractFilePath:
         # file_path takes priority over path
         result = _extract_file_path({"file_path": "a.py", "path": "b.py"})
         assert result == "a.py"
+
+
+def test_distinct_alias_groups_stay_disjoint():
+    """Guard rail for the obvious 'fix' to the native-editor alias gap.
+
+    ``str_replace_based_edit_tool`` multiplexes view/str_replace/create/
+    insert, so it's tempting to widen ANTHROPIC_NATIVE_EDITOR_ALIASES to
+    map it to create_file and read_file as well. That silently breaks
+    unrelated hooks: ``_build_lookup`` groups by internal name and unions
+    every provider name mapping to it, so a second mapping transitively
+    merges the Edit and Write groups and ``matches("Write", "Edit")``
+    starts returning True -- a hook scoped to file creation would begin
+    firing on every in-place edit.
+
+    Asserted through the public matcher (not the lookup internals) because
+    the cross-group bleed is what actually harms users.
+    """
+    assert not matches("Write", "Edit", {"file_path": "a.py"})
+    assert not matches("create_file", "replace_in_file", {"file_path": "a.py"})
+    assert not matches("Read", "Edit", {"file_path": "a.py"})
+    assert not matches("read_file", "replace_in_file", {"file_path": "a.py"})

--- a/tests/test_anthropic_native_editor_model.py
+++ b/tests/test_anthropic_native_editor_model.py
@@ -1,0 +1,96 @@
+"""``AnthropicNativeEditorModel`` wire-declaration override tests.
+
+Verifies the one seam this class exists for: the native editor tool gets
+Anthropic's fixed client-executed-tool shape (no schema/description), while
+every other tool still gets the normal JSON-schema tool param the base
+class builds. A regression here would either leak our schema onto the wire
+for the native tool (defeating the point of using the trained-on interface)
+or silently stop declaring some other tool correctly.
+"""
+
+from unittest.mock import patch
+
+from pydantic_ai.tools import ToolDefinition
+
+from code_puppy.anthropic_native_editor_model import AnthropicNativeEditorModel
+from code_puppy.model_capabilities import (
+    NATIVE_EDITOR_TOOL_NAME,
+    NATIVE_EDITOR_TOOL_TYPE,
+)
+
+
+def _make_model() -> AnthropicNativeEditorModel:
+    # __init__ requires a real/valid provider; bypass it since these tests
+    # only exercise _map_tool_definition, a pure function of its arguments.
+    return AnthropicNativeEditorModel.__new__(AnthropicNativeEditorModel)
+
+
+def test_native_editor_tool_gets_the_raw_anthropic_shape_with_no_schema():
+    model = _make_model()
+    tool_def = ToolDefinition(
+        name=NATIVE_EDITOR_TOOL_NAME,
+        description="whatever our function's docstring says",
+        parameters_json_schema={"type": "object", "properties": {"command": {}}},
+    )
+
+    result = model._map_tool_definition(tool_def, {}, visibility="visible")
+
+    assert result == {
+        "name": NATIVE_EDITOR_TOOL_NAME,
+        "type": NATIVE_EDITOR_TOOL_TYPE,
+    }
+
+
+def test_native_editor_tool_sets_defer_loading_when_deferred():
+    model = _make_model()
+    tool_def = ToolDefinition(
+        name=NATIVE_EDITOR_TOOL_NAME, description="", parameters_json_schema={}
+    )
+
+    result = model._map_tool_definition(tool_def, {}, visibility="deferred")
+
+    assert result == {
+        "name": NATIVE_EDITOR_TOOL_NAME,
+        "type": NATIVE_EDITOR_TOOL_TYPE,
+        "defer_loading": True,
+    }
+
+
+def test_every_other_tool_still_uses_the_base_class_json_schema_path():
+    """A tool with any other name must be completely unaffected -- proves
+    this is a narrow, single-tool override, not a broad behavior change."""
+    model = _make_model()
+    other_tool = ToolDefinition(
+        name="read_file",
+        description="Reads a file.",
+        parameters_json_schema={"type": "object", "properties": {"path": {}}},
+    )
+
+    with patch(
+        "pydantic_ai.models.anthropic.AnthropicModel._map_tool_definition"
+    ) as base_map:
+        base_map.return_value = {
+            "name": "read_file",
+            "sentinel": "base-class-built-this",
+        }
+        result = model._map_tool_definition(other_tool, {}, visibility="visible")
+
+    base_map.assert_called_once_with(other_tool, {}, visibility="visible")
+    assert result == {"name": "read_file", "sentinel": "base-class-built-this"}
+
+
+def test_no_message_history_or_serialization_method_is_overridden():
+    """Model-switch safety (see `History and model switching` in the plan)
+    rests on this class touching *only* outbound tool-declaration shape --
+    never how a request/response/history message is built or replayed.
+    Assert that directly on the class body rather than trusting the module
+    docstring's claim: this fails the moment a second override is added
+    without updating the model-switching reasoning that depends on there
+    being exactly one.
+    """
+    own_members = {
+        name: value
+        for name, value in vars(AnthropicNativeEditorModel).items()
+        if callable(value) and not name.startswith("__")
+    }
+    assert set(own_members) == {"_map_tool_definition"}

--- a/tests/test_anthropic_native_editor_model.py
+++ b/tests/test_anthropic_native_editor_model.py
@@ -10,6 +10,13 @@ or silently stop declaring some other tool correctly.
 
 from unittest.mock import patch
 
+from pydantic_ai import Agent
+from pydantic_ai.messages import (
+    ModelMessagesTypeAdapter,
+    ToolCallPart,
+    ToolReturnPart,
+)
+from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import ToolDefinition
 
 from code_puppy.anthropic_native_editor_model import AnthropicNativeEditorModel
@@ -17,6 +24,7 @@ from code_puppy.model_capabilities import (
     NATIVE_EDITOR_TOOL_NAME,
     NATIVE_EDITOR_TOOL_TYPE,
 )
+from code_puppy.tools.anthropic_editor_tool import register_str_replace_based_edit_tool
 
 
 def _make_model() -> AnthropicNativeEditorModel:
@@ -94,3 +102,48 @@ def test_no_message_history_or_serialization_method_is_overridden():
         if callable(value) and not name.startswith("__")
     }
     assert set(own_members) == {"_map_tool_definition"}
+
+
+def test_native_editor_history_replays_cleanly_through_a_non_anthropic_model():
+    """Verification (not the sole safeguard -- see the plan's `History and
+    model switching` section) for the highest-risk claim in this plan: a
+    native-editor tool call/result surviving a mid-session model switch
+    without producing a hard 400 on the next provider.
+
+    The prior test proves *why* this should hold (no history-shaping
+    override exists). This test proves it end-to-end using the exact
+    mechanism `session_storage.py` relies on for every save/load regardless
+    of provider (`ModelMessagesTypeAdapter`): run the real tool through a
+    plain, non-Anthropic pydantic-ai model, then round-trip the resulting
+    history through that adapter and assert it comes back byte-for-byte
+    identical, made only of ordinary ToolCallPart/ToolReturnPart -- never an
+    Anthropic-specific block type a different provider's mapper could choke
+    on.
+    """
+    agent = Agent(TestModel(call_tools=[NATIVE_EDITOR_TOOL_NAME]))
+    register_str_replace_based_edit_tool(agent)
+
+    result = agent.run_sync("call the editor tool")
+    messages = result.all_messages()
+
+    tool_call_parts = [
+        p for m in messages for p in m.parts if isinstance(p, ToolCallPart)
+    ]
+    tool_return_parts = [
+        p for m in messages for p in m.parts if isinstance(p, ToolReturnPart)
+    ]
+    assert tool_call_parts and all(
+        type(p) is ToolCallPart and p.tool_name == NATIVE_EDITOR_TOOL_NAME
+        for p in tool_call_parts
+    )
+    assert tool_return_parts and all(
+        type(p) is ToolReturnPart and p.tool_name == NATIVE_EDITOR_TOOL_NAME
+        for p in tool_return_parts
+    )
+    # The dispatcher's result is a plain JSON-shaped dict, not some
+    # Anthropic-only content block.
+    assert all(isinstance(p.content, dict) for p in tool_return_parts)
+
+    dumped = ModelMessagesTypeAdapter.dump_python(messages)
+    restored = ModelMessagesTypeAdapter.validate_python(dumped)
+    assert restored == messages

--- a/tests/test_file_modification_auxiliary.py
+++ b/tests/test_file_modification_auxiliary.py
@@ -13,11 +13,18 @@ def test_replace_in_file_missing_file(tmp_path):
 
 
 def test_replace_in_file_multiple_replacements(tmp_path):
+    """Multiple, distinct, unambiguous replacements in one call all apply.
+
+    Uses unique old_str values -- under the strict exact-match contract a
+    non-unique old_str (e.g. "bar" appearing twice) is deliberately rejected
+    as an ambiguous_match rather than silently replacing the first hit; that
+    behavior is covered separately in test_replace_in_file_safety.py.
+    """
     path = tmp_path / "multi.txt"
-    path.write_text("foo bar baz bar foo")
+    path.write_text("foo bar baz qux foo")
     reps = [
-        {"old_str": "bar", "new_str": "dog"},
-        {"old_str": "foo", "new_str": "biscuit"},
+        {"old_str": "bar baz", "new_str": "dog"},
+        {"old_str": "qux", "new_str": "biscuit"},
     ]
     res = file_modifications._replace_in_file(None, str(path), reps)
     assert res["success"]

--- a/tests/test_model_capabilities.py
+++ b/tests/test_model_capabilities.py
@@ -99,6 +99,29 @@ def test_get_model_config_uses_provided_config_without_reloading(monkeypatch):
     }
 
 
+def test_get_model_config_falls_back_to_cached_loader_when_no_config_given(
+    monkeypatch,
+):
+    """The real production call path -- register_tools_for_agent calling
+    supports_anthropic_native_editor(model_name) with NO explicit config --
+    goes through _model_config_cache/_load_models_config, not the
+    provided-config short-circuit the test above covers. Every other test in
+    this module passes ``_MODELS_CONFIG`` explicitly and so never exercises
+    this branch at all."""
+    from code_puppy import model_capabilities
+
+    model_capabilities._model_config_cache.clear()
+    monkeypatch.setattr(
+        model_capabilities, "_load_models_config", lambda: dict(_MODELS_CONFIG)
+    )
+    try:
+        resolved = get_model_config("claude-direct")
+        assert resolved == {"type": "anthropic", "name": "claude-direct"}
+        assert is_direct_anthropic_route(resolved) is True
+    finally:
+        model_capabilities._model_config_cache.clear()
+
+
 def test_get_model_config_returns_none_for_unknown_or_missing_name():
     assert get_model_config("does-not-exist", _MODELS_CONFIG) is None
     assert get_model_config(None, _MODELS_CONFIG) is None

--- a/tests/test_model_capabilities.py
+++ b/tests/test_model_capabilities.py
@@ -1,0 +1,119 @@
+"""Route/feature-flag capability resolution for the Anthropic native editor.
+
+Covers the two independent gates ``supports_anthropic_native_editor`` must
+apply: the opt-in feature flag and the declared-route check. Each test would
+fail if the gate were dropped or if the route check ever fell back to a
+model-name guess.
+"""
+
+import pytest
+
+from code_puppy.model_capabilities import (
+    get_model_config,
+    is_direct_anthropic_route,
+    supports_anthropic_native_editor,
+)
+
+_MODELS_CONFIG = {
+    "claude-direct": {"type": "anthropic", "name": "claude-direct"},
+    "claude-via-code": {"type": "claude_code", "name": "claude-via-code"},
+    "claude-custom-endpoint": {
+        "type": "custom_anthropic",
+        "name": "claude-custom-endpoint",
+    },
+    "claude-via-openrouter": {
+        "type": "openai",
+        "name": "claude-via-openrouter",
+        "provider": "openrouter",
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "model_name,expected",
+    [
+        ("claude-direct", True),
+        ("claude-via-code", False),
+        ("claude-custom-endpoint", False),
+        ("claude-via-openrouter", False),
+        ("does-not-exist", False),
+        (None, False),
+    ],
+)
+def test_native_editor_requires_declared_direct_anthropic_route(
+    monkeypatch, model_name, expected
+):
+    """Route decision must come from the declared config ``type``, never a
+    model-name substring -- 'claude-via-openrouter' must not pass despite
+    the name."""
+    monkeypatch.setattr(
+        "code_puppy.model_capabilities.get_anthropic_native_editor_enabled",
+        lambda: True,
+    )
+    assert supports_anthropic_native_editor(model_name, _MODELS_CONFIG) is expected
+
+
+def test_native_editor_disabled_when_feature_flag_off_even_on_direct_route(
+    monkeypatch,
+):
+    """A supported route must still be refused if the feature flag is off --
+    the native path must not be reachable by route alone."""
+    monkeypatch.setattr(
+        "code_puppy.model_capabilities.get_anthropic_native_editor_enabled",
+        lambda: False,
+    )
+    assert supports_anthropic_native_editor("claude-direct", _MODELS_CONFIG) is False
+
+
+def test_get_anthropic_native_editor_enabled_defaults_off(monkeypatch):
+    """The rollout switch must default to off -- native must not be the
+    default at merge (Phase 4 decides the default later)."""
+    monkeypatch.setattr("code_puppy.config.get_value", lambda key: None)
+    from code_puppy.model_capabilities import get_anthropic_native_editor_enabled
+
+    assert get_anthropic_native_editor_enabled() is False
+
+
+def test_get_anthropic_native_editor_enabled_reads_config_flag(monkeypatch):
+    monkeypatch.setattr(
+        "code_puppy.config.get_value",
+        lambda key: "true" if key == "enable_anthropic_native_editor" else None,
+    )
+    from code_puppy.model_capabilities import get_anthropic_native_editor_enabled
+
+    assert get_anthropic_native_editor_enabled() is True
+
+
+def test_get_model_config_uses_provided_config_without_reloading(monkeypatch):
+    """When a config dict is supplied, it must be used as-is -- no full
+    reload (which would defeat the point of passing an already-loaded
+    config to avoid a second load per agent-build pass)."""
+
+    def _explode():
+        raise AssertionError("must not reload config when one was provided")
+
+    monkeypatch.setattr("code_puppy.model_capabilities._load_models_config", _explode)
+    assert get_model_config("claude-direct", _MODELS_CONFIG) == {
+        "type": "anthropic",
+        "name": "claude-direct",
+    }
+
+
+def test_get_model_config_returns_none_for_unknown_or_missing_name():
+    assert get_model_config("does-not-exist", _MODELS_CONFIG) is None
+    assert get_model_config(None, _MODELS_CONFIG) is None
+
+
+@pytest.mark.parametrize(
+    "model_config,expected",
+    [
+        ({"type": "anthropic"}, True),
+        ({"type": "custom_anthropic"}, False),
+        ({"type": "claude_code"}, False),
+        ({"type": "openai"}, False),
+        (None, False),
+        ({}, False),
+    ],
+)
+def test_is_direct_anthropic_route(model_config, expected):
+    assert is_direct_anthropic_route(model_config) is expected

--- a/tests/test_model_factory_native_editor.py
+++ b/tests/test_model_factory_native_editor.py
@@ -1,0 +1,45 @@
+"""``model_factory._resolve_anthropic_model_class`` selection tests."""
+
+from code_puppy.anthropic_native_editor_model import AnthropicNativeEditorModel
+from code_puppy.model_factory import AnthropicModel, _resolve_anthropic_model_class
+
+
+def test_resolves_to_plain_model_when_capability_disabled(monkeypatch):
+    monkeypatch.setattr(
+        "code_puppy.model_factory.supports_anthropic_native_editor",
+        lambda model_name, config: False,
+    )
+    result = _resolve_anthropic_model_class("claude-x", {"type": "anthropic"})
+    assert result is AnthropicModel
+
+
+def test_resolves_to_native_editor_model_when_capability_enabled(monkeypatch):
+    monkeypatch.setattr(
+        "code_puppy.model_factory.supports_anthropic_native_editor",
+        lambda model_name, config: True,
+    )
+    result = _resolve_anthropic_model_class("claude-x", {"type": "anthropic"})
+    assert result is AnthropicNativeEditorModel
+
+
+def test_passes_a_single_entry_config_keyed_by_the_resolved_model_name(monkeypatch):
+    """The helper must hand the capability check a config shaped like the
+    full models.json (``{name: config}``), not the bare model_config dict --
+    ``get_model_config`` looks it up by key."""
+    seen = {}
+
+    def _fake_supports(model_name, models_config):
+        seen["model_name"] = model_name
+        seen["models_config"] = models_config
+        return False
+
+    monkeypatch.setattr(
+        "code_puppy.model_factory.supports_anthropic_native_editor", _fake_supports
+    )
+    model_config = {"type": "anthropic", "name": "claude-x"}
+    _resolve_anthropic_model_class("claude-x", model_config)
+
+    assert seen == {
+        "model_name": "claude-x",
+        "models_config": {"claude-x": model_config},
+    }

--- a/tests/test_replace_in_file_safety.py
+++ b/tests/test_replace_in_file_safety.py
@@ -1,0 +1,262 @@
+"""Safety-contract regression tests for ``_replace_in_file``.
+
+This module replaces ``tests/test_replace_in_file_baseline.py`` (2026-08-25),
+which documented the pre-fix behavior of
+``code_puppy.tools.file_modifications._replace_in_file`` -- including several
+live bugs (silent empty-``old_str`` corruption, unconditional undo recording,
+a fuzzy-mutation fallback that could silently pick the wrong location). That
+baseline was used to verify this fix actually changes behavior; it is
+superseded by this file, which asserts the corrected, intended contract:
+
+- an empty ``old_str`` is rejected explicitly, never silently mutated;
+- zero exact matches and ambiguous (multiple) exact matches both fail closed
+  without writing -- fuzzy matching is used only to build a bounded,
+  whole-line suggestion, never to select a mutation target;
+- undo is recorded exactly once, only immediately before a real write, never
+  on a validation failure or no-op; and
+- a plain no-op replacement is reported as such without erroring.
+"""
+
+from unittest.mock import patch
+
+from code_puppy.tools.file_modifications import _replace_in_file
+
+
+def _write(tmp_path, name, content):
+    p = tmp_path / name
+    p.write_text(content)
+    return p
+
+
+def test_empty_old_str_is_rejected_explicitly(tmp_path):
+    """An empty old_str must never be treated as a valid (zero-width) match."""
+    original = "line1\nline2\nline3\n"
+    p = _write(tmp_path, "f.txt", original)
+
+    result = _replace_in_file(None, str(p), [{"old_str": "", "new_str": "INJECTED"}])
+
+    assert result["error"] == "empty_old_str"
+    assert "diff" in result
+    assert not result.get("success")
+    # File must be completely untouched -- no silent prepend.
+    assert p.read_text() == original
+
+
+def test_near_miss_fuzzy_match_fails_closed_with_suggestion(tmp_path):
+    """A near-miss (high overlap, not exact) must fail closed with a bounded
+    suggestion, never silently mutate at the closest guess."""
+    original = "STATUS_LINE: not_started\nother\n"
+    p = _write(tmp_path, "f2.txt", original)
+
+    result = _replace_in_file(
+        None,
+        str(p),
+        [{"old_str": "STATUS_LINE: done", "new_str": "STATUS_LINE: xxx"}],
+    )
+
+    assert result["error"] == "match_not_found"
+    assert result["match_count"] == 0
+    assert result["received"] == "STATUS_LINE: done"
+    assert result["diff"] == ""
+    # A bounded, whole-line, line-numbered suggestion is offered for retry.
+    assert "suggested_current_text" in result
+    assert "1: STATUS_LINE: not_started" in result["suggested_current_text"]
+
+    # File is untouched on a failed match -- no approximate mutation.
+    assert p.read_text() == original
+
+
+def test_record_change_not_called_on_guaranteed_failure(tmp_path):
+    """must not be recorded when nothing was written."""
+    missing = tmp_path / "does_not_exist.txt"
+
+    with patch("code_puppy.undo_manager.UndoManager.record_change") as mock_record:
+        result = _replace_in_file(None, str(missing), [{"old_str": "a", "new_str": "b"}])
+
+    assert result["error"] == f"File '{missing}' does not exist."
+    mock_record.assert_not_called()
+
+
+def test_record_change_called_once_only_on_successful_write(tmp_path):
+    """Undo must be recorded exactly once, and only after a real write."""
+    p = _write(tmp_path, "f3.txt", "hello world\n")
+
+    with patch("code_puppy.undo_manager.UndoManager.record_change") as mock_record:
+        result = _replace_in_file(None, str(p), [{"old_str": "hello", "new_str": "hi"}])
+
+    assert result["success"] is True
+    assert result["changed"] is True
+    mock_record.assert_called_once_with(str(p), "replace_in_file")
+
+
+def test_noop_replacement_returns_changed_false_without_recording_undo(tmp_path):
+    """A no-op (old_str == new_str, present) must report unchanged, not error,
+    and must not record undo since nothing was written."""
+    original = "hello world\n"
+    p = _write(tmp_path, "f4.txt", original)
+
+    with patch("code_puppy.undo_manager.UndoManager.record_change") as mock_record:
+        result = _replace_in_file(None, str(p), [{"old_str": "hello", "new_str": "hello"}])
+
+    assert "error" not in result
+    assert result["success"] is False
+    assert result["changed"] is False
+    assert result["message"] == "No changes to apply."
+    assert result["diff"] == ""
+    mock_record.assert_not_called()
+
+    assert p.read_text() == original
+
+
+def test_zero_exact_matches_fails_closed_without_writing(tmp_path):
+    """A wholly-absent pattern fails closed with no fuzzy guess applied."""
+    original = "aaaa\nbbbb\ncccc\n"
+    p = _write(tmp_path, "f5.txt", original)
+
+    result = _replace_in_file(None, str(p), [{"old_str": "zzzzzzzzzzz", "new_str": "q"}])
+
+    assert result["error"] == "match_not_found"
+    assert result["match_count"] == 0
+    assert result["received"] == "zzzzzzzzzzz"
+    assert result["diff"] == ""
+
+    assert p.read_text() == original
+
+
+def test_multiple_exact_matches_is_ambiguous_and_fails_closed(tmp_path):
+    """Multiple exact matches must never guess "the first one" -- fail closed
+    and require the caller to disambiguate. This is a deliberate behavior
+    change from the old ``str.replace(old, new, 1)`` silent-first-match
+    approach."""
+    p = _write(tmp_path, "f6.txt", "dog dog dog\n")
+
+    result = _replace_in_file(None, str(p), [{"old_str": "dog", "new_str": "cat"}])
+
+    assert result["error"] == "ambiguous_match"
+    assert result["match_count"] == 3
+    assert result["received"] == "dog"
+    assert result["diff"] == ""
+
+    # File is untouched -- no first-match guess applied.
+    assert p.read_text() == "dog dog dog\n"
+
+
+def test_unique_exact_match_replaces_and_preserves_crlf(tmp_path):
+    """A single unique exact match is applied via plain string replacement,
+    which naturally preserves original line endings (CRLF in this case) --
+    unlike the old fuzzy-branch splitlines()/join() reconstruction, which
+    normalized CRLF to LF across the whole file on any fuzzy hit."""
+    p = tmp_path / "f7.txt"
+    p.write_bytes(b"line one\r\nline two\r\nline three\r\n")
+
+    result = _replace_in_file(
+        None, str(p), [{"old_str": "line two", "new_str": "LINE TWO"}]
+    )
+
+    assert result["success"] is True
+    assert result["changed"] is True
+    assert p.read_bytes() == b"line one\r\nLINE TWO\r\nline three\r\n"
+
+
+def test_undo_restores_true_pre_edit_content(tmp_path):
+    """Regression guard for a subtle timing bug introduced (and caught by
+    tests/tools/test_fs_backend.py::test_undo_is_backend_coherent) while
+    fixing this file: record_change() snapshots whatever is CURRENTLY on
+    disk, so it must run immediately before the write, never after -- after
+    the write it would snapshot the NEW content and undo would restore into
+    a no-op instead of reverting."""
+    from code_puppy.undo_manager import UndoManager
+
+    original = "before\n"
+    p = _write(tmp_path, "f9.txt", original)
+
+    UndoManager()._instance.history.clear()
+    result = _replace_in_file(None, str(p), [{"old_str": "before", "new_str": "after"}])
+    assert result["success"] is True
+    assert p.read_text() == "after\n"
+
+    msg = UndoManager().undo_last()
+    assert "restored" in msg
+    assert p.read_text() == original
+
+
+def test_crlf_file_matches_model_supplied_lf_pattern(tmp_path):
+    """Regression guard for a break introduced while fixing CRLF handling.
+
+    Making the I/O layer byte-faithful (newline="") is correct, but it means
+    in-memory content keeps literal \\r\\n while models ALWAYS emit \\n in
+    old_str. Without reconciliation every multi-line edit to every CRLF file
+    failed with match_count=0 despite a perfect jw_score of 1.0.
+    """
+    p = tmp_path / "crlf.py"
+    p.write_bytes(b"def foo():\r\n    return 1\r\n\r\ndef bar():\r\n    return 2\r\n")
+
+    result = _replace_in_file(
+        None,
+        str(p),
+        [{"old_str": "def foo():\n    return 1", "new_str": "def foo():\n    return 99"}],
+    )
+
+    assert result["success"] is True
+    assert p.read_bytes() == (
+        b"def foo():\r\n    return 99\r\n\r\ndef bar():\r\n    return 2\r\n"
+    )
+
+
+def test_multiline_new_str_adopts_file_line_endings(tmp_path):
+    """Inserted text must adopt the file's style, not leave an LF island."""
+    p = tmp_path / "crlf2.py"
+    p.write_bytes(b"a = 1\r\nb = 2\r\n")
+
+    result = _replace_in_file(
+        None, str(p), [{"old_str": "a = 1", "new_str": "a = 1\nassert a"}]
+    )
+
+    assert result["success"] is True
+    assert p.read_bytes() == b"a = 1\r\nassert a\r\nb = 2\r\n"
+
+
+def test_mixed_line_endings_leave_untouched_regions_byte_identical(tmp_path):
+    """A targeted edit must not normalize terminators elsewhere in the file."""
+    p = tmp_path / "mixed.py"
+    p.write_bytes(b"crlf = 1\r\nlf = 2\ncrlf2 = 3\r\n")
+
+    result = _replace_in_file(
+        None, str(p), [{"old_str": "lf = 2", "new_str": "lf = 22"}]
+    )
+
+    assert result["success"] is True
+    assert p.read_bytes() == b"crlf = 1\r\nlf = 22\ncrlf2 = 3\r\n"
+
+
+def test_cr_only_legacy_file_is_editable(tmp_path):
+    """Classic-Mac CR-only files must round-trip without corruption."""
+    p = tmp_path / "cr.py"
+    p.write_bytes(b"a = 1\rb = 2\r")
+
+    result = _replace_in_file(
+        None, str(p), [{"old_str": "a = 1\rb = 2", "new_str": "a = 9\rb = 8"}]
+    )
+
+    assert result["success"] is True
+    assert p.read_bytes() == b"a = 9\rb = 8\r"
+
+
+def test_atomic_multi_replacement_all_or_nothing(tmp_path):
+    """If any replacement in a multi-replacement batch is invalid, none of
+    the batch is written -- validated fully in memory before a single write."""
+    original = "alpha\nbeta\ngamma\n"
+    p = _write(tmp_path, "f8.txt", original)
+
+    result = _replace_in_file(
+        None,
+        str(p),
+        [
+            {"old_str": "alpha", "new_str": "ALPHA"},
+            {"old_str": "does-not-exist", "new_str": "X"},
+        ],
+    )
+
+    assert result["error"] == "match_not_found"
+    # Neither replacement was applied -- the first one is not partially written.
+    assert p.read_text() == original

--- a/tests/test_replace_in_file_safety.py
+++ b/tests/test_replace_in_file_safety.py
@@ -72,7 +72,9 @@ def test_record_change_not_called_on_guaranteed_failure(tmp_path):
     missing = tmp_path / "does_not_exist.txt"
 
     with patch("code_puppy.undo_manager.UndoManager.record_change") as mock_record:
-        result = _replace_in_file(None, str(missing), [{"old_str": "a", "new_str": "b"}])
+        result = _replace_in_file(
+            None, str(missing), [{"old_str": "a", "new_str": "b"}]
+        )
 
     assert result["error"] == f"File '{missing}' does not exist."
     mock_record.assert_not_called()
@@ -112,7 +114,9 @@ def test_noop_replacement_returns_changed_false_without_recording_undo(tmp_path)
     p = _write(tmp_path, "f4.txt", original)
 
     with patch("code_puppy.undo_manager.UndoManager.record_change") as mock_record:
-        result = _replace_in_file(None, str(p), [{"old_str": "hello", "new_str": "hello"}])
+        result = _replace_in_file(
+            None, str(p), [{"old_str": "hello", "new_str": "hello"}]
+        )
 
     assert "error" not in result
     assert result["success"] is False
@@ -129,7 +133,9 @@ def test_zero_exact_matches_fails_closed_without_writing(tmp_path):
     original = "aaaa\nbbbb\ncccc\n"
     p = _write(tmp_path, "f5.txt", original)
 
-    result = _replace_in_file(None, str(p), [{"old_str": "zzzzzzzzzzz", "new_str": "q"}])
+    result = _replace_in_file(
+        None, str(p), [{"old_str": "zzzzzzzzzzz", "new_str": "q"}]
+    )
 
     assert result["error"] == "match_not_found"
     assert result["match_count"] == 0
@@ -210,7 +216,12 @@ def test_crlf_file_matches_model_supplied_lf_pattern(tmp_path):
     result = _replace_in_file(
         None,
         str(p),
-        [{"old_str": "def foo():\n    return 1", "new_str": "def foo():\n    return 99"}],
+        [
+            {
+                "old_str": "def foo():\n    return 1",
+                "new_str": "def foo():\n    return 99",
+            }
+        ],
     )
 
     assert result["success"] is True

--- a/tests/test_replace_in_file_safety.py
+++ b/tests/test_replace_in_file_safety.py
@@ -20,6 +20,7 @@ superseded by this file, which asserts the corrected, intended contract:
 from unittest.mock import patch
 
 from code_puppy.tools.file_modifications import _replace_in_file
+from code_puppy.undo_manager import UndoManager
 
 
 def _write(tmp_path, name, content):
@@ -78,15 +79,30 @@ def test_record_change_not_called_on_guaranteed_failure(tmp_path):
 
 
 def test_record_change_called_once_only_on_successful_write(tmp_path):
-    """Undo must be recorded exactly once, and only after a real write."""
+    """Undo must be captured once and committed once, only after a real write.
+
+    capture_change/commit_change (rather than the old one-shot record_change)
+    is what lets a failed write skip history entirely without an unsafe
+    pop-the-most-recent-entry rollback -- see UndoManager.capture_change.
+    """
     p = _write(tmp_path, "f3.txt", "hello world\n")
 
-    with patch("code_puppy.undo_manager.UndoManager.record_change") as mock_record:
+    with (
+        patch(
+            "code_puppy.undo_manager.UndoManager.capture_change",
+            wraps=UndoManager().capture_change,
+        ) as mock_capture,
+        patch(
+            "code_puppy.undo_manager.UndoManager.commit_change",
+            wraps=UndoManager().commit_change,
+        ) as mock_commit,
+    ):
         result = _replace_in_file(None, str(p), [{"old_str": "hello", "new_str": "hi"}])
 
     assert result["success"] is True
     assert result["changed"] is True
-    mock_record.assert_called_once_with(str(p), "replace_in_file")
+    mock_capture.assert_called_once_with(str(p), "replace_in_file")
+    mock_commit.assert_called_once()
 
 
 def test_noop_replacement_returns_changed_false_without_recording_undo(tmp_path):

--- a/tests/test_tools_registration.py
+++ b/tests/test_tools_registration.py
@@ -78,6 +78,42 @@ class TestToolRegistration:
             "invalid_tool" in str(call) for call in mock_agent.call_args_list
         )
 
+    def test_explicitly_requesting_native_editor_by_name_is_still_capability_gated(
+        self,
+    ):
+        """Regression: the swap block in register_tools_for_agent only ever
+        ADDS str_replace_based_edit_tool -- it never blocks a caller (a JSON
+        agent config, or a plugin's register_agent_tools extra) that names
+        the tool directly. Since it's an ordinary TOOL_REGISTRY entry, the
+        generic registration loop used to register it for ANY model
+        regardless of the feature flag or the direct-Anthropic-route
+        requirement, defeating the least-privilege gate documented in
+        model_capabilities.py. Must be blocked at the point of registration
+        too, not just at swap time."""
+        mock_agent = MagicMock()
+
+        register_tools_for_agent(
+            mock_agent, ["str_replace_based_edit_tool"], model_name="gpt-5"
+        )
+
+        assert mock_agent.tool.call_count == 0
+
+    def test_native_editor_registers_when_capability_actually_supported(self):
+        """Sanity counterpart to the regression above: the gate must not be
+        so strict it blocks a genuinely-eligible direct-Anthropic model."""
+        mock_agent = MagicMock()
+
+        with patch(
+            "code_puppy.tools.supports_anthropic_native_editor", return_value=True
+        ):
+            register_tools_for_agent(
+                mock_agent,
+                ["str_replace_based_edit_tool"],
+                model_name="claude-5-sonnet",
+            )
+
+        assert mock_agent.tool.call_count == 1
+
     def test_register_all_tools(self):
         """Test registering all available tools."""
         mock_agent = MagicMock()

--- a/tests/test_tools_registration.py
+++ b/tests/test_tools_registration.py
@@ -96,7 +96,11 @@ class TestToolRegistration:
             mock_agent, ["str_replace_based_edit_tool"], model_name="gpt-5"
         )
 
-        assert mock_agent.tool.call_count == 0
+        registered_names = {
+            getattr(call.args[0], "__name__", None)
+            for call in mock_agent.tool.call_args_list
+        }
+        assert "str_replace_based_edit_tool" not in registered_names
 
     def test_native_editor_registers_when_capability_actually_supported(self):
         """Sanity counterpart to the regression above: the gate must not be
@@ -112,7 +116,11 @@ class TestToolRegistration:
                 model_name="claude-5-sonnet",
             )
 
-        assert mock_agent.tool.call_count == 1
+        registered_names = {
+            getattr(call.args[0], "__name__", None)
+            for call in mock_agent.tool.call_args_list
+        }
+        assert "str_replace_based_edit_tool" in registered_names
 
     def test_register_all_tools(self):
         """Test registering all available tools."""

--- a/tests/tools/test_anthropic_editor_tool.py
+++ b/tests/tools/test_anthropic_editor_tool.py
@@ -1,0 +1,444 @@
+"""Command dispatch tests for the Anthropic native text-editor tool.
+
+Each command is verified for its distinct failure modes (the same litmus as
+every other tool: would flipping the boundary check make this test fail?).
+``str_replace``/``create`` delegate to the already-hardened generic engine
+(see ``tests/test_replace_in_file_safety.py``); these tests confirm the
+delegation is real (the same typed errors surface through this tool) rather
+than re-proving the underlying engine's full contract.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from code_puppy.tools.anthropic_editor_tool import dispatch_editor_command
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_create_then_view_round_trips_line_numbered_content(tmp_path):
+    p = tmp_path / "f.txt"
+
+    create_result = _run(
+        dispatch_editor_command(
+            None, "create", str(p), file_text="alpha\nbeta\ngamma\n"
+        )
+    )
+    assert create_result == {
+        "success": True,
+        "path": str(p),
+        "message": f"File '{p}' created successfully.",
+        "changed": True,
+    }
+
+    view_result = _run(dispatch_editor_command(None, "view", str(p)))
+    assert view_result == {
+        "path": str(p),
+        "start_line": 1,
+        "end_line": 3,
+        "total_lines": 3,
+        "content": "     1\talpha\n     2\tbeta\n     3\tgamma",
+    }
+
+
+def test_view_range_minus_one_end_means_through_end_of_file(tmp_path):
+    p = tmp_path / "f.txt"
+    p.write_text("one\ntwo\nthree\nfour\n")
+
+    result = _run(dispatch_editor_command(None, "view", str(p), view_range=[2, -1]))
+
+    assert result == {
+        "path": str(p),
+        "start_line": 2,
+        "end_line": 4,
+        "total_lines": 4,
+        "content": "     2\ttwo\n     3\tthree\n     4\tfour",
+    }
+
+
+def test_view_range_out_of_bounds_is_rejected(tmp_path):
+    p = tmp_path / "f.txt"
+    p.write_text("one\ntwo\n")
+
+    result = _run(dispatch_editor_command(None, "view", str(p), view_range=[5, 6]))
+
+    assert result["error"] == "invalid_view_range"
+    assert result["total_lines"] == 2
+
+
+def test_view_missing_file_reports_not_found(tmp_path):
+    p = tmp_path / "missing.txt"
+    result = _run(dispatch_editor_command(None, "view", str(p)))
+    assert result == {"error": "not_found", "path": str(p)}
+
+
+def test_view_ranged_empty_file_does_not_crash_on_the_bus_message(tmp_path):
+    """Regression: view_range=[1, 1] on a 0-line file used to clip `end` to
+    0 while `start` stayed at 1, producing num_lines = end - start + 1 = 0
+    -- which raises a pydantic ValidationError on FileContentMessage
+    (num_lines requires >= 1). Must succeed with an explicitly empty range.
+    """
+    p = tmp_path / "f.txt"
+    p.write_text("")
+
+    result = _run(dispatch_editor_command(None, "view", str(p), view_range=[1, 1]))
+
+    assert result == {
+        "path": str(p),
+        "start_line": 0,
+        "end_line": 0,
+        "total_lines": 0,
+        "content": "",
+    }
+
+
+def test_view_unranged_empty_file_reports_a_consistent_zero_range(tmp_path):
+    """Regression: the unranged path used to leave start_line=1 alongside
+    end_line=0/total_lines=0 for an empty file -- a self-contradictory
+    'starts at line 1 but ends before it' result."""
+    p = tmp_path / "f.txt"
+    p.write_text("")
+
+    result = _run(dispatch_editor_command(None, "view", str(p)))
+
+    assert result == {
+        "path": str(p),
+        "start_line": 0,
+        "end_line": 0,
+        "total_lines": 0,
+        "content": "",
+    }
+
+
+def test_str_replace_delegates_ambiguous_match_to_the_hardened_engine(tmp_path):
+    """Proves the delegation is real: the generic engine's ambiguous-match
+    guard (never guess which occurrence) surfaces through this tool too."""
+    p = tmp_path / "f.txt"
+    p.write_text("dup\ndup\n")
+
+    result = _run(
+        dispatch_editor_command(None, "str_replace", str(p), old_str="dup", new_str="x")
+    )
+
+    assert result["error"] == "ambiguous_match"
+    assert result["match_count"] == 2
+    assert p.read_text() == "dup\ndup\n"
+
+
+def test_str_replace_unique_match_writes(tmp_path):
+    p = tmp_path / "f.txt"
+    p.write_text("hello world\n")
+
+    result = _run(
+        dispatch_editor_command(
+            None, "str_replace", str(p), old_str="world", new_str="puppy"
+        )
+    )
+
+    assert result["success"] is True
+    assert p.read_text() == "hello puppy\n"
+
+
+def test_str_replace_missing_old_str_is_a_typed_error(tmp_path):
+    p = tmp_path / "f.txt"
+    p.write_text("hello\n")
+
+    result = _run(dispatch_editor_command(None, "str_replace", str(p), new_str="x"))
+
+    assert result == {
+        "error": "missing_field",
+        "command": "str_replace",
+        "field": "old_str",
+        "message": "command 'str_replace' requires 'old_str'.",
+    }
+
+
+def test_str_replace_missing_new_str_is_a_typed_error_not_a_silent_delete(tmp_path):
+    """Regression: omitting new_str must fail loudly, not be coerced to ""
+    (which would silently delete the matched text and report success --
+    exactly the class of silent-corruption bug Phase 2 exists to remove)."""
+    p = tmp_path / "f.txt"
+    original = "hello world\n"
+    p.write_text(original)
+
+    result = _run(dispatch_editor_command(None, "str_replace", str(p), old_str="world"))
+
+    assert result == {
+        "error": "missing_field",
+        "command": "str_replace",
+        "field": "new_str",
+        "message": "command 'str_replace' requires 'new_str'.",
+    }
+    assert p.read_text() == original
+
+
+def test_str_replace_explicit_empty_new_str_is_a_deliberate_deletion(tmp_path):
+    """An explicitly-passed empty string (as opposed to an omitted field)
+    is a legitimate delete-the-match request and must still work."""
+    p = tmp_path / "f.txt"
+    p.write_text("hello world\n")
+
+    result = _run(
+        dispatch_editor_command(
+            None, "str_replace", str(p), old_str=" world", new_str=""
+        )
+    )
+
+    assert result["success"] is True
+    assert p.read_text() == "hello\n"
+
+
+def test_create_missing_file_text_is_a_typed_error(tmp_path):
+    p = tmp_path / "f.txt"
+    result = _run(dispatch_editor_command(None, "create", str(p)))
+    assert result == {
+        "error": "missing_field",
+        "command": "create",
+        "field": "file_text",
+        "message": "command 'create' requires 'file_text'.",
+    }
+
+
+def test_create_overwrites_an_existing_file_unlike_portable_create_file(tmp_path):
+    """Deliberate spec conformance: Anthropic's `create` always overwrites,
+    unlike the portable create_file tool's default refuse-if-exists."""
+    p = tmp_path / "f.txt"
+    p.write_text("old content\n")
+
+    result = _run(
+        dispatch_editor_command(None, "create", str(p), file_text="new content\n")
+    )
+
+    assert result["success"] is True
+    assert p.read_text() == "new content\n"
+
+
+@pytest.mark.parametrize(
+    "insert_line,new_str,expected_lines",
+    [
+        (0, "PREPENDED", ["PREPENDED", "one", "two", "three"]),
+        (1, "MIDDLE", ["one", "MIDDLE", "two", "three"]),
+        (3, "APPENDED", ["one", "two", "three", "APPENDED"]),
+    ],
+)
+def test_insert_places_text_at_the_requested_line(
+    tmp_path, insert_line, new_str, expected_lines
+):
+    p = tmp_path / "f.txt"
+    p.write_text("one\ntwo\nthree\n")
+
+    result = _run(
+        dispatch_editor_command(
+            None, "insert", str(p), insert_line=insert_line, new_str=new_str
+        )
+    )
+
+    assert result["success"] is True
+    assert p.read_text().splitlines() == expected_lines
+
+
+def test_insert_into_empty_file_at_line_zero(tmp_path):
+    p = tmp_path / "f.txt"
+    p.write_text("")
+
+    result = _run(
+        dispatch_editor_command(None, "insert", str(p), insert_line=0, new_str="only")
+    )
+
+    assert result["success"] is True
+    assert p.read_text() == "only\n"
+
+
+def test_insert_out_of_range_line_is_rejected_without_writing(tmp_path):
+    p = tmp_path / "f.txt"
+    original = "one\ntwo\n"
+    p.write_text(original)
+
+    result = _run(
+        dispatch_editor_command(None, "insert", str(p), insert_line=5, new_str="x")
+    )
+
+    assert result["error"] == "invalid_insert_line"
+    assert result["line_count"] == 2
+    assert p.read_text() == original
+
+
+def test_insert_preserves_crlf_line_endings(tmp_path):
+    """Regression guard: Phase 2 fixed a universal CRLF-loss bug in the
+    read-modify-write path (see phase2-implementation-log.md). Insert must
+    not reintroduce it by rebuilding the file through a plain-LF join."""
+    p = tmp_path / "f.txt"
+    p.write_bytes(b"one\r\ntwo\r\nthree\r\n")
+
+    result = _run(
+        dispatch_editor_command(None, "insert", str(p), insert_line=1, new_str="MIDDLE")
+    )
+
+    assert result["success"] is True
+    assert p.read_bytes() == b"one\r\nMIDDLE\r\ntwo\r\nthree\r\n"
+
+
+def test_insert_empty_new_str_is_a_no_op_and_pushes_no_undo_entry(tmp_path):
+    """Regression: an insert that produces byte-identical content must be
+    reported as a no-op, not routed through write_to_file_async as a
+    'successful' write -- the same no-op contract _replace_in_file honors
+    (see test_replace_in_file_safety.py::test_record_change_not_called...).
+    """
+    p = tmp_path / "f.txt"
+    original = "one\ntwo\n"
+    p.write_text(original)
+
+    with patch("code_puppy.undo_manager.UndoManager.capture_change") as mock_capture:
+        result = _run(
+            dispatch_editor_command(None, "insert", str(p), insert_line=1, new_str="")
+        )
+
+    assert result == {
+        "success": False,
+        "path": str(p),
+        "changed": False,
+        "message": "No change: the inserted text was empty.",
+    }
+    assert p.read_text() == original
+    mock_capture.assert_not_called()
+
+
+def test_view_sanitizes_invalid_utf8_instead_of_leaking_a_surrogate(tmp_path):
+    """Regression: a raw non-UTF-8 byte must be replaced, not surfaced as a
+    lone surrogate codepoint that later crashes JSON/UTF-8 serialization."""
+    p = tmp_path / "f.bin"
+    p.write_bytes(b"good\xffbad\n")
+
+    result = _run(dispatch_editor_command(None, "view", str(p)))
+
+    assert "error" not in result
+    assert "\udcff" not in result["content"]
+    assert "\ufffd" in result["content"]
+
+
+def test_insert_sanitizes_invalid_utf8_instead_of_raising(tmp_path):
+    """Regression: inserting into a file with a stray non-UTF-8 byte must
+    not leak an untyped UnicodeEncodeError from the eventual write."""
+    p = tmp_path / "f.bin"
+    p.write_bytes(b"good\xffbad\n")
+
+    result = _run(
+        dispatch_editor_command(None, "insert", str(p), insert_line=0, new_str="NEW")
+    )
+
+    assert result["success"] is True
+    written = p.read_text(encoding="utf-8")
+    assert "\udcff" not in written
+    assert "\ufffd" in written
+
+
+def test_insert_missing_required_fields_are_typed_errors(tmp_path):
+    p = tmp_path / "f.txt"
+    p.write_text("one\n")
+
+    missing_line = _run(dispatch_editor_command(None, "insert", str(p), new_str="x"))
+    assert missing_line == {
+        "error": "missing_field",
+        "command": "insert",
+        "field": "insert_line",
+        "message": "command 'insert' requires 'insert_line'.",
+    }
+
+    missing_text = _run(dispatch_editor_command(None, "insert", str(p), insert_line=0))
+    assert missing_text == {
+        "error": "missing_field",
+        "command": "insert",
+        "field": "new_str",
+        "message": "command 'insert' requires 'new_str'.",
+    }
+
+
+def test_undo_edit_is_explicitly_rejected_as_unsupported(tmp_path):
+    """The 2025-04-29/2025-07-28 tool versions this façade targets have no
+    undo_edit command (verified: zero matches in the installed SDK) --
+    reject by name rather than falling through to unknown_command, in case
+    a model trained on the older tool still emits it."""
+    p = tmp_path / "f.txt"
+    p.write_text("one\n")
+
+    result = _run(dispatch_editor_command(None, "undo_edit", str(p)))
+
+    assert result["error"] == "unsupported_command"
+    assert result["command"] == "undo_edit"
+
+
+def test_unknown_command_lists_the_supported_set(tmp_path):
+    p = tmp_path / "f.txt"
+    p.write_text("one\n")
+
+    result = _run(dispatch_editor_command(None, "delete", str(p)))
+
+    assert result == {
+        "error": "unknown_command",
+        "command": "delete",
+        "supported_commands": ["create", "insert", "str_replace", "view"],
+        "message": "Unknown command 'delete'. Supported: "
+        "['create', 'insert', 'str_replace', 'view'].",
+    }
+
+
+@pytest.mark.parametrize(
+    "command,kwargs,expected_payload_type",
+    [
+        (
+            "str_replace",
+            {"old_str": "world", "new_str": "puppy"},
+            "ReplacementsPayload",
+        ),
+        ("create", {"file_text": "hi\n"}, "ContentPayload"),
+        ("insert", {"insert_line": 0, "new_str": "NEW"}, "ContentPayload"),
+    ],
+)
+def test_mutation_commands_fire_on_edit_file_like_the_portable_tools(
+    tmp_path, command, kwargs, expected_payload_type
+):
+    """Regression: str_replace/create/insert used to call write_to_file_async
+    / replace_in_file_async directly and return early, silently skipping the
+    on_edit_file callback that the portable create_file/replace_in_file
+    tools fire after every write (see file_modifications.py). Any plugin
+    hooking on_edit_file -- e.g. for rejection-detail enrichment or
+    telemetry -- must see native-editor writes too, not just portable ones.
+    """
+    p = tmp_path / "f.txt"
+    p.write_text("hello world\n")
+
+    with patch(
+        "code_puppy.tools.anthropic_editor_tool.on_edit_file", return_value=None
+    ) as mock_hook:
+        result = _run(dispatch_editor_command(None, command, str(p), **kwargs))
+
+    assert result["success"] is True
+    mock_hook.assert_called_once()
+    call_args = mock_hook.call_args.args
+    assert call_args[0] is None  # context
+    assert call_args[1] is result  # the result dict passed to the hook
+    assert type(call_args[2]).__name__ == expected_payload_type
+
+
+def test_on_edit_file_enhancement_result_overrides_the_returned_dict(tmp_path):
+    """Mirrors the portable tools' contract: the first non-None value a
+    plugin returns from on_edit_file replaces the tool's own result."""
+    p = tmp_path / "f.txt"
+    p.write_text("hello world\n")
+    sentinel = {"success": True, "path": str(p), "enhanced": True}
+
+    with patch(
+        "code_puppy.tools.anthropic_editor_tool.on_edit_file",
+        return_value=[None, sentinel],
+    ):
+        result = _run(
+            dispatch_editor_command(
+                None, "str_replace", str(p), old_str="world", new_str="puppy"
+            )
+        )
+
+    assert result == sentinel

--- a/tests/tools/test_anthropic_editor_tool.py
+++ b/tests/tools/test_anthropic_editor_tool.py
@@ -241,6 +241,20 @@ def test_create_missing_file_text_is_a_typed_error(tmp_path):
     }
 
 
+def test_create_over_a_directory_is_a_typed_error_not_a_raw_errno(tmp_path):
+    """`view`/`insert` already guard against operating on a directory;
+    `create` fell through to `_write_to_file`'s bare `except Exception` and
+    leaked a raw `[Errno 21] Is a directory: ...` string, violating this
+    module's own \"fail loudly and specifically\" contract."""
+    d = tmp_path / "a_directory"
+    d.mkdir()
+
+    result = _run(dispatch_editor_command(None, "create", str(d), file_text="hi\n"))
+
+    assert result["error"] == "not_a_regular_file"
+    assert d.is_dir()
+
+
 def test_create_overwrites_an_existing_file_unlike_portable_create_file(tmp_path):
     """Deliberate spec conformance: Anthropic's `create` always overwrites,
     unlike the portable create_file tool's default refuse-if-exists."""
@@ -264,9 +278,7 @@ def test_create_of_a_brand_new_file_reports_the_diff_operation_as_create(tmp_pat
     whether the file already existed, not hardcoded True."""
     p = tmp_path / "brand_new.txt"
 
-    with patch(
-        "code_puppy.tools.file_modifications._emit_diff_message"
-    ) as mock_emit:
+    with patch("code_puppy.tools.file_modifications._emit_diff_message") as mock_emit:
         result = _run(dispatch_editor_command(None, "create", str(p), file_text="hi\n"))
 
     assert result["success"] is True
@@ -280,9 +292,7 @@ def test_create_over_an_existing_file_still_reports_the_diff_operation_as_modify
     p = tmp_path / "existing.txt"
     p.write_text("old\n")
 
-    with patch(
-        "code_puppy.tools.file_modifications._emit_diff_message"
-    ) as mock_emit:
+    with patch("code_puppy.tools.file_modifications._emit_diff_message") as mock_emit:
         result = _run(
             dispatch_editor_command(None, "create", str(p), file_text="new\n")
         )

--- a/tests/tools/test_anthropic_editor_tool.py
+++ b/tests/tools/test_anthropic_editor_tool.py
@@ -9,15 +9,26 @@ than re-proving the underlying engine's full contract.
 """
 
 import asyncio
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from code_puppy.callbacks import clear_callbacks, register_callback
 from code_puppy.tools.anthropic_editor_tool import dispatch_editor_command
 
 
 def _run(coro):
     return asyncio.run(coro)
+
+
+@pytest.fixture(autouse=True)
+def _clear_file_permission_callbacks():
+    """No test in this module relies on a permission callback surviving
+    past its own test; guard against order-dependent leakage the way
+    ``tests/test_file_permissions.py`` does for the same global registry."""
+    clear_callbacks("file_permission")
+    yield
+    clear_callbacks("file_permission")
 
 
 def test_create_then_view_round_trips_line_numbered_content(tmp_path):
@@ -77,9 +88,7 @@ def test_view_range_with_non_integer_elements_is_rejected(tmp_path):
     p = tmp_path / "f.txt"
     p.write_text("one\ntwo\n")
 
-    result = _run(
-        dispatch_editor_command(None, "view", str(p), view_range=["a", "b"])
-    )
+    result = _run(dispatch_editor_command(None, "view", str(p), view_range=["a", "b"]))
 
     assert result["error"] == "invalid_view_range"
 
@@ -280,6 +289,69 @@ def test_insert_into_empty_file_at_line_zero(tmp_path):
 
     assert result["success"] is True
     assert p.read_text() == "only\n"
+
+
+def test_insert_permission_denied_leaves_file_untouched(tmp_path):
+    p = tmp_path / "f.txt"
+    original = "one\ntwo\n"
+    p.write_text(original)
+
+    def deny(
+        context,
+        file_path,
+        operation,
+        preview=None,
+        message_group=None,
+        operation_data=None,
+    ):
+        return False
+
+    register_callback("file_permission", deny)
+
+    result = _run(
+        dispatch_editor_command(
+            MagicMock(), "insert", str(p), insert_line=1, new_str="X"
+        )
+    )
+
+    assert result["success"] is False
+    assert result["user_rejection"] is True
+    assert p.read_text() == original
+
+
+def test_insert_detects_concurrent_modification_during_permission_wait(tmp_path):
+    """Regression: insert computes its spliced content from a snapshot read
+    BEFORE the (possibly slow, human-in-the-loop) permission prompt. If the
+    file changes while approval is pending, writing the stale splice would
+    silently discard whatever changed it -- exactly the "wrong successful
+    edit" class of bug this plan exists to eliminate. Simulate that race by
+    mutating the file from inside the permission callback itself."""
+    p = tmp_path / "f.txt"
+    p.write_text("one\ntwo\n")
+
+    def approve_but_mutate_first(
+        context,
+        file_path,
+        operation,
+        preview=None,
+        message_group=None,
+        operation_data=None,
+    ):
+        p.write_text("one\ntwo\nCONCURRENTLY ADDED\n")
+        return True
+
+    register_callback("file_permission", approve_but_mutate_first)
+
+    result = _run(
+        dispatch_editor_command(
+            MagicMock(), "insert", str(p), insert_line=1, new_str="X"
+        )
+    )
+
+    assert result["error"] == "concurrent_modification"
+    # The concurrent write must survive untouched -- not be clobbered by the
+    # stale insert going through anyway.
+    assert p.read_text() == "one\ntwo\nCONCURRENTLY ADDED\n"
 
 
 def test_insert_out_of_range_line_is_rejected_without_writing(tmp_path):

--- a/tests/tools/test_anthropic_editor_tool.py
+++ b/tests/tools/test_anthropic_editor_tool.py
@@ -679,3 +679,75 @@ def test_registered_tool_never_crashes_the_agent_run_on_unexpected_exception():
     assert result["error"] == "str_replace_based_edit_tool failed: boom"
     assert result["command"] == "view"
     assert result["path"] == "/tmp/whatever"
+
+
+def test_view_size_budget_matches_read_file_and_ignores_the_line_number_gutter(
+    tmp_path,
+):
+    """Regression: the content_too_large guard used to measure the
+    LINE-NUMBERED rendering, not the file content. The ``f"{idx:6d}\\t"``
+    gutter adds a fixed 7 chars per line, so on narrow-line files it
+    dominated the estimate and made ``view`` reject files that portable
+    ``read_file`` accepts.
+
+    5,000 one-char lines = 10,000 bytes = 2,500 tokens (well under the
+    shared 10k budget) but 40,000 chars once numbered -- which tripped
+    the old check. Because the native-editor profile REPLACES read_file,
+    that left the model with no way at all to read a perfectly ordinary
+    file, so this is a capability regression rather than a cosmetic one.
+
+    Pinned against ``_read_file`` directly so the two limits can't drift
+    apart silently: if either budget changes, this fails.
+    """
+    from code_puppy.tools.file_operations import _read_file
+
+    p = tmp_path / "narrow.txt"
+    p.write_text("x\n" * 5000)
+
+    assert _read_file(None, str(p)).error is None, (
+        "precondition: portable read_file must accept this file"
+    )
+
+    result = _run(dispatch_editor_command(None, "view", str(p)))
+
+    assert "error" not in result, f"view rejected a file read_file accepts: {result}"
+    assert result["total_lines"] == 5000
+    # The gutter is still applied to what the model actually receives.
+    assert result["content"].startswith("     1\tx\n     2\tx")
+
+
+def test_view_still_rejects_genuinely_oversized_content(tmp_path):
+    """The budget fix must not disarm the guard: real oversized content
+    (over the same 10k-token limit read_file enforces) is still refused,
+    and the error carries total_lines so the model can pick a range."""
+    from code_puppy.tools.file_operations import _read_file
+
+    p = tmp_path / "big.txt"
+    p.write_text(("x" * 79 + "\n") * 2000)  # 160KB -> ~40k tokens
+
+    assert _read_file(None, str(p)).error is not None, (
+        "precondition: portable read_file must reject this file too"
+    )
+
+    result = _run(dispatch_editor_command(None, "view", str(p)))
+
+    assert result["error"] == "content_too_large"
+    assert result["total_lines"] == 2000
+
+
+def test_view_oversized_file_is_still_readable_via_a_narrowed_range(tmp_path):
+    """The recovery path the content_too_large message advertises must
+    actually work -- otherwise an oversized file is permanently
+    unreadable under the native profile (which has no read_file)."""
+    p = tmp_path / "big.txt"
+    p.write_text(("x" * 79 + "\n") * 2000)
+
+    assert _run(dispatch_editor_command(None, "view", str(p)))["error"] == (
+        "content_too_large"
+    )
+
+    result = _run(dispatch_editor_command(None, "view", str(p), view_range=[1, 50]))
+
+    assert "error" not in result
+    assert result["start_line"] == 1
+    assert result["end_line"] == 50

--- a/tests/tools/test_anthropic_editor_tool.py
+++ b/tests/tools/test_anthropic_editor_tool.py
@@ -108,6 +108,57 @@ def test_view_directory_listing_is_bounded(tmp_path):
     assert result["truncated"] is True
 
 
+def test_view_directory_listing_hides_ignore_pattern_entries(tmp_path):
+    """Regression: `view` on a directory must not see more than `list_files`
+    does -- `view` swaps IN for `list_files`'s directory-listing capability
+    (see the swap gate in tools/__init__.py), so a raw unfiltered
+    `fs_access.list_dir()` would let a model discover `.env`/`.git`/
+    `node_modules` purely by switching from `list_files` to `view`."""
+    (tmp_path / "visible.txt").touch()
+    (tmp_path / ".env").touch()
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "config").touch()
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "pkg.json").touch()
+
+    result = _run(dispatch_editor_command(None, "view", str(tmp_path)))
+
+    assert result["is_directory"] is True
+    assert result["entries"] == ["visible.txt"]
+    assert ".env" not in result["entries"]
+    assert ".git/" not in result["entries"]
+    assert "node_modules/" not in result["entries"]
+
+
+def test_view_directory_listing_emits_file_listing_message(tmp_path):
+    """Regression: a directory `view` used to emit nothing to the message
+    bus, unlike the file-content branch (which emits FileContentMessage).
+    Combined with `NATIVE_EDITOR_TOOL_NAME` being in run_stats'
+    `_TOOLS_WITH_RENDERER`, that made a directory listing the model acted
+    on completely invisible to the user in high-output mode."""
+    (tmp_path / "visible.txt").write_text("hi")
+    (tmp_path / "sub").mkdir()
+
+    captured = []
+    mock_bus = MagicMock()
+    mock_bus.emit = lambda msg: captured.append(msg)
+
+    with patch(
+        "code_puppy.tools.anthropic_editor_tool.get_message_bus",
+        return_value=mock_bus,
+    ):
+        result = _run(dispatch_editor_command(None, "view", str(tmp_path)))
+
+    assert result["is_directory"] is True
+    from code_puppy.messaging import FileListingMessage
+
+    listing_msgs = [m for m in captured if isinstance(m, FileListingMessage)]
+    assert len(listing_msgs) == 1
+    assert listing_msgs[0].recursive is False
+    assert listing_msgs[0].file_count == 1
+    assert listing_msgs[0].dir_count == 1
+
+
 def test_view_missing_file_reports_not_found(tmp_path):
     p = tmp_path / "missing.txt"
     result = _run(dispatch_editor_command(None, "view", str(p)))

--- a/tests/tools/test_anthropic_editor_tool.py
+++ b/tests/tools/test_anthropic_editor_tool.py
@@ -355,15 +355,24 @@ def test_insert_permission_denied_leaves_file_untouched(tmp_path):
 
     register_callback("file_permission", deny)
 
-    result = _run(
-        dispatch_editor_command(
-            MagicMock(), "insert", str(p), insert_line=1, new_str="X"
+    with patch(
+        "code_puppy.tools.anthropic_editor_tool.on_edit_file", return_value=None
+    ) as mock_hook:
+        result = _run(
+            dispatch_editor_command(
+                MagicMock(), "insert", str(p), insert_line=1, new_str="X"
+            )
         )
-    )
 
     assert result["success"] is False
     assert result["user_rejection"] is True
     assert p.read_text() == original
+    # Regression: a denied insert used to return before on_edit_file ever
+    # ran, unlike str_replace/create (whose engine calls always route
+    # through it) -- a plugin doing rejection-detail enrichment would
+    # silently never see a rejected insert.
+    mock_hook.assert_called_once()
+    assert mock_hook.call_args.args[1] is result
 
 
 def test_insert_detects_concurrent_modification_during_permission_wait(tmp_path):
@@ -389,16 +398,22 @@ def test_insert_detects_concurrent_modification_during_permission_wait(tmp_path)
 
     register_callback("file_permission", approve_but_mutate_first)
 
-    result = _run(
-        dispatch_editor_command(
-            MagicMock(), "insert", str(p), insert_line=1, new_str="X"
+    with patch(
+        "code_puppy.tools.anthropic_editor_tool.on_edit_file", return_value=None
+    ) as mock_hook:
+        result = _run(
+            dispatch_editor_command(
+                MagicMock(), "insert", str(p), insert_line=1, new_str="X"
+            )
         )
-    )
 
     assert result["error"] == "concurrent_modification"
     # The concurrent write must survive untouched -- not be clobbered by the
     # stale insert going through anyway.
     assert p.read_text() == "one\ntwo\nCONCURRENTLY ADDED\n"
+    # Same on_edit_file parity as the permission-denied case above.
+    mock_hook.assert_called_once()
+    assert mock_hook.call_args.args[1] is result
 
 
 def test_insert_out_of_range_line_is_rejected_without_writing(tmp_path):
@@ -751,3 +766,20 @@ def test_view_oversized_file_is_still_readable_via_a_narrowed_range(tmp_path):
     assert "error" not in result
     assert result["start_line"] == 1
     assert result["end_line"] == 50
+
+
+def test_view_rejects_pathological_blank_line_gutter_blowup(tmp_path):
+    """Regression: the raw-content budget alone is blind to per-line gutter
+    overhead. 40,000 blank lines is ~39KB raw (comfortably under the 10k-
+    token raw budget) but the ``f"{idx:6d}\\t"`` gutter on every one of
+    those lines balloons the actual model-facing payload to roughly
+    320KB/~80k tokens -- 8x the intended limit -- if only the raw slice is
+    measured. The backstop on the numbered rendering must catch this even
+    though the raw check alone would wave it through."""
+    p = tmp_path / "blank.txt"
+    p.write_text("\n" * 40_000)
+
+    result = _run(dispatch_editor_command(None, "view", str(p)))
+
+    assert result["error"] == "content_too_large"
+    assert result["total_lines"] == 40_000

--- a/tests/tools/test_anthropic_editor_tool.py
+++ b/tests/tools/test_anthropic_editor_tool.py
@@ -70,6 +70,35 @@ def test_view_range_out_of_bounds_is_rejected(tmp_path):
     assert result["total_lines"] == 2
 
 
+def test_view_range_with_non_integer_elements_is_rejected(tmp_path):
+    """Regression: a non-integer view_range element (e.g. a model sending
+    strings) used to raise an unhandled TypeError from the `<`/`>`
+    comparisons below instead of a typed, retryable error."""
+    p = tmp_path / "f.txt"
+    p.write_text("one\ntwo\n")
+
+    result = _run(
+        dispatch_editor_command(None, "view", str(p), view_range=["a", "b"])
+    )
+
+    assert result["error"] == "invalid_view_range"
+
+
+def test_view_directory_listing_is_bounded(tmp_path):
+    """Regression: an unbounded directory listing (e.g. node_modules) could
+    dump thousands of entries straight into context, defeating the same
+    token budget the file-view branch already enforces."""
+    for i in range(1500):
+        (tmp_path / f"f{i}.txt").touch()
+
+    result = _run(dispatch_editor_command(None, "view", str(tmp_path)))
+
+    assert result["is_directory"] is True
+    assert result["total_entries"] == 1500
+    assert len(result["entries"]) < result["total_entries"]
+    assert result["truncated"] is True
+
+
 def test_view_missing_file_reports_not_found(tmp_path):
     p = tmp_path / "missing.txt"
     result = _run(dispatch_editor_command(None, "view", str(p)))
@@ -305,6 +334,66 @@ def test_insert_empty_new_str_is_a_no_op_and_pushes_no_undo_entry(tmp_path):
     }
     assert p.read_text() == original
     mock_capture.assert_not_called()
+
+
+def test_insert_empty_new_str_on_file_without_trailing_newline_is_a_true_no_op(
+    tmp_path,
+):
+    """Regression: the no-op check used to run AFTER a terminator was
+    already appended to the file's last line (to prep for an insertion that
+    then never happened), so an empty insert against a file lacking a
+    trailing newline silently added one and reported success."""
+    p = tmp_path / "f.txt"
+    p.write_bytes(b"one\ntwo")  # no trailing newline
+
+    with patch("code_puppy.undo_manager.UndoManager.capture_change") as mock_capture:
+        result = _run(
+            dispatch_editor_command(None, "insert", str(p), insert_line=2, new_str="")
+        )
+
+    assert result == {
+        "success": False,
+        "path": str(p),
+        "changed": False,
+        "message": "No change: the inserted text was empty.",
+    }
+    assert p.read_bytes() == b"one\ntwo"
+    mock_capture.assert_not_called()
+
+
+def test_insert_line_non_integer_is_rejected(tmp_path):
+    p = tmp_path / "f.txt"
+    original = "one\ntwo\n"
+    p.write_text(original)
+
+    result = _run(
+        dispatch_editor_command(None, "insert", str(p), insert_line="1", new_str="x")
+    )
+
+    assert result["error"] == "invalid_insert_line"
+    assert p.read_text() == original
+
+
+def test_view_and_insert_agree_on_line_numbers_across_form_feed(tmp_path):
+    """Regression: `view` used to number lines with str.splitlines(), which
+    also breaks on form feed/vertical tab/U+2028/U+2029 -- characters
+    `insert` does not treat as line boundaries. A line number read from
+    `view` and handed back to `insert` could then land mid-record. Using a
+    form-feed byte (not a line break for either command post-fix) as the
+    probe: both must agree there are 2 lines, and inserting after line 1
+    must not split the form-feed-joined first line."""
+    p = tmp_path / "f.txt"
+    p.write_bytes(b"alpha\x0cbeta\ngamma\n")
+
+    view_result = _run(dispatch_editor_command(None, "view", str(p)))
+    assert view_result["total_lines"] == 2
+
+    insert_result = _run(
+        dispatch_editor_command(None, "insert", str(p), insert_line=1, new_str="X")
+    )
+
+    assert insert_result["success"] is True
+    assert p.read_bytes() == b"alpha\x0cbeta\nX\ngamma\n"
 
 
 def test_view_sanitizes_invalid_utf8_instead_of_leaking_a_surrogate(tmp_path):

--- a/tests/tools/test_anthropic_editor_tool.py
+++ b/tests/tools/test_anthropic_editor_tool.py
@@ -255,6 +255,43 @@ def test_create_overwrites_an_existing_file_unlike_portable_create_file(tmp_path
     assert p.read_text() == "new content\n"
 
 
+def test_create_of_a_brand_new_file_reports_the_diff_operation_as_create(tmp_path):
+    """Regression: native `create` always passed overwrite=True to
+    write_to_file_async for spec conformance (always (over)write), but that
+    function derives its diff-message operation label purely from that flag
+    ("modify" if overwrite else "create") -- so a brand-new file was being
+    reported to the UI as a "modify". overwrite must be derived from
+    whether the file already existed, not hardcoded True."""
+    p = tmp_path / "brand_new.txt"
+
+    with patch(
+        "code_puppy.tools.file_modifications._emit_diff_message"
+    ) as mock_emit:
+        result = _run(dispatch_editor_command(None, "create", str(p), file_text="hi\n"))
+
+    assert result["success"] is True
+    mock_emit.assert_called_once()
+    assert mock_emit.call_args.args[1] == "create"
+
+
+def test_create_over_an_existing_file_still_reports_the_diff_operation_as_modify(
+    tmp_path,
+):
+    p = tmp_path / "existing.txt"
+    p.write_text("old\n")
+
+    with patch(
+        "code_puppy.tools.file_modifications._emit_diff_message"
+    ) as mock_emit:
+        result = _run(
+            dispatch_editor_command(None, "create", str(p), file_text="new\n")
+        )
+
+    assert result["success"] is True
+    mock_emit.assert_called_once()
+    assert mock_emit.call_args.args[1] == "modify"
+
+
 @pytest.mark.parametrize(
     "insert_line,new_str,expected_lines",
     [
@@ -603,3 +640,32 @@ def test_on_edit_file_enhancement_result_overrides_the_returned_dict(tmp_path):
         )
 
     assert result == sentinel
+
+
+def test_registered_tool_never_crashes_the_agent_run_on_unexpected_exception():
+    """Regression: every portable file-modification tool wraps its whole
+    body in a last-line-of-defense try/except so a backend/plugin error
+    never crashes the agent run (see file_modifications.py). The registered
+    str_replace_based_edit_tool function had no equivalent guard."""
+    from code_puppy.tools.anthropic_editor_tool import (
+        register_str_replace_based_edit_tool,
+    )
+
+    captured = {}
+
+    class FakeAgent:
+        def tool(self, fn):
+            captured["fn"] = fn
+            return fn
+
+    register_str_replace_based_edit_tool(FakeAgent())
+
+    with patch(
+        "code_puppy.tools.anthropic_editor_tool.dispatch_editor_command",
+        side_effect=RuntimeError("boom"),
+    ):
+        result = _run(captured["fn"](MagicMock(), "view", "/tmp/whatever"))
+
+    assert result["error"] == "str_replace_based_edit_tool failed: boom"
+    assert result["command"] == "view"
+    assert result["path"] == "/tmp/whatever"

--- a/tests/tools/test_line_endings.py
+++ b/tests/tools/test_line_endings.py
@@ -1,0 +1,107 @@
+"""Unit tests for ``code_puppy.tools.line_endings.split_lines``.
+
+Round-1 through round-6 review of the Phase 3 Anthropic editor adapter
+exercised ``split_lines`` only indirectly (via the ``view``/``insert``
+commands). This file gives it direct coverage: it is a small, brand-new
+shared helper that ``view`` and ``insert`` both depend on to agree about
+line numbers (see the module docstring), so a regression here silently
+breaks native-editor line addressing for both commands at once.
+"""
+
+from code_puppy.tools.line_endings import split_lines
+
+
+def test_empty_string_returns_no_lines():
+    assert split_lines("") == []
+    assert split_lines("", keepends=True) == []
+
+
+def test_no_terminator_returns_single_line():
+    assert split_lines("hello world") == ["hello world"]
+    assert split_lines("hello world", keepends=True) == ["hello world"]
+
+
+def test_lf_only():
+    assert split_lines("a\nb\nc") == ["a", "b", "c"]
+    assert split_lines("a\nb\nc", keepends=True) == ["a\n", "b\n", "c"]
+
+
+def test_crlf_only():
+    assert split_lines("a\r\nb\r\nc") == ["a", "b", "c"]
+    assert split_lines("a\r\nb\r\nc", keepends=True) == ["a\r\n", "b\r\n", "c"]
+
+
+def test_cr_only():
+    assert split_lines("a\rb\rc") == ["a", "b", "c"]
+    assert split_lines("a\rb\rc", keepends=True) == ["a\r", "b\r", "c"]
+
+
+def test_mixed_terminators_in_one_file():
+    text = "unix\nwindows\r\nold-mac\rend"
+    assert split_lines(text) == ["unix", "windows", "old-mac", "end"]
+    assert split_lines(text, keepends=True) == [
+        "unix\n",
+        "windows\r\n",
+        "old-mac\r",
+        "end",
+    ]
+
+
+def test_trailing_terminator_yields_no_extra_empty_line():
+    # Matches str.splitlines()'s own convention: a trailing newline does not
+    # produce a spurious final empty element.
+    assert split_lines("a\nb\n") == ["a", "b"]
+    assert split_lines("a\nb\n", keepends=True) == ["a\n", "b\n"]
+
+
+def test_lone_terminator_is_one_empty_line():
+    assert split_lines("\n") == [""]
+    assert split_lines("\n", keepends=True) == ["\n"]
+
+
+def test_consecutive_terminators_yield_empty_lines():
+    assert split_lines("a\n\nb") == ["a", "", "b"]
+    assert split_lines("a\r\n\r\nb") == ["a", "", "b"]
+
+
+def test_crlf_pair_never_splits_into_dangling_cr_lf():
+    # A char-by-char scanner that checks LF/CR independently before CRLF
+    # would double-count a "\r\n" pair as two terminators; this pins the
+    # correct precedence (CRLF checked first).
+    assert split_lines("a\r\nb", keepends=True) == ["a\r\n", "b"]
+    assert len(split_lines("\r\n")) == 1
+
+
+def test_does_not_break_on_characters_str_splitlines_treats_as_newlines():
+    # Deliberately narrower than str.splitlines(): form feed, vertical tab,
+    # unit/record/group separators, and the Unicode line/paragraph
+    # separators are NOT terminators here -- see the module docstring for
+    # why (they occur in ordinary text without meaning "new line" there).
+    for exotic in ("\x0b", "\x0c", "\x1c", "\x1d", "\x1e", "\u2028", "\u2029"):
+        text = f"a{exotic}b"
+        assert split_lines(text) == [text]
+        assert split_lines(text, keepends=True) == [text]
+
+
+def test_keepends_round_trip_reconstructs_original_text():
+    for text in (
+        "",
+        "a",
+        "a\nb\r\nc\rd",
+        "\n\n\r\r\r\n",
+        "no newline at all",
+        "trailing\n",
+    ):
+        assert "".join(split_lines(text, keepends=True)) == text
+
+
+def test_view_and_insert_agree_on_line_numbers_for_mixed_endings():
+    # The scenario the module docstring calls out by name: view() numbers
+    # lines with split_lines(), insert() maps a line number back with the
+    # same function -- they must never disagree about what line N is.
+    text = "first\r\nsecond\rthird\nfourth"
+    view_lines = split_lines(text)
+    insert_lines = split_lines(text, keepends=True)
+    assert view_lines == ["first", "second", "third", "fourth"]
+    assert len(view_lines) == len(insert_lines)
+    assert "".join(insert_lines) == text

--- a/tests/tools/test_tools_init_native_editor_swap.py
+++ b/tests/tools/test_tools_init_native_editor_swap.py
@@ -1,0 +1,98 @@
+"""``register_tools_for_agent`` swap-in behavior for the Anthropic native
+editor (Phase 3): when active, overlapping portable tools are replaced by
+the native tool ONLY for an agent that already carries the full portable
+mutation surface (create_file AND replace_in_file); delete tools are always
+preserved; and an agent that never requested the full surface never gains
+the native tool either -- see has_full_native_editor_mutation_surface in
+model_capabilities.py for why partial overlap must not trigger it.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from code_puppy.tools import TOOL_REGISTRY, register_tools_for_agent
+
+
+def _registered_names(tool_names, model_name="claude-direct", capability=True):
+    """Run register_tools_for_agent and return which registry entries fired."""
+    mock_agent = MagicMock()
+    calls: list[str] = []
+    fake_registry = {
+        name: (lambda agent, n=name: calls.append(n)) for name in TOOL_REGISTRY
+    }
+    with (
+        patch.dict("code_puppy.tools.TOOL_REGISTRY", fake_registry, clear=True),
+        patch(
+            "code_puppy.tools.supports_anthropic_native_editor",
+            return_value=capability,
+        ),
+    ):
+        register_tools_for_agent(mock_agent, tool_names, model_name=model_name)
+    return calls
+
+
+def test_native_editor_replaces_overlapping_tools_when_capability_active():
+    calls = _registered_names(
+        ["read_file", "replace_in_file", "create_file", "delete_snippet"],
+        capability=True,
+    )
+    assert sorted(calls) == sorted(["delete_snippet", "str_replace_based_edit_tool"])
+
+
+def test_delete_tools_are_never_hidden_even_when_native_editor_active():
+    calls = _registered_names(
+        ["replace_in_file", "create_file", "delete_snippet", "delete_file"],
+        capability=True,
+    )
+    assert "delete_snippet" in calls
+    assert "delete_file" in calls
+    assert "replace_in_file" not in calls
+    assert "create_file" not in calls
+
+
+def test_portable_tools_kept_as_is_when_capability_inactive():
+    tool_names = ["read_file", "replace_in_file", "create_file", "delete_snippet"]
+    calls = _registered_names(tool_names, capability=False)
+    assert sorted(calls) == sorted(tool_names)
+    assert "str_replace_based_edit_tool" not in calls
+
+
+def test_agent_that_never_requested_editing_tools_does_not_gain_native_editor():
+    """Least-privilege: capability alone must not grant an editing tool to
+    an agent whose own tool list never asked for one."""
+    calls = _registered_names(["list_files", "grep"], capability=True)
+    assert calls == ["list_files", "grep"]
+    assert "str_replace_based_edit_tool" not in calls
+
+
+def test_read_only_agent_without_a_mutation_tool_does_not_gain_write_access():
+    """Regression: a read-only profile (read_file + non-editing tools, no
+    replace_in_file/create_file) must not be silently upgraded to the
+    native editor -- read_file alone being in OVERLAPPING_PORTABLE_TOOLS
+    must not be the trigger, only the full mutation surface may be."""
+    calls = _registered_names(["list_files", "read_file", "grep"], capability=True)
+    assert sorted(calls) == sorted(["list_files", "read_file", "grep"])
+    assert "str_replace_based_edit_tool" not in calls
+
+
+def test_create_only_agent_does_not_gain_replace_and_insert_access():
+    """Regression: agent_model_judge's real profile is read_file+create_file
+    with no replace_in_file. Swapping it to the native editor would grant
+    str_replace/insert access to arbitrary *existing* files (and the
+    native `create` command's always-overwrite semantics) it never had
+    and never asked for -- create_file alone must not trigger the swap.
+    """
+    tool_names = ["read_file", "create_file"]
+    calls = _registered_names(tool_names, capability=True)
+    assert sorted(calls) == sorted(tool_names)
+    assert "str_replace_based_edit_tool" not in calls
+
+
+def test_replace_only_agent_does_not_gain_create_access():
+    """Symmetric regression: an agent with only replace_in_file (no
+    create_file) must not gain the native `create` command's always-
+    overwrite whole-file write, which it could never do before.
+    """
+    tool_names = ["read_file", "replace_in_file"]
+    calls = _registered_names(tool_names, capability=True)
+    assert sorted(calls) == sorted(tool_names)
+    assert "str_replace_based_edit_tool" not in calls

--- a/tests/tools/test_tools_init_native_editor_swap.py
+++ b/tests/tools/test_tools_init_native_editor_swap.py
@@ -1,10 +1,12 @@
 """``register_tools_for_agent`` swap-in behavior for the Anthropic native
 editor (Phase 3): when active, overlapping portable tools are replaced by
 the native tool ONLY for an agent that already carries the full portable
-mutation surface (create_file AND replace_in_file); delete tools are always
-preserved; and an agent that never requested the full surface never gains
-the native tool either -- see has_full_native_editor_mutation_surface in
-model_capabilities.py for why partial overlap must not trigger it.
+read+write surface (read_file AND create_file AND replace_in_file); delete
+tools are always preserved; and an agent that never requested the full
+surface never gains the native tool either -- see
+has_full_native_editor_mutation_surface in model_capabilities.py for why
+partial overlap must not trigger it, and the read_file requirement at the
+call site for why the mutation subset alone isn't sufficient either.
 """
 
 from unittest.mock import MagicMock, patch
@@ -40,7 +42,7 @@ def test_native_editor_replaces_overlapping_tools_when_capability_active():
 
 def test_delete_tools_are_never_hidden_even_when_native_editor_active():
     calls = _registered_names(
-        ["replace_in_file", "create_file", "delete_snippet", "delete_file"],
+        ["read_file", "replace_in_file", "create_file", "delete_snippet", "delete_file"],
         capability=True,
     )
     assert "delete_snippet" in calls
@@ -93,6 +95,19 @@ def test_replace_only_agent_does_not_gain_create_access():
     overwrite whole-file write, which it could never do before.
     """
     tool_names = ["read_file", "replace_in_file"]
+    calls = _registered_names(tool_names, capability=True)
+    assert sorted(calls) == sorted(tool_names)
+    assert "str_replace_based_edit_tool" not in calls
+
+
+def test_full_mutation_surface_without_read_file_does_not_gain_view_access():
+    """Regression: an agent with the full write surface (create_file AND
+    replace_in_file) but no read_file -- an unusual but legal, deliberately
+    write-only JSON agent config -- must not be swapped to the native
+    editor. `view` is a brand-new read capability that surface never had;
+    the swap must require read_file's presence too, not just the mutation
+    subset."""
+    tool_names = ["replace_in_file", "create_file", "delete_snippet"]
     calls = _registered_names(tool_names, capability=True)
     assert sorted(calls) == sorted(tool_names)
     assert "str_replace_based_edit_tool" not in calls

--- a/tests/tools/test_tools_init_native_editor_swap.py
+++ b/tests/tools/test_tools_init_native_editor_swap.py
@@ -42,7 +42,13 @@ def test_native_editor_replaces_overlapping_tools_when_capability_active():
 
 def test_delete_tools_are_never_hidden_even_when_native_editor_active():
     calls = _registered_names(
-        ["read_file", "replace_in_file", "create_file", "delete_snippet", "delete_file"],
+        [
+            "read_file",
+            "replace_in_file",
+            "create_file",
+            "delete_snippet",
+            "delete_file",
+        ],
         capability=True,
     )
     assert "delete_snippet" in calls

--- a/tests/tools/test_tools_init_native_editor_swap.py
+++ b/tests/tools/test_tools_init_native_editor_swap.py
@@ -34,10 +34,12 @@ def _registered_names(tool_names, model_name="claude-direct", capability=True):
 
 def test_native_editor_replaces_overlapping_tools_when_capability_active():
     calls = _registered_names(
-        ["read_file", "replace_in_file", "create_file", "delete_snippet"],
+        ["read_file", "replace_in_file", "create_file", "list_files", "delete_snippet"],
         capability=True,
     )
-    assert sorted(calls) == sorted(["delete_snippet", "str_replace_based_edit_tool"])
+    assert sorted(calls) == sorted(
+        ["list_files", "delete_snippet", "str_replace_based_edit_tool"]
+    )
 
 
 def test_delete_tools_are_never_hidden_even_when_native_editor_active():
@@ -46,6 +48,7 @@ def test_delete_tools_are_never_hidden_even_when_native_editor_active():
             "read_file",
             "replace_in_file",
             "create_file",
+            "list_files",
             "delete_snippet",
             "delete_file",
         ],
@@ -117,3 +120,43 @@ def test_full_mutation_surface_without_read_file_does_not_gain_view_access():
     calls = _registered_names(tool_names, capability=True)
     assert sorted(calls) == sorted(tool_names)
     assert "str_replace_based_edit_tool" not in calls
+
+
+def test_full_mutation_and_read_surface_without_list_files_does_not_gain_directory_view():
+    """Regression: an agent with the full read+write surface (read_file,
+    create_file, replace_in_file) but no list_files must not be swapped --
+    `view` on a directory path returns a directory listing, which is
+    list_files's equivalent capability, not read_file's. Gaining it as a
+    side effect of the swap would be a least-privilege violation identical
+    in kind to the read_file-less case above."""
+    tool_names = ["read_file", "replace_in_file", "create_file", "delete_snippet"]
+    calls = _registered_names(tool_names, capability=True)
+    assert sorted(calls) == sorted(tool_names)
+    assert "str_replace_based_edit_tool" not in calls
+
+
+def test_explicit_models_config_is_forwarded_to_the_capability_check():
+    """Regression: register_tools_for_agent's own callers may have already
+    loaded a fresh models config (e.g. the agent builder, right before
+    picking the model class from that same config). Without threading it
+    through here too, this call would fall back to a separately-TTL-cached
+    config load that can very briefly disagree with the fresh one -- a
+    real (if narrow) window for the model class and the registered tool
+    set to be decided from two different configs. Asserted via the actual
+    call arguments, not just behavior, so a future refactor that silently
+    drops the parameter is caught even if it doesn't happen to flip any
+    single test's capability outcome."""
+    mock_agent = MagicMock()
+    sentinel_config = {"claude-direct": {"type": "anthropic"}}
+    with patch(
+        "code_puppy.tools.supports_anthropic_native_editor", return_value=False
+    ) as mock_supports:
+        register_tools_for_agent(
+            mock_agent,
+            ["read_file", "replace_in_file", "create_file", "list_files"],
+            model_name="claude-direct",
+            models_config=sentinel_config,
+        )
+    assert mock_supports.called
+    for call in mock_supports.call_args_list:
+        assert call.args == ("claude-direct", sentinel_config)

--- a/tests/tools/test_tools_init_native_editor_swap.py
+++ b/tests/tools/test_tools_init_native_editor_swap.py
@@ -160,3 +160,42 @@ def test_explicit_models_config_is_forwarded_to_the_capability_check():
     assert mock_supports.called
     for call in mock_supports.call_args_list:
         assert call.args == ("claude-direct", sentinel_config)
+
+
+def test_capability_check_evaluated_exactly_once_per_registration_call():
+    """Regression: supports_anthropic_native_editor() re-reads the live
+    feature flag on every call (never cached), so evaluating it twice
+    within one register_tools_for_agent() pass -- once for the swap
+    trigger, once for the defense-in-depth re-check that fires when the
+    tool is also named explicitly -- could observe two different answers
+    if config changed mid-call. Demonstrated with a side effect that flips
+    its answer on a second call: under the old double-evaluation code this
+    left the agent with NEITHER the portable mutation tools (removed by
+    the swap) NOR the native editor (rejected by the now-stale re-check).
+    """
+    mock_agent = MagicMock()
+    calls: list[str] = []
+    fake_registry = {
+        name: (lambda agent, n=name: calls.append(n)) for name in TOOL_REGISTRY
+    }
+    answers = iter([True, False])
+    with (
+        patch.dict("code_puppy.tools.TOOL_REGISTRY", fake_registry, clear=True),
+        patch(
+            "code_puppy.tools.supports_anthropic_native_editor",
+            side_effect=lambda *a, **k: next(answers),
+        ) as mock_supports,
+    ):
+        register_tools_for_agent(
+            mock_agent,
+            [
+                "read_file",
+                "replace_in_file",
+                "create_file",
+                "list_files",
+                "str_replace_based_edit_tool",
+            ],
+            model_name="claude-direct",
+        )
+    assert mock_supports.call_count == 1
+    assert sorted(calls) == sorted(["list_files", "str_replace_based_edit_tool"])


### PR DESCRIPTION
## What

Adds a hardened, three-phase Anthropic editor adapter to Code Puppy's file tools:

1. **Phase 1** — Exact-match safety for `_replace_in_file`: a write only happens
   when `old_str` matches **exactly once**. Zero matches or multiple matches now
   return a typed error (`match_not_found` / `ambiguous_match`) instead of
   guessing.
2. **Phase 2** — Undo-integrity and ambiguity-detection fixes across the
   generic edit tools (line-ending fidelity, capture/commit-based undo so a
   failed write can never poison history).
3. **Phase 3** — A native Anthropic `str_replace_based_edit_tool` adapter
   (`view` / `str_replace` / `create` / `insert`) that dispatches `str_replace`
   and `create` straight into the same hardened engine the portable tools use
   (no duplicated safety logic), and implements `view`/`insert` with their own
   guarded read/write paths.

Includes 13 commits of iterative review-and-fix rounds (Opus + GPT-5.6-Sol
review passes), a merge from `main` (resolving one additive conflict —
`main`'s new `_refuse_user_plugin_tree` guard on `_delete_file`), and two
additional fixes found by a post-merge review pass (see Testing).

## Why

Before this change, `_replace_in_file` used `str.replace(old, new, 1)`: if
`old_str` matched more than once, it silently edited the *first* occurrence
and reported `success: true`, even when that wasn't the location the caller
meant. There was no way to tell, from the tool's own output, that the wrong
spot got edited.

A 50-sample empirical baseline (real `claude-4-5-haiku` completions attempting
a realistic ambiguous-ordinal edit, replayed through both the old and new
`_replace_in_file` engines against identical input) confirmed this is not a
theoretical edge case:

| | Old engine | New engine |
|---|---|---|
| Correctly edited the intended location | 20/50 (40%) | 20/50 (40%) |
| **Silently edited the WRONG location, reported `success: true`** | **30/50 (60%)** | 0/50 |
| Safely refused with `ambiguous_match`, file untouched | 0/50 | **30/50 (60%)** |

The new engine converts every one of those 30 silent-corruption cases into a
safe, actionable failure — by construction (the code never writes unless
`match_count == 1`), not by chance. The Phase 3 native-editor tool inherits
this guarantee for free since it dispatches into the same engine rather than
reimplementing matching.

## How

- `code_puppy/tools/file_modifications.py`: match-count gate in
  `_replace_in_file`; capture/commit undo pattern; `_refuse_user_plugin_tree`
  guard on all write-capable entry points.
- `code_puppy/tools/anthropic_editor_tool.py`: new Anthropic native
  text-editor command dispatch (`view`/`str_replace`/`create`/`insert`),
  reusing the file-modification engine for `str_replace`/`create`.
- `code_puppy/tools/line_endings.py`: line-ending detection/conversion helpers
  shared by the above.

### Fixed during this PR's own merge/review pass

- Merge conflict  `_delete_file` resolved by keeping `main`'s new
  `_refuse_user_plugin_tree` guard (additive, no logic dropped).
- Removed a leftover `UndoManager().record_change(...)` call the merge
  introduced into `_delete_file` — it double-recorded undo history (and fired
  even when permission was later denied), duplicating
  `_delete_file_after_permission`'s own capture/commit pair. The async twin
  never had this call.
- Added the missing `_refuse_user_plugin_tree` guard to `_insert_into_file`
  (Anthropic native `insert` command), which previously called `_write_to_file`
  directly and bypassed the plugin-tree write protection every other
  write-capable path already has.

## Testing

- `ruff check .` / `ruff format --check .`: clean.
- Full suite: `pytest tests/ --ignore tests/integration` → **7592 passed, 14
  skipped, 0 failed**.
- Targeted Phase 1-3 tests (exact-match safety, undo integrity, native editor
  dispatch, plugin-tree guard): all passing.
- 50-sample empirical baseline (see Why) comparing old vs. new
  `_replace_in_file` against identical real-model-generated edit candidates,
  run against isolated temp files in throwaway git worktrees (not committed).
- Two-round `puppy-review` + `code-puppy-1-layer` LOCAL_GATE pass, both clean
  on the final diff.

Not yet done (tracked separately, not blocking this PR): a live end-to-end
smoke test against the real Anthropic API, and Phase 4 production-value
metrics (failure rate, token/latency/cache-hit tracking).

## Scope

Touches `code_puppy/tools/file_modifications.py`,
`code_puppy/tools/anthropic_editor_tool.py`, `code_puppy/tools/line_endings.py`,
and their test files. No unrelated files included — a local `.gitignore` /
`AGENTS.md` / `uv.lock` drift present before this work started was
deliberately excluded (stashed, not committed) as out of scope for this
change.
