### PR TITLE
feat(model_utils): let prepare_model_prompt plugins emit a standing SystemPromptPart

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
 from pydantic_ai import Agent as PydanticAgent
 from pydantic_ai.capabilities import ProcessHistory
@@ -42,6 +42,9 @@ from code_puppy.config import (
 from code_puppy.mcp_ import get_mcp_manager
 from code_puppy.messaging import emit_error, emit_info, emit_warning
 from code_puppy.model_factory import ModelFactory, make_model_settings
+
+if TYPE_CHECKING:
+    from code_puppy.model_utils import PreparedPrompt
 
 _AGENT_RULE_FILES = ("AGENTS.md", "AGENT.md", "agents.md", "agent.md")
 _CODE_PUPPY_DIR = ".code_puppy"
@@ -572,8 +575,13 @@ def _agent_exposes_tool(agent: Any, tool_name: str) -> bool:
         return False
 
 
-def _assemble_instructions(agent: Any, resolved_model_name: str) -> str:
-    """Compose full system prompt + puppy rules + extended-thinking note."""
+def _assemble_instructions(agent: Any, resolved_model_name: str) -> PreparedPrompt:
+    """Compose full system prompt + puppy rules + extended-thinking note.
+
+    Returns the model-prepared prompt: ``instructions`` for the agent plus any
+    standing ``system_prompt`` a plugin wants emitted as its own
+    ``SystemPromptPart`` ahead of them.
+    """
     from code_puppy.model_utils import prepare_prompt_for_model
     from code_puppy.tools import (
         EXTENDED_THINKING_PROMPT_NOTE,
@@ -594,10 +602,9 @@ def _assemble_instructions(agent: Any, resolved_model_name: str) -> str:
         if _agent_exposes_tool(agent, "agent_run_shell_command"):
             instructions += _GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT
 
-    prepared = prepare_prompt_for_model(
+    return prepare_prompt_for_model(
         agent.get_model_name(), instructions, "", prepend_system_to_user=False
     )
-    return prepared.instructions
 
 
 def build_pydantic_agent(
@@ -637,7 +644,7 @@ def build_pydantic_agent(
         message_group,
         agent_name=getattr(agent, "name", None),
     )
-    instructions = _assemble_instructions(agent, resolved_model_name)
+    prepared = _assemble_instructions(agent, resolved_model_name)
     mcp_servers = load_mcp_servers(agent_name=getattr(agent, "name", None))
     model_settings = make_model_settings(
         resolved_model_name,
@@ -657,7 +664,10 @@ def build_pydantic_agent(
             # caller's frame variables, so observability spans read
             # "invoke_agent pydantic_agent" instead of the logical agent name.
             name=logical_agent_name,
-            instructions=instructions,
+            # A standing system_prompt (if any) becomes its own SystemPromptPart
+            # in the first request, rendered ahead of the instructions block.
+            system_prompt=prepared.system_prompt_parts,
+            instructions=prepared.instructions,
             output_type=output_type,
             retries=3,
             toolsets=toolsets,

--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -257,7 +257,7 @@ class BaseAgent(ABC):
                 user_prompt="",
                 prepend_system_to_user=False,
             )
-            resolved = prepared.instructions or system_prompt
+            resolved = prepared.system_text or system_prompt
         except Exception:
             resolved = system_prompt
 

--- a/code_puppy/callbacks.py
+++ b/code_puppy/callbacks.py
@@ -1128,8 +1128,8 @@ def on_prepare_model_prompt(
 
     This is the hook fired from ``model_utils.prepare_prompt_for_model`` to let
     plugins take over prompt preparation for specific model families (e.g.
-    claude-code OAuth models which need a hard-coded instruction string and
-    have the system prompt prepended to the user message).
+    claude-code OAuth models, which need a fixed identity line as the
+    opening system block ahead of the real system prompt).
 
     Unlike ``get_model_system_prompt`` (which is used by augmenting plugins like
     agent_skills), this hook is for plugins that want to *fully handle* the
@@ -1148,6 +1148,8 @@ def on_prepare_model_prompt(
         - ``"handled"``: bool — True if this callback fully prepared the prompt.
         - ``"instructions"``: str — the system prompt/instructions to use.
         - ``"user_prompt"``: str — the (possibly modified) user prompt.
+        - ``"system_prompt"``: str — (optional) a standing system prompt emitted
+          as its own ``SystemPromptPart`` *before* ``instructions``.
         - ``"is_claude_code"``: bool — (optional) flag preserved on PreparedPrompt.
 
     Or return ``None`` to indicate "I don't handle this model".

--- a/code_puppy/model_utils.py
+++ b/code_puppy/model_utils.py
@@ -25,11 +25,39 @@ class PreparedPrompt:
         user_prompt: The user prompt (possibly modified)
         is_claude_code: Whether this is a claude-code model (set by the
             claude_code_oauth plugin via the ``prepare_model_prompt`` hook).
+        system_prompt: A standing system prompt emitted as its own
+            ``SystemPromptPart`` *ahead of* ``instructions`` (pydantic-ai's
+            ``Agent(system_prompt=...)``). Empty means none, the default.
+            Used by model families that fingerprint the opening system block
+            (claude-code OAuth) so the real prompt stays a separate block.
     """
 
     instructions: str
     user_prompt: str
     is_claude_code: bool
+    system_prompt: str = ""
+
+    @property
+    def system_prompt_parts(self) -> tuple[str, ...]:
+        """Value for ``Agent(system_prompt=...)``: one standing part, or none."""
+        return (self.system_prompt,) if self.system_prompt else ()
+
+    @property
+    def system_text(self) -> str:
+        """Everything that lands in the model's system slot (for token estimates)."""
+        return "\n\n".join(p for p in (self.system_prompt, self.instructions) if p)
+
+
+def _prepared_from_hook_result(
+    result: dict, system_prompt: str, user_prompt: str
+) -> PreparedPrompt:
+    """Build a ``PreparedPrompt`` from a taker-over hook's ``handled=True`` dict."""
+    return PreparedPrompt(
+        instructions=result.get("instructions", system_prompt),
+        user_prompt=result.get("user_prompt", user_prompt),
+        is_claude_code=bool(result.get("is_claude_code", False)),
+        system_prompt=result.get("system_prompt", ""),
+    )
 
 
 def prepare_prompt_for_model(
@@ -69,11 +97,7 @@ def prepare_prompt_for_model(
         model_name, system_prompt, user_prompt, prepend_system_to_user
     ):
         if result and isinstance(result, dict) and result.get("handled"):
-            return PreparedPrompt(
-                instructions=result.get("instructions", system_prompt),
-                user_prompt=result.get("user_prompt", user_prompt),
-                is_claude_code=bool(result.get("is_claude_code", False)),
-            )
+            return _prepared_from_hook_result(result, system_prompt, user_prompt)
 
     # 2) Legacy per-model hook: "taker-over" plugins return handled=True (first
     #    wins); "augmenters" (e.g. agent_skills) mutate prompts — thread those through.
@@ -85,11 +109,7 @@ def prepare_prompt_for_model(
         if not (result and isinstance(result, dict)):
             continue
         if result.get("handled"):
-            return PreparedPrompt(
-                instructions=result.get("instructions", system_prompt),
-                user_prompt=result.get("user_prompt", user_prompt),
-                is_claude_code=bool(result.get("is_claude_code", False)),
-            )
+            return _prepared_from_hook_result(result, system_prompt, user_prompt)
         # Augmenter: carry its mutations forward. Last augmenter wins on
         # collisions (YAGNI: there's exactly one augmenter today).
         if "instructions" in result:

--- a/code_puppy/token_usage.py
+++ b/code_puppy/token_usage.py
@@ -237,7 +237,7 @@ def _resolved_system_prompt(agent) -> str:
             user_prompt="",
             prepend_system_to_user=False,
         )
-        return prepared.instructions or system_prompt
+        return prepared.system_text or system_prompt
     except Exception:
         return system_prompt
 

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -415,7 +415,8 @@ async def _invoke_agent_impl(
             # via BaseAgent — appending again would double-inject them.
             from code_puppy.model_utils import prepare_prompt_for_model
 
-            # Handle claude-code models: swap instructions, and prepend system prompt only on first message
+            # Model-family prep (e.g. claude-code): may split off a standing
+            # system_prompt part, or touch the user prompt on the first message.
             prepared = prepare_prompt_for_model(
                 effective_model_name,
                 instructions,
@@ -467,6 +468,7 @@ async def _invoke_agent_impl(
                 # span reads "invoke_agent temp_agent" instead of the logical
                 # agent name (e.g. "invoke_agent web-retriever").
                 name=agent_name,
+                system_prompt=prepared.system_prompt_parts,
                 instructions=instructions,
                 output_type=str,
                 retries=3,

--- a/tests/agents/test_agent_model_settings.py
+++ b/tests/agents/test_agent_model_settings.py
@@ -8,6 +8,7 @@ import pytest
 from code_puppy.agents._builder import build_pydantic_agent
 from code_puppy.agents.json_agent import JSONAgent
 from code_puppy.model_factory import ModelFactory, make_model_settings
+from code_puppy.model_utils import PreparedPrompt
 
 
 def _json_agent_config(**overrides):
@@ -230,7 +231,9 @@ def test_main_agent_builder_passes_agent_model_settings():
         ),
         patch(
             "code_puppy.agents._builder._assemble_instructions",
-            return_value="instructions",
+            return_value=PreparedPrompt(
+                instructions="instructions", user_prompt="", is_claude_code=False
+            ),
         ),
         patch("code_puppy.agents._builder.load_mcp_servers", return_value=[]),
         patch("code_puppy.agents._builder.make_model_settings") as make_settings,

--- a/tests/test_prepare_prompt_system_prompt.py
+++ b/tests/test_prepare_prompt_system_prompt.py
@@ -1,0 +1,94 @@
+"""Tests for the ``system_prompt`` seam on ``PreparedPrompt``.
+
+A ``prepare_model_prompt`` plugin may return a standing ``system_prompt``; it
+must ride through ``prepare_prompt_for_model`` and land on pydantic-ai's
+``Agent(system_prompt=...)`` as its own ``SystemPromptPart``, ahead of the
+``instructions`` block.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic_ai.messages import ModelRequest, SystemPromptPart, UserPromptPart
+from pydantic_ai.models.test import TestModel
+
+from code_puppy.callbacks import clear_callbacks, register_callback
+from code_puppy.model_utils import PreparedPrompt, prepare_prompt_for_model
+
+IDENTITY = "You are a very good dog."
+REAL_PROMPT = "Fetch things. Do not eat the couch."
+
+
+_PROMPT_HOOKS = ("prepare_model_prompt", "get_model_system_prompt")
+
+
+@pytest.fixture(autouse=True)
+def _clean_hooks():
+    """Both prompt hooks feed ``prepare_prompt_for_model``; isolate both."""
+    for phase in _PROMPT_HOOKS:
+        clear_callbacks(phase)
+    yield
+    for phase in _PROMPT_HOOKS:
+        clear_callbacks(phase)
+
+
+def _register_splitting_plugin():
+    def plugin(model_name, system_prompt, user_prompt, prepend_system_to_user=True):
+        if not model_name.startswith("splitty"):
+            return None
+        return {
+            "handled": True,
+            "system_prompt": IDENTITY,
+            "instructions": system_prompt,
+            "user_prompt": user_prompt,
+        }
+
+    register_callback("prepare_model_prompt", plugin)
+
+
+def test_default_has_no_standing_system_prompt():
+    prepared = prepare_prompt_for_model("plain-model", REAL_PROMPT, "hi")
+
+    assert prepared.system_prompt == ""
+    assert prepared.system_prompt_parts == ()
+    assert prepared.system_text == REAL_PROMPT
+
+
+def test_hook_system_prompt_flows_through():
+    _register_splitting_plugin()
+
+    prepared = prepare_prompt_for_model("splitty-9000", REAL_PROMPT, "hi")
+
+    assert prepared.system_prompt == IDENTITY
+    assert prepared.instructions == REAL_PROMPT
+    assert prepared.user_prompt == "hi"
+    assert prepared.system_prompt_parts == (IDENTITY,)
+    assert prepared.system_text == f"{IDENTITY}\n\n{REAL_PROMPT}"
+
+
+def test_system_prompt_parts_becomes_a_separate_system_prompt_part():
+    """End-to-end through pydantic-ai: identity is its own SystemPromptPart,
+    the real prompt rides on ``ModelRequest.instructions``."""
+    from pydantic_ai import Agent
+
+    prepared = PreparedPrompt(
+        instructions=REAL_PROMPT,
+        user_prompt="hi",
+        is_claude_code=False,
+        system_prompt=IDENTITY,
+    )
+    agent = Agent(
+        TestModel(),
+        system_prompt=prepared.system_prompt_parts,
+        instructions=prepared.instructions,
+    )
+
+    result = agent.run_sync("hi")
+
+    first = result.all_messages()[0]
+    assert isinstance(first, ModelRequest)
+    assert isinstance(first.parts[0], SystemPromptPart)
+    assert first.parts[0].content == IDENTITY
+    assert isinstance(first.parts[1], UserPromptPart)
+    assert first.parts[1].content == "hi"
+    assert first.instructions == REAL_PROMPT


### PR DESCRIPTION
## Why

The `claude_code_oauth` plugin has been returning only the Claude Code identity line as `instructions` and smuggling the **real** system prompt into the first user turn. The OAuth endpoint fingerprints the *first system block*, so the identity line has to lead — but nothing says the real prompt has to leave the system slot.

The Claude Code CLI itself sends two system blocks: `[identity][real prompt]`. pydantic-ai's Anthropic mapper renders the leading request's `SystemPromptPart`s as the first block and each `InstructionPart` after it, so the natural way to get that layout is `Agent(system_prompt=identity, instructions=real_prompt)`. Core had no way for a plugin to ask for that.

## What

- `PreparedPrompt.system_prompt: str = ""` — a standing system prompt a `prepare_model_prompt` plugin may return; emitted as its own `SystemPromptPart` ahead of `instructions`.
  - `system_prompt_parts` → value for `Agent(system_prompt=...)` (one part, or none)
  - `system_text` → whole system slot, for token estimators
- `_builder` and `subagent_invocation` pass `system_prompt=prepared.system_prompt_parts` to the `Agent`.
- `base_agent._estimate_context_overhead` / `token_usage._resolved_system_prompt` count `system_text` instead of `instructions` only.
- DRY'd the two identical dict→`PreparedPrompt` blocks in `prepare_prompt_for_model` into `_prepared_from_hook_result`.
- Hook docs updated in `callbacks.py`.

Model-agnostic: nothing here mentions claude-code beyond the docstrings. Default behaviour is unchanged (`system_prompt=()`).

## Wire proof

Run through pydantic-ai's real `AnthropicModel._map_message` with the plugin change applied:

```json
"system": [
  {"type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude."},
  {"type": "text", "text": "<real system prompt>", "cache_control": {"type": "ephemeral", "ttl": "5m"}}
]
```

Cache breakpoint still lands after the real prompt.

## Tests

- New `tests/test_prepare_prompt_system_prompt.py` (default is empty; hook value flows through; end-to-end via pydantic-ai `TestModel` that the identity is a separate `SystemPromptPart` and the real prompt is `ModelRequest.instructions`).
- `tests/agents/test_agent_model_settings.py` updated: `_assemble_instructions` now returns a `PreparedPrompt`.
- Full suite: 7677 passed, run against the local plugin branch via an editable override.

## Sequencing

Land + release this **before** the companion plugin PR (`code_puppy_core_plugins`: `fix/claude-code-oauth-system-prompt-placement`). On an older core the plugin's `system_prompt` key is simply ignored and the transport's `_ensure_claude_code_system_prompt` safety net still prepends the identity block — correct, just not the two-block layout.

## Known wart (not new)

The `SystemPromptPart` persists in `_message_history` like any standing system prompt, so switching away from claude-code mid-session leaves the identity line at the top of history. The old user-turn smuggling had the same property. Flagging, not fixing.