### PR TITLE
feat(grep): make the match budget configurable via grep_max_matches

### DIFF
--- a/code_puppy/command_line/set_menu_catalog.py
+++ b/code_puppy/command_line/set_menu_catalog.py
@@ -39,6 +39,7 @@ from code_puppy.config import (
     get_frontend_emitter_max_recent_events,
     get_frontend_emitter_queue_size,
     get_global_model_name,
+    get_grep_max_matches,
     get_grep_output_verbose,
     get_http2,
     get_max_hook_retries,
@@ -240,6 +241,17 @@ _BEHAVIOR = SettingsCategory(
             ),
             type_hint="bool",
             effective_getter=get_grep_output_verbose,
+        ),
+        Setting(
+            key="grep_max_matches",
+            display_name="Grep Match Budget",
+            description=(
+                "Maximum matches a single grep call returns. Results past "
+                "the budget are dropped and the tool reports truncated=True. "
+                "Default 50; minimum 1."
+            ),
+            type_hint="int",
+            effective_getter=get_grep_max_matches,
         ),
     ),
 )

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -1538,6 +1538,27 @@ def get_grep_output_verbose():
     return get_truthy_bool_value("grep_output_verbose", False)
 
 
+GREP_MAX_MATCHES_DEFAULT = 50
+
+
+def get_grep_max_matches() -> int:
+    """Return the per-call grep match budget.
+
+    Read from the ``grep_max_matches`` config key (``/set grep_max_matches=<int>``).
+    Defaults to ``GREP_MAX_MATCHES_DEFAULT`` when unset or non-numeric, and is
+    floored at 1: a budget of zero would make every search return nothing,
+    which is a foot-gun rather than a legitimate opt-out. Results past the
+    budget are dropped and reported via ``GrepOutput.truncated``.
+    """
+    val = get_value("grep_max_matches")
+    if val is None or not str(val).strip():
+        return GREP_MAX_MATCHES_DEFAULT
+    try:
+        return max(1, int(val))
+    except (ValueError, TypeError):
+        return GREP_MAX_MATCHES_DEFAULT
+
+
 def get_disable_dangerous_command_guard() -> bool:
     """
     Checks puppy.cfg for 'disable_dangerous_command_guard' (case-insensitive in value only).

--- a/code_puppy/tools/file_operations.py
+++ b/code_puppy/tools/file_operations.py
@@ -63,13 +63,9 @@ class GrepOutput(BaseModel):
     truncated: bool = False
 
 
-# Total real-match budget for a single grep call, shared by the ripgrep and
-# backend paths. Context rows have their own budget below.
-_MAX_GREP_MATCHES = 50
-
 # Upper bound on -A/-B/-C context rows returned alongside the (up to
-# _MAX_GREP_MATCHES) matches, so a wide context value can't grow the result
-# without limit.
+# get_grep_max_matches()) matches, so a wide context value can't grow the
+# result without limit.
 # Context never evicts a real match: once this budget is full we keep scanning
 # for matches and simply stop collecting further context.
 _MAX_GREP_CONTEXT_ROWS = 200
@@ -1180,6 +1176,9 @@ def _grep_via_backend(directory: str, search_string: str) -> "GrepOutput":
 
     skip_dir, skip_file = _relative_ignore_predicates(directory)
 
+    from code_puppy.config import get_grep_max_matches
+
+    max_matches = get_grep_max_matches()
     max_filesize = 5 * 1024 * 1024  # mirror ripgrep --max-filesize 5M
     matches: List[MatchInfo] = []
     for full, entry in fs_access.walk(
@@ -1205,7 +1204,7 @@ def _grep_via_backend(directory: str, search_string: str) -> "GrepOutput":
                 continue
             # Same total budget as the ripgrep path. Only a match *beyond* the
             # budget proves there was more, so exactly-at-cap is not truncated.
-            if len(matches) >= _MAX_GREP_MATCHES:
+            if len(matches) >= max_matches:
                 return _emit_grep_result(
                     search_string, directory, matches, None, truncated=True
                 )
@@ -1248,6 +1247,9 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
     if get_filesystem_backend() is not None:
         return _grep_via_backend(directory, search_string)
 
+    from code_puppy.config import get_grep_max_matches
+
+    max_matches = get_grep_max_matches()
     matches: List[MatchInfo] = []
     error_message: str | None = None
     truncated = False
@@ -1300,7 +1302,7 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
             rg_path,
             "--json",
             "--max-count",
-            str(_MAX_GREP_MATCHES + 1),
+            str(max_matches + 1),
             "--max-filesize",
             "5M",
         ]
@@ -1397,7 +1399,7 @@ def _grep(context: RunContext, search_string: str, directory: str = ".") -> Grep
                             if context_row_count >= _MAX_GREP_CONTEXT_ROWS:
                                 continue
                             context_row_count += 1
-                        elif real_match_count >= _MAX_GREP_MATCHES:
+                        elif real_match_count >= max_matches:
                             # A real match past the budget is the proof there
                             # was more; exactly-at-cap stays un-truncated.
                             truncated = True
@@ -1524,9 +1526,9 @@ def register_grep(agent):
         supported and return an error. To search for a pattern that itself
         starts with '-', use: -e '-pattern'
 
-        Returns at most 50 matches. When the result has truncated=True there
-        were MORE matches than shown: do not treat the list as complete --
-        narrow the search (a tighter pattern, -t/--type, or -g globs) and
-        search again until truncated is False.
+        Results are capped at a fixed match budget (50 by default). When the
+        result has truncated=True there were MORE matches than shown: do not
+        treat the list as complete -- narrow the search (a tighter pattern,
+        -t/--type, or -g globs) and search again until truncated is False.
         """
         return _grep(context, search_string, directory)

