### PR TITLE
feat: configure auto-continue classifier model

### DIFF
--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -472,6 +472,7 @@ def get_config_keys():
         "protected_token_count",
         "compaction_threshold",
         "summarization_model",
+        "auto_continue_model",
         "message_limit",
         "allow_recursion",
         "subagent_recursion_limit",
@@ -918,6 +919,19 @@ def set_model_name(model: str):
 
     # Clear model cache when switching models to ensure fresh validation
     clear_model_cache()
+
+
+def get_auto_continue_model_name() -> str | None:
+    """Return the model used by the automatic continuation classifier.
+
+    ``auto_continue_model`` is an optional dedicated override. An unset or
+    blank value follows the session's global model so existing installations
+    need no configuration change.
+    """
+    value = get_value("auto_continue_model")
+    if value and value.strip():
+        return value.strip()
+    return get_global_model_name()
 
 
 def get_summarization_model_name() -> str:

--- a/tests/test_config_full_coverage.py
+++ b/tests/test_config_full_coverage.py
@@ -684,6 +684,20 @@ class TestConfigKeys:
         assert "enable_streaming" in keys
         assert "cancel_agent_key" in keys
         assert "resume_message_count" in keys
+        assert "auto_continue_model" in keys
+
+
+def test_auto_continue_model_uses_override(monkeypatch):
+    monkeypatch.setattr(cp_config, "get_value", lambda key: "  tiny-model  ")
+
+    assert cp_config.get_auto_continue_model_name() == "tiny-model"
+
+
+def test_auto_continue_model_falls_back_to_global(monkeypatch):
+    monkeypatch.setattr(cp_config, "get_value", lambda key: "")
+    monkeypatch.setattr(cp_config, "get_global_model_name", lambda: "global-model")
+
+    assert cp_config.get_auto_continue_model_name() == "global-model"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- expose `auto_continue_model` through `/set` config keys
- add a resolver that uses the dedicated override when set
- fall back to the global session model when blank or unset

## Testing

- Ruff check and format pass
- focused config tests pass