### PR TITLE
test: read block-reason helpers from their own module

### DIFF
--- a/tests/test_callbacks_fail_closed.py
+++ b/tests/test_callbacks_fail_closed.py
@@ -17,6 +17,7 @@ broad `except Exception: pass`, and the tool ran anyway.
 import pytest
 
 from code_puppy import callbacks
+from code_puppy._pydantic_tool_helpers import _GENERIC_BLOCK_REASON, _block_reason
 
 
 @pytest.fixture(autouse=True)
@@ -194,13 +195,9 @@ class TestBlockReasonRendering:
     """An explicit deny must render as a deny whatever the plugin supplied."""
 
     def test_a_non_string_reason_still_renders_a_deny(self):
-        from code_puppy.pydantic_patches import _block_reason
-
         assert _block_reason({"blocked": True, "reason": 123}) == "123"
 
     def test_a_reason_whose_str_raises_falls_back_to_generic_text(self):
-        from code_puppy.pydantic_patches import _GENERIC_BLOCK_REASON, _block_reason
-
         class Hostile:
             def __str__(self):
                 raise RuntimeError("nope")
@@ -214,8 +211,6 @@ class TestBlockReasonRendering:
         )
 
     def test_a_reason_whose_truthiness_raises_still_renders_a_deny(self):
-        from code_puppy.pydantic_patches import _GENERIC_BLOCK_REASON, _block_reason
-
         class Unbooleanable:
             def __bool__(self):
                 raise RuntimeError("nope")
@@ -226,16 +221,12 @@ class TestBlockReasonRendering:
         )
 
     def test_the_marker_still_trims_the_prefix(self):
-        from code_puppy.pydantic_patches import _block_reason
-
         assert (
             _block_reason({"blocked": True, "reason": "noise [BLOCKED] the real one"})
             == "[BLOCKED] the real one"
         )
 
     def test_error_message_wins_over_reason(self):
-        from code_puppy.pydantic_patches import _block_reason
-
         assert (
             _block_reason(
                 {"blocked": True, "error_message": "from error_message", "reason": "x"}
@@ -244,7 +235,5 @@ class TestBlockReasonRendering:
         )
 
     def test_an_absent_or_blank_reason_gets_the_generic_text(self):
-        from code_puppy.pydantic_patches import _GENERIC_BLOCK_REASON, _block_reason
-
         assert _block_reason({"blocked": True}) == _GENERIC_BLOCK_REASON
         assert _block_reason({"blocked": True, "reason": " "}) == _GENERIC_BLOCK_REASON


### PR DESCRIPTION
## What

Fixes the 3 red tests on `main` (run [33263710261](https://github.com/mpfaffenberger/code_puppy/actions/runs/33263710261)):

```
FAILED tests/test_callbacks_fail_closed.py::TestBlockReasonRendering::test_a_reason_whose_str_raises_falls_back_to_generic_text
FAILED tests/test_callbacks_fail_closed.py::TestBlockReasonRendering::test_a_reason_whose_truthiness_raises_still_renders_a_deny
FAILED tests/test_callbacks_fail_closed.py::TestBlockReasonRendering::test_an_absent_or_blank_reason_gets_the_generic_text
ImportError: cannot import name '_GENERIC_BLOCK_REASON' from 'code_puppy.pydantic_patches'
```

## Why

`8f396963` extracted the tool-patch helpers into `code_puppy/_pydantic_tool_helpers.py`. `pydantic_patches` re-imports `_block_reason` (so the tests importing only that kept passing), but `_GENERIC_BLOCK_REASON` never came along — so the three tests asserting against the generic deny text died at import.

## How

Test-only change. Point `TestBlockReasonRendering` at the defining module instead of `pydantic_patches`, and hoist the six duplicated per-test imports into one module-level import — the tests stop depending on an incidental re-export.

Deliberately **not** re-exporting `_GENERIC_BLOCK_REASON` from `pydantic_patches`: nothing there uses it, and `_pydantic_tool_helpers.__all__` intentionally advertises only the function.

## Verified

- On pristine `main` (8f396963): exactly those 3 tests fail → with this patch, 25/25 pass.
- `test_pydantic_patches.py`, `test_apply_patch_tool.py`, `test_anthropic_sampling_settings.py` also green (85 passed).
- `ruff format --check` + `ruff check` clean.