### PR TITLE
fix(grep): report truncation instead of silently capping at 50 matches

### DIFF
--- a/code_puppy/messaging/messages.py
+++ b/code_puppy/messaging/messages.py
@@ -156,6 +156,10 @@ class GrepResultMessage(BaseMessage):
         default=False,
         description="Whether to show verbose output with line content",
     )
+    truncated: bool = Field(
+        default=False,
+        description="Whether the match budget was hit with more matches unseen",
+    )
 
 
 # =============================================================================

--- a/code_puppy/messaging/rich_renderer.py
+++ b/code_puppy/messaging/rich_renderer.py
@@ -830,6 +830,11 @@ class RichConsoleRenderer:
             f"[dim]Found {msg.total_matches} {match_word} "
             f"across {num_files} {file_word}[/dim]"
         )
+        if msg.truncated:
+            self._console.print(
+                "[yellow]  Truncated: more matches exist beyond the "
+                f"{msg.total_matches} shown[/yellow]"
+            )
 
         # Trailing newline for spinner separation
         self._console.print()

--- a/code_puppy/tools/file_operations.py
+++ b/code_puppy/tools/file_operations.py
@@ -57,10 +57,19 @@ class MatchInfo(BaseModel):
 class GrepOutput(BaseModel):
     matches: List[MatchInfo]
     error: str | None = None
+    # True when the search hit the match budget and more matches exist. A
+    # capped result that can't say so is indistinguishable from a complete
+    # one, and callers build completeness claims on top of grep.
+    truncated: bool = False
 
 
-# Upper bound on -A/-B/-C context rows returned alongside the (up to 50)
-# matches, so a wide context value can't grow the result without limit.
+# Total real-match budget for a single grep call, shared by the ripgrep and
+# backend paths. Context rows have their own budget below.
+_MAX_GREP_MATCHES = 50
+
+# Upper bound on -A/-B/-C context rows returned alongside the (up to
+# _MAX_GREP_MATCHES) matches, so a wide context value can't grow the result
+# without limit.
 # Context never evicts a real match: once this budget is full we keep scanning
 # for matches and simply stop collecting further context.
 _MAX_GREP_CONTEXT_ROWS = 200
@@ -1098,11 +1107,14 @@ def _emit_grep_result(
     directory: str,
     matches: List["MatchInfo"],
     error_message: str | None,
+    *,
+    truncated: bool = False,
 ) -> "GrepOutput":
     """Emit the structured grep result to the UI and return the tool output.
 
     Shared by the local (ripgrep) and backend (composed) grep paths so the UI
     behavior is identical regardless of where the search actually ran.
+    ``truncated`` flags that the match budget was hit with more left unseen.
     """
     from code_puppy.config import get_grep_output_verbose
 
@@ -1124,9 +1136,10 @@ def _emit_grep_result(
         total_matches=len(real_matches),
         files_searched=unique_files,
         verbose=get_grep_output_verbose(),
+        truncated=truncated,
     )
     get_message_bus().emit(grep_result_msg)
-    return GrepOutput(matches=matches, error=error_message)
+    return GrepOutput(matches=matches, error=error_message, truncated=truncated)
 
 
 def _missing_directory_error(directory: str, *, exists: bool) -> str:
@@ -1188,17 +1201,21 @@ def _grep_via_backend(directory: str, search_string: str) -> "GrepOutput":
         if "\x00" in text[:8192]:  # cheap binary sniff, like ripgrep
             continue
         for line_number, line in enumerate(text.splitlines(), start=1):
