### PR TITLE
TUI: width-budget the prompt, restore NO_COLOR, quiet the startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,10 @@
 **🐶✨The sassy AI code agent that makes IDEs look outdated** ✨🐶
 
 [![Version](https://img.shields.io/pypi/v/code-puppy?style=for-the-badge&logo=python&label=Version&color=purple)](https://pypi.org/project/code-puppy/)
-[![Downloads](https://img.shields.io/badge/Downloads-170k%2B-brightgreen?style=for-the-badge&logo=download)](https://pypi.org/project/code-puppy/)
+[![Downloads](https://img.shields.io/pypi/dm/code-puppy?style=for-the-badge&logo=python&label=Downloads&color=brightgreen)](https://pypi.org/project/code-puppy/)
 [![Python](https://img.shields.io/badge/Python-3.11%2B-blue?style=for-the-badge&logo=python&logoColor=white)](https://python.org)
 [![License](https://img.shields.io/badge/License-MIT-green?style=for-the-badge)](LICENSE)
-[![Build Status](https://img.shields.io/badge/Build-Passing-brightgreen?style=for-the-badge&logo=github)](https://github.com/mpfaffenberger/code_puppy/actions)
-[![Tests](https://img.shields.io/badge/Tests-Passing-success?style=for-the-badge&logo=pytest)](https://github.com/mpfaffenberger/code_puppy/tests)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/mpfaffenberger/code_puppy/ci.yml?branch=main&style=for-the-badge&logo=github&label=Build)](https://github.com/mpfaffenberger/code_puppy/actions/workflows/ci.yml)
 
 [![100% Open Source](https://img.shields.io/badge/100%25-Open%20Source-blue?style=for-the-badge)](https://github.com/mpfaffenberger/code_puppy)
 [![Pydantic AI](https://img.shields.io/badge/Pydantic-AI-success?style=for-the-badge)](https://github.com/pydantic/pydantic-ai)

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -33,6 +33,7 @@ from code_puppy.config import (
     ensure_config_exists,
     finalize_autosave_session,
     get_current_session_name,
+    get_quiet_startup,
     initialize_command_history_file,
     record_terminal_session,
     save_command_to_history,
@@ -315,16 +316,17 @@ async def main():
             emit_system_message(t("cli.loading"))
 
         # Powered-by tagline under the big banner (prints even without pyfiglet).
-        display_console.print(
-            f"[dim]{t('cli.banner.powered_by')}[/dim] "
-            "[link=https://github.com/pydantic/pydantic-ai-harness]"
-            "[cyan]https://github.com/pydantic/pydantic-ai-harness[/cyan][/link]"
-        )
-        display_console.print(
-            f"[dim]{t('cli.banner.observability_pitch')}[/dim] "
-            "[link=https://pydantic.dev/logfire]"
-            "[cyan]https://pydantic.dev/logfire[/cyan][/link]\n"
-        )
+        if not get_quiet_startup():
+            display_console.print(
+                f"[dim]{t('cli.banner.powered_by')}[/dim] "
+                "[link=https://github.com/pydantic/pydantic-ai-harness]"
+                "[cyan]https://github.com/pydantic/pydantic-ai-harness[/cyan][/link]"
+            )
+            display_console.print(
+                f"[dim]{t('cli.banner.observability_pitch')}[/dim] "
+                "[link=https://pydantic.dev/logfire]"
+                "[cyan]https://pydantic.dev/logfire[/cyan][/link]\n"
+            )
 
         # Truecolor warning moved to interactive_mode() so it prints last — max visibility.
 
@@ -448,12 +450,15 @@ async def main():
         else:
             default_version_mismatch_behavior(current_version)
 
-    core_plugins_version = get_core_plugins_version()
-    if core_plugins_version is None:
-        core_plugins_message = t("version.core_plugins_unknown")
-    else:
-        core_plugins_message = t("version.core_plugins", version=core_plugins_version)
-    emit_system_message(core_plugins_message)
+    if not get_quiet_startup():
+        core_plugins_version = get_core_plugins_version()
+        if core_plugins_version is None:
+            core_plugins_message = t("version.core_plugins_unknown")
+        else:
+            core_plugins_message = t(
+                "version.core_plugins", version=core_plugins_version
+            )
+        emit_system_message(core_plugins_message)
 
     # One-shot sweep of legacy ~/.code_puppy/contexts/ into autosaves/ (idempotent
     # via sentinel). Must run before plugin startup callbacks read AUTOSAVE_DIR and
@@ -784,9 +789,11 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
     # "[bold]...[/bold]" in the i18n string would show up as literal
     # brackets. A Text object bypasses that string branch entirely and
     # renders as one line, actually bold.
-    emit_system_message(Text(t("cli.help.press_tab"), style="bold"))
+    if not get_quiet_startup():
+        emit_system_message(Text(t("cli.help.press_tab"), style="bold"))
     # Print truecolor warning LAST so it's the most visible thing on startup
-    # Big ugly red box should be impossible to miss!
+    # Big ugly red box should be impossible to miss! Never gated on
+    # quiet_startup -- that flag hides chrome, never warnings.
     print_truecolor_warning(display_console)
 
     # Shell pass-through for initial_command: !<cmd> bypasses the agent

--- a/code_puppy/command_line/completers.py
+++ b/code_puppy/command_line/completers.py
@@ -9,8 +9,10 @@ through :func:`build_completer_stack`.
 from __future__ import annotations
 
 import os
+import shutil
 import unicodedata
 
+from rich.cells import cell_len
 from termflow.tui.completion import Completer, Completion, merge_completers
 
 from code_puppy.command_line.command_registry import get_unique_commands
@@ -386,11 +388,121 @@ PROMPT_STYLES = {
 }
 
 
+#: Columns kept clear to the right of the prompt so there is always room to
+#: type. Below this the prompt is not a prompt, it is a wall.
+_MIN_TYPING_ROOM = 24
+
+#: Give up and render a bare arrow rather than a shredded prefix.
+_MIN_PREFIX_BUDGET = 8
+
+
+def _middle_truncate(text: str, limit: int) -> str:
+    """Shorten ``text`` to ``limit`` cells, dropping from the middle.
+
+    Model ids carry their meaning at both ends (``openrouter/...`` and
+    ``...-opus-4-8``), so a trailing ellipsis throws away the half that
+    tells you which model is actually spending your money.
+    """
+    if limit <= 0:
+        return ""
+    if cell_len(text) <= limit:
+        return text
+    if limit <= 1:
+        return "…"
+    keep = limit - 1
+    head = (keep + 1) // 2
+    tail = keep - head
+    return text[:head] + "…" + (text[len(text) - tail :] if tail else "")
+
+
+def _fit_prompt_parts(
+    puppy: str,
+    agent_display: str,
+    model_display: str,
+    cwd_display: str,
+    base: str,
+    columns: int,
+) -> tuple:
+    """Trim prompt segments to fit ``columns``, most droppable first.
+
+    ``platform_utils.startup_banner_text`` already budgets the *banner* by
+    width; the prompt had no such budget, so at 80 columns -- the most
+    common terminal width there is -- the line wrapped and split the
+    ``>>>`` marker across two rows, leaving the user typing after a lone
+    ``>``. Reduce in priority order instead: the arrow always survives,
+    then the model (you need to know what you are paying for), then the
+    agent, then cwd, then the puppy name.
+
+    Returns ``(puppy, agent_display, model_display, cwd_display)`` with
+    dropped segments as empty strings.
+    """
+    budget = columns - _MIN_TYPING_ROOM - cell_len(base)
+    if budget < _MIN_PREFIX_BUDGET:
+        return "", "", "", ""
+
+    def width(p: str, a: str, m: str, c: str) -> int:
+        total = 0
+        if p:
+            total += cell_len(p) + 1
+        if a:
+            total += cell_len(a) + 3  # "[" + "] "
+        if m:
+            total += cell_len(m) + 1
+        if c:
+            total += cell_len(c) + 3  # "(" + ") "
+        return total
+
+    if width(puppy, agent_display, model_display, cwd_display) <= budget:
+        return puppy, agent_display, model_display, cwd_display
+
+    # 1. cwd to its basename -- the leaf is the part you actually read.
+    if cwd_display:
+        leaf = cwd_display.rstrip("/").rsplit("/", 1)[-1] or cwd_display
+        if leaf != cwd_display:
+            cwd_display = "…/" + leaf
+            if width(puppy, agent_display, model_display, cwd_display) <= budget:
+                return puppy, agent_display, model_display, cwd_display
+
+    # 2. Drop the puppy name -- decorative once the line is under pressure.
+    if puppy:
+        puppy = ""
+        if width(puppy, agent_display, model_display, cwd_display) <= budget:
+            return puppy, agent_display, model_display, cwd_display
+
+    # 3. Drop cwd entirely.
+    if cwd_display:
+        cwd_display = ""
+        if width(puppy, agent_display, model_display, cwd_display) <= budget:
+            return puppy, agent_display, model_display, cwd_display
+
+    # 4. Drop the agent label before mangling the model id.
+    if agent_display:
+        agent_display = ""
+        if width(puppy, agent_display, model_display, cwd_display) <= budget:
+            return puppy, agent_display, model_display, cwd_display
+
+    # 5. Last resort: squeeze the model itself.
+    if model_display:
+        model_display = _middle_truncate(model_display, max(budget - 1, 0))
+
+    return puppy, agent_display, model_display, cwd_display
+
+
 def get_prompt_with_active_model(base: str = ">>> ") -> list:
     """Styled prompt fragments: puppy [agent] [model] (cwd) >>>.
 
     Returns a plain list of ``(style, text)`` tuples (the FormattedText
     shape without the class) for ``flatten_prompt_fragments``.
+
+    Segments are fitted to the detected terminal width so the prompt never
+    wraps and never splits its own arrow.
+
+    The signature is deliberately frozen at ``(base)``. Shipped plugins
+    (``statusline``, ``prompt_newline``) wrap this function with
+    ``def patched(base=">>> ")`` and no ``**kwargs``, so adding a
+    parameter here raises ``TypeError`` and takes the prompt out entirely
+    for anyone running them. Width is detected inside instead; tests
+    drive it by patching ``shutil.get_terminal_size``.
     """
     from code_puppy.agents.agent_manager import get_current_agent
     from code_puppy.command_line.model_picker_completion import get_active_model
@@ -421,14 +533,23 @@ def get_prompt_with_active_model(base: str = ">>> ") -> list:
         cwd_display = "~" + cwd[len(home) :]
     else:
         cwd_display = cwd
-    return [
-        ("class:puppy class:tui.header", f"{puppy}"),
-        ("", " "),
-        (
-            "class:agent class:tui.label",
-            f"[{_normalize_emoji_spacing(agent_display)}] ",
-        ),
-        ("class:model class:tui.title", model_display + " "),
-        ("class:cwd class:tui.muted", "(" + str(cwd_display) + ") "),
-        ("class:arrow class:tui.help-key", str(base)),
-    ]
+
+    columns = shutil.get_terminal_size(fallback=(80, 24)).columns
+
+    agent_display = _normalize_emoji_spacing(agent_display)
+    puppy, agent_display, model_display, cwd_display = _fit_prompt_parts(
+        puppy, agent_display, model_display, str(cwd_display), base, columns
+    )
+
+    fragments = []
+    if puppy:
+        fragments.append(("class:puppy class:tui.header", f"{puppy}"))
+        fragments.append(("", " "))
+    if agent_display:
+        fragments.append(("class:agent class:tui.label", f"[{agent_display}] "))
+    if model_display:
+        fragments.append(("class:model class:tui.title", model_display + " "))
+    if cwd_display:
+        fragments.append(("class:cwd class:tui.muted", "(" + cwd_display + ") "))
+    fragments.append(("class:arrow class:tui.help-key", str(base)))
+    return fragments

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -286,6 +286,26 @@ def get_suppress_directory_listing() -> bool:
     return get_truthy_bool_value("suppress_directory_listing", True)
 
 
+def get_quiet_startup() -> bool:
+    """Whether to skip decorative startup chrome.
+
+    Interactive startup prints nine messages before the prompt and only
+    one of them is situational -- the untrusted-hooks warning, which says
+    project hooks can run arbitrary shell commands. It renders with the
+    same weight as an install log, so the line that matters is the one
+    nobody reads.
+
+    When true, the purely decorative lines are skipped: the powered-by
+    tagline, the observability pitch, the two version banners, and the
+    Tab hint. Warnings, errors, and update notifications are never
+    suppressed by this flag.
+
+    Defaults to False so existing installs see no change; set
+    ``quiet_startup = true`` in ``puppy.cfg`` to opt in.
+    """
+    return get_truthy_bool_value("quiet_startup", False)
+
+
 DEFAULT_SECTION = "puppy"
 REQUIRED_KEYS = ["puppy_name", "owner_name"]
 
@@ -501,6 +521,8 @@ def get_config_keys():
     default_keys.append("enable_logfire")
     # Add suppress directory listing key
     default_keys.append("suppress_directory_listing")
+    # Skip decorative startup chrome (never warnings or errors)
+    default_keys.append("quiet_startup")
     # Add cancel agent key configuration
     default_keys.append("cancel_agent_key")
     # Max pause seconds: event_stream_handler's wait_if_paused() auto-resumes

--- a/code_puppy/splash.py
+++ b/code_puppy/splash.py
@@ -110,6 +110,33 @@ _SHEEN_PERIOD = 70
 _SHEEN_WIDTH = 7
 _FRAME_SECONDS = 0.033
 
+#: Frame interval over a remote link. Each frame repaints the whole
+#: raster, so the ~30fps local rate writes roughly a megabyte of escape
+#: sequences during a one-second boot -- 99.7% of everything the CLI
+#: writes to the terminal at startup. On a local terminal that is free.
+#: Over SSH or a forwarded tmux it is the dominant cost of launching, and
+#: the animation ends up *slower* than the imports it was hiding.
+_REMOTE_FRAME_SECONDS = 0.1
+
+#: Environment markers set by sshd on the remote side of a session.
+_REMOTE_MARKERS = ("SSH_CONNECTION", "SSH_TTY", "SSH_CLIENT")
+
+
+def _frame_seconds() -> float:
+    """Seconds between splash repaints, eased off on a remote link.
+
+    Same animation, roughly a third of the bytes. Kept deliberately
+    coarse: a precise bandwidth estimate is not worth a syscall on the
+    startup path, and being wrong only costs a slightly choppier splash.
+    """
+    try:
+        if any(os.environ.get(marker) for marker in _REMOTE_MARKERS):
+            return _REMOTE_FRAME_SECONDS
+    except Exception:
+        pass
+    return _FRAME_SECONDS
+
+
 # argv values that still mean "interactive boot" (splash-worthy).
 _INTERACTIVE_ARGS = frozenset({"-i", "--interactive"})
 
@@ -287,7 +314,8 @@ class _Splash:
                 f"{_SYNC_START}{reposition}{first}{_SYNC_END}"
             )
             self._stream.flush()
-            while not self._stop_event.wait(_FRAME_SECONDS):
+            frame_seconds = _frame_seconds()
+            while not self._stop_event.wait(frame_seconds):
                 phase = (phase + 2) % _SHEEN_PERIOD
                 frame = _build_frame(phase, self._truecolor, self._rows)
                 # One atomic write per frame: no tearing between reposition

--- a/code_puppy/tools/common.py
+++ b/code_puppy/tools/common.py
@@ -150,6 +150,23 @@ def resolve_path(file_path: str) -> str:
     return os.path.abspath(os.path.join(get_working_directory(), expanded))
 
 
+def _no_color_setting() -> bool | None:
+    """Resolve the ``no_color`` argument for a Rich ``Console``.
+
+    ``CODE_PUPPY_NO_COLOR=1`` forces color off. Otherwise return ``None``
+    rather than ``False``: Rich only auto-detects the cross-tool
+    ``NO_COLOR`` standard (no-color.org) when ``no_color`` is left unset,
+    so passing an explicit ``False`` silently *overrides* that support and
+    keeps emitting SGR codes for users who asked for none. ``splash.py``
+    already honors ``NO_COLOR``; half-honoring a standard is worse than
+    ignoring it, because the user watches the splash obey and reasonably
+    assumes the rest did too.
+    """
+    if bool(int(os.environ.get("CODE_PUPPY_NO_COLOR", "0"))):
+        return True
+    return None
+
+
 # Import our queue-based console system
 try:
     from code_puppy.messaging import (
@@ -161,15 +178,13 @@ try:
     )
 
     # Use queue console by default, but allow fallback
-    NO_COLOR = bool(int(os.environ.get("CODE_PUPPY_NO_COLOR", "0")))
-    _rich_console = Console(no_color=NO_COLOR)
+    _rich_console = Console(no_color=_no_color_setting())
     console = get_queue_console()
     # Set the fallback console for compatibility
     console.fallback_console = _rich_console
 except ImportError:
     # Fallback to regular Rich console if messaging system not available
-    NO_COLOR = bool(int(os.environ.get("CODE_PUPPY_NO_COLOR", "0")))
-    console = Console(no_color=NO_COLOR)
+    console = Console(no_color=_no_color_setting())
 
     # Provide fallback emit functions
     def emit_error(msg: str) -> None:

--- a/code_puppy/version_checker.py
+++ b/code_puppy/version_checker.py
@@ -74,8 +74,13 @@ def default_version_mismatch_behavior(current_version):
     )
     get_message_bus().emit(version_msg)
 
-    # Also emit plain text for legacy renderer
-    emit_info(t("version.current", version=current_version))
+    # Also emit plain text for legacy renderer. Chrome when nothing is
+    # wrong, so quiet_startup skips it -- the structured VersionCheckMessage
+    # above still carries update_available, so update notices are never lost.
+    from code_puppy.config import get_quiet_startup
+
+    if update_available or not get_quiet_startup():
+        emit_info(t("version.current", version=current_version))
 
     if update_available:
         emit_info(t("version.latest", version=latest_version))

--- a/tests/test_no_color_standard.py
+++ b/tests/test_no_color_standard.py
@@ -1,0 +1,79 @@
+"""Rich's built-in ``NO_COLOR`` support must not be overridden.
+
+Regression coverage for consoles constructed as ``Console(no_color=False)``.
+Rich auto-detects the cross-tool ``NO_COLOR`` standard (no-color.org) only
+when ``no_color`` is left unset -- passing an explicit ``False`` silently
+defeats it, so a user who exported ``NO_COLOR=1`` still got SGR codes.
+
+``code_puppy/splash.py`` honors ``NO_COLOR`` already, which made the old
+behavior worse than a clean miss: the splash obeyed and everything after
+it did not.
+"""
+
+import io
+
+from rich.console import Console
+
+from code_puppy.tools.common import _no_color_setting
+
+
+def test_unset_returns_none_so_rich_can_detect_no_color(monkeypatch):
+    """None, not False -- False is what defeated the standard."""
+    monkeypatch.delenv("CODE_PUPPY_NO_COLOR", raising=False)
+    assert _no_color_setting() is None
+
+
+def test_explicit_opt_in_still_forces_color_off(monkeypatch):
+    """The project's own override keeps working."""
+    monkeypatch.setenv("CODE_PUPPY_NO_COLOR", "1")
+    assert _no_color_setting() is True
+
+
+def test_no_color_env_actually_suppresses_color(monkeypatch):
+    """End to end: NO_COLOR=1 means no color codes reach the terminal.
+
+    Asserted on a color-only style on purpose. Rich's ``no_color`` strips
+    color while preserving attributes such as bold, which is correct --
+    the NO_COLOR standard is about color, not about all styling.
+    """
+    monkeypatch.delenv("CODE_PUPPY_NO_COLOR", raising=False)
+    monkeypatch.setenv("NO_COLOR", "1")
+
+    buf = io.StringIO()
+    console = Console(
+        no_color=_no_color_setting(), force_terminal=True, file=buf, width=40
+    )
+    console.print("[red]danger[/red]")
+
+    assert "\x1b[" not in buf.getvalue()
+    assert "danger" in buf.getvalue()
+    assert console.no_color is True
+
+
+def test_color_still_emitted_when_no_color_is_absent(monkeypatch):
+    """The fix must not turn color off for everybody else."""
+    monkeypatch.delenv("CODE_PUPPY_NO_COLOR", raising=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+
+    buf = io.StringIO()
+    console = Console(
+        no_color=_no_color_setting(), force_terminal=True, file=buf, width=40
+    )
+    console.print("[red]danger[/red]")
+
+    assert "\x1b[" in buf.getvalue()
+    assert console.no_color is False
+
+
+def test_project_override_beats_absent_no_color(monkeypatch):
+    """CODE_PUPPY_NO_COLOR=1 works even when NO_COLOR is unset."""
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("CODE_PUPPY_NO_COLOR", "1")
+
+    buf = io.StringIO()
+    console = Console(
+        no_color=_no_color_setting(), force_terminal=True, file=buf, width=40
+    )
+    console.print("[red]danger[/red]")
+
+    assert "\x1b[" not in buf.getvalue()

--- a/tests/test_prompt_width_budget.py
+++ b/tests/test_prompt_width_budget.py
@@ -1,0 +1,164 @@
+"""The REPL prompt must fit the terminal it is drawn in.
+
+Regression coverage for a prompt that wrapped at 80 columns -- the most
+common terminal width there is -- and split its own ``>>>`` marker across
+two rows, leaving the user typing after a lone ``>``.
+
+``platform_utils.startup_banner_text`` already budgets the *banner* by
+width (CODE PUPPY -> PUP below 79 columns, pinned by
+tests/test_platform_utils.py). These tests hold the prompt to the same
+standard.
+"""
+
+import inspect
+import os
+
+from rich.cells import cell_len
+
+from code_puppy.command_line import completers
+from code_puppy.command_line.completers import (
+    _fit_prompt_parts,
+    _middle_truncate,
+    get_prompt_with_active_model,
+)
+
+BASE = ">>> "
+
+
+def rendered_width(parts, base: str = BASE) -> int:
+    """Cells consumed by the prompt prefix as it is actually assembled."""
+    puppy, agent, model, cwd = parts
+    total = 0
+    if puppy:
+        total += cell_len(puppy) + 1
+    if agent:
+        total += cell_len(agent) + 3
+    if model:
+        total += cell_len(model) + 1
+    if cwd:
+        total += cell_len(cwd) + 3
+    return total + cell_len(base)
+
+
+def test_the_exact_case_from_the_audit_fits_in_80_columns():
+    """The captured 80-col prompt used to wrap and split the arrow."""
+    parts = _fit_prompt_parts(
+        "airmac-puppy",
+        "Code-Puppy 🐶",
+        "[claude-code-claude-opus-4-8-long]",
+        "~/codepuppy",
+        BASE,
+        80,
+    )
+    assert rendered_width(parts) <= 80
+
+
+def test_arrow_is_never_what_gets_dropped(monkeypatch):
+    """Whatever else goes, the prompt still ends in an arrow.
+
+    Width is driven by patching ``shutil.get_terminal_size`` rather than
+    by a keyword argument: the shipped ``statusline`` and
+    ``prompt_newline`` plugins wrap this function with
+    ``def patched(base=">>> ")``, so a new parameter would raise
+    TypeError through them and take the prompt out entirely.
+    """
+    monkeypatch.setattr(
+        completers.shutil,
+        "get_terminal_size",
+        lambda fallback=None: os.terminal_size((20, 24)),
+    )
+    fragments = get_prompt_with_active_model(BASE)
+    assert fragments, "prompt must never render empty"
+    assert fragments[-1][1] == BASE
+
+
+def test_public_signature_stays_plugin_compatible():
+    """Shipped plugins wrap this as ``patched(base)`` with no **kwargs.
+
+    Adding a parameter to the public prompt builder is a breaking change
+    for the plugin ecosystem, not just an internal refactor.
+    """
+    params = list(inspect.signature(get_prompt_with_active_model).parameters)
+    assert params == ["base"], (
+        "statusline/prompt_newline wrap this as patched(base=...); "
+        f"extra parameters break them. Got: {params}"
+    )
+
+
+def test_dual_model_worst_case_fits():
+    """An agent override renders TWO model ids -- the widest real case."""
+    parts = _fit_prompt_parts(
+        "puppy",
+        "Agent",
+        "[openrouter/anthropic/claude-sonnet-4.5 → anthropic/claude-opus-4-1-20250805]",
+        "~/work/clients/acme/backend/services/api",
+        BASE,
+        80,
+    )
+    assert rendered_width(parts) <= 80
+
+
+def test_model_survives_longer_than_decoration():
+    """You need to know which model is spending your money."""
+    puppy, agent, model, cwd = _fit_prompt_parts(
+        "airmac-puppy", "Code-Puppy", "[gpt-5]", "~/a/b/c/d/e/f/g", BASE, 46
+    )
+    assert model, "model dropped before puppy name/cwd"
+    assert not puppy or not cwd
+
+
+def test_wide_terminal_keeps_every_segment_intact():
+    """No gratuitous trimming when there is room."""
+    parts = _fit_prompt_parts(
+        "airmac-puppy", "Code-Puppy 🐶", "[gpt-5]", "~/codepuppy", BASE, 200
+    )
+    assert parts == ("airmac-puppy", "Code-Puppy 🐶", "[gpt-5]", "~/codepuppy")
+
+
+def test_absurdly_narrow_terminal_degrades_to_bare_arrow():
+    """A 20-col terminal gets a usable prompt, not a shredded one."""
+    assert _fit_prompt_parts("p", "A", "[m]", "~/x", BASE, 20) == ("", "", "", "")
+
+
+def test_emoji_counted_as_two_cells_not_one():
+    """Naive len() would under-count the agent emoji and still overflow."""
+    wide = "🐶🐶🐶🐶🐶🐶🐶🐶🐶🐶"
+    assert cell_len(wide) == 20
+    parts = _fit_prompt_parts("puppy", wide, "[gpt-5]", "~/codepuppy", BASE, 60)
+    assert rendered_width(parts) <= 60
+
+
+def test_middle_truncate_keeps_both_ends_of_a_model_id():
+    """Model ids carry meaning at both ends; a tail ellipsis loses half."""
+    out = _middle_truncate("openrouter/anthropic/claude-opus-4-8", 20)
+    assert cell_len(out) <= 20
+    assert out.startswith("open")
+    assert out.endswith("4-8")
+    assert "…" in out
+
+
+def test_fits_across_a_sweep_of_widths():
+    """No width between 30 and 200 may overflow."""
+    for columns in range(30, 201):
+        parts = _fit_prompt_parts(
+            "airmac-puppy",
+            "Code-Puppy 🐶",
+            "[claude-code-claude-opus-4-8-long]",
+            "~/codepuppy/deep/nested/path",
+            BASE,
+            columns,
+        )
+        assert rendered_width(parts) <= columns, f"overflow at {columns} cols"
+
+
+def test_leaves_room_to_actually_type():
+    """A prompt that fills the line exactly is still unusable."""
+    parts = _fit_prompt_parts(
+        "airmac-puppy",
+        "Code-Puppy 🐶",
+        "[claude-code-claude-opus-4-8-long]",
+        "~/codepuppy",
+        BASE,
+        80,
+    )
+    assert 80 - rendered_width(parts) >= 20, "no room left to type a prompt"

--- a/tests/test_quiet_startup.py
+++ b/tests/test_quiet_startup.py
@@ -1,0 +1,91 @@
+"""``quiet_startup`` hides chrome and never hides warnings.
+
+Interactive startup prints nine messages before the prompt and exactly
+one is situational: the untrusted-hooks warning, which says project hooks
+can run arbitrary shell commands. It renders with the same weight as an
+install log, so the line that matters is the one nobody reads.
+
+These tests pin the boundary. The flag may skip decoration; it may never
+skip anything that tells the user something is wrong.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from code_puppy.config import get_quiet_startup
+
+
+def test_defaults_to_off_so_existing_installs_are_unchanged():
+    with patch("code_puppy.config.get_truthy_bool_value", return_value=False) as g:
+        assert get_quiet_startup() is False
+    g.assert_called_once_with("quiet_startup", False)
+
+
+def test_reads_the_config_key():
+    with patch("code_puppy.config.get_truthy_bool_value", return_value=True):
+        assert get_quiet_startup() is True
+
+
+def test_quiet_startup_is_an_advertised_config_key():
+    """It must show up in /config so it is discoverable, not folklore."""
+    from code_puppy.config import get_config_keys
+
+    assert "quiet_startup" in get_config_keys()
+
+
+def test_version_line_suppressed_when_quiet_and_up_to_date():
+    """The 'Current version:' line is chrome when nothing is wrong."""
+    from code_puppy import version_checker
+
+    with (
+        patch.object(version_checker, "fetch_latest_version", return_value="1.0.0"),
+        patch.object(version_checker, "get_message_bus", return_value=MagicMock()),
+        patch.object(version_checker, "emit_info") as emit,
+        patch("code_puppy.config.get_quiet_startup", return_value=True),
+    ):
+        version_checker.default_version_mismatch_behavior("1.0.0")
+
+    assert emit.call_count == 0
+
+
+def test_update_notice_survives_quiet_startup():
+    """An available update is news, not chrome. It must still print."""
+    from code_puppy import version_checker
+
+    with (
+        patch.object(version_checker, "fetch_latest_version", return_value="9.9.9"),
+        patch.object(version_checker, "get_message_bus", return_value=MagicMock()),
+        patch.object(version_checker, "emit_info") as emit,
+        patch("code_puppy.config.get_quiet_startup", return_value=True),
+    ):
+        version_checker.default_version_mismatch_behavior("1.0.0")
+
+    emitted = " ".join(str(c.args[0]) for c in emit.call_args_list)
+    assert "1.0.0" in emitted, "current version must still print alongside an update"
+    assert "9.9.9" in emitted, "update notice must not be silenced by quiet_startup"
+
+
+def test_version_line_prints_normally_when_not_quiet():
+    from code_puppy import version_checker
+
+    with (
+        patch.object(version_checker, "fetch_latest_version", return_value="1.0.0"),
+        patch.object(version_checker, "get_message_bus", return_value=MagicMock()),
+        patch.object(version_checker, "emit_info") as emit,
+        patch("code_puppy.config.get_quiet_startup", return_value=False),
+    ):
+        version_checker.default_version_mismatch_behavior("1.0.0")
+
+    assert emit.call_count == 1
+
+
+def test_truecolor_warning_is_never_gated_on_quiet_startup():
+    """Warnings are exempt by construction -- pin it against a refactor."""
+    import inspect
+
+    from code_puppy import cli_runner
+
+    source = inspect.getsource(cli_runner)
+    idx = source.index("print_truecolor_warning(display_console)")
+    preceding = source[max(0, idx - 400) : idx]
+    warn_line = preceding.rsplit("\n", 2)[-1]
+    assert "get_quiet_startup" not in warn_line

--- a/tests/test_splash_remote_frame_rate.py
+++ b/tests/test_splash_remote_frame_rate.py
@@ -1,0 +1,61 @@
+"""The splash must not flood a remote terminal.
+
+Every frame repaints the whole raster, so the ~30fps local rate writes
+roughly a megabyte of escape sequences during a one-second boot --
+measured at 1,058,225 bytes against 3,363 bytes for the real UI, i.e.
+99.7% of everything the CLI writes to the terminal at startup.
+
+Free on a local terminal. Over SSH or a forwarded tmux it becomes the
+dominant cost of launching, and the animation ends up slower than the
+imports it existed to hide.
+"""
+
+from code_puppy.splash import (
+    _FRAME_SECONDS,
+    _REMOTE_FRAME_SECONDS,
+    _frame_seconds,
+)
+
+REMOTE_MARKERS = ("SSH_CONNECTION", "SSH_TTY", "SSH_CLIENT")
+
+
+def _clear_remote(monkeypatch):
+    for marker in REMOTE_MARKERS:
+        monkeypatch.delenv(marker, raising=False)
+
+
+def test_local_session_keeps_the_smooth_frame_rate(monkeypatch):
+    _clear_remote(monkeypatch)
+    assert _frame_seconds() == _FRAME_SECONDS
+
+
+def test_each_ssh_marker_slows_the_frame_rate(monkeypatch):
+    for marker in REMOTE_MARKERS:
+        _clear_remote(monkeypatch)
+        monkeypatch.setenv(marker, "1")
+        assert _frame_seconds() == _REMOTE_FRAME_SECONDS, f"{marker} not honored"
+
+
+def test_remote_rate_is_actually_slower(monkeypatch):
+    assert _REMOTE_FRAME_SECONDS > _FRAME_SECONDS
+
+
+def test_remote_writes_meaningfully_fewer_frames(monkeypatch):
+    """A one-second boot should cost roughly a third of the bytes."""
+    local_frames = 1.0 / _FRAME_SECONDS
+    remote_frames = 1.0 / _REMOTE_FRAME_SECONDS
+    assert remote_frames <= local_frames / 3
+
+
+def test_empty_marker_is_not_treated_as_remote(monkeypatch):
+    """An exported-but-empty SSH_TTY is not a remote session."""
+    _clear_remote(monkeypatch)
+    monkeypatch.setenv("SSH_TTY", "")
+    assert _frame_seconds() == _FRAME_SECONDS
+
+
+def test_still_animates_remotely(monkeypatch):
+    """Slower, not disabled -- the splash still hides import latency."""
+    _clear_remote(monkeypatch)
+    monkeypatch.setenv("SSH_CONNECTION", "10.0.0.1 22 10.0.0.2 22")
+    assert 0 < _frame_seconds() < 1.0


### PR DESCRIPTION
Five findings from a live design audit of the TUI: I ran the CLI through a pty at 120, 60, and 80 columns and rendered the output with a terminal emulator, so every claim below is a measurement rather than a reading of the source. Each fix is its own commit with tests.

## The prompt wrapped at 80 columns

`get_prompt_with_active_model()` composed four unbounded segments (puppy name, agent, model, cwd) and never consulted the terminal. At 80 columns the prefix measured **82 cells**, wrapped, and split its own `>>>` marker across two rows, leaving the user typing after a lone `>`:

```
airmac-puppy [Code-Puppy 🐶] [claude-code-claude-opus-4-8-long] (~/codepuppy) >>
>
```

`platform_utils.startup_banner_text()` already budgets the *banner* by width (CODE PUPPY → PUP below 79 columns, pinned by a test). This holds the prompt to the same standard: measure with `rich.cells.cell_len` so emoji count as two cells, then reduce in priority order — cwd to its basename, drop the puppy name, drop cwd, drop the agent, and only then middle-truncate the model id, which carries meaning at both ends. The arrow always survives and 24 columns stay clear to type in.

At 80 columns it now renders `[Code-Puppy 🐶] [claude-code-claude-opus-4-8-long] >>>` in 55 cells; at 60, `[claude-code-cl…-opus-4-8-long] >>>`.

**The public signature stays frozen at `(base)` on purpose.** `statusline` and `prompt_newline` both wrap this function as `def patched(base=">>> ")` with no `**kwargs`, so adding a parameter raises `TypeError` through them and takes the prompt out entirely. Width is detected inside instead, and a test pins the signature. Your own plugin tests caught this when I first tried it the other way.

## NO_COLOR was being actively defeated

Rich auto-detects the `NO_COLOR` standard only when its `no_color` argument is left unset. Both consoles in `tools/common.py` passed an explicit boolean that defaults to `False`, and an explicit `False` *overrides* Rich's detection:

```
Console(no_color=False) -> '\x1b[31mdanger\x1b[0m'
Console(no_color=None)  -> 'danger'
```

`splash.py` already honors `NO_COLOR`, which made this worse than a clean miss — the splash obeyed and everything after it did not, so a user had no reason to suspect the rest was ignoring them. Now returns `None` when the project's own override is unset. `CODE_PUPPY_NO_COLOR=1` still forces color off.

## Startup prints nine messages and one of them matters

Eleven rendered lines before the prompt; exactly one is situational — the warning that untrusted project hooks **can run arbitrary shell commands**. It renders with the same weight as `Flux commands installed -> (25 new, 0 updated, 0 backed up, 0 unchanged)`, so the line that could prevent arbitrary code execution sits sixth in a stack of nine.

New `quiet_startup` flag, following the existing `suppress_directory_listing` pattern and advertised through `get_config_keys()`. It skips only decoration owned by this repo: powered-by tagline, observability pitch, core-plugins version, Tab hint, and the legacy `Current version:` line. Warnings, errors, and update notices are never gated on it — the truecolor warning keeps its deliberate print-last placement, and `VersionCheckMessage` still carries `update_available`, so an available update prints even when quiet.

**Defaults to `False`.** No existing install changes behavior. Flipping the default is your call, not a drive-by one — and the remaining lines (context-indicator legend, flux install log, hooks warning) come from `code-puppy-core-plugins` and would need the same treatment there. With it on, startup drops from 11 lines to 4 and the hooks warning lands last, right above the prompt.

## The splash writes ~1 MB to the terminal

Every frame repaints the whole raster. On a cold start that measured **1,058,225 bytes of splash against 3,363 bytes of real UI** — 99.7% of everything written at startup. Frame count scales with import time, so a first run is the worst case.

Free locally; over SSH or a forwarded tmux it becomes the dominant cost of launching, and the animation ends up slower than the imports it existed to hide. Now drops to 10fps when sshd's session markers are present: measured 277,828 → 108,027 bytes for the same warm boot, a 61% reduction. Still animates.

## Three badges asserted things that were not checked

- **Build** used the static `/badge/` endpoint, so it read "Passing" regardless of CI state. Now wired to `ci.yml`'s real workflow status on main.
- **Tests** was also hardcoded, and its link 404'd (`/code_puppy/tests`). `ci.yml` already runs the suite, so a live Tests badge would only restate Build. Removed rather than duplicated.
- **Downloads** was frozen at "170k+". Now `pypi/dm`. I checked `pypi-downloads.yml` first — it reports to Discord and never touched this badge, so nothing was keeping it current.

Static badges for genuinely static facts (Python version, licence, Discord, docs) are left alone.

## Verification

- **7,548 passed, 32 skipped**, `ruff check` and `ruff format` clean.
- Both bugs reproduced against the pre-fix logic before fixing, and the prompt fix verified live in a pty at 60, 80, and 120 columns.
- The width fix is pinned by a sweep asserting no overflow at every width from 30 to 200 columns.

## Not addressed

Repo settings I can't reach: the About panel has no homepage (`code-puppy.dev` returns 200 and is badged in the README) and no topics. Both are a couple of minutes in settings and would be the highest impact-to-effort change available. Happy to open separate PRs for a CONTRIBUTING/SECURITY pass or splitting the agent-authoring half of the README into `docs/` if either is welcome.