### PR TITLE
feat(agents): add transform_mcp_toolsets extension seam to BaseAgent

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -20,12 +20,12 @@ from pydantic_ai.capabilities import ProcessHistory
 
 from code_puppy.agents._compaction import make_history_processor
 from code_puppy.agents._model_message_transform import build_model_message_transform
+from code_puppy.agents._subagent_recursion import build_subagent_recursion_guard
 from code_puppy.agents._output_limits import (
     build_response_clamp,
     build_tool_output_limits,
 )
 from code_puppy.agents._steer_processor import make_steer_history_processor
-from code_puppy.agents._subagent_recursion import build_subagent_recursion_guard
 from code_puppy.agents.event_stream_handler import event_stream_handler
 from code_puppy.callbacks import (
     on_pre_mcp_autostart,
@@ -615,13 +615,15 @@ def build_pydantic_agent(
     - ``agent._last_model_name``      ← resolved model name
     - ``agent.pydantic_agent``        ← the final (possibly plugin-wrapped) agent
     - ``agent._code_generation_agent`` ← same as ``pydantic_agent``
-    - ``agent._mcp_servers``          ← MCP toolsets (post-filter)
+    - ``agent._mcp_servers``          ← MCP toolsets (post-filter,
+      post-``transform_mcp_toolsets``)
 
     The build happens in two passes: we construct once with ``toolsets=[]`` so
     we can introspect registered tool names, then rebuild with MCP servers
-    filtered against those names to prevent collisions. Plugins may wrap the
-    final pydantic agent via the ``wrap_pydantic_agent`` hook (e.g. to swap
-    in a durable-exec wrapper).
+    filtered against those names to prevent collisions and passed through
+    ``agent.transform_mcp_toolsets()`` (a subclass extension seam, no-op by
+    default). Plugins may wrap the final pydantic agent via the
+    ``wrap_pydantic_agent`` hook (e.g. to swap in a durable-exec wrapper).
     """
     from code_puppy.tools import register_tools_for_agent
 
@@ -700,22 +702,32 @@ def build_pydantic_agent(
 
     # Extension seam: let a BaseAgent subclass post-process the resolved MCP
     # toolsets (e.g. wrap/filter/replace) before the final agent is built.
-    # Default implementation is a no-op identity transform. Fails open: an
-    # override that raises falls back to the original filtered list rather
-    # than crashing agent construction. See ``BaseAgent.transform_mcp_toolsets``.
+    # Default implementation is a no-op identity transform. Fails open on a
+    # RAISING override: falls back to the original filtered list rather than
+    # crashing agent construction. NOTE: fail-open means this seam is not a
+    # safe place to enforce security-sensitive gating -- a raising gate
+    # override degrades to "no gate" rather than "deny all". See
+    # ``BaseAgent.transform_mcp_toolsets``.
+    final_mcp_servers = filtered_mcp_servers
     try:
-        final_mcp_servers = agent.transform_mcp_toolsets(filtered_mcp_servers)
-        if not isinstance(final_mcp_servers, list):
-            raise TypeError(
-                "transform_mcp_toolsets must return a list, got "
-                f"{type(final_mcp_servers).__name__}"
-            )
+        transformed = agent.transform_mcp_toolsets(filtered_mcp_servers)
     except Exception as exc:
         emit_warning(
             f"transform_mcp_toolsets override for agent '{logical_agent_name}' "
-            f"raised {exc!r}; falling back to unmodified MCP toolsets."
+            f"raised {exc!r}; falling back to unmodified MCP toolsets.",
+            message_group=message_group,
         )
-        final_mcp_servers = filtered_mcp_servers
+    else:
+        if isinstance(transformed, list):
+            final_mcp_servers = transformed
+        else:
+            emit_warning(
+                "transform_mcp_toolsets override for agent "
+                f"'{logical_agent_name}' returned "
+                f"{type(transformed).__name__}, not a list; falling back to "
+                "unmodified MCP toolsets.",
+                message_group=message_group,
+            )
 
     # Pass 2: real build. MCP servers always go in the constructor; plugins
     # (e.g. DBOS) may swap them at run time via ``agent_run_context``.

--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -700,14 +700,8 @@ def build_pydantic_agent(
         mcp_servers, existing_tool_names
     )
 
-    # Extension seam: let a BaseAgent subclass post-process the resolved MCP
-    # toolsets (e.g. wrap/filter/replace) before the final agent is built.
-    # Default implementation is a no-op identity transform. Fails open on a
-    # RAISING override: falls back to the original filtered list rather than
-    # crashing agent construction. NOTE: fail-open means this seam is not a
-    # safe place to enforce security-sensitive gating -- a raising gate
-    # override degrades to "no gate" rather than "deny all". See
-    # ``BaseAgent.transform_mcp_toolsets``.
+    # Extension seam; see BaseAgent.transform_mcp_toolsets for the contract
+    # (fails open on raise/bad return type -- not safe for security gating).
     final_mcp_servers = filtered_mcp_servers
     try:
         transformed = agent.transform_mcp_toolsets(filtered_mcp_servers)

--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -20,12 +20,12 @@ from pydantic_ai.capabilities import ProcessHistory
 
 from code_puppy.agents._compaction import make_history_processor
 from code_puppy.agents._model_message_transform import build_model_message_transform
-from code_puppy.agents._subagent_recursion import build_subagent_recursion_guard
 from code_puppy.agents._output_limits import (
     build_response_clamp,
     build_tool_output_limits,
 )
 from code_puppy.agents._steer_processor import make_steer_history_processor
+from code_puppy.agents._subagent_recursion import build_subagent_recursion_guard
 from code_puppy.agents.event_stream_handler import event_stream_handler
 from code_puppy.callbacks import (
     on_pre_mcp_autostart,
@@ -698,9 +698,28 @@ def build_pydantic_agent(
         mcp_servers, existing_tool_names
     )
 
+    # Extension seam: let a BaseAgent subclass post-process the resolved MCP
+    # toolsets (e.g. wrap/filter/replace) before the final agent is built.
+    # Default implementation is a no-op identity transform. Fails open: an
+    # override that raises falls back to the original filtered list rather
+    # than crashing agent construction. See ``BaseAgent.transform_mcp_toolsets``.
+    try:
+        final_mcp_servers = agent.transform_mcp_toolsets(filtered_mcp_servers)
+        if not isinstance(final_mcp_servers, list):
+            raise TypeError(
+                "transform_mcp_toolsets must return a list, got "
+                f"{type(final_mcp_servers).__name__}"
+            )
+    except Exception as exc:
+        emit_warning(
+            f"transform_mcp_toolsets override for agent '{logical_agent_name}' "
+            f"raised {exc!r}; falling back to unmodified MCP toolsets."
+        )
+        final_mcp_servers = filtered_mcp_servers
+
     # Pass 2: real build. MCP servers always go in the constructor; plugins
     # (e.g. DBOS) may swap them at run time via ``agent_run_context``.
-    final_pydantic = _new_pydantic_agent(toolsets=filtered_mcp_servers)
+    final_pydantic = _new_pydantic_agent(toolsets=final_mcp_servers)
     register_tools_for_agent(
         final_pydantic,
         agent_tools,
@@ -710,7 +729,7 @@ def build_pydantic_agent(
 
     agent.cur_model = model
     agent._last_model_name = resolved_model_name
-    agent._mcp_servers = filtered_mcp_servers
+    agent._mcp_servers = final_mcp_servers
 
     wrapped = on_wrap_pydantic_agent(
         agent,

--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -310,14 +310,10 @@ class BaseAgent(ABC):
         compact oversized tool results, or gate certain servers behind
         runtime conditions.
 
-        Must return a list of toolsets. If an override raises, the builder
-        fails open: it logs a warning and falls back to the original,
-        pre-override toolsets list rather than crashing agent construction.
-        This fail-open behavior means the seam is NOT a safe place to enforce
-        security-sensitive gating -- a raising "deny" override degrades to
-        "no gate applied" rather than "deny all," so gating logic that must
-        never be silently bypassed should fail closed itself (e.g. return an
-        empty list on error) rather than relying on the builder's fallback.
+        Must return a list of toolsets; the builder fails open on a raise
+        or a non-list return (falls back to the pre-override list), so
+        gating logic that must never be bypassed should fail closed itself
+        (e.g. return an empty list) rather than rely on that fallback.
         """
         return toolsets
 

--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -313,6 +313,11 @@ class BaseAgent(ABC):
         Must return a list of toolsets. If an override raises, the builder
         fails open: it logs a warning and falls back to the original,
         pre-override toolsets list rather than crashing agent construction.
+        This fail-open behavior means the seam is NOT a safe place to enforce
+        security-sensitive gating -- a raising "deny" override degrades to
+        "no gate applied" rather than "deny all," so gating logic that must
+        never be silently bypassed should fail closed itself (e.g. return an
+        empty list on error) rather than relying on the builder's fallback.
         """
         return toolsets
 

--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -299,6 +299,23 @@ class BaseAgent(ABC):
         return await run_with_mcp(self, prompt, **kwargs)
 
     # ---- MCP integration shims --------------------------------------------
+    def transform_mcp_toolsets(self, toolsets: List[Any]) -> List[Any]:
+        """Extension seam: post-process resolved MCP toolsets before build.
+
+        Called exactly once by ``_builder.build_pydantic_agent`` after MCP
+        toolsets have been resolved and filtered for tool-name collisions,
+        but before the final ``pydantic_ai.Agent`` is constructed. The
+        default implementation is a no-op identity transform. Subclasses may
+        override this to wrap, filter, or replace toolsets -- for example to
+        compact oversized tool results, or gate certain servers behind
+        runtime conditions.
+
+        Must return a list of toolsets. If an override raises, the builder
+        fails open: it logs a warning and falls back to the original,
+        pre-override toolsets list rather than crashing agent construction.
+        """
+        return toolsets
+
     def update_mcp_tool_cache_sync(self) -> None:
         """Best-effort warm of each MCP toolset's tool-definition cache.
 

--- a/tests/agents/test_transform_mcp_toolsets.py
+++ b/tests/agents/test_transform_mcp_toolsets.py
@@ -95,16 +95,9 @@ def test_default_build_uses_unmodified_toolsets():
 
 
 def test_override_invoked_once_and_result_used_for_construction():
-    """An override's return value drives both the agent and lifecycle list.
-
-    The override must receive the *post-filter* toolset list (whatever
-    ``filter_conflicting_mcp_tools`` produced), not the raw pre-filter
-    ``mcp_servers`` the loader returned -- so this patches the filter step
-    to return a distinct sentinel object and asserts the seam saw exactly
-    that sentinel, by identity.
-    """
+    """Override receives the post-filter list, not the raw mcp_servers."""
     original = [FunctionToolset()]
-    filtered_sentinel = [FunctionToolset()]  # distinct object from `original`
+    filtered_sentinel = [FunctionToolset()]  # distinct object, asserted by identity
     replacement = [FunctionToolset(), FunctionToolset()]
     calls = []
 

--- a/tests/agents/test_transform_mcp_toolsets.py
+++ b/tests/agents/test_transform_mcp_toolsets.py
@@ -95,8 +95,16 @@ def test_default_build_uses_unmodified_toolsets():
 
 
 def test_override_invoked_once_and_result_used_for_construction():
-    """An override's return value drives both the agent and lifecycle list."""
+    """An override's return value drives both the agent and lifecycle list.
+
+    The override must receive the *post-filter* toolset list (whatever
+    ``filter_conflicting_mcp_tools`` produced), not the raw pre-filter
+    ``mcp_servers`` the loader returned -- so this patches the filter step
+    to return a distinct sentinel object and asserts the seam saw exactly
+    that sentinel, by identity.
+    """
     original = [FunctionToolset()]
+    filtered_sentinel = [FunctionToolset()]  # distinct object from `original`
     replacement = [FunctionToolset(), FunctionToolset()]
     calls = []
 
@@ -106,11 +114,18 @@ def test_override_invoked_once_and_result_used_for_construction():
 
     agent = _FakeAgentConfig(transform=_transform)
 
-    with _patched_build(agent, original):
+    with (
+        _patched_build(agent, original),
+        patch.object(
+            _builder,
+            "filter_conflicting_mcp_tools",
+            lambda *_a, **_k: filtered_sentinel,
+        ),
+    ):
         built = _builder.build_pydantic_agent(agent)
 
     assert len(calls) == 1
-    assert calls[0] == original
+    assert calls[0] is filtered_sentinel
     assert agent._mcp_servers is replacement
     assert built is not None
 
@@ -135,23 +150,9 @@ def test_faulty_override_fails_open_to_original_toolsets():
     mock_warn.assert_called_once()
 
 
-def test_non_list_return_also_fails_open():
-    """An override that returns a non-list is treated as a fault, not used."""
-    original = [FunctionToolset()]
-    agent = _FakeAgentConfig(transform=lambda _toolsets: "not-a-list")
-
-    with (
-        _patched_build(agent, original),
-        patch.object(_builder, "emit_warning") as mock_warn,
-    ):
-        _builder.build_pydantic_agent(agent)
-
-    assert agent._mcp_servers == original
-    mock_warn.assert_called_once()
-
-
-@pytest.mark.parametrize("bad_result", [None, "nope", 42])
+@pytest.mark.parametrize("bad_result", [None, "nope", 42, "not-a-list"])
 def test_various_non_list_returns_fail_open(bad_result):
+    """An override that returns a non-list is treated as a fault, not used."""
     original = [FunctionToolset()]
     agent = _FakeAgentConfig(transform=lambda _toolsets: bad_result)
 

--- a/tests/agents/test_transform_mcp_toolsets.py
+++ b/tests/agents/test_transform_mcp_toolsets.py
@@ -1,0 +1,165 @@
+"""Extension seam: BaseAgent.transform_mcp_toolsets.
+
+Covers the contract enforced in ``_builder.build_pydantic_agent``:
+
+* default (no override) is a true identity no-op
+* an override is invoked exactly once and its return value is what actually
+  gets used for both agent construction and MCP lifecycle tracking
+* a faulty override fails open (falls back to the original toolsets, warns,
+  and still lets construction succeed)
+"""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.toolsets import FunctionToolset
+
+from code_puppy.agents import _builder
+from code_puppy.agents.base_agent import BaseAgent
+
+
+class _FakeAgentConfig(BaseAgent):
+    """Minimal concrete BaseAgent for driving the real build path."""
+
+    def __init__(self, transform=None):
+        super().__init__()
+        self._transform = transform
+
+    @property
+    def name(self):
+        return "test-agent"
+
+    @property
+    def display_name(self):
+        return "Test Agent"
+
+    @property
+    def description(self):
+        return "test"
+
+    def get_system_prompt(self):
+        return "You are a test agent."
+
+    def get_available_tools(self):
+        return []
+
+    def get_model_name(self):
+        return "test-model"
+
+    def transform_mcp_toolsets(self, toolsets):
+        if self._transform is not None:
+            return self._transform(toolsets)
+        return super().transform_mcp_toolsets(toolsets)
+
+
+def _fake_load_model_with_fallback(*_args, **_kwargs):
+    return TestModel(custom_output_text="woof"), "test-model"
+
+
+@contextmanager
+def _patched_build(agent, mcp_servers):
+    with (
+        patch.object(
+            _builder, "load_model_with_fallback", _fake_load_model_with_fallback
+        ),
+        patch.object(_builder.ModelFactory, "load_config", staticmethod(dict)),
+        patch.object(_builder, "load_mcp_servers", lambda **k: mcp_servers),
+        patch.object(_builder, "make_model_settings", lambda *a, **k: None),
+        patch("code_puppy.tools.register_tools_for_agent", lambda *a, **k: None),
+    ):
+        yield
+
+
+def test_default_transform_is_identity_no_op():
+    """No override: the exact same objects, same order, come back out."""
+    toolsets = [FunctionToolset(), FunctionToolset()]
+    agent = _FakeAgentConfig()
+
+    result = agent.transform_mcp_toolsets(toolsets)
+
+    assert result is toolsets
+    assert result == toolsets
+
+
+def test_default_build_uses_unmodified_toolsets():
+    """End-to-end: with no override, the builder wires up the same toolsets."""
+    toolsets = [FunctionToolset()]
+    agent = _FakeAgentConfig()
+
+    with _patched_build(agent, toolsets):
+        _builder.build_pydantic_agent(agent)
+
+    assert agent._mcp_servers == toolsets
+
+
+def test_override_invoked_once_and_result_used_for_construction():
+    """An override's return value drives both the agent and lifecycle list."""
+    original = [FunctionToolset()]
+    replacement = [FunctionToolset(), FunctionToolset()]
+    calls = []
+
+    def _transform(toolsets):
+        calls.append(toolsets)
+        return replacement
+
+    agent = _FakeAgentConfig(transform=_transform)
+
+    with _patched_build(agent, original):
+        built = _builder.build_pydantic_agent(agent)
+
+    assert len(calls) == 1
+    assert calls[0] == original
+    assert agent._mcp_servers is replacement
+    assert built is not None
+
+
+def test_faulty_override_fails_open_to_original_toolsets():
+    """A raising override must not crash construction; it falls back."""
+    original = [FunctionToolset()]
+
+    def _transform(_toolsets):
+        raise RuntimeError("boom")
+
+    agent = _FakeAgentConfig(transform=_transform)
+
+    with (
+        _patched_build(agent, original),
+        patch.object(_builder, "emit_warning") as mock_warn,
+    ):
+        built = _builder.build_pydantic_agent(agent)
+
+    assert built is not None
+    assert agent._mcp_servers == original
+    mock_warn.assert_called_once()
+
+
+def test_non_list_return_also_fails_open():
+    """An override that returns a non-list is treated as a fault, not used."""
+    original = [FunctionToolset()]
+    agent = _FakeAgentConfig(transform=lambda _toolsets: "not-a-list")
+
+    with (
+        _patched_build(agent, original),
+        patch.object(_builder, "emit_warning") as mock_warn,
+    ):
+        _builder.build_pydantic_agent(agent)
+
+    assert agent._mcp_servers == original
+    mock_warn.assert_called_once()
+
+
+@pytest.mark.parametrize("bad_result", [None, "nope", 42])
+def test_various_non_list_returns_fail_open(bad_result):
+    original = [FunctionToolset()]
+    agent = _FakeAgentConfig(transform=lambda _toolsets: bad_result)
+
+    with (
+        _patched_build(agent, original),
+        patch.object(_builder, "emit_warning") as mock_warn,
+    ):
+        _builder.build_pydantic_agent(agent)
+
+    assert agent._mcp_servers == original
+    mock_warn.assert_called_once()


### PR DESCRIPTION
## What
Adds a minimal, generic extension seam so a `BaseAgent` subclass can
post-process its resolved MCP toolsets before the pydantic-ai agent is
constructed: `BaseAgent.transform_mcp_toolsets(toolsets)`, a no-op identity
by default.

## Why
An internal Confluence search agent needs to wrap its MCP toolset to compact
oversized search results before they enter the model's context (full page
bodies were causing heavy rate-limit throttling). There was no supported way
for a `BaseAgent` subclass to intercept/replace its own MCP toolsets, only
the module-level plugin callback registry. This seam is intentionally
Confluence-free and Walmart-free -- it's a generic hook any subclass can use.

## How
- `BaseAgent.transform_mcp_toolsets()`: no-op identity default, documented
  extension point. Explicitly documents that fail-open behavior makes this
  seam unsuitable for security-sensitive gating.
- `_builder.build_pydantic_agent`: calls it exactly once, after MCP
  collision filtering and before the final `pydantic_ai.Agent` is built.
  The result drives both agent construction and `agent._mcp_servers`
  lifecycle tracking. A raising override or a non-list return fails open
  (warns, falls back to the original toolsets) rather than crashing.

## Testing
- `pytest tests/agents/test_transform_mcp_toolsets.py` -- 8/8 passing
  (default identity, override-invoked-once via the post-filter list,
  raising-override fail-open, non-list-return fail-open).
- `pytest tests/agents/` -- 443/443 passing (no regression to unrelated
  agents/builder behavior).
- `ruff check` / `ruff format --check` clean on all touched files.

## Scope
Only `code_puppy/agents/base_agent.py`, `code_puppy/agents/_builder.py`, and
one new test file. No new dependencies, no unrelated refactors. This PR has
no in-repo caller yet -- an internal downstream Confluence-agent PR is the
consumer; happy to discuss whether a `callbacks.py` phase would fit better
than a subclass hook if that's the project's preferred extension pattern.


---

Supersedes #886 (same commits; recreated only to drop a misleading branch name -- a PR head branch cannot be re-pointed after creation).
