### PR TITLE
fix: default agency level to high

### DIFF
--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -1487,7 +1487,8 @@ def get_agency_level() -> str:
     """
     Checks puppy.cfg for 'agency_level' (case-insensitive in value only).
     Allowed values: 'low', 'medium', 'high', 'extreme'.
-    Defaults to 'extreme' if not set or invalid.
+    Defaults to 'high' if not set or invalid: fully autonomous on requested
+    work, without the relentless background-process vigil of 'extreme'.
 
     Headless (``-p``) runs always report 'extreme' no matter what the config
     says — there is nobody at the keyboard to answer check-ins, so anything
@@ -1502,7 +1503,7 @@ def get_agency_level() -> str:
         normalized = str(cfg_val).strip().lower()
         if normalized in AGENCY_LEVELS:
             return normalized
-    return "extreme"
+    return "high"
 
 
 def get_mcp_disabled():

--- a/tests/test_config_full_coverage.py
+++ b/tests/test_config_full_coverage.py
@@ -137,8 +137,8 @@ class TestAgencyLevel:
         """Other tests may exercise the -p path, leaking the sticky flag."""
         monkeypatch.setattr(cp_config, "_headless_mode", False)
 
-    def test_default_extreme(self):
-        assert cp_config.get_agency_level() == "extreme"
+    def test_default_high(self):
+        assert cp_config.get_agency_level() == "high"
 
     def test_valid_levels(self):
         for level in cp_config.AGENCY_LEVELS:
@@ -149,9 +149,9 @@ class TestAgencyLevel:
         cp_config.set_config_value("agency_level", "  MeDiUm ")
         assert cp_config.get_agency_level() == "medium"
 
-    def test_invalid_falls_back_to_extreme(self):
+    def test_invalid_falls_back_to_high(self):
         cp_config.set_config_value("agency_level", "ludicrous")
-        assert cp_config.get_agency_level() == "extreme"
+        assert cp_config.get_agency_level() == "high"
 
     def test_headless_forces_extreme(self, monkeypatch):
         cp_config.set_config_value("agency_level", "low")

--- a/tests/test_coverage_agents_gaps.py
+++ b/tests/test_coverage_agents_gaps.py
@@ -76,10 +76,12 @@ class TestCodePuppyAgentTools:
         assert "model_name" not in prompt
         assert "invoke_agent_with_model" not in prompt
 
-    def test_prompt_waits_for_gating_background_processes(self):
-        from code_puppy.agents.agent_code_puppy import CodePuppyAgent
+    def test_prompt_waits_for_gating_background_processes(self, monkeypatch):
+        """The relentless background vigil is EXTREME-agency wording."""
+        from code_puppy.agents import agent_code_puppy
 
-        prompt = CodePuppyAgent().get_system_prompt()
+        monkeypatch.setattr(agent_code_puppy, "get_agency_level", lambda: "extreme")
+        prompt = agent_code_puppy.CodePuppyAgent().get_system_prompt()
 
         assert "do not stop and force the user to reprompt you" in prompt
         assert "wait 60 seconds and check its progress" in prompt


### PR DESCRIPTION
## What

Flips the `agency_level` default from `extreme` to `high` (follow-up to #897).

## Why

`extreme` as the out-of-the-box default preserved pre-dial behavior, but it's the wrong policy for new users: they shouldn't start with the never-stop background vigil enabled. `high` keeps full autonomy on requested work — no routine permission-asking, continue unless input is definitively required — and only drops the extreme-only relentlessness.

**Headless `-p` runs still force `extreme`**, unchanged.

## Changes

- `get_agency_level()` falls back to `high` (unset *and* invalid values)
- `TestAgencyLevel`: default/invalid-fallback expectations updated to `high`
- `test_prompt_waits_for_gating_background_processes` now pins agency to `extreme`, since the 60-second vigil wording is extreme-only by design

## Testing

Full suite: **7631 passed, 32 skipped**; ruff clean.