--- a/code_puppy/tools/tools_content.py
+++ b/code_puppy/tools/tools_content.py
@@ -12,7 +12,7 @@ Woof! 🐶 Here's my complete toolkit! I'm like a Swiss Army knife but way more 
 - **`delete_file(file_path)`** - Remove files when needed (use with caution!)
 
 # **Search & Analysis**
-- **`grep(search_string, directory)`** - Search for text across files recursively using ripgrep (rg) for high-performance searching (up to 50 matches; `truncated=True` in the result means more exist -- narrow the search). Searches across all text file types, not just Python files. Supports common ripgrep flags in the search string (-i, -w, -F, -e, -t, -A/-B/-C, -g, -v, -S, ...); -A/-B/-C context lines are honored only on the local rg path (the filesystem-backend path has no context support) and never count toward the 50-match cap, but are themselves limited to 200 rows total so a wide context value can't grow the result without bound. Output-format flags are rejected.
+- **`grep(search_string, directory)`** - Search for text across files recursively using ripgrep (rg) for high-performance searching (up to 50 matches by default, configurable via `grep_max_matches`; `truncated=True` in the result means more exist -- narrow the search). Searches across all text file types, not just Python files. Supports common ripgrep flags in the search string (-i, -w, -F, -e, -t, -A/-B/-C, -g, -v, -S, ...); -A/-B/-C context lines are honored only on the local rg path (the filesystem-backend path has no context support) and never count toward the 50-match cap, but are themselves limited to 200 rows total so a wide context value can't grow the result without bound. Output-format flags are rejected.
 
 # 💻 **System Operations**
 - **`agent_run_shell_command(command, cwd, timeout)`** - Execute shell commands with full output capture (stdout, stderr, exit codes)

--- a/tests/test_config_full_coverage.py
+++ b/tests/test_config_full_coverage.py
@@ -92,6 +92,21 @@ class TestBooleanGetters:
         cp_config.set_config_value("grep_output_verbose", "1")
         assert cp_config.get_grep_output_verbose() is True
 
+    def test_get_grep_max_matches_default(self):
+        assert cp_config.get_grep_max_matches() == cp_config.GREP_MAX_MATCHES_DEFAULT
+
+    def test_get_grep_max_matches_configured(self):
+        cp_config.set_config_value("grep_max_matches", "200")
+        assert cp_config.get_grep_max_matches() == 200
+
+    def test_get_grep_max_matches_floors_at_one(self):
+        cp_config.set_config_value("grep_max_matches", "0")
+        assert cp_config.get_grep_max_matches() == 1
+
+    def test_get_grep_max_matches_garbage_falls_back(self):
+        cp_config.set_config_value("grep_max_matches", "lots")
+        assert cp_config.get_grep_max_matches() == cp_config.GREP_MAX_MATCHES_DEFAULT
+
     def test_get_http2_values(self):
         cp_config.set_http2(True)
         assert cp_config.get_http2() is True

--- a/tests/tools/test_fs_backend.py
+++ b/tests/tools/test_fs_backend.py
@@ -351,16 +351,17 @@ def test_grep_unsupported_flag_errors_loudly(backend):
 
 def test_grep_backend_flags_truncation_only_beyond_budget(backend):
     """Backend path mirrors ripgrep: over budget -> truncated, at budget -> not."""
-    from code_puppy.tools.file_operations import _MAX_GREP_MATCHES, _grep
+    from code_puppy.config import GREP_MAX_MATCHES_DEFAULT
+    from code_puppy.tools.file_operations import _grep
 
-    backend.write_text_file("/ws/many.py", "HIT\n" * (_MAX_GREP_MATCHES + 1))
+    backend.write_text_file("/ws/many.py", "HIT\n" * (GREP_MAX_MATCHES_DEFAULT + 1))
     over = _grep(None, "HIT", "/ws")
-    assert len(over.matches) == _MAX_GREP_MATCHES
+    assert len(over.matches) == GREP_MAX_MATCHES_DEFAULT
     assert over.truncated is True
 
-    backend.write_text_file("/ws/many.py", "HIT\n" * _MAX_GREP_MATCHES)
+    backend.write_text_file("/ws/many.py", "HIT\n" * GREP_MAX_MATCHES_DEFAULT)
     exact = _grep(None, "HIT", "/ws")
-    assert len(exact.matches) == _MAX_GREP_MATCHES
+    assert len(exact.matches) == GREP_MAX_MATCHES_DEFAULT
     assert exact.truncated is False
 
 

