### PR TITLE
Fix Windows lock ordering and config decode fallback

### DIFF
--- a/code_puppy/atomic_io.py
+++ b/code_puppy/atomic_io.py
@@ -21,6 +21,7 @@ modules rather than hand-rolling ``open()``/``json.load()`` again.
 from __future__ import annotations
 
 import contextlib
+import errno
 import logging
 import os
 import tempfile
@@ -78,6 +79,68 @@ def _unlock(fd: int) -> None:
         msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
 
 
+def _truncate_fd(fd: int, size: int) -> None:
+    """Best-effort fd truncation across Python/OS builds.
+
+    ``os.ftruncate`` is absent on some Windows Python builds. Fall back to
+    truncating through a duplicated file object when needed.
+    """
+    ftruncate = getattr(os, "ftruncate", None)
+    if callable(ftruncate):
+        try:
+            ftruncate(fd, size)
+            return
+        except NotImplementedError:
+            pass
+        except OSError as exc:
+            if exc.errno != errno.ENOSYS:
+                raise
+
+    dup_fd = os.dup(fd)
+    try:
+        file = os.fdopen(dup_fd, "r+b", buffering=0)
+    except BaseException:
+        os.close(dup_fd)
+        raise
+    with file:
+        file.truncate(size)
+
+
+def _prepare_windows_lockfile(fd: int) -> None:
+    """Normalize the Windows lock sidecar to exactly one byte.
+
+    ``msvcrt.locking`` requires at least one byte to lock. Keep the sidecar at
+    one byte so repeated acquisitions cannot balloon it over time.
+
+    Call this only while holding the lock for this file descriptor.
+    """
+    os.lseek(fd, 0, os.SEEK_SET)
+    if os.fstat(fd).st_size != 1:
+        _truncate_fd(fd, 1)
+        os.lseek(fd, 0, os.SEEK_SET)
+        os.write(fd, b"\0")
+    os.lseek(fd, 0, os.SEEK_SET)
+
+
+def _prime_windows_lockfile_if_empty(fd: int) -> None:
+    """Seed a zero-length Windows sidecar with one byte, best effort.
+
+    ``msvcrt.locking`` can reject locking byte 0 of an empty file on some
+    runtimes. This helper initializes only truly empty sidecars and swallows
+    contention/share-violation errors so lock polling semantics stay intact.
+    """
+    os.lseek(fd, 0, os.SEEK_SET)
+    if os.fstat(fd).st_size != 0:
+        return
+
+    try:
+        os.write(fd, b"\0")
+    except OSError:
+        pass
+    finally:
+        os.lseek(fd, 0, os.SEEK_SET)
+
+
 @contextlib.contextmanager
 def path_lock(
     path: str, timeout: float = DEFAULT_LOCK_TIMEOUT_SECONDS
@@ -94,12 +157,17 @@ def path_lock(
     acquired = False
     try:
         if msvcrt is not None:
-            os.write(fd, b"\0")
+            _prime_windows_lockfile_if_empty(fd)
         deadline = time.monotonic() + timeout
         while not (acquired := _try_lock(fd)):
+            if msvcrt is not None:
+                _prime_windows_lockfile_if_empty(fd)
             if time.monotonic() >= deadline:
                 raise LockTimeout(f"Timed out waiting for lock: {lock_path}")
             time.sleep(_LOCK_POLL_SECONDS)
+
+        if msvcrt is not None:
+            _prepare_windows_lockfile(fd)
         yield
     finally:
         if acquired:

--- a/code_puppy/config_file.py
+++ b/code_puppy/config_file.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 
 import configparser
 import io
+import locale
 import logging
+import os
 from collections.abc import Callable
 
 from code_puppy import atomic_io
@@ -41,6 +43,40 @@ def _config_lock(path: str):
     return atomic_io.path_lock(path, timeout=_LOCK_TIMEOUT_SECONDS)
 
 
+def _decode_config_text(raw: bytes) -> str:
+    """Decode config text as UTF-8, with a narrow Windows locale fallback.
+
+    Canonical on-disk encoding is UTF-8 (with or without BOM). For Windows
+    upgrades from older builds that may have locale-encoded config bytes,
+    make one fallback attempt using the active locale encoding before treating
+    the file as corrupt.
+    """
+    try:
+        return raw.decode("utf-8-sig")
+    except UnicodeDecodeError as utf8_error:
+        if os.name != "nt":
+            raise
+
+        fallback_encoding = locale.getpreferredencoding(False)
+        if not fallback_encoding:
+            raise
+
+        try:
+            decoded = raw.decode(fallback_encoding)
+        except (LookupError, UnicodeDecodeError):
+            raise utf8_error
+
+        if "\x00" in decoded or "[" not in decoded:
+            raise utf8_error
+
+        logger.warning(
+            "Loaded config with Windows locale fallback encoding (%s); "
+            "rewrite as UTF-8 on next save",
+            fallback_encoding,
+        )
+        return decoded
+
+
 def _read_unlocked(path: str) -> configparser.ConfigParser:
     """Read and parse a bounded snapshot; propagate filesystem failures."""
     parser = configparser.ConfigParser()
@@ -50,7 +86,7 @@ def _read_unlocked(path: str) -> configparser.ConfigParser:
         raise ConfigFileCorrupt(str(exc)) from exc
 
     try:
-        text = raw.decode("utf-8")
+        text = _decode_config_text(raw)
         if text:
             parser.read_string(text, source=path)
     except (UnicodeDecodeError, configparser.Error) as exc:

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -157,6 +157,14 @@ class TestAtomicWriteBytes:
         assert leftovers == []
 
 
+class _FakeMsvcrt:
+    LK_NBLCK = 1
+    LK_UNLCK = 2
+
+    def locking(self, _fd, _mode, _nbytes):
+        return None
+
+
 class TestPathLock:
     def test_lock_is_reentrant_safe_after_release(self, target_path):
         with atomic_io.path_lock(str(target_path)):
@@ -174,6 +182,101 @@ class TestPathLock:
     def test_lock_file_created_alongside_target(self, target_path):
         with atomic_io.path_lock(str(target_path)):
             assert os.path.exists(f"{target_path}.lock")
+
+    def test_windows_lock_sidecar_stays_one_byte_even_if_fd_starts_at_end(
+        self, target_path, monkeypatch
+    ):
+        """Guard against sidecar ballooning on Windows-style lock paths."""
+        lock_file = f"{target_path}.lock"
+        real_open = os.open
+
+        def _open_at_end(path, flags, mode=0o777):
+            fd = real_open(path, flags, mode)
+            os.lseek(fd, 0, os.SEEK_END)
+            return fd
+
+        monkeypatch.setattr(atomic_io, "fcntl", None)
+        monkeypatch.setattr(atomic_io, "msvcrt", _FakeMsvcrt())
+        monkeypatch.setattr(atomic_io.os, "open", _open_at_end)
+
+        for _ in range(5):
+            with atomic_io.path_lock(str(target_path)):
+                pass
+
+        assert os.path.getsize(lock_file) == 1
+
+    def test_windows_lock_sidecar_stays_one_byte_without_os_ftruncate(
+        self, target_path, monkeypatch
+    ):
+        lock_file = f"{target_path}.lock"
+        real_open = os.open
+
+        def _open_at_end(path, flags, mode=0o777):
+            fd = real_open(path, flags, mode)
+            os.lseek(fd, 0, os.SEEK_END)
+            return fd
+
+        monkeypatch.setattr(atomic_io, "fcntl", None)
+        monkeypatch.setattr(atomic_io, "msvcrt", _FakeMsvcrt())
+        monkeypatch.setattr(atomic_io.os, "open", _open_at_end)
+        monkeypatch.setattr(atomic_io.os, "ftruncate", None, raising=False)
+
+        for _ in range(5):
+            with atomic_io.path_lock(str(target_path)):
+                pass
+
+        assert os.path.getsize(lock_file) == 1
+
+    def test_windows_contention_does_not_mutate_sidecar_until_lock_acquired(
+        self, target_path, monkeypatch
+    ):
+        lock_file = f"{target_path}.lock"
+        with open(lock_file, "wb") as lock:
+            lock.write(b"oversized-lock")
+
+        attempts = {"n": 0}
+
+        def _contended_then_acquired(_fd):
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                # Simulate another process owning the byte lock: first attempt
+                # must observe the untouched oversized sidecar.
+                assert os.path.getsize(lock_file) == len(b"oversized-lock")
+                return False
+            return True
+
+        monkeypatch.setattr(atomic_io, "fcntl", None)
+        monkeypatch.setattr(atomic_io, "msvcrt", _FakeMsvcrt())
+        monkeypatch.setattr(atomic_io, "_try_lock", _contended_then_acquired)
+
+        with atomic_io.path_lock(str(target_path), timeout=0.5):
+            assert os.path.getsize(lock_file) == 1
+
+        assert attempts["n"] >= 2
+
+    def test_windows_prime_swallows_write_error_on_empty_sidecar(
+        self, target_path, monkeypatch
+    ):
+        lock_file = f"{target_path}.lock"
+        open(lock_file, "wb").close()
+
+        real_write = os.write
+        write_calls = {"n": 0}
+
+        def _flaky_write(fd, data):
+            write_calls["n"] += 1
+            if write_calls["n"] == 1:
+                raise OSError("simulated share violation")
+            return real_write(fd, data)
+
+        monkeypatch.setattr(atomic_io, "fcntl", None)
+        monkeypatch.setattr(atomic_io, "msvcrt", _FakeMsvcrt())
+        monkeypatch.setattr(atomic_io.os, "write", _flaky_write)
+
+        with atomic_io.path_lock(str(target_path), timeout=0.5):
+            pass
+
+        assert write_calls["n"] >= 1
 
 
 class TestConcurrentWritersDoNotLoseUpdates:

--- a/tests/test_config_corruption_resilience.py
+++ b/tests/test_config_corruption_resilience.py
@@ -59,7 +59,60 @@ class TestLoadConfigCorruption:
         assert "not [valid ini" in open(backups[0]).read()
 
     def test_invalid_utf8_is_quarantined(self, cfg_path):
-        cfg_path.write_bytes(b"\xff\xfe garbage \x00\x00 noutf8 [[[")
+        cfg_path.write_bytes(b"\xff\xfe garbage \x00\x00 noutf8 [[[" )
+
+        config = config_file.load_config(str(cfg_path))
+
+        assert isinstance(config, configparser.ConfigParser)
+        assert glob.glob(f"{cfg_path}.corrupted-*")
+
+    def test_utf8_bom_is_accepted_without_quarantine(self, cfg_path):
+        cfg_path.write_bytes("[puppy]\nowner_name = María\n".encode("utf-8-sig"))
+
+        config = config_file.load_config(str(cfg_path))
+
+        assert config.get("puppy", "owner_name") == "María"
+        assert not glob.glob(f"{cfg_path}.corrupted-*")
+
+    def test_windows_locale_encoded_config_is_accepted(self, cfg_path, monkeypatch):
+        cfg_path.write_bytes("[puppy]\nowner_name = María\n".encode("cp1252"))
+        monkeypatch.setattr(config_file.os, "name", "nt", raising=False)
+        monkeypatch.setattr(
+            config_file.locale,
+            "getpreferredencoding",
+            lambda _do_setlocale=False: "cp1252",
+        )
+
+        config = config_file.load_config(str(cfg_path))
+
+        assert config.get("puppy", "owner_name") == "María"
+        assert not glob.glob(f"{cfg_path}.corrupted-*")
+
+    def test_windows_locale_fallback_logs_warning(self, cfg_path, monkeypatch, caplog):
+        cfg_path.write_bytes("[puppy]\nowner_name = María\n".encode("cp1252"))
+        monkeypatch.setattr(config_file.os, "name", "nt", raising=False)
+        monkeypatch.setattr(
+            config_file.locale,
+            "getpreferredencoding",
+            lambda _do_setlocale=False: "cp1252",
+        )
+
+        with caplog.at_level("WARNING"):
+            config_file.load_config(str(cfg_path))
+
+        assert any(
+            "Windows locale fallback encoding" in message
+            for message in caplog.messages
+        )
+
+    def test_windows_locale_fallback_rejects_non_ini_text(self, cfg_path, monkeypatch):
+        cfg_path.write_bytes(b"\x96\x97\x98\x99\x80")
+        monkeypatch.setattr(config_file.os, "name", "nt", raising=False)
+        monkeypatch.setattr(
+            config_file.locale,
+            "getpreferredencoding",
+            lambda _do_setlocale=False: "cp1252",
+        )
 
         config = config_file.load_config(str(cfg_path))
 

--- a/tests/test_config_corruption_resilience.py
+++ b/tests/test_config_corruption_resilience.py
@@ -59,7 +59,7 @@ class TestLoadConfigCorruption:
         assert "not [valid ini" in open(backups[0]).read()
 
     def test_invalid_utf8_is_quarantined(self, cfg_path):
-        cfg_path.write_bytes(b"\xff\xfe garbage \x00\x00 noutf8 [[[" )
+        cfg_path.write_bytes(b"\xff\xfe garbage \x00\x00 noutf8 [[[")
 
         config = config_file.load_config(str(cfg_path))
 
@@ -101,8 +101,7 @@ class TestLoadConfigCorruption:
             config_file.load_config(str(cfg_path))
 
         assert any(
-            "Windows locale fallback encoding" in message
-            for message in caplog.messages
+            "Windows locale fallback encoding" in message for message in caplog.messages
         )
 
     def test_windows_locale_fallback_rejects_non_ini_text(self, cfg_path, monkeypatch):


### PR DESCRIPTION
## Summary
This PR includes the generic core fix set for Windows lock behavior and config decoding hardening:

- acquire the Windows byte lock **before** normalizing/truncating the lock sidecar
- normalize sidecar size only while the lock is held
- best-effort prime for empty lock sidecars so contention errors do not leak
- decode config using `utf-8-sig` (BOM-safe) with a narrow Windows locale fallback for legacy files
- preserve strict corruption handling and quarantine behavior

## Why
A review flagged a lock-ordering issue: sidecar mutation could happen before lock acquisition and potentially leak `OSError` under contention. This change ensures ordering is lock-first, mutate-after-acquire.

## Tests
Added/updated targeted coverage for:
- Windows lock sidecar normalization behavior
- contention regression: sidecar is not mutated until lock acquisition
- empty-sidecar prime path swallowing transient write error
- UTF-8 BOM config decode acceptance
- Windows locale fallback decode handling and warning path

## Validation run
- `pytest -q -o addopts='' tests/test_atomic_io.py tests/test_config_corruption_resilience.py` → **40 passed**
- `ruff check code_puppy/atomic_io.py code_puppy/config_file.py tests/test_atomic_io.py tests/test_config_corruption_resilience.py` → **passed**

## Notes
- Generic/open-source-safe change; no Walmart-specific behavior.
