### PR TITLE
fix(tools): match grep/list ignore patterns relative to the search root

### DIFF
--- a/code_puppy/tools/file_operations.py
+++ b/code_puppy/tools/file_operations.py
@@ -5,7 +5,7 @@ import re
 import shutil
 import subprocess
 import tempfile
-from typing import List
+from typing import Callable, List, Tuple
 
 from pydantic import BaseModel, conint
 from pydantic_ai import RunContext
@@ -161,6 +161,32 @@ def would_match_directory(pattern: str, directory: str) -> bool:
     return False
 
 
+def _relative_ignore_predicates(root: str) -> Tuple[Callable[[str], bool], ...]:
+    """``(skip_dir, skip_file)`` predicates that match ignore patterns to *root*.
+
+    The ignore patterns exist to prune directories *inside* the searched tree
+    (``node_modules``, ``.git``, ``tmp``). Matched against an absolute path they also
+    hit the root's own ancestors, so a root under ``/tmp`` matched ``**/tmp/**`` and
+    every single entry was skipped -- silently, with no error. Both backend traversals
+    (``grep`` and recursive ``list_files``) need the same rule, so it is defined once.
+
+    Relative matching keeps the original intent: a ``tmp/`` *below* the root is still
+    pruned, only the ancestors stop counting as grounds for a total veto.
+    """
+    from code_puppy.tools.common import should_ignore_dir_path, should_ignore_path
+
+    def _relative_to_root(path: str) -> str:
+        try:
+            return os.path.relpath(path, root)
+        except ValueError:  # different drive on Windows
+            return path
+
+    return (
+        lambda p: should_ignore_dir_path(_relative_to_root(p)),
+        lambda p: should_ignore_path(_relative_to_root(p)),
+    )
+
+
 def _list_entries_via_backend(directory: str, recursive: bool) -> List["ListedFile"]:
     """Build ``ListedFile`` results from the installed filesystem backend.
 
@@ -169,8 +195,6 @@ def _list_entries_via_backend(directory: str, recursive: bool) -> List["ListedFi
     ``grep`` see), rather than the local ripgrep path used when no backend is
     installed. Honors the same ignore rules as the local path.
     """
-    from code_puppy.tools.common import should_ignore_dir_path, should_ignore_path
-
     results: List[ListedFile] = []
 
     def _rel(full: str) -> str:
