### PR TITLE
chore: bump core plugins to 0.0.32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Code generation agent"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"
 dependencies = [
-    "code-puppy-core-plugins>=0.0.31",
+    "code-puppy-core-plugins>=0.0.32",
     "logfire>=4.0",
     "pydantic-ai-slim[openai,anthropic,mcp]==2.35.0",
     "pydantic-ai-harness==0.23.0",

--- a/tests/plugins/test_plugin_list.py
+++ b/tests/plugins/test_plugin_list.py
@@ -23,25 +23,21 @@ _PLUGINS_CONFIG_MOD = "code_puppy.plugins.config"
 
 class TestFormatPluginList:
     def test_empty_list(self):
-        assert _format_plugin_list([], set()) == "  (none)"
+        assert _format_plugin_list([], "builtin", set()) == "  (none)"
 
     def test_single_plugin(self):
-        result = _format_plugin_list(["shell_safety"], set())
+        result = _format_plugin_list(["shell_safety"], "builtin", set())
         assert "shell_safety" in result
 
     def test_multiple_sorted(self):
-        result = _format_plugin_list(["zebra", "alpha", "mid"], set())
-        lines = result.split("\n")
-        assert len(lines) == 3
-        assert "alpha" in lines[0]
-        assert "mid" in lines[1]
-        assert "zebra" in lines[2]
+        result = _format_plugin_list(["zebra", "alpha", "mid"], "builtin", set())
+        assert result.index("  alpha") < result.index("  mid")
+        assert result.index("  mid") < result.index("  zebra")
 
     def test_disabled_shown(self):
-        result = _format_plugin_list(["alpha", "beta"], {"beta"})
-        lines = result.split("\n")
-        assert "(disabled)" not in lines[0]  # alpha
-        assert "(disabled)" in lines[1]  # beta
+        result = _format_plugin_list(["alpha", "beta"], "builtin", {"beta"})
+        assert "  alpha  (disabled)" not in result
+        assert "  beta  (disabled)" in result
 
 
 class TestBuildOutput:

--- a/uv.lock
+++ b/uv.lock
@@ -465,7 +465,7 @@ requires-dist = [
     { name = "azure-identity", specifier = ">=1.15.0" },
     { name = "boto3", specifier = ">=1.43.9" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.35.0" },
-    { name = "code-puppy-core-plugins", specifier = ">=0.0.31" },
+    { name = "code-puppy-core-plugins", specifier = ">=0.0.32" },
     { name = "dbos", marker = "extra == 'durable'", specifier = ">=2.11.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.24.1" },
     { name = "httpx2", specifier = ">=2.7" },
@@ -506,15 +506,15 @@ dev = [
 
 [[package]]
 name = "code-puppy-core-plugins"
-version = "0.0.31"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic-ai-slim", extra = ["anthropic", "mcp", "openai"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/3f/27f36a9ede36815b05fe93c60df7fdac74eb56d6359cdfe8eea6761479dc/code_puppy_core_plugins-0.0.31.tar.gz", hash = "sha256:bc43ea203834f8730eca0bcaa4ed88410669c17e57a4b83ad8da9b469fde9914", size = 541376, upload-time = "2026-08-29T13:04:23.815Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/3a/4dc64c5dc5b90eec4fd9feb96136ecb8f3b3c6ee69c11284fd79fbddeb6a/code_puppy_core_plugins-0.0.32.tar.gz", hash = "sha256:6c9ca8c82a7d859eb5901a0038487fb6e6070d10d62290fb5e1087f24cd7545b", size = 541659, upload-time = "2026-08-29T14:29:50.217Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/82/439d1aae43c22902d1d15d50cd639ccd680dcb07a91c8d755bdad6322567/code_puppy_core_plugins-0.0.31-py3-none-any.whl", hash = "sha256:eea0a29505e8a98cb01f9bd2a823fffbabb45d242e2ac015774e2c0fe3364848", size = 731938, upload-time = "2026-08-29T13:04:22.569Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e2/58916d668f284a7bc470f14c23c11e99e7ed715a4e82765b0ddc829dbf33/code_puppy_core_plugins-0.0.32-py3-none-any.whl", hash = "sha256:eea8ca7674b1013e58e62dcb821a159a208c30dfeb08c210da1e3e506cc9df1c", size = 732371, upload-time = "2026-08-29T14:29:48.989Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- require `code-puppy-core-plugins>=0.0.32` for the private auto-continue classifier
- refresh the uv lockfile

## Testing

- `uv lock --check`
- verified installed core plugins version is `0.0.32`
- installed-plugin and tool-registration tests pass