### PR TITLE
feat: keep waiting for gating background work

### DIFF
--- a/code_puppy/agents/agent_code_puppy.py
+++ b/code_puppy/agents/agent_code_puppy.py
@@ -87,6 +87,7 @@ Important rules:
 - Prefer edit over create_file. Keep diffs small (100-300 lines).
 {r["loop_rule"]}
 - Continue autonomously unless user input is definitively required
+- If a backgrounded process gates completion, do not stop and force the user to reprompt you. Keep doing useful work, then wait 60 seconds and check its progress when no other work remains; repeat until it completes or user input is genuinely required. Be as agentic as possible.
 """
         # NOTE: runtime ``load_prompt`` fragments (env context, permission
         # rules, memory recall) are intentionally NOT appended here — injected

--- a/tests/test_coverage_agents_gaps.py
+++ b/tests/test_coverage_agents_gaps.py
@@ -76,6 +76,14 @@ class TestCodePuppyAgentTools:
         assert "model_name" not in prompt
         assert "invoke_agent_with_model" not in prompt
 
+    def test_prompt_waits_for_gating_background_processes(self):
+        from code_puppy.agents.agent_code_puppy import CodePuppyAgent
+
+        prompt = CodePuppyAgent().get_system_prompt()
+
+        assert "do not stop and force the user to reprompt you" in prompt
+        assert "wait 60 seconds and check its progress" in prompt
+
 
 # =============================================================================
 # display.py line 39 – subagent early return


### PR DESCRIPTION
## Summary

- tell the main agent not to stop while a background process gates task completion
- prioritize useful parallel work, then recheck progress every 60 seconds
- continue until completion or genuine user input is required

## Testing

- Ruff check and format pass
- focused CodePuppyAgent prompt tests pass