@@ -179,10 +203,11 @@ def _list_entries_via_backend(directory: str, recursive: bool) -> List["ListedFi
         return full
 
     if recursive:
+        skip_dir, skip_file = _relative_ignore_predicates(directory)
         for full, entry in fs_access.walk(
             directory,
-            skip_dir=should_ignore_dir_path,
-            skip_file=should_ignore_path,
+            skip_dir=skip_dir,
+            skip_file=skip_file,
         ):
             rel = _rel(full)
             if not rel:
@@ -1104,6 +1129,17 @@ def _emit_grep_result(
     return GrepOutput(matches=matches, error=error_message)
 
 
+def _missing_directory_error(directory: str, *, exists: bool) -> str:
+    """Error text for a bad grep target, shared by both grep paths.
+
+    Both the local-ripgrep and backend paths need to say the same thing; neither may
+    fall back to "no matches", which is indistinguishable from an empty search.
+    """
+    if not exists:
+        return f"Error: Directory '{directory}' does not exist"
+    return f"Error: '{directory}' is not a directory"
+
+
 def _grep_via_backend(directory: str, search_string: str) -> "GrepOutput":
     """Search through the installed filesystem backend (no local ripgrep).
 
@@ -1117,15 +1153,11 @@ def _grep_via_backend(directory: str, search_string: str) -> "GrepOutput":
     cap and binary files (NUL in the first chunk) are skipped, matching
     ripgrep's defaults.
     """
-    from code_puppy.tools.common import should_ignore_dir_path, should_ignore_path
-
     # Missing/non-directory target = error (matches local ripgrep, not silent
     # zero matches); ``walk`` itself tolerates a bad root.
     if not fs_access.is_dir(directory):
-        error_msg = (
-            f"Error: Directory '{directory}' does not exist"
-            if not fs_access.exists(directory)
-            else f"Error: '{directory}' is not a directory"
+        error_msg = _missing_directory_error(
+            directory, exists=fs_access.exists(directory)
         )
         return _emit_grep_result(search_string, directory, [], error_msg)
 
@@ -1133,10 +1165,14 @@ def _grep_via_backend(directory: str, search_string: str) -> "GrepOutput":
     if error is not None:
         return _emit_grep_result(search_string, directory, [], error)
 
+    skip_dir, skip_file = _relative_ignore_predicates(directory)
+
     max_filesize = 5 * 1024 * 1024  # mirror ripgrep --max-filesize 5M
     matches: List[MatchInfo] = []
     for full, entry in fs_access.walk(
-        directory, skip_dir=should_ignore_dir_path, skip_file=should_ignore_path
+        directory,
+        skip_dir=skip_dir,
+        skip_file=skip_file,
     ):
         if entry.is_dir:
             continue
@@ -1198,6 +1234,15 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
     matches: List[MatchInfo] = []
     error_message: str | None = None
 
+    # ripgrep runs with cwd=directory below, so a bad target would surface as a
+    # FileNotFoundError from the spawn and get misreported as "ripgrep not found".
+    # Name the real problem, and agree with the backend path's wording.
+    if not os.path.isdir(directory):
+        return GrepOutput(
+            matches=[],
+            error=_missing_directory_error(directory, exists=os.path.exists(directory)),
+        )
+
     # Create a temporary ignore file with our ignore patterns
     ignore_file = None
     try:
@@ -1248,7 +1293,14 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
 
         cmd.extend(["--ignore-file", ignore_file])
         cmd.extend(rg_args)
-        cmd.append(directory)
+        # Search '.' with cwd=directory rather than passing the absolute path.
+        # ripgrep matches --ignore-file patterns against the paths it walks, so an
+        # absolute root lets one of the root's *ancestors* veto the whole search:
+        # rooted under /tmp, the '**/tmp/**' pattern ignored every file and grep
+        # returned zero matches with no error at all (every pytest tmp_path on
+        # Linux, and any project parked in /tmp, ~/.cache or node_modules).
+        # Relative to the root, 'tmp' only prunes a tmp directory *inside* it.
+        cmd.append(".")
         # Use encoding with error handling to handle files with invalid UTF-8
         result = subprocess.run(
             cmd,
@@ -1257,6 +1309,7 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
             timeout=30,
             encoding="utf-8",
             errors="replace",  # Replace invalid chars instead of crashing
+            cwd=directory,
         )
 
         if result.returncode not in (0, 1):
@@ -1286,6 +1339,9 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
                     file_path = (
                         path_data.get("text", "") if path_data.get("text") else ""
                     )
+                    if file_path:
+                        # rg searched '.' from cwd=directory; report absolute paths.
+                        file_path = os.path.normpath(os.path.join(directory, file_path))
                     line_number = data.get("line_number", None)
                     line_content = (
                         data.get("lines", {}).get("text", "")

--- a/tests/tools/test_file_operations_coverage.py
+++ b/tests/tools/test_file_operations_coverage.py
@@ -291,8 +291,13 @@ class TestGrepFunction:
         invoked_cmd = mock_run.call_args[0][0]
         e_index = invoked_cmd.index("-e")
         assert invoked_cmd[e_index + 1] == "class ResourceLimits"
-        # The only path argument should be the search directory.
-        assert invoked_cmd[-1] == os.path.abspath(str(tmp_path))
+        # The only path argument is the search target, and it is relative: rg runs
+        # with the search directory as cwd so ignore patterns cannot be vetoed by
+        # one of the root's ancestor directories (e.g. a root under /tmp).
+        assert invoked_cmd[-1] == "."
+        assert mock_run.call_args.kwargs["cwd"] == os.path.abspath(str(tmp_path))
+        # Nothing from the multi-word pattern leaked out as a bare path argument.
+        assert "class" not in invoked_cmd and "ResourceLimits" not in invoked_cmd
 
     def test_grep_rejects_output_format_flags(self, tmp_path):
         """Flags incompatible with JSON match parsing produce a clear error."""

--- a/tests/tools/test_fs_backend.py
+++ b/tests/tools/test_fs_backend.py
@@ -210,6 +210,38 @@ def test_list_files_tool_uses_backend(backend):
     assert "c.txt" in out.content
 
 
+def test_list_files_tool_lists_backend_root_under_ignored_dir(backend):
+    """Recursive listing must not be vetoed by the root's *ancestors*.
+
+    Same traversal and same ancestor-matching bug as grep: a root under ``/tmp``
+    matched ``**/tmp/**`` against every absolute candidate path, so each entry was
+    skipped and the listing came back empty -- with no error at all.
+    """
+    from code_puppy.tools.file_operations import _list_files
+
+    backend.write_text_file("/tmp/ws/a.py", "x\n")
+    backend.write_text_file("/tmp/ws/pkg/b.py", "y\n")
+
+    out = _list_files(None, "/tmp/ws", recursive=True)
+
+    assert out.error is None
+    assert "a.py" in out.content
+    assert "b.py" in out.content
+
+
+def test_list_files_tool_prunes_ignored_dirs_inside_backend_root(backend):
+    """The ancestor fix must not weaken ignoring *below* the backend root."""
+    from code_puppy.tools.file_operations import _list_files
+
+    backend.write_text_file("/ws/node_modules/vendored.py", "z\n")
+
+    out = _list_files(None, "/ws", recursive=True)
+
+    assert out.error is None
+    assert "vendored.py" not in out.content
+    assert "a.py" in out.content
+
+
 def test_grep_tool_searches_backend(backend):
     """``_grep`` searches the backend's files (walk + read), not local ripgrep."""
     from code_puppy.tools.file_operations import _grep
@@ -220,6 +252,42 @@ def test_grep_tool_searches_backend(backend):
     assert ("/ws/pkg/b.py", "NEEDLE = 42") in hits
     # c.txt has no match -> not present
     assert all(m.file_path != "/ws/pkg/c.txt" for m in out.matches)
+
+
+def test_grep_tool_searches_backend_root_under_ignored_dir(backend):
+    """A backend root nested under an ignored dir name is still searched.
+
+    The ignore patterns exist to prune directories *inside* the root. Matched
+    against absolute paths they also matched the root's ancestors, so a root like
+    this one -- under /tmp -- silently produced no matches.
+    """
+    from code_puppy.tools.file_operations import _grep
+
+    backend.write_text_file("/tmp/ws/app.py", "MARKER = 1\n")
+
+    out = _grep(None, "MARKER", "/tmp/ws")
+
+    assert out.error is None
+    assert any(m.file_path == "/tmp/ws/app.py" for m in out.matches)
+
+
+def test_grep_tool_prunes_ignored_dirs_inside_backend_root(backend):
+    """The ancestor fix must not weaken ignoring *below* the backend root.
+
+    Matching ignore patterns relative to the root changed what they are compared
+    against, so this pins the other half of that trade: a ``node_modules`` sitting
+    under the root is still pruned, while ordinary files are still found.
+    """
+    from code_puppy.tools.file_operations import _grep
+
+    backend.write_text_file("/ws/node_modules/vendored.py", "NEEDLE = 99\n")
+
+    out = _grep(None, "NEEDLE", "/ws")
+
+    assert out.error is None
+    hits = {m.file_path for m in out.matches}
+    assert "/ws/node_modules/vendored.py" not in hits
+    assert "/ws/pkg/b.py" in hits
 
 
 def test_created_file_is_listable_and_greppable(backend):

--- a/tests/tools/test_grep_live_behavior.py
+++ b/tests/tools/test_grep_live_behavior.py
@@ -31,6 +31,51 @@ def test_grep_returns_context_lines(tmp_path):
     assert contents.count("match") == 3
 
 
+def test_grep_searches_a_root_nested_under_an_ignored_directory(tmp_path):
+    """A root sitting *inside* an ignored directory name must still be searched.
+
+    ``DIR_IGNORE_PATTERNS`` carries ``**/tmp/**`` (and ``**/.cache/**``,
+    ``**/node_modules/**`` ...) to prune a project's own scratch dirs. Matched
+    against absolute paths they also matched the search root's *ancestors*, so a
+    root under /tmp -- every pytest tmp_path on Linux, and any project parked in
+    /tmp, ~/.cache or node_modules -- had every file skipped: zero matches, no
+    error, completely silent. CI only runs macOS, whose temp dirs live elsewhere.
+    """
+    root = tmp_path / ".cache" / "checkout"
+    root.mkdir(parents=True)
+    (root / "app.py").write_text("needle\n")
+
+    out = _grep(None, "needle", str(root))
+
+    assert out.error is None
+    assert [m.line_content for m in out.matches] == ["needle"]
+
+
+def test_grep_still_prunes_ignored_dirs_inside_the_search_root(tmp_path):
+    """The ancestor fix must not weaken ignoring below the root.
+
+    Also pins that reported paths stay absolute now that ripgrep is handed '.'.
+    """
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "vendored.py").write_text("needle\n")
+    (tmp_path / "app.py").write_text("needle\n")
+
+    out = _grep(None, "needle", str(tmp_path))
+
+    assert out.error is None
+    assert {m.file_path for m in out.matches} == {str(tmp_path / "app.py")}
+
+
+def test_grep_missing_directory_names_the_directory(tmp_path):
+    """A bad target must blame itself, not the ripgrep binary we cwd'd into it."""
+    missing = tmp_path / "nope"
+
+    out = _grep(None, "needle", str(missing))
+
+    assert out.matches == []
+    assert out.error is not None and "does not exist" in out.error
+
+
 def test_grep_type_flag_restricts_matches(tmp_path):
     _setup(tmp_path)
 


### PR DESCRIPTION
## What

Fixes grep's **silent false negatives**, and the same bug in recursive `list_files`.

`grep` and `list_files(recursive=True)` returned **zero results with no error** whenever the search root sat under a directory named in `DIR_IGNORE_PATTERNS` -- `/tmp`, `~/.cache`, `node_modules`, `dist`, `build`, ...

```
backend, identical content, only the ancestor name differs:
  list_files("/ws",     recursive=True) -> a.py, pkg/b.py
  list_files("/tmp/ws", recursive=True) -> 0 directories, 0 files   # silent
```

Closes #881

## Root cause

Ignore patterns are meant to prune directories *inside* the searched tree. Both paths matched them against each candidate's **absolute** path instead, so one of the search root's own *ancestors* could veto the entire search:

```
should_ignore_path("/tmp/ws/app.py") -> True    # '**/tmp/**' matched an ANCESTOR
should_ignore_path("app.py")         -> False   # relative to the root: searched
should_ignore_path("tmp/app.py")     -> True    # a tmp/ *below* the root: still pruned
```

Silent false negatives are the worst failure mode for a search tool -- the agent decides a symbol doesn't exist and hallucinates or duplicates code instead of reading it. CI hid this for eons because macOS temp dirs are not under `/tmp`; on Linux every `pytest tmp_path` is, which is how it appeared as "6 failing grep tests".

## How

Match ignore patterns **relative to the search root**:

- `_grep` (local): pass `.` and run with `cwd=directory`; re-join reported paths with the root so tool output stays absolute
- both backend traversals: one shared `_relative_ignore_predicates(root)` feeding `fs_access.walk`'s skip callbacks

Two things worth calling out for review:

1. **`list_files` had the identical bug and is fixed here too.** The in-progress work covered grep only; `_list_entries_via_backend` matched absolute paths and was silently returning nothing under an ignored ancestor. Rather than paste a second copy of the relative-path closure, both backend traversals now share one helper -- one mechanism instead of two.
2. **`_grep` now rejects a bad target up front.** Since rg runs with `cwd=directory`, a missing directory would raise `FileNotFoundError` from the spawn and get misreported as *"ripgrep not found"*. It now names the directory, in the same wording the backend path uses. The `cwd` change is what makes this check necessary, so they belong in one commit.

## Tests

Pinned in **both directions** for **both** traversals: a root under an ignored ancestor is searched, and ignored dirs *inside* the root are still pruned. The backend "still prunes below root" guard did not exist before -- that absence is exactly how the backend bug survived. Command-shape test pins `cwd` and the `.` target.

Full suite: **7595 passed, 33 skipped, 0 failed** -- first Linux-green run on this repo. The 6 grep failures are genuinely fixed, not skipped or xfailed.

## Known, deliberately out of scope

`_list_files`' local ripgrep path still carries an older band-aid (`would_match_directory`) for this same cause. It works, but it over-prunes in the other direction and makes three mechanisms for one problem. Converting it is filed as #882, kept out of this diff so it stays reviewable. #882 also notes `file_operations.py` is ~1493 lines and wants a split.

Refs #881