### PR TITLE
Persist sessions after manual compaction

### DIFF
--- a/code_puppy/command_line/session_commands.py
+++ b/code_puppy/command_line/session_commands.py
@@ -201,7 +201,8 @@ def handle_compact_command(command: str) -> bool:
         # Slash commands run outside the normal turn-finalization path, which
         # is where updated history is ordinarily auto-saved. Persist now so a
         # subsequent /quit + --quick-resume restores the compacted history.
-        auto_save_session_if_enabled()
+        if not auto_save_session_if_enabled(force=True):
+            return True
 
         after_tokens = sum(agent.estimate_tokens_for_message(m) for m in compacted)
         reduction_pct = (

--- a/code_puppy/command_line/session_commands.py
+++ b/code_puppy/command_line/session_commands.py
@@ -145,7 +145,10 @@ def handle_clear_command(command: str) -> bool:
 def handle_compact_command(command: str) -> bool:
     """Compact message history using configured strategy."""
     from code_puppy.agents.agent_manager import get_current_agent
-    from code_puppy.config import get_compaction_strategy
+    from code_puppy.config import (
+        auto_save_session_if_enabled,
+        get_compaction_strategy,
+    )
     from code_puppy.messaging import emit_error, emit_info, emit_success, emit_warning
 
     try:
@@ -194,6 +197,11 @@ def handle_compact_command(command: str) -> bool:
             return True
 
         agent.set_message_history(list(compacted))
+
+        # Slash commands run outside the normal turn-finalization path, which
+        # is where updated history is ordinarily auto-saved. Persist now so a
+        # subsequent /quit + --quick-resume restores the compacted history.
+        auto_save_session_if_enabled()
 
         after_tokens = sum(agent.estimate_tokens_for_message(m) for m in compacted)
         reduction_pct = (

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -2274,9 +2274,9 @@ def set_current_autosave_from_session_name(session_name: str) -> str:
     return pin_current_session_name(session_name)
 
 
-def auto_save_session_if_enabled() -> bool:
-    """Automatically save the current session if auto_save_session is enabled."""
-    if not get_auto_save_session():
+def auto_save_session_if_enabled(*, force: bool = False) -> bool:
+    """Save the current session when enabled, or unconditionally when forced."""
+    if not force and not get_auto_save_session():
         return False
 
     try:

--- a/tests/command_line/test_session_commands.py
+++ b/tests/command_line/test_session_commands.py
@@ -82,6 +82,12 @@ class TestHandleSessionCommand:
 
 
 class TestHandleCompactCommand:
+    @pytest.fixture(autouse=True)
+    def _mock_autosave(self):
+        with patch("code_puppy.config.auto_save_session_if_enabled") as autosave:
+            self.autosave = autosave
+            yield
+
     def _run(self, cmd="/compact"):
         from code_puppy.command_line.session_commands import handle_compact_command
 
@@ -139,6 +145,7 @@ class TestHandleCompactCommand:
         ):
             assert self._run() is True
             rcs.assert_called_once()
+            self.autosave.assert_called_once_with()
             ms.assert_called_once()
             assert "truncation" in ms.call_args[0][0]
 
@@ -165,6 +172,7 @@ class TestHandleCompactCommand:
             patch("code_puppy.messaging.emit_success") as ms,
         ):
             assert self._run() is True
+            self.autosave.assert_called_once_with()
             ms.assert_called_once()
 
     def test_compaction_fails(self):
@@ -190,6 +198,7 @@ class TestHandleCompactCommand:
             patch("code_puppy.messaging.emit_error") as me,
         ):
             assert self._run() is True
+            self.autosave.assert_not_called()
             me.assert_called_once()
 
     def test_exception(self):

--- a/tests/command_line/test_session_commands.py
+++ b/tests/command_line/test_session_commands.py
@@ -145,7 +145,7 @@ class TestHandleCompactCommand:
         ):
             assert self._run() is True
             rcs.assert_called_once()