-            if pattern.search(line):
-                matches.append(
-                    MatchInfo(
-                        file_path=full,
-                        line_number=line_number,
-                        line_content=_sanitize_string(line.strip()),
-                    )
+            if not pattern.search(line):
+                continue
+            # Same total budget as the ripgrep path. Only a match *beyond* the
+            # budget proves there was more, so exactly-at-cap is not truncated.
+            if len(matches) >= _MAX_GREP_MATCHES:
+                return _emit_grep_result(
+                    search_string, directory, matches, None, truncated=True
                 )
-                # Cap total matches to mirror the local path's 50-match limit.
-                if len(matches) >= 50:
-                    return _emit_grep_result(search_string, directory, matches, None)
+            matches.append(
+                MatchInfo(
+                    file_path=full,
+                    line_number=line_number,
+                    line_content=_sanitize_string(line.strip()),
+                )
+            )
     return _emit_grep_result(search_string, directory, matches, None)
 
 
@@ -1233,6 +1250,7 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
 
     matches: List[MatchInfo] = []
     error_message: str | None = None
+    truncated = False
 
     # ripgrep runs with cwd=directory below, so a bad target would surface as a
     # FileNotFoundError from the spawn and get misreported as "ripgrep not found".
@@ -1274,7 +1292,18 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
         if args_error is not None:
             return GrepOutput(matches=[], error=args_error)
 
-        cmd = [rg_path, "--json", "--max-count", "50", "--max-filesize", "5M"]
+        # --max-count is ripgrep's *per-file* cap; the total cap lives in the
+        # JSON consumer below. Ask for one past the budget so a single file
+        # holding more than the budget still yields the extra match that
+        # proves truncation, instead of looking like exactly-at-cap.
+        cmd = [
+            rg_path,
+            "--json",
+            "--max-count",
+            str(_MAX_GREP_MATCHES + 1),
+            "--max-filesize",
+            "5M",
+        ]
         # rg's type filters are additive, so the default all-types selection
         # must not dilute an explicit -t/--type from the search string.
         if not _carries_type_filter(rg_args):
@@ -1359,7 +1388,7 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
                             line_content=_sanitize_string(line_content.strip()),
                             is_context=is_context,
                         )
-                        # Context rides along without consuming the 50-match
+                        # Context rides along without consuming the match
                         # budget, but is itself capped so a wide -A/-B/-C can't
                         # grow the result without bound. Real matches are never
                         # evicted: once the context budget is full we keep
@@ -1368,11 +1397,14 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
                             if context_row_count >= _MAX_GREP_CONTEXT_ROWS:
                                 continue
                             context_row_count += 1
-                        matches.append(match_info)
-                        if not is_context:
+                        elif real_match_count >= _MAX_GREP_MATCHES:
+                            # A real match past the budget is the proof there
+                            # was more; exactly-at-cap stays un-truncated.
+                            truncated = True
+                            break
+                        else:
                             real_match_count += 1
-                            if real_match_count >= 50:
-                                break
+                        matches.append(match_info)
             except json.JSONDecodeError:
                 # Skip lines that aren't valid JSON
                 continue
@@ -1391,7 +1423,9 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
             os.unlink(ignore_file)
 
     # Build structured GrepMatch objects for the UI
-    return _emit_grep_result(search_string, directory, matches, error_message)
+    return _emit_grep_result(
+        search_string, directory, matches, error_message, truncated=truncated
+    )
 
 
 def register_list_files(agent):
@@ -1489,5 +1523,10 @@ def register_grep(agent):
         Output-format flags (-l, -c, --files, --count, --json, -q) are not
         supported and return an error. To search for a pattern that itself
         starts with '-', use: -e '-pattern'
