### PR TITLE
fix(http): hand pydantic-ai providers httpx2 clients

### DIFF
--- a/code_puppy/http_retry.py
+++ b/code_puppy/http_retry.py
@@ -1,0 +1,138 @@
+"""Retry behaviour shared by both httpx families.
+
+Code Puppy talks to providers with two different HTTP libraries:
+
+* legacy ``httpx`` -- the MCP SDK and the Anthropic/Google SDK shims still want it,
+* ``httpx2`` -- what pydantic-ai's providers now require (see ``httpx2_utils``).
+
+The retry algorithm itself only needs ``status_code``, ``headers`` and ``aclose()`` off
+the response object, so it is duck-type compatible with both. The *exception* classes are
+separate hierarchies, though, so a subclass declares its own ``retryable_exceptions``.
+
+Keeping this in one place is what stops the rate-limit/backoff logic from drifting between
+the two client families.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, ClassVar
+
+try:
+    from .messaging import emit_info, emit_warning
+except ImportError:  # pragma: no cover - fallback when messaging is unavailable
+
+    def emit_info(content: str, **metadata: Any) -> None:
+        pass
+
+    def emit_warning(content: str, **metadata: Any) -> None:
+        pass
+
+
+class RetryingSendMixin:
+    """Adds rate-limit handling (429) and retries to an httpx-family ``AsyncClient``.
+
+    This replaces the Tenacity transport with a more direct subclass implementation,
+    which plays nicer with proxies and custom transports. Mix in *before* the client
+    base class so this ``send`` wins the MRO and cooperates via ``super()``::
+
+        class RetryingAsyncClient(RetryingSendMixin, httpx.AsyncClient):
+            retryable_exceptions = (httpx.ConnectError, httpx.ReadTimeout, httpx.PoolTimeout)
+
+    Special handling for Cerebras: their ``Retry-After`` headers are absurdly aggressive
+    (often 60s), so we ignore them and use a 3s base backoff instead.
+    """
+
+    #: Exception types treated as transient connection failures. Set per HTTP family.
+    retryable_exceptions: ClassVar[tuple[type[BaseException], ...]] = ()
+
+    def __init__(
+        self,
+        retry_status_codes: tuple = (429, 502, 503, 504),
+        max_retries: int = 5,
+        model_name: str = "",
+        **kwargs: Any,
+    ):
+        super().__init__(**kwargs)
+        self.retry_status_codes = retry_status_codes
+        self.max_retries = max_retries
+        self.model_name = model_name.lower() if model_name else ""
+        # Cerebras sends crazy aggressive Retry-After headers (60s), ignore them
+        self._ignore_retry_headers = "cerebras" in self.model_name
+
+    async def send(self, request: Any, **kwargs: Any) -> Any:
+        """Send request with automatic retries for rate limits and server errors."""
+        last_response = None
+        last_exception = None
+
+        for attempt in range(self.max_retries + 1):
+            try:
+                response = await super().send(request, **kwargs)
+                last_response = response
+
+                # Check for retryable status
+                if response.status_code not in self.retry_status_codes:
+                    return response
+
+                # Close response if we're going to retry
+                await response.aclose()
+
+                # Determine wait time - Cerebras gets special treatment
+                if self._ignore_retry_headers:
+                    # Cerebras: 3s base with exponential backoff (3s, 6s, 12s...)
+                    wait_time = 3.0 * (2**attempt)
+                else:
+                    # Default exponential backoff: 1s, 2s, 4s...
+                    wait_time = 1.0 * (2**attempt)
+
+                    # Check Retry-After header (only for non-Cerebras)
+                    retry_after = response.headers.get("Retry-After")
+                    if retry_after:
+                        try:
+                            wait_time = float(retry_after)
+                        except ValueError:
+                            # Try parsing http-date
+                            from email.utils import parsedate_to_datetime
+
+                            try:
+                                date = parsedate_to_datetime(retry_after)
+                                wait_time = date.timestamp() - time.time()
+                            except Exception:
+                                pass
+
+                # Cap wait time
+                wait_time = max(0.5, min(wait_time, 60.0))
+
+                if attempt < self.max_retries:
+                    provider_note = (
+                        " (ignoring header)" if self._ignore_retry_headers else ""
+                    )
+                    emit_info(
+                        f"HTTP retry: {response.status_code} received{provider_note}. "
+                        f"Waiting {wait_time:.1f}s (attempt {attempt + 1}/{self.max_retries})"
+                    )
+                    await asyncio.sleep(wait_time)
+
+            except self.retryable_exceptions as e:
+                last_exception = e
+                wait_time = 1.0 * (2**attempt)
+                if attempt < self.max_retries:
+                    emit_warning(
+                        f"HTTP connection error: {e}. Retrying in {wait_time}s..."
+                    )
+                    await asyncio.sleep(wait_time)
+                else:
+                    raise
+            except Exception:
+                raise
+
+        # Return last response (even if it's an error status)
+        if last_response:
+            return last_response
+
+        # Should catch this in loop, but just in case
+        if last_exception:
+            raise last_exception
+
+        return last_response

--- a/code_puppy/http_utils.py
+++ b/code_puppy/http_utils.py
@@ -4,18 +4,18 @@ HTTP utilities module for code-puppy.
 This module provides functions for creating properly configured HTTP clients.
 """
 