-            self.autosave.assert_called_once_with()
+            self.autosave.assert_called_once_with(force=True)
             ms.assert_called_once()
             assert "truncation" in ms.call_args[0][0]
 
@@ -172,8 +172,36 @@ class TestHandleCompactCommand:
             patch("code_puppy.messaging.emit_success") as ms,
         ):
             assert self._run() is True
-            self.autosave.assert_called_once_with()
+            self.autosave.assert_called_once_with(force=True)
             ms.assert_called_once()
+
+    def test_save_failure_does_not_report_compaction_success(self):
+        agent = MagicMock()
+        agent.get_message_history.return_value = ["m1", "m2"]
+        agent.estimate_tokens_for_message.return_value = 100
+        self.autosave.return_value = False
+        with (
+            patch(
+                "code_puppy.agents.agent_manager.get_current_agent",
+                return_value=agent,
+            ),
+            patch(
+                "code_puppy.config.get_compaction_strategy",
+                return_value="summarization",
+            ),
+            patch("code_puppy.agents._compaction.build_compaction_strategy"),
+            patch("code_puppy.agents._compaction.resolve_agent_model"),
+            patch(
+                "code_puppy.agents._compaction.run_compaction_sync",
+                return_value=["summary"],
+            ),
+            patch("code_puppy.messaging.emit_info"),
+            patch("code_puppy.messaging.emit_success") as ms,
+        ):
+            assert self._run() is True
+
+        self.autosave.assert_called_once_with(force=True)
+        ms.assert_not_called()
 
     def test_compaction_fails(self):
         agent = MagicMock()

--- a/tests/test_config_full_coverage.py
+++ b/tests/test_config_full_coverage.py
@@ -879,6 +879,25 @@ class TestAutosaveSession:
         cp_config.set_auto_save_session(False)
         assert cp_config.auto_save_session_if_enabled() is False
 
+    def test_auto_save_session_force_overrides_disabled_setting(self):
+        cp_config.set_auto_save_session(False)
+        mock_agent = MagicMock()
+        mock_agent.get_message_history.return_value = [
+            {"role": "user", "content": "compacted"}
+        ]
+        mock_metadata = MagicMock(message_count=1, total_tokens=10)
+        with (
+            patch(
+                "code_puppy.agents.agent_manager.get_current_agent",
+                return_value=mock_agent,
+            ),
+            patch("code_puppy.config.save_session", return_value=mock_metadata),
+            patch("code_puppy.config.record_quick_resume_sessions"),
+            patch("code_puppy.messaging.emit_info"),
+            patch("code_puppy.session_lifecycle.fire_post_autosave_callback"),
+        ):
+            assert cp_config.auto_save_session_if_enabled(force=True) is True
+
     def test_auto_save_session_if_enabled_no_history(self):
         cp_config.set_auto_save_session(True)
         mock_agent = MagicMock()


### PR DESCRIPTION
## Summary

- persist compacted history immediately after a successful manual `/compact`
- force this explicit save even when periodic autosave is disabled
- avoid reporting compaction success when session persistence fails
- add focused regression coverage for successful and failed persistence

## Why

Manual slash commands run outside normal turn finalization. `/compact` updated only in-memory history, so quitting and restarting with `-qr` could restore the older, uncompacted transcript.

## Testing

- `uv run --no-sync pytest -q tests/command_line/test_session_commands.py tests/test_config_full_coverage.py -k "HandleCompactCommand or auto_save_session"`
- `uv run --no-sync ruff check code_puppy/config.py code_puppy/command_line/session_commands.py tests/test_config_full_coverage.py tests/command_line/test_session_commands.py`
- `uv run --no-sync ruff format --check code_puppy/config.py code_puppy/command_line/session_commands.py tests/test_config_full_coverage.py tests/command_line/test_session_commands.py`

Adversarial review completed with no remaining actionable findings.