### PR TITLE
Accept mcp_servers: null in JSON agent config

### DIFF
--- a/code_puppy/agents/json_agent.py
+++ b/code_puppy/agents/json_agent.py
@@ -168,12 +168,6 @@ class JSONAgent(BaseAgent):
         if "mcp_servers" in self._config:
             mcp_servers = self._config["mcp_servers"]
             if mcp_servers is None:
-                # Explicit JSON null means "no bindings" — this is the shape
-                # the marketplace backend emits for agents with no MCP
-                # servers bound, and is functionally identical to the key
-                # being absent entirely. Mirrors the `is not None` guard
-                # already used by get_declared_mcp_bindings() and the
-                # upload/download marketplace plugins.
                 pass
             elif isinstance(mcp_servers, list):
                 for entry in mcp_servers:

--- a/code_puppy/agents/json_agent.py
+++ b/code_puppy/agents/json_agent.py
@@ -167,7 +167,15 @@ class JSONAgent(BaseAgent):
         # message.
         if "mcp_servers" in self._config:
             mcp_servers = self._config["mcp_servers"]
-            if isinstance(mcp_servers, list):
+            if mcp_servers is None:
+                # Explicit JSON null means "no bindings" — this is the shape
+                # the marketplace backend emits for agents with no MCP
+                # servers bound, and is functionally identical to the key
+                # being absent entirely. Mirrors the `is not None` guard
+                # already used by get_declared_mcp_bindings() and the
+                # upload/download marketplace plugins.
+                pass
+            elif isinstance(mcp_servers, list):
                 for entry in mcp_servers:
                     if not isinstance(entry, str):
                         raise ValueError(

--- a/tests/agents/test_json_agent_corruption_resilience.py
+++ b/tests/agents/test_json_agent_corruption_resilience.py
@@ -82,3 +82,41 @@ def test_discover_json_agents_skips_corrupt_files_without_raising(
 
     assert agents.get("test-agent") == str(good)
     assert len(agents) == 1
+
+
+def test_mcp_servers_null_is_accepted(agent_path):
+    """Explicit JSON ``null`` for ``mcp_servers`` must be treated as "no
+    bindings declared", not rejected. This is the shape the marketplace
+    backend emits for agents with no MCP servers bound (see
+    ``AgentPublish.mcp_servers: dict[str, dict] | None`` in puppy-frontend),
+    so a downloaded agent with no bindings must load cleanly rather than
+    raising during ``_validate_config()``.
+    """
+    agent_path.write_text(json.dumps({**VALID_CONFIG, "mcp_servers": None}))
+
+    agent = JSONAgent(str(agent_path))
+
+    assert agent._config["name"] == "test-agent"
+    assert agent.get_declared_mcp_bindings() == {}
+
+
+def test_mcp_servers_null_agent_is_discoverable(tmp_path, monkeypatch):
+    """Before the fix, ``mcp_servers: null`` raised a ``ValueError`` from
+    ``_validate_config()`` that ``discover_json_agents()`` silently
+    swallowed, so the agent vanished from the registry entirely
+    (presenting to the user as "agent not found"). Confirm the agent now
+    survives discovery.
+    """
+    from code_puppy.agents.json_agent import discover_json_agents
+
+    agent_file = tmp_path / "no-bindings.json"
+    agent_file.write_text(json.dumps({**VALID_CONFIG, "mcp_servers": None}))
+
+    monkeypatch.setattr(
+        "code_puppy.config.get_user_agents_directory", lambda: str(tmp_path)
+    )
+    monkeypatch.setattr("code_puppy.config.get_project_agents_directory", lambda: None)
+
+    agents = discover_json_agents()
+
+    assert agents.get("test-agent") == str(agent_file)

--- a/tests/agents/test_json_agent_corruption_resilience.py
+++ b/tests/agents/test_json_agent_corruption_resilience.py
@@ -85,13 +85,7 @@ def test_discover_json_agents_skips_corrupt_files_without_raising(
 
 
 def test_mcp_servers_null_is_accepted(agent_path):
-    """Explicit JSON ``null`` for ``mcp_servers`` must be treated as "no
-    bindings declared", not rejected. This is the shape the marketplace
-    backend emits for agents with no MCP servers bound (see
-    ``AgentPublish.mcp_servers: dict[str, dict] | None`` in puppy-frontend),
-    so a downloaded agent with no bindings must load cleanly rather than
-    raising during ``_validate_config()``.
-    """
+    """A null mcp_servers value represents no declared bindings."""
     agent_path.write_text(json.dumps({**VALID_CONFIG, "mcp_servers": None}))
 
     agent = JSONAgent(str(agent_path))
@@ -101,12 +95,7 @@ def test_mcp_servers_null_is_accepted(agent_path):
 
 
 def test_mcp_servers_null_agent_is_discoverable(tmp_path, monkeypatch):
-    """Before the fix, ``mcp_servers: null`` raised a ``ValueError`` from
-    ``_validate_config()`` that ``discover_json_agents()`` silently
-    swallowed, so the agent vanished from the registry entirely
-    (presenting to the user as "agent not found"). Confirm the agent now
-    survives discovery.
-    """
+    """A null-valued agent remains visible during discovery."""
     from code_puppy.agents.json_agent import discover_json_agents
 
     agent_file = tmp_path / "no-bindings.json"


### PR DESCRIPTION
## Problem
Downstream marketplace tooling can emit an explicit JSON `null` for an
agent's `mcp_servers` field to mean "no MCP server bindings declared."
`JSONAgent._validate_config()` only accepted `list`/`dict` for that
field and raised `ValueError` on `None`. The discovery path silently
swallows that exception, so the agent simply vanished from the local
registry with no error surfaced to the user.

## Fix
Treat an explicit `null` the same as the field being absent entirely:
no bindings declared. Narrow, additive change to the validator -- no
other validation behavior changes.

## Testing
- New regression tests: direct construction with `mcp_servers: null`,
  and end-to-end discovery of an agent with `mcp_servers: null`.
- Full JSON-agent test suite passes.
- Ruff clean.

(Internal tracking: https://jira.walmart.com/browse/PUP-713)