--- a/tests/tools/test_grep_live_behavior.py
+++ b/tests/tools/test_grep_live_behavior.py
@@ -5,10 +5,10 @@ returned, -t restricts types, and a trailing value flag errors instead of
 silently re-scoping the search.
 """
 
+from code_puppy.config import GREP_MAX_MATCHES_DEFAULT
 from code_puppy.tools import file_operations
 from code_puppy.tools.file_operations import (
     _MAX_GREP_CONTEXT_ROWS,
-    _MAX_GREP_MATCHES,
     MatchInfo,
     _emit_grep_result,
     _grep,
@@ -172,43 +172,61 @@ def test_grep_beyond_budget_is_flagged_truncated(tmp_path):
     out = _grep(None, "hit", str(tmp_path))
 
     assert out.error is None
-    assert len(out.matches) == _MAX_GREP_MATCHES
+    assert len(out.matches) == GREP_MAX_MATCHES_DEFAULT
     assert out.truncated is True
 
 
 def test_grep_exactly_at_budget_is_not_truncated(tmp_path):
     """Exactly the budget is complete, not truncated -- never lie either way."""
     _write_hits(tmp_path / "a.py", 20)
-    _write_hits(tmp_path / "b.py", _MAX_GREP_MATCHES - 20)
+    _write_hits(tmp_path / "b.py", GREP_MAX_MATCHES_DEFAULT - 20)
 
     out = _grep(None, "hit", str(tmp_path))
 
     assert out.error is None
-    assert len(out.matches) == _MAX_GREP_MATCHES
+    assert len(out.matches) == GREP_MAX_MATCHES_DEFAULT
     assert out.truncated is False
 
 
 def test_grep_single_file_beyond_budget_is_flagged_truncated(tmp_path):
     """ripgrep's per-file --max-count must not mask truncation in one fat file."""
-    _write_hits(tmp_path / "fat.py", _MAX_GREP_MATCHES + 1)
+    _write_hits(tmp_path / "fat.py", GREP_MAX_MATCHES_DEFAULT + 1)
 
     out = _grep(None, "hit", str(tmp_path))
 
     assert out.error is None
-    assert len(out.matches) == _MAX_GREP_MATCHES
+    assert len(out.matches) == GREP_MAX_MATCHES_DEFAULT
     assert out.truncated is True
 
 
 def test_grep_truncation_survives_context_lines(tmp_path):
     """Context rows neither consume the budget nor hide that it overflowed."""
-    lines = ["target", "filler"] * (_MAX_GREP_MATCHES + 5)
+    lines = ["target", "filler"] * (GREP_MAX_MATCHES_DEFAULT + 5)
     (tmp_path / "ctx.py").write_text("\n".join(lines) + "\n")
 
     out = _grep(None, "-A 1 target", str(tmp_path))
 
     real = [m for m in out.matches if not m.is_context]
-    assert len(real) == _MAX_GREP_MATCHES
+    assert len(real) == GREP_MAX_MATCHES_DEFAULT
     assert out.truncated is True
+
+
+def test_grep_match_budget_is_configurable(tmp_path, monkeypatch):
+    """`grep_max_matches` moves the cap; truncation semantics follow it."""
+    import code_puppy.config as cp_config
+
+    monkeypatch.setattr(cp_config, "get_grep_max_matches", lambda: 5)
+    _write_hits(tmp_path / "a.py", 6)
+
+    out = _grep(None, "hit", str(tmp_path))
+    assert len(out.matches) == 5
+    assert out.truncated is True
+
+    (tmp_path / "a.py").unlink()
+    _write_hits(tmp_path / "b.py", 5)
+    out = _grep(None, "hit", str(tmp_path))
+    assert len(out.matches) == 5
+    assert out.truncated is False
 
 
 def test_emit_grep_result_forwards_truncated_to_ui(monkeypatch):


### PR DESCRIPTION
Follow-up to #904 / #903.

#904 made grep truncation *observable*; this makes the budget *adjustable*.

## What changed

- New config key **`grep_max_matches`** (`/set grep_max_matches=<int>`), surfaced in the `/set` menu next to `grep_output_verbose`. Default stays 50 (`GREP_MAX_MATCHES_DEFAULT`).
- Floored at 1: a budget of 0 would make every search return nothing, which is a foot-gun rather than a legitimate opt-out (unlike `tool_output_limit_chars`, where 0 genuinely means "disable"). Non-numeric values fall back to the default.
- Both grep paths (ripgrep and filesystem-backend) read the budget once per call; ripgrep's per-file `--max-count` stays at `budget + 1` so truncation detection is exact at any size.
- Tool docstring and `tools_content.py` no longer hardcode "50" as gospel.

## Tests

- Config getter: default, configured, floor-at-1, garbage fallback.
- Live ripgrep test proving the knob actually moves the cap and truncation semantics follow it (6 hits / budget 5 -> truncated; 5 hits / budget 5 -> not).
- Existing truncation tests now assert against `GREP_MAX_MATCHES_DEFAULT` instead of a private module constant.
