### PR TITLE
feat: make agency level a togglable setting

### DIFF
--- a/code_puppy/agents/agent_code_puppy.py
+++ b/code_puppy/agents/agent_code_puppy.py
@@ -1,8 +1,55 @@
 """Code-Puppy - The default code generation agent."""
 
-from code_puppy.config import get_owner_name, get_puppy_name
+from code_puppy.config import get_agency_level, get_owner_name, get_puppy_name
 
 from .base_agent import BaseAgent
+
+#: Prompt sections keyed by agency level (see ``config.get_agency_level``).
+#: 'extreme' preserves the original maximally-agentic wording verbatim.
+_AGENCY_PROMPT_SECTIONS: dict[str, dict[str, str]] = {
+    "low": {
+        "task_step": "3. Pause between steps so the user can steer",
+        "rules": (
+            "- You are at LOW agency: work one step at a time. After each "
+            "meaningful\n  unit of work, stop, summarize what you did, and ask "
+            "the user before continuing\n"
+            "- Never take consequential or irreversible actions without "
+            "explicit approval"
+        ),
+    },
+    "medium": {
+        "task_step": "3. Handle routine steps yourself; check in at milestones",
+        "rules": (
+            "- You are at MEDIUM agency: complete routine, clearly-requested "
+            "work without\n  asking, but pause and check in at major milestones "
+            "or before consequential\n  or irreversible changes"
+        ),
+    },
+    "high": {
+        "task_step": "3. Continue autonomously whenever possible",
+        "rules": (
+            "- Complete the requested task autonomously. Do not ask for routine permission\n"
+            "  to continue work the user already requested. Ask only when blocked by missing\n"
+            "  requirements, consequential ambiguity, credentials, or an irreversible action\n"
+            "  requiring approval.\n"
+            "- Continue autonomously unless user input is definitively required"
+        ),
+    },
+    "extreme": {
+        "task_step": "3. Continue autonomously whenever possible",
+        "rules": (
+            "- Complete the requested task autonomously. Do not ask for routine permission\n"
+            "  to continue work the user already requested. Ask only when blocked by missing\n"
+            "  requirements, consequential ambiguity, credentials, or an irreversible action\n"
+            "  requiring approval.\n"
+            "- Continue autonomously unless user input is definitively required\n"
+            "- If a backgrounded process gates completion, do not stop and force the user "
+            "to reprompt you. Keep doing useful work, then wait 60 seconds and check its "
+            "progress when no other work remains; repeat until it completes or user input "
+            "is genuinely required. Be as agentic as possible."
+        ),
+    },
+}
 
 
 class CodePuppyAgent(BaseAgent):
@@ -53,11 +100,16 @@ class CodePuppyAgent(BaseAgent):
             ),
         }
 
+    def _get_agency_prompt_sections(self) -> dict[str, str]:
+        """Return prompt sections matching the configured agency level."""
+        return _AGENCY_PROMPT_SECTIONS[get_agency_level()]
+
     def get_system_prompt(self) -> str:
         """Get Code-Puppy's full system prompt."""
         puppy_name = get_puppy_name()
         owner_name = get_owner_name()
         r = self._get_reasoning_prompt_sections()
