### PR TITLE
Add fallback_chain model type for quota-aware auto-degradation

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,55 @@ Then just use /model and tab to select your round-robin model!
 
 The `rotate_every` parameter controls how many requests are made to each model before rotating to the next one. In this example, the round-robin model will use each Qwen model for 5 consecutive requests before moving to the next model in the sequence.
 
+## Fallback Chain (Auto-Downgrade on Quota/Context Exhaustion)
+
+Round-robin distributes load across *equivalent* models. A **fallback chain** is different: it's an ordered preference list (e.g. a large/expensive model, then a medium one, then a free/unmetered one), and Code Puppy only moves down the list when the current model's *budget* is actually used up -- a provider quota fully exhausted, or the conversation grown too large for that model's context window. Ordinary transient errors (a 429 rate-limit, a 5xx blip) are already retried against the *same* model with backoff, so they don't trigger a downgrade.
+
+The switch is **one-directional and sticky**: once a model is marked exhausted, Code Puppy never tries it again for the rest of the process -- it just keeps working from wherever it landed. Restart Code Puppy (or reselect a model with `/model`) to reset back to the top of the chain.
+
+### Configuration
+
+```json
+{
+  "gpt-huge": {
+    "type": "openai",
+    "name": "gpt-5-large",
+    "api_key": "$OPENAI_API_KEY",
+    "context_length": 400000
+  },
+  "gpt-medium": {
+    "type": "openai",
+    "name": "gpt-5-medium",
+    "api_key": "$OPENAI_API_KEY",
+    "context_length": 200000
+  },
+  "gpt-free-tier": {
+    "type": "openai",
+    "name": "gpt-5-nano",
+    "api_key": "$OPENAI_API_KEY",
+    "context_length": 128000
+  },
+  "my_downgrade_chain": {
+    "type": "fallback_chain",
+    "models": ["gpt-huge", "gpt-medium", "gpt-free-tier"]
+  }
+}
+```
+
+Select `my_downgrade_chain` with `/model` and Code Puppy will use `gpt-huge` until its quota/context is exhausted, then `gpt-medium`, then `gpt-free-tier` -- surfacing a warning each time it switches so you know why quality/latency just changed.
+
+`models` requires at least 2 entries (a chain of one is just... that model). Detection covers common provider signatures out of the box: OpenAI-style `insufficient_quota`/`context_length_exceeded` codes, generic "quota exceeded"/"maximum context length"/"prompt is too long" phrasing, and structured error bodies (not just the top-level message). If your provider or internal gateway uses different wording, add it explicitly:
+
+```json
+{
+  "my_downgrade_chain": {
+    "type": "fallback_chain",
+    "models": ["gpt-huge", "gpt-medium", "gpt-free-tier"],
+    "budget_exhausted_patterns": ["large-tier budget depleted"]
+  }
+}
+```
+
 ## Custom OpenAI API Types
 
 Use `custom_openai` for OpenAI-compatible Chat Completions endpoints. If an endpoint requires the OpenAI Responses API, use `custom_openai_responses` instead:

--- a/README.md
+++ b/README.md
@@ -321,52 +321,39 @@ The `rotate_every` parameter controls how many requests are made to each model b
 
 ## Fallback Chain (Auto-Downgrade on Quota/Context Exhaustion)
 
-Round-robin distributes load across *equivalent* models. A **fallback chain** is different: it's an ordered preference list (e.g. a large/expensive model, then a medium one, then a free/unmetered one), and Code Puppy only moves down the list when the current model's *budget* is actually used up -- a provider quota fully exhausted, or the conversation grown too large for that model's context window. Ordinary transient errors (a 429 rate-limit, a 5xx blip) are already retried against the *same* model with backoff, so they don't trigger a downgrade.
+Round-robin distributes load across *equivalent* models. A **fallback chain** is different: it's an ordered preference list, and Code Puppy only moves down the list when the current model's *budget* is actually used up -- a provider quota fully exhausted, or the conversation growing too large for that model's context window. Ordinary transient errors (a 429 rate-limit, a 5xx blip) are already retried against the *same* model with backoff, so they don't trigger a downgrade.
 
-The switch is **one-directional and sticky**: once a model is marked exhausted, Code Puppy never tries it again for the rest of the process -- it just keeps working from wherever it landed. Restart Code Puppy (or reselect a model with `/model`) to reset back to the top of the chain.
+For catalogs that provide the following three keys, Code Puppy automatically creates and selects `default-fallback-chain` when no model has been explicitly selected:
+
+```text
+claude-4-8-opus-long (Opus 4.8 Long)
+        ↓ quota/context exhaustion
+claude-5-sonnet (Sonnet 5)
+        ↓ quota/context exhaustion
+gpt-5.6-luna (Luna)
+```
+
+The switch is **one-directional and sticky**: once a model is marked exhausted, Code Puppy never tries it again for the rest of the process -- it just keeps working from wherever it landed. Restart Code Puppy (or explicitly select a model with `/model`) to reset back to the top of the chain. If your catalog does not provide all three keys, the automatic default is not added and normal model selection is unchanged.
 
 ### Configuration
 
+The automatic chain is equivalent to this configuration:
+
 ```json
 {
-  "gpt-huge": {
-    "type": "openai",
-    "name": "gpt-5-large",
-    "api_key": "$OPENAI_API_KEY",
-    "context_length": 400000
-  },
-  "gpt-medium": {
-    "type": "openai",
-    "name": "gpt-5-medium",
-    "api_key": "$OPENAI_API_KEY",
-    "context_length": 200000
-  },
-  "gpt-free-tier": {
-    "type": "openai",
-    "name": "gpt-5-nano",
-    "api_key": "$OPENAI_API_KEY",
-    "context_length": 128000
-  },
-  "my_downgrade_chain": {
+  "default-fallback-chain": {
     "type": "fallback_chain",
-    "models": ["gpt-huge", "gpt-medium", "gpt-free-tier"]
+    "models": [
+      "claude-4-8-opus-long",
+      "claude-5-sonnet",
+      "gpt-5.6-luna"
+    ]
   }
 }
 ```
 
-Select `my_downgrade_chain` with `/model` and Code Puppy will use `gpt-huge` until its quota/context is exhausted, then `gpt-medium`, then `gpt-free-tier` -- surfacing a warning each time it switches so you know why quality/latency just changed.
+You can also define your own chain with any configured models. Select it with `/model`; Code Puppy surfaces a warning each time it switches so a quality/latency change is never silent.
 