-import asyncio
 import os
 import socket
-import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
 import httpx
 
 if TYPE_CHECKING:
     import requests
 from code_puppy.config import get_http2
+
+from .http_retry import RetryingSendMixin
 
 
 @dataclass
@@ -29,11 +29,14 @@ class ProxyConfig:
     http2_enabled: bool
 
 
-def _resolve_proxy_config(verify: Union[bool, str, None] = None) -> ProxyConfig:
+def resolve_proxy_config(verify: Union[bool, str, None] = None) -> ProxyConfig:
     """Resolve proxy, SSL, and retry settings from environment.
 
     This centralizes the logic for detecting proxies, determining SSL verification,
     and checking if retry transport should be disabled.
+
+    Shared by the legacy ``httpx`` and ``httpx2`` client factories so proxy handling
+    cannot drift between the two.
     """
     if verify is None:
         verify = get_cert_bundle_path()
@@ -97,105 +100,15 @@ except ImportError:
         pass
 
 
-class RetryingAsyncClient(httpx.AsyncClient):
+class RetryingAsyncClient(RetryingSendMixin, httpx.AsyncClient):
     """AsyncClient with built-in rate limit handling (429) and retries.
 
-    This replaces the Tenacity transport with a more direct subclass implementation,
-    which plays nicer with proxies and custom transports.
-
-    Special handling for Cerebras: Their Retry-After headers are absurdly aggressive
-    (often 60s), so we ignore them and use a 3s base backoff instead.
+    Retry behaviour lives in :class:`~code_puppy.http_retry.RetryingSendMixin` so the
+    ``httpx2`` client in :mod:`code_puppy.httpx2_utils` shares the exact same backoff
+    rules; only the exception hierarchy differs per HTTP family.
     """
 