+        a = self._get_agency_prompt_sections()
 
         result = f"""
 You are {puppy_name}, the most loyal digital puppy, helping your owner {owner_name} get coding stuff done!
@@ -77,21 +129,16 @@ If asked 'what is code puppy': 'I am {puppy_name}! 🐶 A sassy, open-source AI 
 When given a coding task:
 1. Analyze the requirements carefully
 2. Execute the plan by using appropriate tools
-3. Continue autonomously whenever possible
+{a["task_step"]}
 
 Important rules:
 - You MUST use tools — DO NOT just output code or descriptions
-- Complete the requested task autonomously. Do not ask for routine permission
-  to continue work the user already requested. Ask only when blocked by missing
-  requirements, consequential ambiguity, credentials, or an irreversible action
-  requiring approval.
 {r["pre_tool_rule"]}
 - Explore directories before reading/modifying files
 - Read existing files before modifying them
 - Prefer edit over create_file. Keep diffs small (100-300 lines).
 {r["loop_rule"]}
-- Continue autonomously unless user input is definitively required
-- If a backgrounded process gates completion, do not stop and force the user to reprompt you. Keep doing useful work, then wait 60 seconds and check its progress when no other work remains; repeat until it completes or user input is genuinely required. Be as agentic as possible.
+{a["rules"]}
 """
         # NOTE: runtime ``load_prompt`` fragments (env context, permission
         # rules, memory recall) are intentionally NOT appended here — injected

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -581,6 +581,11 @@ async def main():
         if args.prompt:
             initial_command = args.prompt
             prompt_only_mode = True
+            # Headless runs have nobody at the keyboard to answer check-ins,
+            # so agency is always EXTREME regardless of config.
+            from code_puppy.config import set_headless_mode
+
+            set_headless_mode(True)
         elif args.command:
             initial_command = " ".join(args.command)
             prompt_only_mode = False
@@ -786,6 +791,10 @@ async def interactive_mode(message_renderer, initial_command: str = None) -> Non
     # brackets. A Text object bypasses that string branch entirely and
     # renders as one line, actually bold.
     emit_system_message(Text(t("cli.help.press_tab"), style="bold"))
+    # Tell the user how relentless the puppy is configured to be.
+    from code_puppy.config import get_agency_level
+
+    emit_info(t("cli.agency.status", level=get_agency_level().upper()))
     # Print truecolor warning LAST so it's the most visible thing on startup
     # Big ugly red box should be impossible to miss!
     print_truecolor_warning(display_console)