+
+        Returns at most 50 matches. When the result has truncated=True there
+        were MORE matches than shown: do not treat the list as complete --
+        narrow the search (a tighter pattern, -t/--type, or -g globs) and
+        search again until truncated is False.
         """
         return _grep(context, search_string, directory)

--- a/code_puppy/tools/tools_content.py
+++ b/code_puppy/tools/tools_content.py
@@ -12,7 +12,7 @@ Woof! 🐶 Here's my complete toolkit! I'm like a Swiss Army knife but way more 
 - **`delete_file(file_path)`** - Remove files when needed (use with caution!)
 
 # **Search & Analysis**
-- **`grep(search_string, directory)`** - Search for text across files recursively using ripgrep (rg) for high-performance searching (up to 50 matches). Searches across all text file types, not just Python files. Supports common ripgrep flags in the search string (-i, -w, -F, -e, -t, -A/-B/-C, -g, -v, -S, ...); -A/-B/-C context lines are honored only on the local rg path (the filesystem-backend path has no context support) and never count toward the 50-match cap, but are themselves limited to 200 rows total so a wide context value can't grow the result without bound. Output-format flags are rejected.
+- **`grep(search_string, directory)`** - Search for text across files recursively using ripgrep (rg) for high-performance searching (up to 50 matches; `truncated=True` in the result means more exist -- narrow the search). Searches across all text file types, not just Python files. Supports common ripgrep flags in the search string (-i, -w, -F, -e, -t, -A/-B/-C, -g, -v, -S, ...); -A/-B/-C context lines are honored only on the local rg path (the filesystem-backend path has no context support) and never count toward the 50-match cap, but are themselves limited to 200 rows total so a wide context value can't grow the result without bound. Output-format flags are rejected.
 
 # 💻 **System Operations**
 - **`agent_run_shell_command(command, cwd, timeout)`** - Execute shell commands with full output capture (stdout, stderr, exit codes)

--- a/tests/messaging/test_rich_renderer.py
+++ b/tests/messaging/test_rich_renderer.py
@@ -260,6 +260,23 @@ def test_render_grep_result_concise(mock_sub, renderer, console):
     renderer._render_grep_result(msg)
     out = output(console)
     assert "2 matches" in out
+    assert "Truncated" not in out
+
+
+@patch("code_puppy.messaging.rich_renderer.is_subagent", return_value=False)
+def test_render_grep_result_flags_truncation(mock_sub, renderer, console):
+    msg = GrepResultMessage(
+        directory="/tmp",
+        search_term="foo",
+        matches=[GrepMatch(file_path="a.py", line_number=1, line_content="foo")],
+        total_matches=1,
+        files_searched=10,
+        verbose=False,
+        truncated=True,
+    )
+    renderer._render_grep_result(msg)
+    out = output(console)
+    assert "Truncated" in out
 
 
 @patch("code_puppy.messaging.rich_renderer.is_subagent", return_value=False)

--- a/tests/tools/test_fs_backend.py
+++ b/tests/tools/test_fs_backend.py
@@ -349,6 +349,21 @@ def test_grep_unsupported_flag_errors_loudly(backend):
     assert out.error is not None and "-z" in out.error
 
 
+def test_grep_backend_flags_truncation_only_beyond_budget(backend):
+    """Backend path mirrors ripgrep: over budget -> truncated, at budget -> not."""
+    from code_puppy.tools.file_operations import _MAX_GREP_MATCHES, _grep
+
+    backend.write_text_file("/ws/many.py", "HIT\n" * (_MAX_GREP_MATCHES + 1))
+    over = _grep(None, "HIT", "/ws")
+    assert len(over.matches) == _MAX_GREP_MATCHES
+    assert over.truncated is True
+
+    backend.write_text_file("/ws/many.py", "HIT\n" * _MAX_GREP_MATCHES)
+    exact = _grep(None, "HIT", "/ws")
+    assert len(exact.matches) == _MAX_GREP_MATCHES
+    assert exact.truncated is False
+
+
 def test_grep_unknown_type_errors(backend):
     from code_puppy.tools.file_operations import _grep
 

--- a/tests/tools/test_grep_live_behavior.py
+++ b/tests/tools/test_grep_live_behavior.py
@@ -8,6 +8,7 @@ silently re-scoping the search.
 from code_puppy.tools import file_operations
 from code_puppy.tools.file_operations import (
     _MAX_GREP_CONTEXT_ROWS,
+    _MAX_GREP_MATCHES,
     MatchInfo,
     _emit_grep_result,
     _grep,
@@ -157,3 +158,69 @@ def test_emit_grep_result_excludes_context_from_counts(monkeypatch):
     # ...but only the two real hits (in a.py and b.py) feed the counts.
     assert captured["msg"].total_matches == 2
     assert captured["msg"].files_searched == 2
+
+
+def _write_hits(path, count):
+    path.write_text("".join(f"hit {i}\n" for i in range(count)))
+
+
+def test_grep_beyond_budget_is_flagged_truncated(tmp_path):
+    """More matches than the budget -> truncated=True, budget-sized result (#903)."""
+    for name in ("a.py", "b.py", "c.py"):
+        _write_hits(tmp_path / name, 30)
+
+    out = _grep(None, "hit", str(tmp_path))
+
+    assert out.error is None
+    assert len(out.matches) == _MAX_GREP_MATCHES
+    assert out.truncated is True
+
+
+def test_grep_exactly_at_budget_is_not_truncated(tmp_path):
+    """Exactly the budget is complete, not truncated -- never lie either way."""
+    _write_hits(tmp_path / "a.py", 20)
+    _write_hits(tmp_path / "b.py", _MAX_GREP_MATCHES - 20)
+
+    out = _grep(None, "hit", str(tmp_path))
+
+    assert out.error is None
+    assert len(out.matches) == _MAX_GREP_MATCHES
+    assert out.truncated is False
+
+
+def test_grep_single_file_beyond_budget_is_flagged_truncated(tmp_path):
+    """ripgrep's per-file --max-count must not mask truncation in one fat file."""
+    _write_hits(tmp_path / "fat.py", _MAX_GREP_MATCHES + 1)
+
+    out = _grep(None, "hit", str(tmp_path))
+
+    assert out.error is None
+    assert len(out.matches) == _MAX_GREP_MATCHES
+    assert out.truncated is True
+
+
+def test_grep_truncation_survives_context_lines(tmp_path):
+    """Context rows neither consume the budget nor hide that it overflowed."""
+    lines = ["target", "filler"] * (_MAX_GREP_MATCHES + 5)
+    (tmp_path / "ctx.py").write_text("\n".join(lines) + "\n")
+
+    out = _grep(None, "-A 1 target", str(tmp_path))
+
+    real = [m for m in out.matches if not m.is_context]
+    assert len(real) == _MAX_GREP_MATCHES
+    assert out.truncated is True
+
+
+def test_emit_grep_result_forwards_truncated_to_ui(monkeypatch):
+    captured = {}
+
+    class _Bus:
+        def emit(self, message):
+            captured["msg"] = message
+
+    monkeypatch.setattr(file_operations, "get_message_bus", lambda: _Bus())
+
+    out = _emit_grep_result("t", ".", [], None, truncated=True)
+
+    assert out.truncated is True
+    assert captured["msg"].truncated is True


### PR DESCRIPTION
Closes #903

`grep()` silently capped at 50 matches and `GrepOutput` had no way to say so. An agent receiving 50 matches could not distinguish "these are all" from "first 50 of 504" -- and as the reporter's PII-audit story shows, that manufactures false "there are no more" answers at exactly the moment they matter.

## What changed

- **`GrepOutput.truncated: bool`** (and `GrepResultMessage.truncated` for the TUI). Set **precisely**: only a real match *beyond* the budget flips it. Exactly 50 matches -> `truncated=False`. No lying in either direction.
- **`_MAX_GREP_MATCHES = 50`** replaces three magic numbers across the ripgrep and backend paths. The old comments claimed the two paths mirrored each other; they now actually do.
- ripgrep's per-file `--max-count` is now `budget + 1`, so a single file with >50 hits still emits the tell-tale 51st event instead of masquerading as exactly-at-cap.
- Tool docstring (the description the model actually receives) now documents the cap and instructs: narrow the search when `truncated=True`. `tools_content.py` blurb updated to match.
- Rich renderer prints a `Truncated: ...` line under the summary.

## Verification

Reporter's repro on this branch:

```
grep("def ", "code_puppy/messaging")   -> matches: 50 | truncated: True
grep("class GrepResultMessage", ...)  -> matches: 1  | truncated: False
```

Tests cover: over-budget across files, exactly-at-budget (not truncated), single fat file (the `--max-count` masking case), truncation with `-A` context rows, backend path both sides of the boundary, `_emit_grep_result` plumbing, and the renderer warning.

## Deliberately out of scope

Raising the cap / making it a parameter. The issue's core point is that the *silence* is the bug; a cap that announces itself is just a limit. Happy to follow up separately if we want a bigger budget.