-`models` requires at least 2 entries (a chain of one is just... that model). Detection covers common provider signatures out of the box: OpenAI-style `insufficient_quota`/`context_length_exceeded` codes, generic "quota exceeded"/"maximum context length"/"prompt is too long" phrasing, and structured error bodies (not just the top-level message). If your provider or internal gateway uses different wording, add it explicitly:
-
-```json
-{
-  "my_downgrade_chain": {
-    "type": "fallback_chain",
-    "models": ["gpt-huge", "gpt-medium", "gpt-free-tier"],
-    "budget_exhausted_patterns": ["large-tier budget depleted"]
-  }
-}
-```
 
 ## Custom OpenAI API Types
 

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -665,6 +665,11 @@ def _default_model_from_models_json():
 
         models_config = ModelFactory.load_config()
         if models_config:
+            from code_puppy.fallback_chain_model import DEFAULT_FALLBACK_CHAIN_NAME
+
+            if DEFAULT_FALLBACK_CHAIN_NAME in models_config:
+                _default_model_cache = DEFAULT_FALLBACK_CHAIN_NAME
+                return _default_model_cache
             # Use first model in the merged config as default
             first_key = next(iter(models_config))
             _default_model_cache = first_key

--- a/code_puppy/fallback_chain_model.py
+++ b/code_puppy/fallback_chain_model.py
@@ -36,6 +36,7 @@ from pydantic_ai.models import (
     ModelResponse,
     ModelSettings,
     StreamedResponse,
+    merge_model_settings,
 )
 
 from code_puppy.messaging import emit_warning