--- a/code_puppy/command_line/set_menu_catalog.py
+++ b/code_puppy/command_line/set_menu_catalog.py
@@ -23,6 +23,8 @@ from code_puppy.command_line.set_menu_shims import (
     get_max_pause_seconds_effective,
 )
 from code_puppy.config import (
+    AGENCY_LEVELS,
+    get_agency_level,
     get_allow_recursion,
     get_auto_save_session,
     get_compaction_strategy,
@@ -133,6 +135,18 @@ _MODEL = SettingsCategory(
 _BEHAVIOR = SettingsCategory(
     name="Behavior",
     settings=(
+        Setting(
+            key="agency_level",
+            display_name="Agency Level",
+            description=(
+                "How relentlessly the agent proceeds without checking in. "
+                "'low' pauses after every step, 'extreme' never stops. "
+                "Headless -p runs always behave as 'extreme'."
+            ),
+            type_hint="choice",
+            valid_values=AGENCY_LEVELS,
+            effective_getter=get_agency_level,
+        ),
         Setting(
             key="yolo_mode",
             display_name="YOLO Mode",

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -520,6 +520,9 @@ def get_config_keys():
     # Add /goal iteration cap (owned by the wiggum plugin, surfaced here so
     # /set autocompletes it). See plugins/wiggum/register_callbacks.py.
     default_keys.append("goal_max_iterations")
+    # How relentlessly the agent proceeds without checking in; headless -p
+    # runs always behave as 'extreme' (see get_agency_level()).
+    default_keys.append("agency_level")
     # Add dangerous command guard disable (skips force push and destructive command guards)
     default_keys.append("disable_dangerous_command_guard")
     # Per-pattern allowlist bypassing the command guards (e.g. "git reset
@@ -1462,6 +1465,44 @@ def get_yolo_mode() -> bool:
         return _cli_yolo_override
 
     return get_truthy_bool_value("yolo_mode", True)
+
+
+AGENCY_LEVELS = ("low", "medium", "high", "extreme")
+
+_headless_mode: bool = False
+
+
+def set_headless_mode(value: bool) -> None:
+    """Mark this process as headless (``-p`` prompt); process-local only."""
+    global _headless_mode
+    _headless_mode = value
+
+
+def get_headless_mode() -> bool:
+    """Return whether this process is running a headless ``-p`` prompt."""
+    return _headless_mode
+
+
+def get_agency_level() -> str:
+    """
+    Checks puppy.cfg for 'agency_level' (case-insensitive in value only).
+    Allowed values: 'low', 'medium', 'high', 'extreme'.
+    Defaults to 'extreme' if not set or invalid.
+
+    Headless (``-p``) runs always report 'extreme' no matter what the config
+    says — there is nobody at the keyboard to answer check-ins, so anything
+    lower would just stall the run.
+
+    Returns the normalized lowercase string.
+    """
+    if _headless_mode:
+        return "extreme"
+    cfg_val = get_value("agency_level")
+    if cfg_val is not None:
+        normalized = str(cfg_val).strip().lower()
+        if normalized in AGENCY_LEVELS:
+            return normalized
+    return "extreme"
 
 
 def get_mcp_disabled():

--- a/code_puppy/i18n/locales/en-US.json
+++ b/code_puppy/i18n/locales/en-US.json
@@ -53,6 +53,7 @@
   "cli.resume.resumed": "Resumed: {messages} messages ({tokens} tokens) from {session}",
   "cli.resume.failed": "Failed to resume from {target}: {error}",
   "cli.help.press_tab": "Press Tab for help (press Tab again to close).",
+  "cli.agency.status": "🐾 Agency level: {level} — change with /set agency_level low|medium|high|extreme (headless -p runs are always EXTREME)",
   "cli.prompt.enter_task": "Enter your coding task:",
   "cli.initial_command.processing": "Processing initial command: {command}",
   "cli.initial_command.continuing": "🐶 Continuing in Interactive Mode",

--- a/tests/agents/test_agents_remaining_coverage.py
+++ b/tests/agents/test_agents_remaining_coverage.py
@@ -124,6 +124,43 @@ def test_code_puppy_prompt_requires_autonomous_task_completion():
     assert "an irreversible action requiring approval" in prompt
 
 
+def test_code_puppy_prompt_reflects_low_agency(monkeypatch):
+    """LOW agency swaps the relentless bullets for step-at-a-time check-ins."""
+    from code_puppy.agents import agent_code_puppy
+
+    monkeypatch.setattr(agent_code_puppy, "get_agency_level", lambda: "low")
+    prompt = " ".join(agent_code_puppy.CodePuppyAgent().get_system_prompt().split())
+
+    assert "LOW agency" in prompt
+    assert "ask the user before continuing" in prompt
+    assert "Complete the requested task autonomously" not in prompt
+    assert "Be as agentic as possible" not in prompt
+
+
+def test_code_puppy_prompt_reflects_medium_agency(monkeypatch):
+    """MEDIUM agency proceeds on routine work but checks in at milestones."""
+    from code_puppy.agents import agent_code_puppy
+
+    monkeypatch.setattr(agent_code_puppy, "get_agency_level", lambda: "medium")
+    prompt = " ".join(agent_code_puppy.CodePuppyAgent().get_system_prompt().split())
+
+    assert "MEDIUM agency" in prompt
+    assert "check in at major milestones" in prompt
+    assert "Be as agentic as possible" not in prompt
+
+
+def test_code_puppy_prompt_reflects_high_agency(monkeypatch):
+    """HIGH agency keeps autonomy but drops the background-gating relentlessness."""
+    from code_puppy.agents import agent_code_puppy
+
+    monkeypatch.setattr(agent_code_puppy, "get_agency_level", lambda: "high")
+    prompt = " ".join(agent_code_puppy.CodePuppyAgent().get_system_prompt().split())
+
+    assert "Complete the requested task autonomously" in prompt
+    assert "Continue autonomously unless user input is definitively required" in prompt
+    assert "Be as agentic as possible" not in prompt
+
+
 def test_planning_agent_routes_scraping_but_allows_direct_curl():
     """Keep the same scraping/fetch boundary in planning guidance."""
     from code_puppy.agents.agent_planning import PlanningAgent

--- a/tests/test_config_full_coverage.py
+++ b/tests/test_config_full_coverage.py
@@ -129,6 +129,48 @@ class TestBooleanGetters:
 
 
 # ---------------------------------------------------------------------------
+# Agency level
+# ---------------------------------------------------------------------------
+class TestAgencyLevel:
+    @pytest.fixture(autouse=True)
+    def _reset_headless_mode(self, monkeypatch):
+        """Other tests may exercise the -p path, leaking the sticky flag."""
+        monkeypatch.setattr(cp_config, "_headless_mode", False)
+
+    def test_default_extreme(self):
+        assert cp_config.get_agency_level() == "extreme"
+
+    def test_valid_levels(self):
+        for level in cp_config.AGENCY_LEVELS:
+            cp_config.set_config_value("agency_level", level)
+            assert cp_config.get_agency_level() == level
+
+    def test_value_is_normalized(self):
+        cp_config.set_config_value("agency_level", "  MeDiUm ")
+        assert cp_config.get_agency_level() == "medium"
+
+    def test_invalid_falls_back_to_extreme(self):
+        cp_config.set_config_value("agency_level", "ludicrous")
+        assert cp_config.get_agency_level() == "extreme"
+
+    def test_headless_forces_extreme(self, monkeypatch):
+        cp_config.set_config_value("agency_level", "low")
+        monkeypatch.setattr(cp_config, "_headless_mode", True)
+        assert cp_config.get_agency_level() == "extreme"
+
+    def test_set_headless_mode_round_trip(self, monkeypatch):
+        monkeypatch.setattr(cp_config, "_headless_mode", False)
+        assert cp_config.get_headless_mode() is False
+        cp_config.set_headless_mode(True)
+        assert cp_config.get_headless_mode() is True
+        cp_config.set_headless_mode(False)
+        assert cp_config.get_headless_mode() is False
+
+    def test_agency_level_in_config_keys(self):
+        assert "agency_level" in cp_config.get_config_keys()
+
+
+# ---------------------------------------------------------------------------
 # Numeric config getters
 # ---------------------------------------------------------------------------
 class TestNumericGetters:


### PR DESCRIPTION
## What

Turns the maximally-agentic prompting (583dbf6 + b738102) into a four-level dial: `low`, `medium`, `high`, and `extreme`.

- **`extreme`** (default — zero behavior change): the current wording verbatim, including the 60-second background-process vigil and *Be as agentic as possible*
- **`high`**: autonomous completion + no routine permission-asking, but drops the background-gating relentlessness
- **`medium`**: routine work proceeds; checks in at major milestones and before consequential changes
- **`low`**: one step at a time; stop, summarize, ask before continuing

## How

- `config.get_agency_level()` + exported `AGENCY_LEVELS`; invalid values fall back to `extreme` (mirrors `get_safety_permission_level`)
- **Headless `-p` runs are always `extreme`** regardless of config — a process-local flag (same pattern as `_cli_yolo_override`) set in the prompt-only path; nobody is at the keyboard to answer check-ins
- Prompt sections are selected at build time, so `/set agency_level ...` takes effect on the next run without a restart
- Interactive startup announces the effective level and how to change it (i18n'd, `cli.agency.status`)
- `/set` menu: curated **Behavior** choice entry with `valid_values` sourced from `AGENCY_LEVELS`; tab completion via `get_config_keys()`

## Testing

- 7 new config tests (`TestAgencyLevel`): defaults, normalization, invalid fallback, headless override, round trip, key registration — with an autouse fixture resetting the sticky headless flag (other tests exercise `-p` and leak it)
- 3 new prompt tests asserting low/medium/high content and that *Be as agentic as possible* only appears at extreme
- Existing agentic-prompt tests pass untouched (default is extreme)
- Full suite: **7652 passed, 32 skipped**; `ruff check` + `ruff format` clean