### PR TITLE
fix(mcp): an unreachable HTTP connector degrades the turn, never ends it

### DIFF
--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -599,6 +599,36 @@ def _checkpoint_cancelled_history(exc_group: BaseException, agent: Any) -> None:
         pass
 
 
+def _is_mcp_transport_failure(exc: BaseException) -> bool:
+    """True for an HTTP/SSE MCP connector that could not be reached.
+
+    A stdio server's readiness is probed at startup, but an HTTP/SSE
+    connector is only dialed when the run task enters the combined toolset.
+    A 401 (expired token, wrong host), a 5xx, or a refused/timed-out
+    connection therefore surfaces mid-run as a raw ``httpx`` error from
+    inside the transport, not as an ``McpError`` — the protocol never got
+    far enough to speak MCP.
+
+    Without this it reaches the generic arm, prints a traceback, and ends
+    the run. One unreachable connector must not do that: the model and
+    every healthy toolset are still usable, so we degrade like ``McpError``.
+
+    Matched by type rather than message so it holds across httpx versions.
+    Note this is deliberately broader than ``_RETRYABLE_EXCEPTIONS``, which
+    excludes ``HTTPStatusError`` because a 401 is not worth retrying — it is
+    still worth surviving.
+    """
+    return isinstance(
+        exc,
+        (
+            httpx.HTTPStatusError,
+            httpx.TransportError,  # ConnectError, ReadTimeout, PoolTimeout, ...
+            httpcore.ConnectError,
+            httpcore.ConnectTimeout,
+        ),
+    )
+
+
 def _collect_exceptions(
     group: BaseException, predicate: Callable[[BaseException], bool]
 ) -> List[BaseException]:
@@ -922,6 +952,26 @@ async def _run_with_mcp_impl(
                     not isinstance(e, (asyncio.CancelledError, UsageLimitExceeded))
                 ),
             )
+            # An HTTP/SSE connector that 401'd or was unreachable is
+            # degraded, not fatal — treat it like McpError: one short nudge,
+            # no traceback, don't re-raise. Pulled out BEFORE the diagnostics
+            # dump so one dead connector can't abort the turn.
+            mcp_transport = [e for e in unexpected if _is_mcp_transport_failure(e)]
+            unexpected = [e for e in unexpected if e not in mcp_transport]
+            if mcp_transport:
+                import logging as _logging
+
+                _logging.getLogger(__name__).debug(
+                    "MCP transport failure(s) during agent run: %s", mcp_transport
+                )
+                emit_warning(
+                    "An MCP server was unreachable this turn (auth or "
+                    "connection failure), so the turn stopped before the model "
+                    "ran — but your session is fine. Fix or disable that "
+                    "connector and resend: [cyan]/mcp status[/cyan] to see "
+                    "which one, [cyan]/mcp logs <name>[/cyan] for details.",
+                    group_id=group_id,
+                )
             for exc in unexpected:
                 emit_exception_diagnostics(exc, group_id=group_id)
             # Re-raise, else the bare except* would silently mask all errors

--- a/tests/agents/test_mcp_transport_degrade.py
+++ b/tests/agents/test_mcp_transport_degrade.py
@@ -1,0 +1,75 @@
+"""An unreachable HTTP/SSE MCP connector degrades the turn, never ends it.
+
+HTTP/SSE connectors are dialed lazily, when the run task enters the combined
+toolset. A 401 or a refused connection therefore surfaces mid-run as a raw
+``httpx`` error rather than an ``McpError``, so it used to reach the generic
+handler and abort the whole run over one dead connector.
+"""
+
+from __future__ import annotations
+
+import httpcore
+import httpx
+import pytest
+from pydantic_ai.exceptions import ModelHTTPError
+
+from code_puppy.agents._runtime import (
+    _collect_exceptions,
+    _is_mcp_transport_failure,
+)
+
+
+def _status_error(code: int) -> httpx.HTTPStatusError:
+    """The shape raised when a connector answers 401/5xx during connect."""
+    request = httpx.Request("POST", "https://mcp.example/sse")
+    response = httpx.Response(code, request=request)
+    return httpx.HTTPStatusError(f"{code}", request=request, response=response)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        _status_error(401),
+        _status_error(503),
+        httpx.ConnectError("connection refused"),
+        httpx.ReadTimeout("timed out"),
+        httpx.PoolTimeout("pool timeout"),
+        httpcore.ConnectError("refused"),
+        httpcore.ConnectTimeout("timed out"),
+    ],
+    ids=["401", "503", "refused", "read-timeout", "pool-timeout", "core", "core-to"],
+)
+def test_transport_failures_are_degradable(exc: BaseException) -> None:
+    assert _is_mcp_transport_failure(exc) is True
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ValueError("a real bug"),
+        RuntimeError("a real bug"),
+        ModelHTTPError(status_code=500, model_name="m", body=None),
+    ],
+    ids=["value-error", "runtime-error", "model-http-error"],
+)
+def test_genuine_failures_still_propagate(exc: BaseException) -> None:
+    """A real bug, and a model-side failure, must stay fatal.
+
+    ``ModelHTTPError`` is the important one: the model itself failing is not
+    a degraded connector, and it is not an ``httpx`` error either.
+    """
+    assert _is_mcp_transport_failure(exc) is False
+
+
+def test_mixed_group_degrades_only_the_connector() -> None:
+    """A dead connector alongside a real bug must not hide the real bug."""
+    connector = _status_error(401)
+    real_bug = ValueError("a real bug")
+    group = BaseExceptionGroup("run failed", [connector, real_bug])
+
+    leaves = _collect_exceptions(group, lambda e: True)
+    degraded = [e for e in leaves if _is_mcp_transport_failure(e)]
+    fatal = [e for e in leaves if not _is_mcp_transport_failure(e)]
+
+    assert degraded == [connector]
+    assert fatal == [real_bug]


### PR DESCRIPTION
One unreachable MCP connector ends the entire run.

HTTP/SSE connectors are dialed lazily, when the run task enters the combined toolset — unlike stdio servers, which are probed at startup. So a 401, a 5xx, or a refused connection surfaces mid-run as a raw `httpx` error from inside the transport, **not** an `McpError` (the protocol never got far enough to speak MCP). It reaches the generic `except* Exception` arm, prints an anyio/httpx traceback, and re-raises — while the model and every healthy toolset were still perfectly usable.

**Fix:** classify those types as degraded, exactly like `McpError` — one short warning, no traceback, no re-raise.

Deliberately broader than `_RETRYABLE_EXCEPTIONS`, which excludes `HTTPStatusError` because a 401 isn't worth *retrying*. It's still worth *surviving*. Genuine bugs and `ModelHTTPError` (the model failing, not a connector) still propagate.

Tests: the classifier, the non-degradable cases, and a mixed `ExceptionGroup` where a dead connector must not mask a real bug.

Companion to #878 — same shape, one layer earlier: connect time rather than call time.