### PR TITLE
fix: headless -p exits 0 on failure; no-model error names a command that doesn't exist

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -491,8 +491,8 @@ def load_model_with_fallback(
                 continue
 
         friendly = (
-            "No valid model could be loaded. Update the model configuration or "
-            "set a valid model with `config set`."
+            "No valid model could be loaded. Run `/add_model` to configure one, "
+            "or `/model <name>` to select an already-configured model."
         )
         emit_error(friendly, message_group=message_group)
         raise ValueError(friendly) from exc

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -585,7 +585,10 @@ async def main():
             prompt_only_mode = False
 
         if prompt_only_mode:
-            await execute_single_prompt(
+            # Propagate the headless exit code: main_entry() feeds main()'s
+            # return straight into sys.exit(), so swallowing it here is what
+            # made a failed `-p` run report success to the shell.
+            return await execute_single_prompt(
                 initial_command,
                 message_renderer,
                 session_name=resolved_resume_session,
@@ -1464,13 +1467,19 @@ async def execute_single_prompt(
     *,
     session_name: str | None = None,
     usage_file: Path | None = None,
-) -> None:
+) -> int:
     """Execute one headless ``-p`` prompt, dispatching commands and autosaving.
 
     Agent turns persist under the explicitly resumed session, when supplied,
     or under this process's generated autosave session otherwise. Handled
     slash commands and shell pass-through do not create or overwrite sessions
     because they never invoke the agent.
+
+    Returns the process exit code: ``0`` on success, ``1`` when the run failed.
+    A failed headless run must not report success — ``code-puppy -p ... && next``
+    would otherwise run ``next`` after the agent did nothing. Only paths that
+    actually emit an error return non-zero; cancellation and empty-prompt
+    warnings keep their previous ``0`` status.
     """
     from code_puppy.command_line.shell_passthrough import (
         execute_shell_passthrough,
@@ -1479,7 +1488,7 @@ async def execute_single_prompt(
 
     if is_shell_passthrough(prompt):
         execute_shell_passthrough(prompt)
-        return
+        return 0
 
     from code_puppy.command_line.command_handler import handle_command
     from code_puppy.config import (
@@ -1504,18 +1513,19 @@ async def execute_single_prompt(
             command_result = handle_command(command_prompt)
         except Exception as command_error:
             emit_error(t("cli.command.error", error=command_error))
-            return
+            return 1
 
         if command_result is True:
-            return
+            return 0
         if command_result == "__AUTOSAVE_LOAD__":
             emit_warning(t("cli.autosave.headless_unsupported"))
-            return
+            return 0
         if isinstance(command_result, str):
             prompt = command_result
 
     effective_session_name = session_name or get_current_session_name()
     agent = None
+    exit_code = 0
     emit_info(t("cli.headless.executing", prompt=prompt))
 
     try:
@@ -1530,7 +1540,7 @@ async def execute_single_prompt(
                 use_run_ui=False,
             )
         if result is None:
-            return
+            return 0
 
         get_message_bus().emit(
             AgentResponseMessage(content=result.output, is_markdown=True)
@@ -1548,6 +1558,7 @@ async def execute_single_prompt(
         emit_warning(t("cli.headless.cancelled"))
     except Exception as error:
         emit_error(t("cli.headless.error", error=error))
+        exit_code = 1
     finally:
         try:
             session_agent = agent or get_current_agent()
@@ -1570,6 +1581,8 @@ async def execute_single_prompt(
                     error=save_error,
                 )
             )
+
+    return exit_code
 
 
 def _force_utf8_stdio():

--- a/tests/test_cli_headless_exit_code.py
+++ b/tests/test_cli_headless_exit_code.py
@@ -1,0 +1,153 @@
+"""Headless ``-p`` runs must report failure to the shell.
+
+Regression coverage for a headless run that printed an error and still exited
+0. ``code-puppy -p "..." && next-step`` ran ``next-step`` after the agent had
+done nothing, because ``execute_single_prompt`` swallowed the exception and
+returned ``None`` (which ``main_entry`` maps to exit status 0).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from code_puppy.cli_runner import execute_single_prompt
+
+
+def _headless_patches(agent, run_result):
+    """Patch set matching tests/test_cli_usage_file.py's harness."""
+    return (
+        patch(
+            "code_puppy.command_line.shell_passthrough.is_shell_passthrough",
+            return_value=False,
+        ),
+        patch(
+            "code_puppy.cli_runner.parse_prompt_attachments",
+            return_value=SimpleNamespace(prompt="do it"),
+        ),
+        patch("code_puppy.cli_runner.get_current_agent", return_value=agent),
+        patch(
+            "code_puppy.cli_runner.run_prompt_with_attachments",
+            new=run_result,
+        ),
+        patch("code_puppy.messaging.get_message_bus"),
+        patch("code_puppy.session_lifecycle.persist_named_session"),
+        patch("code_puppy.config.record_quick_resume_sessions"),
+    )
+
+
+@pytest.mark.anyio
+async def test_agent_failure_returns_nonzero():
+    """An exception during the agent run must surface as exit code 1."""
+    agent = MagicMock()
+    renderer = MagicMock()
+    boom = AsyncMock(side_effect=RuntimeError("No valid model could be loaded."))
+
+    p1, p2, p3, p4, p5, p6, p7 = _headless_patches(agent, boom)
+    with p1, p2, p3, p4, p5, p6, p7:
+        rc = await execute_single_prompt("do it", renderer)
+
+    assert rc == 1, "a failed headless run must not report success to the shell"
+
+
+@pytest.mark.anyio
+async def test_successful_run_returns_zero():
+    """The success path keeps exit code 0."""
+    result = MagicMock(output="done")
+    result.usage = SimpleNamespace()
+    result.all_messages.return_value = []
+    agent = MagicMock()
+    renderer = MagicMock()
+    ok = AsyncMock(return_value=(result, MagicMock()))
+
+    p1, p2, p3, p4, p5, p6, p7 = _headless_patches(agent, ok)
+    with p1, p2, p3, p4, p5, p6, p7:
+        rc = await execute_single_prompt("do it", renderer)
+
+    assert rc == 0
+
+
+@pytest.mark.anyio
+async def test_cancellation_keeps_zero_status():
+    """Cancellation is not an error; it keeps its previous 0 status.
+
+    Pinned deliberately: this fix narrowed itself to paths that emit an
+    *error*. If the maintainer decides a cancelled headless run should also be
+    non-zero (e.g. 130), this is the test to change on purpose rather than by
+    accident.
+    """
+    agent = MagicMock()
+    renderer = MagicMock()
+    cancelled = AsyncMock(side_effect=__import__("asyncio").CancelledError())
+
+    p1, p2, p3, p4, p5, p6, p7 = _headless_patches(agent, cancelled)
+    with p1, p2, p3, p4, p5, p6, p7:
+        rc = await execute_single_prompt("do it", renderer)
+
+    assert rc == 0
+
+
+@pytest.mark.anyio
+async def test_failing_slash_command_returns_nonzero():
+    """A slash command that raises is also an error path that returned 0."""
+    renderer = MagicMock()
+
+    with (
+        patch(
+            "code_puppy.command_line.shell_passthrough.is_shell_passthrough",
+            return_value=False,
+        ),
+        patch(
+            "code_puppy.cli_runner.parse_prompt_attachments",
+            return_value=SimpleNamespace(prompt="/bogus"),
+        ),
+        patch(
+            "code_puppy.command_line.command_handler.handle_command",
+            side_effect=RuntimeError("nope"),
+        ),
+    ):
+        rc = await execute_single_prompt("/bogus", renderer)
+
+    assert rc == 1
+
+
+@pytest.mark.anyio
+async def test_handled_slash_command_returns_zero():
+    """A slash command handled without an agent run is a success."""
+    renderer = MagicMock()
+
+    with (
+        patch(
+            "code_puppy.command_line.shell_passthrough.is_shell_passthrough",
+            return_value=False,
+        ),
+        patch(
+            "code_puppy.cli_runner.parse_prompt_attachments",
+            return_value=SimpleNamespace(prompt="/help"),
+        ),
+        patch(
+            "code_puppy.command_line.command_handler.handle_command",
+            return_value=True,
+        ),
+    ):
+        rc = await execute_single_prompt("/help", renderer)
+
+    assert rc == 0
+
+
+def test_no_model_error_names_a_real_command():
+    """The stuck-user error must not name a command that does not exist.
+
+    ``config set`` was never a registered command; the real ones are
+    ``/add_model`` and ``/model``. Telling a blocked user to run a
+    non-existent command is worse than saying nothing.
+    """
+    from pathlib import Path
+
+    source = (
+        Path(__file__).resolve().parents[1] / "code_puppy" / "agents" / "_builder.py"
+    )
+    text = source.read_text(encoding="utf-8")
+
+    assert "`config set`" not in text, "config set is not a real command"
+    assert "/add_model" in text


### PR DESCRIPTION
Found these by dogfooding the published `0.0.788` CLI on a clean machine (isolated `HOME`, no models configured). Both are small and independent; happy to split into two PRs if you'd rather.

## 1. `code-puppy -p` exits 0 after a failed run

Reproduction on a fresh machine:

```bash
HOME=$(mktemp -d) && mkdir -p "$HOME/.code_puppy"
printf '[puppy]\nputppy_name = Rex\nowner_name = Dev\n' > "$HOME/.code_puppy/puppy.cfg"
code-puppy -p "say hi"; echo "exit: $?"
```

Before:
```
No valid model could be loaded. ...
Error executing prompt: No valid model could be loaded. ...
exit: 0
```

`main_entry` already has the plumbing — `rc = asyncio.run(main())` then `sys.exit(rc)`, with the comment "Capture main()'s return so plugins / normal paths set the exit status (None -> 0 or an int exit code)". But `execute_single_prompt` was typed `-> None`, and `main()` discarded its result, so the failure never reached that plumbing.

Practical impact: `code-puppy -p "..." && next-step` runs `next-step` after the agent has done nothing. Any CI step wrapping headless mode reports green on total failure.

Two paths were affected: the agent-run `except Exception`, and a slash command that raises (`cli.command.error`, which also just `return`ed).

**Scope:** deliberately narrow — only paths that emit an *error* return non-zero. Cancellation and the empty-prompt warning keep their previous `0`, pinned by tests so changing them later is a deliberate act. If you'd rather a cancelled headless run also be non-zero (130?), that felt like your call and I'm glad to follow up.

## 2. The no-model error names a command that doesn't exist

`code_puppy/agents/_builder.py` told a stuck user to "set a valid model with \`config set\`". There is no `config set` command — the registered one is `set`, and the string appeared exactly once in the tree, in that error. Now it names `/add_model` and `/model`, matching what the startup warning already tells you.

This is the message a brand-new user hits, because `models.json` ships empty (`{\n}\n` in the wheel), so a first run always lands here until `/add_model` is run.

## Verification

- End to end against a clean `HOME`: exit `0` -> exit `1`, message now names real commands.
- 6 regression tests added, **each verified to fail without the source change** (stashed the two source files, watched all 6 go red, restored).
- Full suite green: `7527 passed, 28 skipped`. `ruff check` and `ruff format` clean.

## Notes

- Followed `AGENTS.md` rule 7 — no Claude co-author trailer on the commit.
- Test file follows the existing patch harness in `tests/test_cli_usage_file.py`.