### PR TITLE
fix(mcp): a failing MCP tool degrades the turn, never kills the session

### DIFF
--- a/code_puppy/mcp_/managed_server.py
+++ b/code_puppy/mcp_/managed_server.py
@@ -269,10 +269,19 @@ class ManagedMCPServer:
         'optional'. Pinned off to preserve the direct-call semantics our
         timeout/stderr-capture/blocking-startup plumbing was built against;
         servers that *require* tasks still get them regardless of this flag.
+
+        ``tool_error_behavior="failed"``: a failing MCP tool must not end the
+        session. The default ``"retry"`` exhausts the retry budget and then
+        raises ``UnexpectedModelBehavior``, which is not an ``McpError`` and
+        so reaches the generic handler in ``run_agent_task`` and aborts the
+        run. ``"failed"`` hands the model a failed tool result instead, like
+        a native tool returning an error string. Bound repeated failures with
+        ``UsageLimits`` at the run level.
         """
         kwargs: Dict[str, Any] = {
             "process_tool_call": process_tool_call,
             "prefer_tasks": False,
+            "tool_error_behavior": "failed",
         }
         if "timeout" in config:
             kwargs["init_timeout"] = config["timeout"]

--- a/tests/mcp/test_managed_server.py
+++ b/tests/mcp/test_managed_server.py
@@ -414,6 +414,27 @@ class TestCreateServerSSE:
         assert mock_transport.call_args.kwargs["httpx_client_factory"] is None
 
 
+class TestToolErrorsAreNotFatal:
+    """A failing MCP tool must degrade the turn, never end the session.
+
+    Under the default ``"retry"``, exhausting the budget raises
+    ``UnexpectedModelBehavior`` — not an ``McpError``, so it reaches the
+    generic handler and aborts the run.
+    """
+
+    def test_sse_marks_tool_errors_failed(self):
+        _, mock_toolset, _ = _sse()
+        assert mock_toolset.call_args.kwargs["tool_error_behavior"] == "failed"
+
+    def test_http_marks_tool_errors_failed(self):
+        _, mock_toolset, _ = _http()
+        assert mock_toolset.call_args.kwargs["tool_error_behavior"] == "failed"
+
+    def test_stdio_marks_tool_errors_failed(self):
+        _, _, mock_cls = _stdio()
+        assert mock_cls.call_args.kwargs["tool_error_behavior"] == "failed"
+
+
 class TestCreateServerStdio:
     def test_requires_command(self):
         server = ManagedMCPServer(

--- a/tests/mcp/test_tool_failure_not_fatal.py
+++ b/tests/mcp/test_tool_failure_not_fatal.py
@@ -1,0 +1,101 @@
+"""A failing MCP tool must not end the agent run.
+
+Behavioral counterpart to the wiring assertions in ``test_managed_server``,
+run against a real stdio MCP server: ``"retry"`` kills the run once the budget
+is spent, ``"failed"`` survives. Mock-based tests alone would keep passing if
+pydantic-ai ever redefined these semantics.
+"""
+
+import sys
+import textwrap
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
+from pydantic_ai.models.function import FunctionModel
+
+# A server whose only tool always raises, mimicking the reported JS error.
+_SERVER_SOURCE = textwrap.dedent(
+    """
+    from mcp.server.fastmcp import FastMCP
+
+    mcp = FastMCP("boom")
+
+    @mcp.tool()
+    def evaluate_script(script: str) -> str:
+        "Evaluate a script in the page."
+        raise RuntimeError("Error: Cannot read properties of null (reading 'click')")
+
+    if __name__ == "__main__":
+        mcp.run()
+    """
+).strip()
+
+RETRIES = 3
+ANSWER = "The tool failed; carrying on."
+
+
+@pytest.fixture
+def failing_server(tmp_path):
+    """Path to a stdio MCP server whose single tool always fails."""
+    script = tmp_path / "always_fails_server.py"
+    script.write_text(_SERVER_SOURCE)
+    return script
+
+
+def _model_that_keeps_calling(tool_name: str, calls: dict):
+    """Calls ``tool_name`` past the retry budget, then answers.
+
+    Going past the budget is the point — that boundary is where the default
+    behavior raises instead of letting the model continue.
+    """
+
+    def model_fn(messages, info):
+        calls["n"] += 1
+        if calls["n"] <= RETRIES + 2:
+            return ModelResponse(
+                parts=[ToolCallPart(tool_name, {"script": "el.click()"})]
+            )
+        return ModelResponse(parts=[TextPart(ANSWER)])
+
+    return model_fn
+
+
+async def _run_with(behavior: str, server_script) -> str:
+    """Run an agent against the always-failing server; return its output."""
+    from fastmcp.client.transports import StdioTransport
+    from pydantic_ai.mcp import MCPToolset
+
+    toolset = MCPToolset(
+        StdioTransport(command=sys.executable, args=[str(server_script)]),
+        tool_error_behavior=behavior,
+        prefer_tasks=False,
+    ).prefixed("boom")
+
+    calls = {"n": 0}
+    agent = Agent(
+        FunctionModel(_model_that_keeps_calling("boom_evaluate_script", calls)),
+        toolsets=[toolset],
+        retries=RETRIES,
+    )
+    result = await agent.run("Click the button.")
+    return result.output
+
+
+@pytest.mark.asyncio
+async def test_failing_tool_does_not_kill_the_run(failing_server):
+    """Our setting: the model sees the failure and finishes the turn."""
+    assert await _run_with("failed", failing_server) == ANSWER
+
+
+@pytest.mark.asyncio
+async def test_default_retry_behavior_would_kill_the_run(failing_server):
+    """Characterize the default we are deliberately overriding.
+
+    If this ever stops raising, pydantic-ai changed its retry semantics and
+    the override above should be re-evaluated rather than blindly kept.
+    """
+    from pydantic_ai.exceptions import UnexpectedModelBehavior
+
+    with pytest.raises(UnexpectedModelBehavior, match="exceeded max retries"):
+        await _run_with("retry", failing_server)


### PR DESCRIPTION
An MCP tool that reports an error ends the whole run. A `chrome-devtools` call hit an in-page `Cannot read properties of null (reading 'click')` — a stale selector — and terminated an interactive session.

`MCPToolset` defaults to `tool_error_behavior="retry"`, which turns every tool error into a `ModelRetry`. Once the budget is spent that becomes `UnexpectedModelBehavior`, which is not an `McpError`, so it reaches the generic `except*` arm in `run_agent_task`, prints a traceback, and re-raises.

The retry ladder isn't the problem — the model self-corrects a bad selector on its own. The problem is that exhausting it is treated as a fatal runtime fault rather than as a tool that failed.

**Fix:** `tool_error_behavior="failed"` on the shared toolset kwargs, covering SSE, stdio and streamable HTTP. The model receives a failed tool result and adapts, exactly as it does for a native tool returning an error string. It also doesn't consume the retry budget, so `UsageLimits` bounds runaway failures at the run level.

Measured against a real stdio MCP server whose only tool always raises:

```
tool_error_behavior='retry'   RUN DIED  -> UnexpectedModelBehavior: exceeded max retries count of 3
tool_error_behavior='failed'  SURVIVED  -> model saw the failure and finished the turn
```

Tests: wiring assertions per transport, plus that behavioral test and a characterization test pinning the `"retry"` default — so a future pydantic-ai change fails loudly rather than silently restoring the crash.

One caveat: the A/B only shows a difference if the model calls the tool *past* the budget. Fewer failures than `retries` and both settings survive.