### PR TITLE
fix(messaging): complete request futures on owning loop

### DIFF
--- a/code_puppy/messaging/bus.py
+++ b/code_puppy/messaging/bus.py
@@ -400,7 +400,7 @@ class MessageBus:
     def _complete_request(self, prompt_id: str, result: object) -> None:
         """Complete a pending request on the Future's owning event loop."""
         with self._lock:
-            pending = self._pending_requests.get(prompt_id)
+            pending = self._pending_requests.pop(prompt_id, None)
 
         if pending is None:
             return

--- a/code_puppy/messaging/bus.py
+++ b/code_puppy/messaging/bus.py
@@ -79,15 +79,14 @@ class MessageBus:
         self._outgoing: queue.Queue[AnyMessage] = queue.Queue(maxsize=maxsize)
         self._incoming: queue.Queue[AnyCommand] = queue.Queue(maxsize=maxsize)
 
-        # Event loop reference for async request/response (optional)
-        self._event_loop: Optional[asyncio.AbstractEventLoop] = None
-
         # Startup buffering
         self._startup_buffer: List[AnyMessage] = []
         self._has_active_renderer = False
 
-        # Request/Response correlation: prompt_id → Future (for async usage)
-        self._pending_requests: Dict[str, asyncio.Future[Any]] = {}
+        # Request/Response correlation: prompt_id → owning loop and Future.
+        self._pending_requests: Dict[
+            str, Tuple[asyncio.AbstractEventLoop, asyncio.Future[Any]]
+        ] = {}
 
         # Session context for multi-agent tracking
         self._current_session_id: Optional[str] = None
@@ -234,7 +233,7 @@ class MessageBus:
         future: asyncio.Future[str] = loop.create_future()
 
         with self._lock:
-            self._pending_requests[prompt_id] = future
+            self._pending_requests[prompt_id] = (loop, future)
 
         # Emit the request
         request = UserInputRequest(
@@ -281,7 +280,7 @@ class MessageBus:
         future: asyncio.Future[Tuple[bool, Optional[str]]] = loop.create_future()
 
         with self._lock:
-            self._pending_requests[prompt_id] = future
+            self._pending_requests[prompt_id] = (loop, future)
 
         request = ConfirmationRequest(
             prompt_id=prompt_id,
@@ -324,7 +323,7 @@ class MessageBus:
         future: asyncio.Future[Tuple[int, str]] = loop.create_future()
 
         with self._lock:
-            self._pending_requests[prompt_id] = future
+            self._pending_requests[prompt_id] = (loop, future)
 
         request = SelectionRequest(
             prompt_id=prompt_id,
@@ -399,27 +398,24 @@ class MessageBus:
                     pass
 
     def _complete_request(self, prompt_id: str, result: object) -> None:
-        """Complete a pending request with the given result."""
+        """Complete a pending request on the Future's owning event loop."""
         with self._lock:
-            future = self._pending_requests.get(prompt_id)
+            pending = self._pending_requests.get(prompt_id)
 
-        if future is not None and not future.done():
-            # Must set result from the event loop thread if we have one
-            if self._event_loop is not None:
-                try:
-                    self._event_loop.call_soon_threadsafe(
-                        self._set_future_result, future, result
-                    )
+        if pending is None:
+            return
 
-                except RuntimeError:
-                    # Event loop closed - try direct set
-                    self._set_future_result(future, result)
+        loop, future = pending
+        try:
+            loop.call_soon_threadsafe(self._set_future_result, future, result)
 
-            else:
-                # No event loop - try direct set
-                self._set_future_result(future, result)
+        except RuntimeError:
+            # A closed loop cannot resume its waiter. Never mutate its Future
+            # directly from this potentially foreign thread.
+            return
 
-    def _set_future_result(self, future: asyncio.Future[Any], result: object) -> None:
+    @staticmethod
+    def _set_future_result(future: asyncio.Future[Any], result: object) -> None:
         """Set a future's result if not already done."""
         if not future.done():
             future.set_result(result)

--- a/tests/messaging/test_bus.py
+++ b/tests/messaging/test_bus.py
@@ -3,7 +3,7 @@
 import asyncio
 import queue
 import threading
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -191,6 +191,7 @@ async def test_request_input_response_from_foreign_thread(bus):
     thread.join()
 
     assert result == "thread-safe"
+    assert bus.pending_requests_count == 0
 
 
 @pytest.mark.asyncio
@@ -285,12 +286,56 @@ def test_complete_request_unknown_prompt_id(bus):
     bus._complete_request("nonexistent", "value")
 
 
+def test_complete_request_consumes_pending_before_scheduling(bus):
+    loop = Mock()
+    future = Mock()
+
+    def assert_consumed(*_args):
+        assert bus.pending_requests_count == 0
+
+    loop.call_soon_threadsafe.side_effect = assert_consumed
+    with bus._lock:
+        bus._pending_requests["test-id"] = (loop, future)
+
+    bus._complete_request("test-id", "result")
+
+    loop.call_soon_threadsafe.assert_called_once_with(
+        bus._set_future_result, future, "result"
+    )
+
+
+def test_complete_request_racing_responses_schedule_once(bus):
+    loop = Mock()
+    future = Mock()
+    barrier = threading.Barrier(3)
+    with bus._lock:
+        bus._pending_requests["test-id"] = (loop, future)
+
+    def respond(result):
+        barrier.wait()
+        bus._complete_request("test-id", result)
+
+    threads = [
+        threading.Thread(target=respond, args=(result,))
+        for result in ("first", "second")
+    ]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join()
+
+    loop.call_soon_threadsafe.assert_called_once()
+    assert bus.pending_requests_count == 0
+
+
 def test_complete_request_with_event_loop(bus):
     loop = asyncio.new_event_loop()
     future = loop.create_future()
     with bus._lock:
         bus._pending_requests["test-id"] = (loop, future)
     bus._complete_request("test-id", "result")
+    assert bus.pending_requests_count == 0
     loop.run_until_complete(asyncio.sleep(0.01))
     assert future.result() == "result"
     loop.close()
@@ -304,7 +349,25 @@ def test_complete_request_event_loop_closed(bus):
         bus._pending_requests["test-id"] = (loop, future)
     # Should not raise or mutate a Future owned by a closed loop.
     bus._complete_request("test-id", "result")
+    assert bus.pending_requests_count == 0
     assert not future.done()
+
+
+def test_complete_request_cancelled_before_callback_runs(bus):
+    loop = asyncio.new_event_loop()
+    future = loop.create_future()
+    callback_errors = []
+    loop.set_exception_handler(lambda _loop, context: callback_errors.append(context))
+    with bus._lock:
+        bus._pending_requests["test-id"] = (loop, future)
+
+    bus._complete_request("test-id", "result")
+    future.cancel()
+    loop.run_until_complete(asyncio.sleep(0))
+
+    assert future.cancelled()
+    assert callback_errors == []
+    loop.close()
 
 
 def test_set_future_result_already_done(bus):

--- a/tests/messaging/test_bus.py
+++ b/tests/messaging/test_bus.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import queue
+import threading
 from unittest.mock import patch
 
 import pytest
@@ -173,6 +174,26 @@ async def test_request_input(bus):
 
 
 @pytest.mark.asyncio
+async def test_request_input_response_from_foreign_thread(bus):
+    request = asyncio.create_task(bus.request_input("Enter:"))
+    while bus.pending_requests_count == 0:
+        await asyncio.sleep(0)
+
+    with bus._lock:
+        prompt_id = next(iter(bus._pending_requests))
+
+    thread = threading.Thread(
+        target=bus.provide_response,
+        args=(UserInputResponse(prompt_id=prompt_id, value="thread-safe"),),
+    )
+    thread.start()
+    result = await asyncio.wait_for(request, timeout=1)
+    thread.join()
+
+    assert result == "thread-safe"
+
+
+@pytest.mark.asyncio
 async def test_request_input_empty_uses_default(bus):
     async def respond():
         await asyncio.sleep(0.05)
@@ -267,9 +288,8 @@ def test_complete_request_unknown_prompt_id(bus):
 def test_complete_request_with_event_loop(bus):
     loop = asyncio.new_event_loop()
     future = loop.create_future()
-    bus._event_loop = loop
     with bus._lock:
-        bus._pending_requests["test-id"] = future
+        bus._pending_requests["test-id"] = (loop, future)
     bus._complete_request("test-id", "result")
     loop.run_until_complete(asyncio.sleep(0.01))
     assert future.result() == "result"
@@ -279,12 +299,12 @@ def test_complete_request_with_event_loop(bus):
 def test_complete_request_event_loop_closed(bus):
     loop = asyncio.new_event_loop()
     future = loop.create_future()
-    bus._event_loop = loop
     loop.close()  # Close loop so call_soon_threadsafe raises RuntimeError
     with bus._lock:
-        bus._pending_requests["test-id"] = future
-    # Should not raise
+        bus._pending_requests["test-id"] = (loop, future)
+    # Should not raise or mutate a Future owned by a closed loop.
     bus._complete_request("test-id", "result")
+    assert not future.done()
 
 
 def test_set_future_result_already_done(bus):
@@ -296,27 +316,13 @@ def test_set_future_result_already_done(bus):
     loop.close()
 
 
-def test_complete_request_no_event_loop(bus):
-    """With no event loop, falls back to direct set."""
-    loop = asyncio.new_event_loop()
-    future = loop.create_future()
-    bus._event_loop = None
-    with bus._lock:
-        bus._pending_requests["test-id"] = future
-    bus._complete_request("test-id", "val")
-    # future.result() needs the loop
-    loop.run_until_complete(asyncio.sleep(0))
-    assert future.result() == "val"
-    loop.close()
-
-
 def test_complete_request_future_already_done(bus):
     """Should not raise when future already done."""
     loop = asyncio.new_event_loop()
     future = loop.create_future()
     future.set_result("done")
     with bus._lock:
-        bus._pending_requests["test-id"] = future
+        bus._pending_requests["test-id"] = (loop, future)
     bus._complete_request("test-id", "ignored")
     loop.close()
 


### PR DESCRIPTION
Complements #859 by fixing the remaining request/response correctness issue from #438's first point.

`MessageBus` previously stored only each `asyncio.Future`. A UI response arriving from another thread could therefore call `Future.set_result()` directly on a Future owned by another event-loop thread. That is not thread-safe and can leave the awaiting task suspended.

## What changed

- Store each pending request as `(loop, future)`.
- Atomically consume the pending correlation under `self._lock` before scheduling completion.
- Complete the Future on its owning loop using `loop.call_soon_threadsafe()`.
- Define duplicate/racing response behavior: **first correlated response wins**.
- If the owning loop is closed, safely decline direct Future mutation.
- Check `future.done()` on the owning loop before setting the result.

## Regression coverage

Tests cover:

- response arriving from a foreign thread
- pending correlation consumed before scheduling
- two racing responses scheduling exactly one completion
- normal event-loop completion
- closed-loop cleanup without unsafe Future mutation
- cancellation between scheduling and callback execution
- already-completed Futures
- unknown prompt IDs

Focused MessageBus suite:

`44 passed`

Additional checks:

- `ruff format --check` — passed
- ruff E/F/I checks — passed
- `git diff --check` — passed

The queue backoff introduced by #859 is intentionally unchanged.

The separate MessageBus locking/refactor work in #875 is also left untouched so the remaining #438 concerns stay narrowly separated.

Thanks to @StarsExpress for coordinating the remaining #438 work and reviewing this approach.