-    def __init__(
-        self,
-        retry_status_codes: tuple = (429, 502, 503, 504),
-        max_retries: int = 5,
-        model_name: str = "",
-        **kwargs,
-    ):
-        super().__init__(**kwargs)
-        self.retry_status_codes = retry_status_codes
-        self.max_retries = max_retries
-        self.model_name = model_name.lower() if model_name else ""
-        # Cerebras sends crazy aggressive Retry-After headers (60s), ignore them
-        self._ignore_retry_headers = "cerebras" in self.model_name
-
-    async def send(self, request: httpx.Request, **kwargs: Any) -> httpx.Response:
-        """Send request with automatic retries for rate limits and server errors."""
-        last_response = None
-        last_exception = None
-
-        for attempt in range(self.max_retries + 1):
-            try:
-                response = await super().send(request, **kwargs)
-                last_response = response
-
-                # Check for retryable status
-                if response.status_code not in self.retry_status_codes:
-                    return response
-
-                # Close response if we're going to retry
-                await response.aclose()
-
-                # Determine wait time - Cerebras gets special treatment
-                if self._ignore_retry_headers:
-                    # Cerebras: 3s base with exponential backoff (3s, 6s, 12s...)
-                    wait_time = 3.0 * (2**attempt)
-                else:
-                    # Default exponential backoff: 1s, 2s, 4s...
-                    wait_time = 1.0 * (2**attempt)
-
-                    # Check Retry-After header (only for non-Cerebras)
-                    retry_after = response.headers.get("Retry-After")
-                    if retry_after:
-                        try:
-                            wait_time = float(retry_after)
-                        except ValueError:
-                            # Try parsing http-date
-                            from email.utils import parsedate_to_datetime
-
-                            try:
-                                date = parsedate_to_datetime(retry_after)
-                                wait_time = date.timestamp() - time.time()
-                            except Exception:
-                                pass
-
-                # Cap wait time
-                wait_time = max(0.5, min(wait_time, 60.0))
-
-                if attempt < self.max_retries:
-                    provider_note = (
-                        " (ignoring header)" if self._ignore_retry_headers else ""
-                    )
-                    emit_info(
-                        f"HTTP retry: {response.status_code} received{provider_note}. "
-                        f"Waiting {wait_time:.1f}s (attempt {attempt + 1}/{self.max_retries})"
-                    )
-                    await asyncio.sleep(wait_time)
-
-            except (httpx.ConnectError, httpx.ReadTimeout, httpx.PoolTimeout) as e:
-                last_exception = e
-                wait_time = 1.0 * (2**attempt)
-                if attempt < self.max_retries:
-                    emit_warning(
-                        f"HTTP connection error: {e}. Retrying in {wait_time}s..."
-                    )
-                    await asyncio.sleep(wait_time)
-                else:
-                    raise
-            except Exception:
-                raise
-
-        # Return last response (even if it's an error status)
-        if last_response:
-            return last_response
-
-        # Should catch this in loop, but just in case
-        if last_exception:
-            raise last_exception
-
-        return last_response
+    retryable_exceptions = (httpx.ConnectError, httpx.ReadTimeout, httpx.PoolTimeout)
 
 
 def get_cert_bundle_path() -> str | None:
@@ -203,6 +116,10 @@ def get_cert_bundle_path() -> str | None:
     ssl_cert_file = os.environ.get("SSL_CERT_FILE")
     if ssl_cert_file and os.path.exists(ssl_cert_file):
         return ssl_cert_file
