### PR TITLE
feat: add opt-in is_fork flag to distinguish /fork banner from invoke_agent

### DIFF
--- a/code_puppy/messaging/messages.py
+++ b/code_puppy/messaging/messages.py
@@ -282,6 +282,10 @@ class SubAgentInvocationMessage(BaseMessage):
         default=None,
         description="Optional per-invocation model override requested for this sub-agent run",
     )
+    is_fork: bool = Field(
+        default=False,
+        description="Whether this invocation was started via /fork (renders a distinct banner)",
+    )
 
 
 class SubAgentResponseMessage(BaseMessage):

--- a/code_puppy/messaging/rich_renderer.py
+++ b/code_puppy/messaging/rich_renderer.py
@@ -1023,7 +1023,8 @@ class RichConsoleRenderer:
             if msg.is_new_session
             else f"Continuing ({msg.message_count} messages)"
         )
-        banner = self._format_banner("invoke_agent", "🤖 INVOKE AGENT")
+        banner_text = "\U0001f374 FORK" if msg.is_fork else "\U0001f916 INVOKE AGENT"
+        banner = self._format_banner("invoke_agent", banner_text)
         self._console.print(
             f"\n{banner} "
             f"[bold cyan]{msg.agent_name}[/bold cyan] "

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -245,7 +245,10 @@ async def _invoke_agent_impl(
     at all, so ``invoke_agent`` callers see zero behavioral or performance
     change from before this instrumentation existed.
 
-    ``is_fork`` is set by the ``/fork`` command only; it flags the emitted
+    ``is_fork`` is set by the ``/fork`` plugin (a companion package,
+    ``code_puppy_core_plugins.fork.register_callbacks::_run_fork``, which
+    feature-detects this kwarg via ``inspect.signature`` before passing it --
+    this repo has no direct caller). It flags the emitted
     ``SubAgentInvocationMessage`` so renderers can show a distinct banner
     instead of the generic tool-call one.
     """

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -235,6 +235,7 @@ async def _invoke_agent_impl(
     model_name: str | None = None,
     emit_response_message: bool = True,
     include_usage_metrics: bool = False,
+    is_fork: bool = False,
 ) -> AgentInvokeOutput:
     """Invoke a sub-agent, optionally suppressing its standard response message.
 
@@ -243,6 +244,10 @@ async def _invoke_agent_impl(
     ``AgentInvokeOutput``) and whether any timing/usage instrumentation runs
     at all, so ``invoke_agent`` callers see zero behavioral or performance
     change from before this instrumentation existed.
+
+    ``is_fork`` is set by the ``/fork`` command only; it flags the emitted
+    ``SubAgentInvocationMessage`` so renderers can show a distinct banner
+    instead of the generic tool-call one.
     """
     from code_puppy.agents.agent_manager import load_agent
 
@@ -312,6 +317,7 @@ async def _invoke_agent_impl(
             is_new_session=is_new_session,
             message_count=len(message_history),
             model_name=model_name,
+            is_fork=is_fork,
         )
     )
 

--- a/tests/messaging/test_rich_renderer.py
+++ b/tests/messaging/test_rich_renderer.py
@@ -450,6 +450,37 @@ def test_render_subagent_invocation_continuing(mock_sub, renderer, console):
     assert "codex-gpt-5.2" in out
 
 
+@patch("code_puppy.messaging.rich_renderer.is_subagent", return_value=False)
+def test_render_subagent_invocation_fork(mock_sub, renderer, console):
+    msg = SubAgentInvocationMessage(
+        agent_name="code-puppy",
+        session_id="sess-fork-1",
+        prompt="hello",
+        is_new_session=True,
+        message_count=0,
+        is_fork=True,
+    )
+    renderer._render_subagent_invocation(msg)
+    out = output(console)
+    assert "FORK" in out
+    assert "INVOKE AGENT" not in out
+
+
+@patch("code_puppy.messaging.rich_renderer.is_subagent", return_value=False)
+def test_render_subagent_invocation_not_fork_by_default(mock_sub, renderer, console):
+    msg = SubAgentInvocationMessage(
+        agent_name="code-puppy",
+        session_id="sess-2",
+        prompt="hello",
+        is_new_session=True,
+        message_count=0,
+    )
+    renderer._render_subagent_invocation(msg)
+    out = output(console)
+    assert "INVOKE AGENT" in out
+    assert "FORK" not in out
+
+
 def test_render_subagent_response(renderer, console):
     msg = SubAgentResponseMessage(
         agent_name="qa",


### PR DESCRIPTION
## What

Adds an optional `is_fork: bool = False` parameter to `_invoke_agent_impl`,
threaded through to a new `is_fork` field on `SubAgentInvocationMessage`, and
consumed by the rich console renderer to render ` FORK` instead of
` INVOKE AGENT` when set.

## Why

The `/fork` command (shipped as a companion plugin in
[`code_puppy_core_plugins`](https://github.com/mpfaffenberger/code_puppy_core_plugins))
currently calls this repo's `_invoke_agent_impl` directly and gets labeled
identically to the generic `invoke_agent` tool in the UI. Users can't tell a
background fork apart from a normal sub-agent invocation at a glance. This
adds a small, purely additive, opt-in flag so the plugin can request a
distinct banner.

**Coordination note:** this PR is one half of a two-repo rollout. The
companion plugin change (in `code_puppy_core_plugins`) feature-detects this
kwarg via `inspect.signature` before passing it, so it degrades gracefully
against any core that predates this change. Landing this PR alone has zero
visible behavior change — the flag simply stays `False` until the companion
plugin PR also ships. That's expected, not a regression.

## How

- `code_puppy/tools/subagent_invocation.py::_invoke_agent_impl` — new
  `is_fork: bool = False` kwarg, appended at the end of the parameter list,
  passed straight through into the emitted `SubAgentInvocationMessage`.
- `code_puppy/messaging/messages.py::SubAgentInvocationMessage` — new
  `is_fork: bool` field, default `False`.
- `code_puppy/messaging/rich_renderer.py::_render_subagent_invocation` — swaps
  the banner text between ` FORK` and ` INVOKE AGENT` based on the flag;
  same banner color key (`invoke_agent`) either way.

Defaults preserve existing behavior exactly for both existing tools
(`invoke_agent`, `invoke_agent_with_model`) — neither passes the new kwarg,
so they're unaffected.

## Testing

- `tests/messaging/test_rich_renderer.py` — added
  `test_render_subagent_invocation_fork` and
  `test_render_subagent_invocation_not_fork_by_default`, asserting the banner
  text swap in both directions.
- Full targeted local test run (changed files + directly-affected adjacent
  tests): 994 passed, 2 skipped (pre-existing, unrelated).
- `ruff check` / `ruff format --check`: clean.

## Scope

Purely additive; no existing call sites changed. 3 files touched
(`subagent_invocation.py`, `messages.py`, `rich_renderer.py`) plus 1 test file.