@@ -62,6 +63,17 @@ DEFAULT_BUDGET_EXHAUSTED_SNIPPETS: tuple = (
     "token budget",
     "usage limit exceeded",
     "exceeded token limit",
+    "quota exhausted",
+    "quota depleted",
+    "quota reached",
+    "exhausted quota",
+    "no quota remaining",
+    "tokens exhausted",
+    "token limit exceeded",
+    "daily limit exceeded",
+    "monthly limit exceeded",
+    "model quota",
+    "llm quota",
     # Context-window overflow phrasing (OpenAI, Anthropic, Gemini, generic)
     "maximum context length",
     "context window",
@@ -71,6 +83,45 @@ DEFAULT_BUDGET_EXHAUSTED_SNIPPETS: tuple = (
     "exceeds the model's maximum",
     "too many tokens",
 )
+
+
+DEFAULT_FALLBACK_CHAIN_NAME = "default-fallback-chain"
+DEFAULT_FALLBACK_CHAIN_MODELS: tuple[str, ...] = (
+    "claude-4-8-opus-long",
+    "claude-5-sonnet",
+    "gpt-5.6-luna",
+)
+
+
+def add_default_fallback_chain(config: dict[str, Any]) -> bool:
+    """Add the requested default chain when all three model keys exist.
+
+    The model entries themselves come from the active catalog/plugins; the
+    public project must not ship Walmart-specific endpoints or credentials.
+    Returning False when any entry is absent keeps vanilla upstream installs
+    unchanged while making the chain automatic for catalogs that provide the
+    requested Opus Long -> Sonnet -> Luna sequence.
+    """
+    if DEFAULT_FALLBACK_CHAIN_NAME in config:
+        return False
+    if not all(
+        isinstance(config.get(name), dict) for name in DEFAULT_FALLBACK_CHAIN_MODELS
+    ):
+        return False
+
+    context_lengths = [
+        config[name].get("context_length", 128000)
+        for name in DEFAULT_FALLBACK_CHAIN_MODELS
+    ]
+    config[DEFAULT_FALLBACK_CHAIN_NAME] = {
+        "type": "fallback_chain",
+        "models": list(DEFAULT_FALLBACK_CHAIN_MODELS),
+        # Use the smallest child window for conservative compaction before
+        # the chain has to degrade. This prevents Sonnet from receiving a
+        # history that only Opus Long could accommodate.
+        "context_length": min(context_lengths or [128000]),
+    }
+    return True
 
 
 class FallbackChainExhausted(RuntimeError):
@@ -129,6 +180,9 @@ class FallbackChainModel(Model):
 
     models: List[Model]
     fallback_on: Callable[[BaseException], bool]
+    _child_settings: List[ModelSettings | None] = field(
+        default_factory=list, repr=False
+    )
     _current_index: int = field(default=0, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 
@@ -137,6 +191,7 @@ class FallbackChainModel(Model):
         *models: Model,
         fallback_on: Optional[Callable[[BaseException], bool]] = None,
         budget_exhausted_patterns: Sequence[str] = (),
+        child_settings: Optional[Sequence[ModelSettings | None]] = None,
         settings: ModelSettings | None = None,
     ):
         """
@@ -148,6 +203,9 @@ class FallbackChainModel(Model):
             budget_exhausted_patterns: Extra lowercase substrings to treat
                 as budget-exhaustion signals, merged with the built-in
                 defaults. Ignored if ``fallback_on`` is supplied explicitly.
+            child_settings: Optional model-specific defaults, in the same
+                order as ``models``. These preserve provider-specific options
+                such as adaptive thinking after a switch.
             settings: Model settings used as defaults for this model.
         """
         super().__init__(settings=settings)
@@ -156,6 +214,12 @@ class FallbackChainModel(Model):
         self.models = list(models)
         self._current_index = 0
         self._lock = threading.Lock()
+        if child_settings is None:
+            self._child_settings = [None] * len(self.models)
+        elif len(child_settings) != len(self.models):
+            raise ValueError("child_settings must match the number of models")
+        else:
+            self._child_settings = list(child_settings)
         if fallback_on is not None:
             self.fallback_on = fallback_on
         else:
@@ -215,8 +279,10 @@ class FallbackChainModel(Model):
         while True:
             index = self._current_index
             current_model = self.models[index]
+            model_defaults = self._child_settings[index]
+            request_settings = merge_model_settings(model_settings, model_defaults)
             merged_settings, prepared_params = current_model.prepare_request(
-                model_settings, model_request_parameters
+                request_settings, model_request_parameters
             )
             try:
                 return await current_model.request(
@@ -244,8 +310,10 @@ class FallbackChainModel(Model):
         while True:
             index = self._current_index
             current_model = self.models[index]
+            model_defaults = self._child_settings[index]
+            request_settings = merge_model_settings(model_settings, model_defaults)
             merged_settings, prepared_params = current_model.prepare_request(
-                model_settings, model_request_parameters
+                request_settings, model_request_parameters
             )
             try:
                 async with current_model.request_stream(

--- a/code_puppy/fallback_chain_model.py
+++ b/code_puppy/fallback_chain_model.py
@@ -1,0 +1,265 @@
+"""A model that permanently degrades to the next model in a chain once the
+current one's *budget* is exhausted (provider quota used up, or the prompt
+no longer fits the model's context window).
+
+This is deliberately **not** the same problem ``RoundRobinModel`` solves.
+Round-robin distributes load across equivalent models; this class assumes
+an ordered preference list (e.g. a large model, then a medium model, then a
+free/unmetered one) and only moves down the list when the current model can
+no longer serve requests *at all* -- not on ordinary transient hiccups like
+a 429 rate-limit or a 5xx blip, which ``code_puppy.agents._runtime``'s
+streaming-retry mechanism already handles by retrying the *same* model with
+backoff. Retrying the same model on a genuine quota-exhausted or
+context-length error is pointless: it will fail identically every time
+until the quota window resets, so the only useful move is to switch models.
+
+The switch is one-directional and "sticky" -- once model N is marked
+exhausted we never try it again for the lifetime of this instance, we just
+keep moving forward through the chain. This mirrors how a human would work
+around the same problem: drop to a cheaper model and stay there, rather
+than re-poking the expensive one every request and eating the failure
+latency each time.
+"""
+
+from __future__ import annotations
+
+import threading
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Callable, List, Optional, Sequence
+
+from pydantic_ai._run_context import RunContext
+from pydantic_ai.models import (
+    Model,
+    ModelMessage,
+    ModelRequestParameters,
+    ModelResponse,
+    ModelSettings,
+    StreamedResponse,
+)
+
+from code_puppy.messaging import emit_warning
+
+# Substring signatures (matched lowercase) that indicate a request failed
+# because the model's *budget* is used up -- not because of a transient
+# network/server hiccup. Kept deliberately separate from
+# ``code_puppy.agents._runtime._RETRYABLE_SNIPPETS``: those are "try the
+# same model again in a few seconds", these are "this model is done, move
+# on". A plain "rate limit"/"too many requests" phrase is intentionally
+# NOT included here -- ordinary per-minute rate limits are already handled
+# by the same-model retry path and should not trigger a permanent downgrade.
+DEFAULT_BUDGET_EXHAUSTED_SNIPPETS: tuple = (
+    # OpenAI-style structured error codes
+    "insufficient_quota",
+    "context_length_exceeded",
+    "rate_limit_exceeded_quota",  # some gateways append _quota to disambiguate
+    # Common provider/gateway wording for hard quota exhaustion
+    "quota exceeded",
+    "quota has been exceeded",
+    "exceeded your current quota",
+    "monthly quota",
+    "budget exhausted",
+    "token budget",
+    "usage limit exceeded",
+    "exceeded token limit",
+    # Context-window overflow phrasing (OpenAI, Anthropic, Gemini, generic)
+    "maximum context length",
+    "context window",
+    "context_length",
+    "prompt is too long",
+    "input is too long",
+    "exceeds the model's maximum",
+    "too many tokens",
+)
+
+
+class FallbackChainExhausted(RuntimeError):
+    """Every model in a ``FallbackChainModel`` has had its budget exhausted."""
+
+
+def is_budget_exhausted_error(
+    exc: BaseException, extra_snippets: Sequence[str] = ()
+) -> bool:
+    """True if ``exc`` (or anything in its cause/context chain) looks like a
+    hard budget-exhaustion failure rather than a transient one.
+
+    Checks both the plain ``str(exc)`` and, for ``ModelHTTPError``, the
+    structured ``.body`` payload (providers often bury the real error code
+    a level deeper than the top-level message, e.g. OpenAI's
+    ``{"error": {"code": "insufficient_quota", ...}}``).
+    """
+    snippets = tuple(s.lower() for s in DEFAULT_BUDGET_EXHAUSTED_SNIPPETS) + tuple(
+        s.lower() for s in extra_snippets
+    )
+
+    seen: set = set()
+    node: Optional[BaseException] = exc
+    depth = 0
+    while node is not None and id(node) not in seen and depth < 5:
+        seen.add(id(node))
+        depth += 1
+
+        haystacks = [str(node)]
+        body = getattr(node, "body", None)
+        if body:
+            haystacks.append(str(body))
+
+        for text in haystacks:
+            lowered = text.lower()
+            if any(s in lowered for s in snippets):
+                return True
+
+        node = node.__cause__ or node.__context__
+
+    return False
+
+
+@dataclass(init=False)
+class FallbackChainModel(Model):
+    """Try ``models[0]``; on a budget-exhaustion error, permanently advance
+    to ``models[1]``, and so on. Any other exception propagates immediately
+    -- this class only ever reacts to "this model's budget is spent", never
+    to ordinary errors (auth failures, bad requests, bugs, etc.), which
+    should surface normally rather than being masked by silently trying a
+    different model.
+
+    Raises :class:`FallbackChainExhausted` if every model in the chain has
+    been exhausted.
+    """
+
+    models: List[Model]
+    fallback_on: Callable[[BaseException], bool]
+    _current_index: int = field(default=0, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def __init__(
+        self,
+        *models: Model,
+        fallback_on: Optional[Callable[[BaseException], bool]] = None,
+        budget_exhausted_patterns: Sequence[str] = (),
+        settings: ModelSettings | None = None,
+    ):
+        """
+        Args:
+            models: Ordered preference chain, e.g. (large, medium, free).
+            fallback_on: Optional custom predicate deciding whether an
+                exception should trigger a permanent switch to the next
+                model. Defaults to :func:`is_budget_exhausted_error`.
+            budget_exhausted_patterns: Extra lowercase substrings to treat
+                as budget-exhaustion signals, merged with the built-in
+                defaults. Ignored if ``fallback_on`` is supplied explicitly.
+            settings: Model settings used as defaults for this model.
+        """
+        super().__init__(settings=settings)
+        if not models:
+            raise ValueError("At least one model must be provided")
+        self.models = list(models)
+        self._current_index = 0
+        self._lock = threading.Lock()
+        if fallback_on is not None:
+            self.fallback_on = fallback_on
+        else:
+            self.fallback_on = lambda exc: is_budget_exhausted_error(
+                exc, budget_exhausted_patterns
+            )
+
+    @property
+    def model_name(self) -> str:
+        """Full configured chain, plus which model is currently active --
+        so status displays (``/model``, ``/usage``) show both the fallback
+        plan and the live degradation state at a glance.
+        """
+        chain = ",".join(m.model_name for m in self.models)
+        active = self.models[self._current_index].model_name
+        return f"fallback_chain:{chain}:active={active}"
+
+    @property
+    def system(self) -> str:
+        return self.models[self._current_index].system
+
+    @property
+    def base_url(self) -> str | None:
+        return self.models[self._current_index].base_url
+
+    def _advance_past_exhausted(self, exhausted_index: int, exc: BaseException) -> bool:
+        """Permanently move past ``exhausted_index``. Returns True if a next
+        model exists, False if the whole chain is now exhausted.
+
+        Guarded so two concurrent requests hitting the same exhaustion don't
+        both emit a warning or both advance the index twice.
+        """
+        with self._lock:
+            if self._current_index != exhausted_index:
+                # Another caller already advanced past this one -- nothing
+                # left for us to do.
+                return self._current_index < len(self.models)
+            if exhausted_index + 1 >= len(self.models):
+                return False
+            exhausted_name = self.models[exhausted_index].model_name
+            next_name = self.models[exhausted_index + 1].model_name
+            self._current_index = exhausted_index + 1
+            emit_warning(
+                f"Model '{exhausted_name}' hit a budget/context limit "
+                f"({exc}); switching to '{next_name}' for the rest of this "
+                "session. Restart code_puppy or reselect a model with "
+                "/model to reset back to the top of the chain."
+            )
+            return True
+
+    async def request(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+    ) -> ModelResponse:
+        while True:
+            index = self._current_index
+            current_model = self.models[index]
+            merged_settings, prepared_params = current_model.prepare_request(
+                model_settings, model_request_parameters
+            )
+            try:
+                return await current_model.request(
+                    messages, merged_settings, prepared_params
+                )
+            except Exception as exc:
+                if not self.fallback_on(exc):
+                    raise
+                if not self._advance_past_exhausted(index, exc):
+                    raise FallbackChainExhausted(
+                        f"All {len(self.models)} model(s) in the fallback "
+                        f"chain are exhausted. Last error from "
+                        f"'{current_model.model_name}': {exc}"
+                    ) from exc
+                # Loop and retry the same request against the new model.
+
+    @asynccontextmanager
+    async def request_stream(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+        run_context: RunContext[Any] | None = None,
+    ) -> AsyncIterator[StreamedResponse]:
+        while True:
+            index = self._current_index
+            current_model = self.models[index]
+            merged_settings, prepared_params = current_model.prepare_request(
+                model_settings, model_request_parameters
+            )
+            try:
+                async with current_model.request_stream(
+                    messages, merged_settings, prepared_params, run_context
+                ) as response:
+                    yield response
+                    return
+            except Exception as exc:
+                if not self.fallback_on(exc):
+                    raise
+                if not self._advance_past_exhausted(index, exc):
+                    raise FallbackChainExhausted(
+                        f"All {len(self.models)} model(s) in the fallback "
+                        f"chain are exhausted. Last error from "
+                        f"'{current_model.model_name}': {exc}"
+                    ) from exc
+                # Loop and retry the same stream request against the new model.

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -25,6 +25,7 @@ from code_puppy.messaging import emit_warning
 from . import callbacks
 from .claude_cache_client import ClaudeCacheAsyncClient
 from .config import EXTRA_MODELS_FILE, get_value, get_yolo_mode
+from .fallback_chain_model import FallbackChainModel
 from .http_utils import create_async_client, get_cert_bundle_path, get_http2
 from .provider_identity import (
     make_anthropic_provider,
@@ -1090,6 +1091,38 @@ class ModelFactory:
 
             # Create and return the round-robin model
             return RoundRobinModel(*models, rotate_every=rotate_every)
+
+        elif model_type == "fallback_chain":
+            # Ordered preference list, e.g. ["gpt-5-large", "gpt-5-medium",
+            # "free-model"]. Unlike round_robin (load distribution across
+            # equivalent models), this permanently degrades to the next
+            # model once the current one's budget (quota or context window)
+            # is exhausted, and stays there for the life of the process.
+            model_names = model_config.get("models")
+            if not model_names or not isinstance(model_names, list):
+                raise ValueError(
+                    f"Fallback-chain model '{model_name}' requires a 'models' list in its configuration."
+                )
+            if len(model_names) < 2:
+                raise ValueError(
+                    f"Fallback-chain model '{model_name}' needs at least 2 models to "
+                    "fall back between (got 1). Use the model directly instead."
+                )
+
+            # Extra provider/gateway-specific substrings that count as
+            # "budget exhausted" on top of the built-in defaults.
+            budget_exhausted_patterns = model_config.get(
+                "budget_exhausted_patterns", []
+            )
+
+            models = []
+            for name in model_names:
+                model = ModelFactory.get_model(name, config)
+                models.append(model)
+
+            return FallbackChainModel(
+                *models, budget_exhausted_patterns=budget_exhausted_patterns
+            )
 
         else:
             # Check for plugin-registered model type handlers

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -25,7 +25,10 @@ from code_puppy.messaging import emit_warning
 from . import callbacks
 from .claude_cache_client import ClaudeCacheAsyncClient
 from .config import EXTRA_MODELS_FILE, get_value, get_yolo_mode
-from .fallback_chain_model import FallbackChainModel
+from .fallback_chain_model import (
+    FallbackChainModel,
+    add_default_fallback_chain,
+)
 from .http_utils import create_async_client, get_cert_bundle_path, get_http2
 from .provider_identity import (
     make_anthropic_provider,
@@ -60,7 +63,11 @@ _load_plugin_model_providers()
 
 # Anthropic beta header required for 1M context window support.
 CONTEXT_1M_BETA = "context-1m-2025-08-07"
-_CUSTOM_OPENAI_MODEL_TYPES = {"custom_openai", "custom_openai_responses"}
+_CUSTOM_OPENAI_MODEL_TYPES = {
+    "custom_openai",
+    "custom_openai_responses",
+    "codex",
+}
 _LEGACY_CUSTOM_OPENAI_RESPONSES_MODEL = "codex-gpt-5-codex"
 
 
@@ -69,7 +76,7 @@ def _custom_openai_uses_responses_api(
 ) -> bool:
     """Return whether a custom OpenAI model should use the Responses API."""
     return (
-        model_config.get("type") == "custom_openai_responses"
+        model_config.get("type") in {"custom_openai_responses", "codex"}
         or model_name == _LEGACY_CUSTOM_OPENAI_RESPONSES_MODEL
     )
 
@@ -662,6 +669,12 @@ class ModelFactory:
                 f"Failed to load plugin models config: {exc}"
             )
 
+        # Add the Walmart default tier chain only when the active catalog
+        # supplies all three named models. The chain definition contains no
+        # endpoint or credential data, so vanilla upstream installs remain
+        # unchanged.
+        add_default_fallback_chain(config)
+
         # Final pass: apply description-only overlays from bundled + plugins.
         # This avoids shallow update() calls clobbering remote model settings.
         try:
@@ -1116,12 +1129,20 @@ class ModelFactory:
             )
 
             models = []
+            child_settings = []
             for name in model_names:
                 model = ModelFactory.get_model(name, config)
+                if model is None:
+                    raise ValueError(
+                        f"Fallback-chain child model '{name}' could not be instantiated."
+                    )
                 models.append(model)
+                child_settings.append(make_model_settings(name))
 
             return FallbackChainModel(
-                *models, budget_exhausted_patterns=budget_exhausted_patterns
+                *models,
+                budget_exhausted_patterns=budget_exhausted_patterns,
+                child_settings=child_settings,
             )
 
         else:

--- a/tests/test_config_full_coverage.py
+++ b/tests/test_config_full_coverage.py
@@ -493,6 +493,29 @@ class TestDefaultModel:
         assert cp_config._default_model_from_models_json() == "cached"
         cp_config._default_model_cache = None
 
+    def test_default_model_prefers_default_fallback_chain_alias(self):
+        cp_config._default_model_cache = None
+        with patch(
+            "code_puppy.model_factory.ModelFactory.load_config",
+            return_value={
+                "claude-4-8-opus-long": {},
+                "claude-5-sonnet": {},
+                "gpt-5.6-luna": {},
+                "default-fallback-chain": {
+                    "type": "fallback_chain",
+                    "models": [
+                        "claude-4-8-opus-long",
+                        "claude-5-sonnet",
+                        "gpt-5.6-luna",
+                    ],
+                },
+            },
+        ):
+            assert (
+                cp_config._default_model_from_models_json() == "default-fallback-chain"
+            )
+        cp_config._default_model_cache = None
+
     def test_default_model_from_config(self):
         cp_config._default_model_cache = None
         with patch(

--- a/tests/test_fallback_chain_model.py
+++ b/tests/test_fallback_chain_model.py
@@ -12,8 +12,11 @@ from pydantic_ai.exceptions import ModelHTTPError
 
 from code_puppy.fallback_chain_model import (
     DEFAULT_BUDGET_EXHAUSTED_SNIPPETS,
+    DEFAULT_FALLBACK_CHAIN_MODELS,
+    DEFAULT_FALLBACK_CHAIN_NAME,
     FallbackChainExhausted,
     FallbackChainModel,
+    add_default_fallback_chain,
     is_budget_exhausted_error,
 )
 
@@ -32,6 +35,60 @@ def _make_model(name: str, response=None, side_effect=None):
     else:
         model.request = AsyncMock(return_value=response or MagicMock())
     return model
+
+
+class TestDefaultFallbackChain:
+    def test_default_model_order_is_exact(self):
+        assert DEFAULT_FALLBACK_CHAIN_MODELS == (
+            "claude-4-8-opus-long",
+            "claude-5-sonnet",
+            "gpt-5.6-luna",
+        )
+
+    @pytest.mark.parametrize("missing_name", DEFAULT_FALLBACK_CHAIN_MODELS)
+    def test_alias_is_added_only_when_every_child_exists(self, missing_name):
+        config = {
+            name: {"type": "openai", "name": name}
+            for name in DEFAULT_FALLBACK_CHAIN_MODELS
+            if name != missing_name
+        }
+
+        assert add_default_fallback_chain(config) is False
+        assert DEFAULT_FALLBACK_CHAIN_NAME not in config
+
+    def test_alias_preserves_existing_definition(self):
+        existing_alias = {
+            "type": "round_robin",
+            "models": ["existing-one", "existing-two"],
+            "context_length": 1234,
+        }
+        config = {DEFAULT_FALLBACK_CHAIN_NAME: existing_alias}
+
+        assert add_default_fallback_chain(config) is False
+        assert config[DEFAULT_FALLBACK_CHAIN_NAME] is existing_alias
+
+    def test_alias_uses_exact_order_and_smallest_child_context(self):
+        config = {
+            "claude-4-8-opus-long": {
+                "type": "anthropic",
+                "context_length": 1_000_000,
+            },
+            "claude-5-sonnet": {
+                "type": "anthropic",
+                "context_length": 200_000,
+            },
+            "gpt-5.6-luna": {
+                "type": "openai",
+                "context_length": 128_000,
+            },
+        }
+
+        assert add_default_fallback_chain(config) is True
+        assert config[DEFAULT_FALLBACK_CHAIN_NAME] == {
+            "type": "fallback_chain",
+            "models": list(DEFAULT_FALLBACK_CHAIN_MODELS),
+            "context_length": 128_000,
+        }
 
 
 class TestIsBudgetExhaustedError:
@@ -142,6 +199,36 @@ class TestFallbackChainModelRequest:
         assert healthy.request.await_count == 3
 
     @pytest.mark.asyncio
+    async def test_default_chain_skips_two_quota_exhausted_models_and_sticks_to_third(
+        self,
+    ):
+        """The catalog's Opus -> Sonnet -> Luna order is permanent after fallback."""
+        opus = _make_model(
+            "claude-4-8-opus-long",
+            side_effect=RuntimeError("claude-4-8-opus-long quota exhausted"),
+        )
+        sonnet = _make_model(
+            "claude-5-sonnet",
+            side_effect=RuntimeError("claude-5-sonnet quota exceeded"),
+        )
+        luna = _make_model("gpt-5.6-luna", response="ok-luna")
+        chain = FallbackChainModel(opus, sonnet, luna)
+
+        with patch("code_puppy.fallback_chain_model.emit_warning") as mock_warn:
+            first_result = await chain.request([], None, MagicMock())
+            second_result = await chain.request([], None, MagicMock())
+
+        assert [model.model_name for model in chain.models] == list(
+            DEFAULT_FALLBACK_CHAIN_MODELS
+        )
+        assert first_result == second_result == "ok-luna"
+        assert opus.request.await_count == 1
+        assert sonnet.request.await_count == 1
+        assert luna.request.await_count == 2
+        assert mock_warn.call_count == 2
+        assert chain.model_name.endswith("active=gpt-5.6-luna")
+
+    @pytest.mark.asyncio
     async def test_exhausting_every_model_raises_fallback_chain_exhausted(self):
         first = _make_model("large", side_effect=RuntimeError("insufficient_quota"))
         second = _make_model(
@@ -183,6 +270,37 @@ class TestFallbackChainModelRequest:
     def test_requires_at_least_one_model(self):
         with pytest.raises(ValueError):
             FallbackChainModel()
+
+    @pytest.mark.asyncio
+    async def test_child_specific_settings_follow_the_request_after_fallback(self):
+        exhausted = _make_model("large", side_effect=RuntimeError("insufficient_quota"))
+        healthy = _make_model("medium", response="ok-medium")
+        first_settings = {"max_tokens": 1111}
+        second_settings = {"max_tokens": 2222, "temperature": 0.2}
+        chain = FallbackChainModel(
+            exhausted,
+            healthy,
+            child_settings=[first_settings, second_settings],
+        )
+
+        with patch("code_puppy.fallback_chain_model.emit_warning"):
+            result = await chain.request([], None, MagicMock())
+
+        assert result == "ok-medium"
+        assert exhausted.prepare_request.call_args.args[0] == first_settings
+        assert healthy.prepare_request.call_args.args[0] == second_settings
+        assert healthy.request.call_args.args[1] == second_settings
+
+    @pytest.mark.parametrize("child_settings", [[], [None, None, None]])
+    def test_child_settings_must_match_model_count(self, child_settings):
+        with pytest.raises(
+            ValueError, match="child_settings must match the number of models"
+        ):
+            FallbackChainModel(
+                _make_model("large"),
+                _make_model("medium"),
+                child_settings=child_settings,
+            )
 
 
 class TestFallbackChainModelName:

--- a/tests/test_fallback_chain_model.py
+++ b/tests/test_fallback_chain_model.py
@@ -1,0 +1,319 @@
+"""Coverage for FallbackChainModel: permanent, sticky degradation through an
+ordered model chain when the current model's budget (quota or context
+window) is exhausted -- as opposed to RoundRobinModel (load distribution)
+or the streaming-retry mechanism in agents/_runtime.py (same-model retry on
+transient errors like a 429 rate-limit or a 5xx blip).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic_ai.exceptions import ModelHTTPError
+
+from code_puppy.fallback_chain_model import (
+    DEFAULT_BUDGET_EXHAUSTED_SNIPPETS,
+    FallbackChainExhausted,
+    FallbackChainModel,
+    is_budget_exhausted_error,
+)
+
+
+def _make_model(name: str, response=None, side_effect=None):
+    """A minimal fake pydantic-ai Model with a mockable async request()."""
+    model = MagicMock()
+    model.model_name = name
+    model.system = "test"
+    model.base_url = None
+    model.prepare_request = MagicMock(
+        side_effect=lambda settings, params: (settings, params)
+    )
+    if side_effect is not None:
+        model.request = AsyncMock(side_effect=side_effect)
+    else:
+        model.request = AsyncMock(return_value=response or MagicMock())
+    return model
+
+
+class TestIsBudgetExhaustedError:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Error code: 400 - insufficient_quota",
+            "This model's maximum context length is 128000 tokens",
+            "You have exceeded your current quota, please check your plan",
+            "context_length_exceeded",
+            "monthly quota has been used up",
+            "prompt is too long for this model",
+        ],
+    )
+    def test_recognizes_known_exhaustion_phrasings(self, message):
+        assert is_budget_exhausted_error(RuntimeError(message)) is True
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "429 Too Many Requests",
+            "rate limit exceeded, please retry",
+            "503 Service Unavailable",
+            "connection error",
+            "invalid API key",
+        ],
+    )
+    def test_does_not_flag_transient_or_unrelated_errors(self, message):
+        """Plain rate-limit / transport errors must NOT trigger a permanent
+        model switch -- those are the same-model streaming-retry mechanism's
+        job (agents/_runtime.py), not this class's.
+        """
+        assert is_budget_exhausted_error(RuntimeError(message)) is False
+
+    def test_checks_structured_body_not_just_top_level_message(self):
+        """Providers often bury the real code a level deeper than the
+        top-level exception message (OpenAI's ``error.code`` field)."""
+        exc = ModelHTTPError(
+            status_code=400,
+            model_name="gpt-mega",
+            body={"error": {"code": "insufficient_quota", "message": "nope"}},
+        )
+        assert is_budget_exhausted_error(exc) is True
+
+    def test_walks_the_cause_chain(self):
+        inner = RuntimeError("context_length_exceeded")
+        outer = RuntimeError("wrapped")
+        outer.__cause__ = inner
+        assert is_budget_exhausted_error(outer) is True
+
+    def test_custom_extra_snippets_extend_defaults(self):
+        exc = RuntimeError("WALMART_LLM_GATEWAY: large-tier budget depleted")
+        assert is_budget_exhausted_error(exc) is False
+        assert (
+            is_budget_exhausted_error(exc, extra_snippets=["budget depleted"]) is True
+        )
+
+    def test_default_snippets_are_all_lowercase(self):
+        """The matcher lowercases input; source-of-truth snippets should be
+        lowercase too so a future edit doesn't accidentally add a
+        case-sensitive dead entry.
+        """
+        assert all(s == s.lower() for s in DEFAULT_BUDGET_EXHAUSTED_SNIPPETS)
+
+
+class TestFallbackChainModelRequest:
+    @pytest.mark.asyncio
+    async def test_uses_first_model_when_healthy(self):
+        good = _make_model("large", response="ok-large")
+        backup = _make_model("free")
+        chain = FallbackChainModel(good, backup)
+
+        result = await chain.request([], None, MagicMock())
+
+        assert result == "ok-large"
+        good.request.assert_awaited_once()
+        backup.request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_and_completes_the_request(self):
+        exhausted = _make_model("large", side_effect=RuntimeError("insufficient_quota"))
+        healthy = _make_model("medium", response="ok-medium")
+        chain = FallbackChainModel(exhausted, healthy)
+
+        with patch("code_puppy.fallback_chain_model.emit_warning") as mock_warn:
+            result = await chain.request([], None, MagicMock())
+
+        assert result == "ok-medium"
+        assert mock_warn.called
+        assert "large" in mock_warn.call_args[0][0]
+        assert "medium" in mock_warn.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_stays_on_the_fallback_model_for_subsequent_requests(self):
+        """The switch is sticky -- once we've moved past model 0, we never
+        try it again, even though a naive retry-from-scratch would.
+        """
+        exhausted = _make_model("large", side_effect=RuntimeError("insufficient_quota"))
+        healthy = _make_model("medium", response="ok-medium")
+        chain = FallbackChainModel(exhausted, healthy)
+
+        with patch("code_puppy.fallback_chain_model.emit_warning"):
+            await chain.request([], None, MagicMock())
+            await chain.request([], None, MagicMock())
+            await chain.request([], None, MagicMock())
+
+        assert exhausted.request.await_count == 1  # only ever tried once
+        assert healthy.request.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_exhausting_every_model_raises_fallback_chain_exhausted(self):
+        first = _make_model("large", side_effect=RuntimeError("insufficient_quota"))
+        second = _make_model(
+            "free", side_effect=RuntimeError("context_length_exceeded")
+        )
+        chain = FallbackChainModel(first, second)
+
+        with patch("code_puppy.fallback_chain_model.emit_warning"):
+            with pytest.raises(FallbackChainExhausted):
+                await chain.request([], None, MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_non_budget_errors_propagate_immediately_without_switching(self):
+        """A real bug/auth failure must surface as itself, not get masked
+        by silently trying a different model.
+        """
+        broken = _make_model("large", side_effect=ValueError("bad api key"))
+        backup = _make_model("free")
+        chain = FallbackChainModel(broken, backup)
+
+        with pytest.raises(ValueError, match="bad api key"):
+            await chain.request([], None, MagicMock())
+
+        backup.request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_custom_fallback_on_predicate_is_honoured(self):
+        """A caller-supplied predicate fully replaces the default
+        budget-exhaustion classifier."""
+        model_a = _make_model("a", side_effect=RuntimeError("anything at all"))
+        model_b = _make_model("b", response="ok-b")
+        chain = FallbackChainModel(model_a, model_b, fallback_on=lambda exc: True)
+
+        with patch("code_puppy.fallback_chain_model.emit_warning"):
+            result = await chain.request([], None, MagicMock())
+
+        assert result == "ok-b"
+
+    def test_requires_at_least_one_model(self):
+        with pytest.raises(ValueError):
+            FallbackChainModel()
+
+
+class TestFallbackChainModelName:
+    def test_model_name_reports_chain_and_active_model(self):
+        chain = FallbackChainModel(_make_model("large"), _make_model("free"))
+        assert chain.model_name == "fallback_chain:large,free:active=large"
+
+    @pytest.mark.asyncio
+    async def test_model_name_updates_after_a_switch(self):
+        exhausted = _make_model("large", side_effect=RuntimeError("insufficient_quota"))
+        healthy = _make_model("free", response="ok")
+        chain = FallbackChainModel(exhausted, healthy)
+
+        with patch("code_puppy.fallback_chain_model.emit_warning"):
+            await chain.request([], None, MagicMock())
+
+        assert chain.model_name == "fallback_chain:large,free:active=free"
+
+    def test_system_and_base_url_delegate_to_the_active_model(self):
+        active = _make_model("large")
+        active.system = "anthropic"
+        active.base_url = "https://api.example.com"
+        chain = FallbackChainModel(active, _make_model("free"))
+
+        assert chain.system == "anthropic"
+        assert chain.base_url == "https://api.example.com"
+
+
+class TestFallbackChainModelConcurrency:
+    @pytest.mark.asyncio
+    async def test_second_caller_sees_already_advanced_index_without_double_warning(
+        self,
+    ):
+        """Simulates two in-flight requests both hitting exhaustion on model
+        0 -- the second call to _advance_past_exhausted for the SAME
+        exhausted index must be a no-op (index already moved), not a second
+        warning/advance.
+        """
+        exhausted = _make_model("large")
+        healthy = _make_model("free")
+        chain = FallbackChainModel(exhausted, healthy)
+
+        with patch("code_puppy.fallback_chain_model.emit_warning") as mock_warn:
+            first = chain._advance_past_exhausted(0, RuntimeError("insufficient_quota"))
+            second = chain._advance_past_exhausted(
+                0, RuntimeError("insufficient_quota")
+            )
+
+        assert first is True
+        assert second is True
+        assert mock_warn.call_count == 1
+        assert chain._current_index == 1
+
+
+class TestFallbackChainModelRequestStream:
+    @pytest.mark.asyncio
+    async def test_streams_from_first_model_when_healthy(self):
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def good_stream(*_a, **_kw):
+            yield "stream-large"
+
+        good = _make_model("large")
+        good.request_stream = good_stream
+        backup = _make_model("free")
+
+        chain = FallbackChainModel(good, backup)
+        async with chain.request_stream([], None, MagicMock()) as response:
+            assert response == "stream-large"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_next_model_on_stream_exhaustion(self):
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def dead_stream(*_a, **_kw):
+            raise RuntimeError("context_length_exceeded")
+            yield  # pragma: no cover - unreachable, satisfies generator shape
+
+        @asynccontextmanager
+        async def healthy_stream(*_a, **_kw):
+            yield "stream-free"
+
+        exhausted = _make_model("large")
+        exhausted.request_stream = dead_stream
+        healthy = _make_model("free")
+        healthy.request_stream = healthy_stream
+
+        chain = FallbackChainModel(exhausted, healthy)
+        with patch("code_puppy.fallback_chain_model.emit_warning"):
+            async with chain.request_stream([], None, MagicMock()) as response:
+                assert response == "stream-free"
+        assert chain.model_name.endswith("active=free")
+
+    @pytest.mark.asyncio
+    async def test_stream_exhaustion_of_entire_chain_raises(self):
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def dead_stream(*_a, **_kw):
+            raise RuntimeError("insufficient_quota")
+            yield  # pragma: no cover - unreachable, satisfies generator shape
+
+        first = _make_model("large")
+        first.request_stream = dead_stream
+        second = _make_model("free")
+        second.request_stream = dead_stream
+
+        chain = FallbackChainModel(first, second)
+        with patch("code_puppy.fallback_chain_model.emit_warning"):
+            with pytest.raises(FallbackChainExhausted):
+                async with chain.request_stream([], None, MagicMock()):
+                    pass  # pragma: no cover - exhausted before yielding
+
+    @pytest.mark.asyncio
+    async def test_stream_non_budget_error_propagates_without_switching(self):
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def broken_stream(*_a, **_kw):
+            raise ValueError("bad api key")
+            yield  # pragma: no cover - unreachable, satisfies generator shape
+
+        broken = _make_model("large")
+        broken.request_stream = broken_stream
+        backup = _make_model("free")
+
+        chain = FallbackChainModel(broken, backup)
+        with pytest.raises(ValueError, match="bad api key"):
+            async with chain.request_stream([], None, MagicMock()):
+                pass  # pragma: no cover - never reached, error raised first
+
+        assert chain.model_name.endswith("active=large")  # no switch happened

--- a/tests/test_model_factory_basics.py
+++ b/tests/test_model_factory_basics.py
@@ -12,6 +12,45 @@ class TestModelFactoryBasics:
 
     @patch("code_puppy.model_factory.pathlib.Path.exists", return_value=False)
     @patch("code_puppy.model_factory.callbacks.get_callbacks", return_value=[])
+    def test_load_config_adds_default_fallback_chain_alias(
+        self, mock_callbacks, mock_exists
+    ):
+        config_without_alias = {
+            "claude-4-8-opus-long": {
+                "type": "anthropic",
+                "name": "claude-opus-long",
+                "context_length": 1_000_000,
+            },
+            "claude-5-sonnet": {
+                "type": "anthropic",
+                "name": "claude-sonnet",
+                "context_length": 200_000,
+            },
+            "gpt-5.6-luna": {
+                "type": "openai",
+                "name": "luna",
+                "context_length": 128_000,
+            },
+        }
+
+        with patch(
+            "builtins.open",
+            mock_open(read_data=json.dumps(config_without_alias)),
+        ):
+            config = ModelFactory.load_config()
+
+        assert config["default-fallback-chain"] == {
+            "type": "fallback_chain",
+            "models": [
+                "claude-4-8-opus-long",
+                "claude-5-sonnet",
+                "gpt-5.6-luna",
+            ],
+            "context_length": 128_000,
+        }
+
+    @patch("code_puppy.model_factory.pathlib.Path.exists", return_value=False)
+    @patch("code_puppy.model_factory.callbacks.get_callbacks", return_value=[])
     def test_load_config_basic(self, mock_callbacks, mock_exists):
         """Test basic config loading from models.json."""
         test_config = {
@@ -231,6 +270,47 @@ class TestModelFactoryBasics:
             ValueError, match="Model 'nonexistent-model' not found in configuration"
         ):
             ModelFactory.get_model("nonexistent-model", config)
+
+    def test_fallback_chain_missing_child_raises_clear_value_error(self):
+        config = {
+            "fallback": {
+                "type": "fallback_chain",
+                "models": ["missing-child", "backup"],
+            },
+            "backup": {"type": "openai", "name": "backup-model"},
+        }
+
+        with pytest.raises(
+            ValueError,
+            match="Model 'missing-child' not found in configuration",
+        ):
+            ModelFactory.get_model("fallback", config)
+
+    def test_fallback_chain_unavailable_child_raises_clear_value_error(self):
+        config = {
+            "fallback": {
+                "type": "fallback_chain",
+                "models": ["unavailable-child", "backup"],
+            },
+            "unavailable-child": {
+                "type": "openai",
+                "name": "unavailable-model",
+            },
+            "backup": {"type": "openai", "name": "backup-model"},
+        }
+
+        with (
+            patch("code_puppy.model_factory.get_api_key", return_value=None),
+            patch("code_puppy.model_factory.emit_warning"),
+        ):
+            with pytest.raises(
+                ValueError,
+                match=(
+                    "Fallback-chain child model "
+                    "'unavailable-child' could not be instantiated"
+                ),
+            ):
+                ModelFactory.get_model("fallback", config)
 
     def test_get_model_unsupported_type(self):
         """Test getting a model with unsupported type."""

--- a/tests/test_model_factory_fallback_chain.py
+++ b/tests/test_model_factory_fallback_chain.py
@@ -1,0 +1,101 @@
+"""Factory-level coverage for the catalog-provided default fallback chain."""
+
+from unittest.mock import MagicMock, patch
+
+from pydantic_ai.models.openai import OpenAIResponsesModel
+
+from code_puppy.fallback_chain_model import FallbackChainModel
+from code_puppy.model_factory import ModelFactory
+
+
+_CHAIN_CHILDREN = (
+    "claude-4-8-opus-long",
+    "claude-5-sonnet",
+    "gpt-5.6-luna",
+)
+
+
+def _sanitized_catalog() -> dict:
+    """Return only the catalog entries needed by the factory smoke test."""
+    custom_anthropic = {
+        "type": "custom_anthropic",
+        "name": "placeholder-anthropic-model",
+        "custom_endpoint": {
+            "url": "https://sanitized.invalid/v1",
+            "headers": {"x-api-key": "$TEST_MODEL_API_KEY"},
+            "api_key": "$TEST_MODEL_API_KEY",
+            "ca_certs_path": False,
+        },
+    }
+    return {
+        "claude-4-8-opus-long": {
+            **custom_anthropic,
+            "name": "claude-4-8-opus-long",
+        },
+        "claude-5-sonnet": {
+            **custom_anthropic,
+            "name": "claude-5-sonnet",
+        },
+        "gpt-5.6-luna": {
+            "type": "codex",
+            "name": "gpt-5.6-luna",
+            "custom_endpoint": {
+                "url": "https://sanitized.invalid/v1",
+                "headers": {"authorization": "Bearer $TEST_MODEL_API_KEY"},
+                "api_key": "$TEST_MODEL_API_KEY",
+                "ca_certs_path": False,
+            },
+        },
+        "default-fallback-chain": {
+            "type": "fallback_chain",
+            "models": list(_CHAIN_CHILDREN),
+        },
+    }
+
+
+def test_factory_resolves_default_alias_with_catalog_child_order():
+    """The configured alias must instantiate the real recursive factory path."""
+    catalog = _sanitized_catalog()
+
+    with (
+        patch.object(ModelFactory, "load_config", return_value=catalog),
+        patch(
+            "code_puppy.model_factory.get_api_key",
+            return_value="test-only-model-key",
+        ),
+        patch("code_puppy.model_factory.ClaudeCacheAsyncClient"),
+        patch("code_puppy.model_factory.AsyncAnthropic"),
+        patch(
+            "code_puppy.model_factory.make_anthropic_provider",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "code_puppy.model_factory.create_async_client",
+            return_value=MagicMock(),
+        ),
+    ):
+        model = ModelFactory.get_model("default-fallback-chain", catalog)
+
+    assert set(catalog) == {*_CHAIN_CHILDREN, "default-fallback-chain"}
+    assert isinstance(model, FallbackChainModel)
+    assert [child.model_name for child in model.models] == list(_CHAIN_CHILDREN)
+
+
+def test_factory_resolves_codex_catalog_entry_to_responses_model():
+    """The Luna child keeps its Codex/Responses API model resolution."""
+    catalog = _sanitized_catalog()
+
+    with (
+        patch(
+            "code_puppy.model_factory.get_api_key", return_value="test-only-model-key"
+        ),
+        patch(
+            "code_puppy.model_factory.create_async_client",
+            return_value=MagicMock(),
+        ) as create_client,
+    ):
+        model = ModelFactory.get_model("gpt-5.6-luna", catalog)
+
+    assert isinstance(model, OpenAIResponsesModel)
+    assert model.model_name == "gpt-5.6-luna"
+    create_client.assert_called_once()


### PR DESCRIPTION
## Summary

Adds quota-aware ordered model fallback and makes the requested catalog-provided default chain automatic:

```text
claude-4-8-opus-long (Opus 4.8 Long)
    -> quota/context exhaustion
claude-5-sonnet (Sonnet 5)
    -> quota/context exhaustion
gpt-5.6-luna (Luna)
```

When the runtime catalog contains those three keys, Code Puppy creates `default-fallback-chain` and selects it for a fresh installation with no explicit model selection.

- Permanently switches down the chain when quota/context capacity is exhausted.
- Does not treat ordinary 429 rate limits, 5xx errors, auth failures, or unrelated errors as fallback triggers.
- Emits a warning on every tier transition.
- Checks common provider signatures, structured `ModelHTTPError.body` payloads, and wrapped exceptions.
- Supports provider-specific additions through `budget_exhausted_patterns`.
- Preserves model-specific settings for each child, including Opus/Sonnet thinking settings and Luna reasoning settings.
- Supports `codex` as a configured Responses-compatible model type.
- Validates unavailable child models during factory construction instead of failing later during a request.
- Adds README documentation and focused tests.

This remains distinct from `RoundRobinModel` (load distribution) and the existing same-model transient streaming retry behavior.

## Validation

- `ruff check .` — passed
- `ruff format --check .` — passed
- `git diff --check` — passed
- Focused default/factory/config/fallback suite: **249 passed**
- New fallback module: **100% coverage**
- Exact quota flow: Opus quota exhausted -> Sonnet quota exhausted -> Luna succeeds -> subsequent request remains on Luna
- Factory smoke: sanitized catalog resolves all three children, including Luna `codex` -> `OpenAIResponsesModel`, with no network calls
- Full local suite: **7522 passed, 32 skipped**