+
+
+# Back-compat alias; the name was private before the httpx2 factory started sharing it.
+_resolve_proxy_config = resolve_proxy_config
 
 
 def create_client(
@@ -234,7 +151,7 @@ def create_async_client(
     retry_status_codes: tuple = (429, 502, 503, 504),
     model_name: str = "",
 ) -> httpx.AsyncClient:
-    config = _resolve_proxy_config(verify)
+    config = resolve_proxy_config(verify)
 
     if not config.disable_retry:
         return RetryingAsyncClient(
@@ -307,7 +224,7 @@ def create_reopenable_async_client(
     retry_status_codes: tuple = (429, 502, 503, 504),
     model_name: str = "",
 ) -> Union[ReopenableAsyncClient, httpx.AsyncClient]:
-    config = _resolve_proxy_config(verify)
+    config = resolve_proxy_config(verify)
 
     base_kwargs = {
         "proxy": config.proxy_url,

--- a/code_puppy/httpx2_utils.py
+++ b/code_puppy/httpx2_utils.py
@@ -1,0 +1,67 @@
+"""``httpx2`` HTTP clients for pydantic-ai providers.
+
+pydantic-ai 2.x hands caller-owned HTTP clients to its providers and warns that legacy
+``httpx.AsyncClient`` support "will be removed in v3" (``PydanticAIDeprecationWarning``,
+raised from ``pydantic_ai/providers/_openai_compatible.py``). Any client we build and pass
+as ``http_client=`` therefore needs to come from ``httpx2``.
+
+Clients that never reach a pydantic-ai provider -- the MCP SDK, ``AsyncAnthropic``, and
+Code Puppy's own ``GeminiModel`` -- keep using :mod:`code_puppy.http_utils`, because those
+libraries are still typed against legacy ``httpx``.
+
+Proxy/SSL/HTTP2 resolution is shared with the legacy factory via
+:func:`~code_puppy.http_utils.resolve_proxy_config`, and retry/backoff is shared via
+:class:`~code_puppy.http_retry.RetryingSendMixin`, so behaviour is identical across both
+HTTP families.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Union
+
+import httpx2
+
+from .http_retry import RetryingSendMixin
+from .http_utils import resolve_proxy_config
+
+
+class RetryingAsyncClient(RetryingSendMixin, httpx2.AsyncClient):
+    """``httpx2`` AsyncClient with built-in rate limit (429) and retry handling.
+
+    Same backoff rules as :class:`~code_puppy.http_utils.RetryingAsyncClient`; only the
+    exception hierarchy differs, since ``httpx2`` exceptions do not subclass ``httpx``'s.
+    """
+
+    retryable_exceptions = (httpx2.ConnectError, httpx2.ReadTimeout, httpx2.PoolTimeout)
+
+
+def create_async_client(
+    timeout: int = 180,
+    verify: Union[bool, str] = None,
+    headers: Optional[Dict[str, str]] = None,
+    retry_status_codes: tuple = (429, 502, 503, 504),
+    model_name: str = "",
+) -> httpx2.AsyncClient:
+    """Build an ``httpx2`` AsyncClient for use as a pydantic-ai provider's ``http_client``.
+
+    Drop-in replacement for :func:`code_puppy.http_utils.create_async_client`, returning an
+    ``httpx2`` client so pydantic-ai's providers do not emit a deprecation warning.
+    """
+    config = resolve_proxy_config(verify)
+
+    client_kwargs = {
+        "proxy": config.proxy_url,
+        "verify": config.verify,
+        "headers": headers or {},
+        "timeout": timeout,
+        "http2": config.http2_enabled,
+        "trust_env": config.trust_env,
+    }
+
+    if not config.disable_retry:
+        return RetryingAsyncClient(
+            retry_status_codes=retry_status_codes,
+            model_name=model_name,
+            **client_kwargs,
+        )
+    return httpx2.AsyncClient(**client_kwargs)

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -5,7 +5,6 @@ import pathlib
 from collections.abc import Mapping
 from typing import Any, Dict, Optional
 
-import httpx
 from anthropic import AsyncAnthropic
 from openai import AsyncAzureOpenAI
 from pydantic_ai.models.anthropic import AnthropicModel, AnthropicModelSettings
@@ -27,6 +26,7 @@ from . import callbacks
 from .claude_cache_client import ClaudeCacheAsyncClient
 from .config import EXTRA_MODELS_FILE, get_value, get_yolo_mode
 from .http_utils import create_async_client, get_cert_bundle_path, get_http2
+from .httpx2_utils import create_async_client as create_provider_async_client
 from .provider_identity import (
     make_anthropic_provider,
     make_openai_provider,
@@ -943,14 +943,13 @@ class ModelFactory:
 
         elif model_type in _CUSTOM_OPENAI_MODEL_TYPES:
             url, headers, verify, api_key, timeout = get_custom_config(model_config)
-            client = create_async_client(
+            # httpx2: pydantic-ai's providers deprecate caller-owned legacy httpx clients.
+            client = create_provider_async_client(
                 headers=headers,
                 verify=verify,
                 timeout=timeout if timeout is not None else 180,
             )
-            provider_args = {"base_url": url}
-            if isinstance(client, httpx.AsyncClient):
-                provider_args["http_client"] = client
+            provider_args = {"base_url": url, "http_client": client}
             if api_key:
                 provider_args["api_key"] = api_key
             provider = make_openai_provider(provider_identity, **provider_args)
@@ -1040,7 +1039,8 @@ class ModelFactory:
             headers["X-Cerebras-3rd-Party-Integration"] = "code-puppy"
             # "cerebras" tells RetryingAsyncClient to ignore Cerebras's aggressive
             # Retry-After headers (they send 60s!). [name] is internal, not provider.
-            client = create_async_client(
+            # httpx2: pydantic-ai's providers deprecate caller-owned legacy httpx clients.
+            client = create_provider_async_client(
                 headers=headers,
                 verify=verify,
                 model_name="cerebras",

--- a/tests/test_httpx2_provider_migration.py
+++ b/tests/test_httpx2_provider_migration.py
@@ -1,0 +1,164 @@
+"""Regression tests for the legacy httpx -> httpx2 provider migration.
+
+Guards issue #876: pydantic-ai warns that caller-owned legacy ``httpx.AsyncClient``
+support on OpenAI-compatible providers is removed in v3. These tests pin three things:
+
+1. the provider-bound clients are ``httpx2``,
+2. building those models raises no ``PydanticAIDeprecationWarning``,
+3. the legacy ``httpx`` clients that MCP / Gemini still require keep working unchanged.
+"""
+
+import warnings
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import httpx2
+import pytest
+from pydantic_ai.exceptions import PydanticAIDeprecationWarning
+
+import code_puppy.http_utils as http_utils
+import code_puppy.httpx2_utils as httpx2_utils
+from code_puppy.http_retry import RetryingSendMixin
+from code_puppy.model_factory import ModelFactory
+
+CUSTOM_ENDPOINT = {
+    "url": "https://fake.url/v1",
+    "headers": {"X-Api-Key": "$TEST_PROVIDER_KEY"},
+    "ca_certs_path": False,
+    "api_key": "$TEST_PROVIDER_KEY",
+}
+
+
+@pytest.fixture(autouse=True)
+def _provider_key(monkeypatch):
+    monkeypatch.setenv("TEST_PROVIDER_KEY", "ok")
+
+
+def _deprecations(caught):
+    return [w for w in caught if issubclass(w.category, PydanticAIDeprecationWarning)]
+
+
+class TestHttpx2ClientFactory:
+    def test_factory_returns_httpx2_retrying_client(self):
+        client = httpx2_utils.create_async_client(timeout=60)
+        try:
+            assert isinstance(client, httpx2.AsyncClient)
+            assert isinstance(client, httpx2_utils.RetryingAsyncClient)
+            # Must NOT be a legacy client, or pydantic-ai warns again.
+            assert not isinstance(client, httpx.AsyncClient)
+        finally:
+            _close_soon(client)
+
+    def test_factory_honours_retry_transport_disable(self, monkeypatch):
+        monkeypatch.setenv("CODE_PUPPY_DISABLE_RETRY_TRANSPORT", "true")
+        client = httpx2_utils.create_async_client(timeout=60)
+        try:
+            assert isinstance(client, httpx2.AsyncClient)
+            assert not isinstance(client, httpx2_utils.RetryingAsyncClient)
+        finally:
+            _close_soon(client)
+
+    def test_factory_mirrors_legacy_kwargs(self):
+        """Both families must resolve proxy/verify/http2/timeout the same way."""
+        legacy = http_utils.create_async_client(timeout=77, headers={"X-A": "1"})
+        modern = httpx2_utils.create_async_client(timeout=77, headers={"X-A": "1"})
+        try:
+            assert legacy.timeout.read == modern.timeout.read == 77
+            assert dict(legacy.headers)["x-a"] == dict(modern.headers)["x-a"] == "1"
+        finally:
+            _close_soon(legacy)
+            _close_soon(modern)
+
+
+class TestRetryMixinShared:
+    """The retry algorithm is defined once and reused by both HTTP families."""
+
+    def test_both_retrying_clients_share_the_mixin(self):
+        assert issubclass(http_utils.RetryingAsyncClient, RetryingSendMixin)
+        assert issubclass(httpx2_utils.RetryingAsyncClient, RetryingSendMixin)
+
+    def test_legacy_client_is_still_legacy_httpx_for_mcp(self):
+        """MCP and AsyncAnthropic are typed against legacy httpx - do not migrate them."""
+        client = http_utils.create_async_client()
+        try:
+            assert isinstance(client, httpx.AsyncClient)
+            assert not isinstance(client, httpx2.AsyncClient)
+        finally:
+            _close_soon(client)
+
+    @pytest.mark.parametrize(
+        "family,client_cls",
+        [
+            (httpx, http_utils.RetryingAsyncClient),
+            (httpx2, httpx2_utils.RetryingAsyncClient),
+        ],
+        ids=["httpx", "httpx2"],
+    )
+    async def test_retry_after_429_shared_by_both_families(self, family, client_cls):
+        calls = {"n": 0}
+
+        def handler(request):
+            calls["n"] += 1
+            status = 429 if calls["n"] == 1 else 200
+            return family.Response(status, request=request)
+
+        # Request/transport classes are family-specific, the retry logic is not.
+        client = client_cls(transport=family.MockTransport(handler), max_retries=2)
+        with patch("code_puppy.http_retry.asyncio.sleep", new_callable=AsyncMock):
+            response = await client.send(family.Request("GET", "https://fake.url/x"))
+        await client.aclose()
+
+        assert response.status_code == 200
+        assert calls["n"] == 2
+
+
+class TestProvidersEmitNoDeprecation:
+    """The real bug: building a model must not raise pydantic-ai's v3 warning."""
+
+    @pytest.mark.parametrize(
+        ("model_type", "extra"),
+        [
+            ("custom_openai", {}),
+            ("custom_openai", {"use_responses_api": True}),
+            ("cerebras", {}),
+        ],
+        ids=["custom_openai", "custom_openai_responses", "cerebras"],
+    )
+    def test_get_model_raises_no_deprecation_warning(self, model_type, extra):
+        config = {
+            "custom": {
+                "type": model_type,
+                "name": "whatever",
+                "custom_endpoint": CUSTOM_ENDPOINT,
+                **extra,
+            }
+        }
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            model = ModelFactory.get_model("custom", config)
+
+        assert model is not None
+        assert _deprecations(caught) == []
+
+    def test_provider_client_is_httpx2(self):
+        config = {
+            "custom": {
+                "type": "custom_openai",
+                "name": "whatever",
+                "custom_endpoint": CUSTOM_ENDPOINT,
+            }
+        }
+        model = ModelFactory.get_model("custom", config)
+        client = model._provider.client._client
+        assert isinstance(client, httpx2.AsyncClient)
+
+
+def _close_soon(client):
+    """Fire-and-close an async client created inside a sync test."""
+    import asyncio
+
+    try:
+        asyncio.run(client.aclose())
+    except RuntimeError:  # pragma: no cover - defensive
+        pass

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -2,6 +2,7 @@ import os
 from unittest.mock import MagicMock, patch
 
 import httpx
+import httpx2
 import pytest
 
 from code_puppy.model_factory import ModelFactory, make_model_settings
@@ -178,14 +179,23 @@ def test_custom_openai_happy(monkeypatch):
     assert hasattr(model._provider, "base_url")
 
 
+# The factory has two HTTP-client seams. OpenAI-compatible paths must hand pydantic-ai an
+# httpx2 client (legacy httpx is deprecated there); custom_gemini feeds Code Puppy's own
+# GeminiModel, which is still typed against legacy httpx.
+_HTTPX2_SEAM = "create_provider_async_client"
+_LEGACY_SEAM = "create_async_client"
+
+
 @pytest.mark.parametrize(
-    ("env_var", "model_type", "model_name"),
+    ("env_var", "model_type", "model_name", "client_seam", "client_cls"),
     [
-        ("OPENAI_API_KEY", "custom_openai", "cust"),
-        ("CUSTOM_API_KEY", "custom_gemini", "gemini"),
+        ("OPENAI_API_KEY", "custom_openai", "cust", _HTTPX2_SEAM, httpx2.AsyncClient),
+        ("CUSTOM_API_KEY", "custom_gemini", "gemini", _LEGACY_SEAM, httpx.AsyncClient),
     ],
 )
-def test_custom_timeout_config(monkeypatch, env_var, model_type, model_name):
+def test_custom_timeout_config(
+    monkeypatch, env_var, model_type, model_name, client_seam, client_cls
+):
     monkeypatch.setenv(env_var, "ok")
     config = {
         "custom": {
@@ -201,8 +211,8 @@ def test_custom_timeout_config(monkeypatch, env_var, model_type, model_name):
         }
     }
 
-    with patch("code_puppy.model_factory.create_async_client") as mock_client:
-        mock_client.return_value = httpx.AsyncClient(timeout=600)
+    with patch(f"code_puppy.model_factory.{client_seam}") as mock_client:
+        mock_client.return_value = client_cls(timeout=600)
         model = ModelFactory.get_model("custom", config)
 
     mock_client.assert_called_once_with(
@@ -382,7 +392,6 @@ async def test_wire_format_merges_leading_system_messages():
     This directly proves the bug is fixed — two leading SystemPromptParts +
     instruction_parts produce one merged system message on the wire, not two.
     """
-    import httpx
     from pydantic_ai.messages import (
         InstructionPart,
         ModelRequest,
@@ -397,7 +406,7 @@ async def test_wire_format_merges_leading_system_messages():
 
     from code_puppy.model_factory import _strict_openai_profile
 
-    async with httpx.AsyncClient(base_url="http://localhost:30000") as client:
+    async with httpx2.AsyncClient(base_url="http://localhost:30000") as client:
         provider = OpenAIProvider(api_key="dummy", http_client=client)
         model = OpenAIChatModel(
             model_name="qwen-sglang",
@@ -489,8 +498,8 @@ def test_cerebras_timeout_config(monkeypatch):
         }
     }
 
-    with patch("code_puppy.model_factory.create_async_client") as mock_client:
-        mock_client.return_value = httpx.AsyncClient(timeout=600)
+    with patch(f"code_puppy.model_factory.{_HTTPX2_SEAM}") as mock_client:
+        mock_client.return_value = httpx2.AsyncClient(timeout=600)
         model = ModelFactory.get_model("custom", config)
 
     mock_client.assert_called_once_with(
@@ -652,8 +661,8 @@ def test_custom_timeout_precedence(monkeypatch):
         }
     }
 
-    with patch("code_puppy.model_factory.create_async_client") as mock_client:
-        mock_client.return_value = httpx.AsyncClient(timeout=300)
+    with patch(f"code_puppy.model_factory.{_HTTPX2_SEAM}") as mock_client:
+        mock_client.return_value = httpx2.AsyncClient(timeout=300)
         model = ModelFactory.get_model("custom", config)
 
     # Should use top-level timeout (300), not custom_endpoint timeout (600)


### PR DESCRIPTION
## What

Kills the `PydanticAIDeprecationWarning` that fired on every `custom_openai` / `cerebras` model build:

```
`httpx.AsyncClient` support for OpenAI-compatible providers is deprecated and
will be removed in v3; use `httpx2.AsyncClient` instead.
```

Closes #876

## Scope (measured, not guessed)

The warning comes from `pydantic_ai/providers/_openai_compatible.py` whenever a caller-owned **legacy** `httpx.AsyncClient` is passed as a provider `http_client`. Reproduced and located exactly two production sites, both fed by `http_utils.create_async_client`:

| site | provider |
|---|---|
| `model_factory.py` `custom_openai` | `OpenAIProvider(http_client=...)` |
| `model_factory.py` `cerebras` | `CerebrasProvider(http_client=...)` |

Deliberately **not** migrated (not pydantic-ai provider consumers; the MCP SDK is typed against legacy `httpx`, and a blanket sweep would have broken it):

- `code_puppy/mcp_/*` - MCP SDK wants legacy `httpx.AsyncClient`
- `GeminiModel` - our own `Model`; talks httpx directly, client never reaches a provider
- `AsyncAnthropic` - already httpx2-based upstream via `ClaudeCacheAsyncClient`

## How

- **`code_puppy/http_retry.py`** (new): the ~100 lines of rate-limit/backoff `send()` logic extracted into an HTTP-library-agnostic `RetryingSendMixin`. Only the exception hierarchy differs per family, so each client declares `retryable_exceptions`. This is what keeps the retry algorithm from forking into two divergent copies.
- **`code_puppy/httpx2_utils.py`** (new): `create_async_client()` returning an `httpx2` client, mirroring the legacy factory's signature and reusing `resolve_proxy_config` so proxy/SSL/HTTP2 handling is shared.
- `http_utils.RetryingAsyncClient` is now `(RetryingSendMixin, httpx.AsyncClient)` - same behaviour, no duplicated retry code.
- Dropped the `isinstance(client, httpx.AsyncClient)` guard in the `custom_openai` branch. Post-migration it is never true, and it would have **silently** dropped `http_client` (losing custom headers, CA bundle and timeouts) instead of failing loudly.

## Tests

- New `tests/test_httpx2_provider_migration.py` (11 tests): pins the client family, asserts `ModelFactory.get_model` raises **no** deprecation warning for `custom_openai`/`cerebras`, runs the shared 429-retry path against *both* families, and guards that the legacy client stays legacy for MCP.
- Updated 3 seams in `tests/test_model_factory.py` to patch the correct factory per model type (`custom_gemini` legitimately still uses the legacy one), plus the one test that built a legacy client itself.

Full suite: `7533 passed, 33 skipped, 6 failed`. The 6 failures are grep/ripgrep tests that **fail identically on pristine `main`** with no changes applied - verified by stashing; unrelated to this PR.

Refs #876