### PR TITLE
feat(prompt): keep the system prompt stable across a resume

### DIFF
--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -61,12 +61,37 @@ def _extract_pydantic_agent_tools(pyd_agent: Any) -> Optional[Dict[str, Any]]:
     return legacy or None
 
 
+HEADLESS_AUTONOMY_PROMPT = """\
+This is an unattended, non-interactive run. Never ask for confirmation, approval,
+clarification, or manual verification, including through tools or MCP servers. Use
+reasonable defaults, proceed autonomously, and validate with the tools available to
+you. State any assumptions or optional manual checks only in the final response.\
+"""
+"""Scoped instruction for an unattended run, applied by the headless entry point.
+
+Defined here rather than in ``cli_runner`` because the prompt assembler has to
+recognise it: earlier builds wrote it INSIDE the durable part of the
+prompt, and ``set_message_history`` has to undo that. One definition, so the
+text the CLI applies and the text a resume heals cannot drift apart.
+"""
+
+
 class BaseAgent(ABC):
     """Abstract base for all Code Puppy agents."""
 
     def __init__(self) -> None:
         self.id: str = str(uuid.uuid4())
         self._message_history: List[Any] = []
+        # ``load_prompt`` fragments as this conversation opened with them.
+        # ``None`` means "not gathered yet"; an empty list is a real answer
+        # (no plugin contributed) and must not re-trigger a gather.
+        # See ``get_full_system_prompt`` for why these are frozen per
+        # conversation rather than recomputed per turn.
+        self._standing_prompt_additions: Optional[List[str]] = None
+        # The system prompt a RESUMED conversation was built with, adopted
+        # verbatim so the provider's cache prefix survives the resume.
+        # ``None`` means this agent is not resuming anything.
+        self._adopted_prompt_body: Optional[str] = None
         self._compacted_message_hashes: Set[str] = set()
         self._code_generation_agent: Any = None
         self._last_model_name: Optional[str] = None
@@ -204,26 +229,209 @@ class BaseAgent(ABC):
         They live here — not in ``get_system_prompt`` — so they're recomputed
         fresh every run and never get persisted into static agent definitions
         (e.g. when an agent is cloned to JSON). See ``clone_agent``.
+
+        Fragments are gathered ONCE PER CONVERSATION, not once per turn.
+        pydantic-ai stamps this string into ``instructions`` on every request,
+        and ``instructions`` is the provider's cache prefix — so a fragment
+        that changes between turns invalidates the cache on every turn. A
+        memory/recall plugin is the worst case: it recalls what the previous
+        turn wrote, so it grows precisely as the conversation gets long enough
+        for caching to matter. Measured on one such thread, the block went
+        5571 → 6129 characters between turn 1 and turn 2, missing the cache
+        each time.
+
+        The system prompt is the CONTRACT and does not change mid-conversation;
+        recall is CONTEXT and belongs in the message stream. Keeping the prefix
+        fixed is what makes a long conversation affordable.
+
+        Gathered on the first call and reused thereafter, rather than keyed on
+        whether history exists: the setup path calls this more than once before
+        any history does, so a history-keyed cache would still re-poll and
+        still drift, only earlier. ``clear_message_history`` (i.e. ``/clear``)
+        is the one reset — the prefix is allowed to change exactly when the
+        conversation does.
         """
         from code_puppy import callbacks
 
-        prompt = self.get_system_prompt()
-        prompt_additions = callbacks.on_load_prompt()
-        if prompt_additions:
-            prompt += "\n" + "\n".join(prompt_additions)
+        # A resumed conversation already has a prompt BODY, and it is
+        # authoritative: it is what the provider cached and what every stored
+        # message was sent under, and recomputing it would drift. The identity
+        # line is not part of it -- see ``set_message_history`` for why.
+        #
+        # It replaces the authored prompt and the standing fragments; it does
+        # NOT replace the runtime additions below. Those are scoped to THIS
+        # run, so a resumed conversation must still get them -- returning here
+        # would silently drop the headless autonomy instruction on every
+        # `code-puppy -p` against an existing session.
+        if self._adopted_prompt_body is not None:
+            prompt = self._adopted_prompt_body
+        else:
+            prompt = self.get_system_prompt()
+            # Gathered on the FIRST call and reused thereafter, not merely on
+            # turns after the first. The setup path calls this more than once
+            # before any history exists -- `_estimate_context_overhead` is one
+            # such caller -- so keying on "history is empty" would still
+            # re-poll and still drift, just earlier. Measured on this branch
+            # before the fix: 2 polls and a changed prompt before turn one had
+            # run.
+            #
+            # `None` means "not gathered yet"; `[]` is a real answer meaning no
+            # plugin contributed, and conflating them re-polls forever for
+            # conversations that have no fragments. Reset by
+            # `clear_message_history`, which is the one moment a new
+            # conversation legitimately begins.
+            if self._standing_prompt_additions is None:
+                self._standing_prompt_additions = callbacks.on_load_prompt()
+            prompt_additions = self._standing_prompt_additions
+            if prompt_additions:
+                prompt += "\n" + "\n".join(prompt_additions)
+        prompt += self.get_identity_prompt()
+        # Runtime additions go AFTER the identity line, which makes them
+        # unadoptable by construction: ``_strip_identity_prompt`` keeps only
+        # the text BEFORE that marker, so scoped text cannot survive into the
+        # next conversation's cached prefix. It also leaves the durable part
+        # (body + identity) as a maximal stable prefix, which is what the
+        # provider actually caches.
+        #
+        # The ordering matters because the headless loop calls
+        # ``set_message_history`` after the scoped block has already exited:
+        # the list is empty by then, so nothing on this object can tell the
+        # resume which bytes were ephemeral. Position is the only reliable
+        # signal, and it survives the trip through storage into another
+        # process.
         if self._runtime_system_prompt_additions:
             prompt += "\n" + "\n".join(self._runtime_system_prompt_additions)
-        return prompt + self.get_identity_prompt()
+        return prompt
 
     # ---- Message history (plain dict-level access) ------------------------
     def get_message_history(self) -> List[Any]:
         return self._message_history
 
-    def set_message_history(self, history: List[Any]) -> None:
+    def set_message_history(
+        self, history: List[Any], *, agent_id: Optional[str] = None
+    ) -> None:
+        """Adopt ``history``, and with it the conversation's prompt and id.
+
+        This is the resume door. Every front door that continues a
+        conversation arrives here -- the CLI through
+        ``restore_named_session``, an embedding runner by calling it
+        directly, a headless loop that rebuilds an agent per turn -- so
+        resume behaviour belongs here rather than in any one caller. Putting
+        it in a caller fixes exactly that caller, which is how an earlier
+        attempt at this passed its own tests while every other front end was
+        unchanged.
+
+        Non-empty history means a conversation is being resumed:
+
+        * Its opening ``instructions`` become this agent's system prompt.
+          pydantic-ai stamps the prompt onto every request message, so the
+          history knows what it was built with, and that string is the
+          provider's cache prefix. Recomputing it in a fresh process yields
+          a different one -- a live timestamp, a grown recall block -- and
+          the cache then misses on every turn of a long conversation, which
+          is exactly when it was worth having.
+        * ``agent_id``, when the caller knows it, replaces the uuid minted
+          in ``__init__``. It is not in the history, so it has to be passed;
+          the prompt tells the agent to use its id "for claiming task
+          ownership or coordination with other agents", and an id minted per
+          process cannot own anything.
+
+        Setting an empty history is not a resume: nothing is adopted, and
+        the agent keeps its own identity and computes its own prompt.
+        """
         self._message_history = history
+        if not history:
+            return
+        if agent_id:
+            self.id = agent_id
+        prior = self._opening_instructions(history)
+        if prior:
+            # Adopt the BODY, not the whole string. ``get_identity_prompt`` is
+            # appended last and is a pure function of ``self.id``, so keeping
+            # it out of the frozen text leaves exactly one representation of
+            # the identity -- the field -- instead of a field plus a copy
+            # rendered into English that the two could drift apart on.
+            #
+            # The alternative, recovering the id by matching the rendered
+            # sentence, closes the gap and opens worse ones: the line shows
+            # six characters of a uuid, so the round trip is lossy, and the
+            # wording of a user-facing sentence becomes load-bearing -- a
+            # translation or a reword would silently corrupt identity.
+            #
+            # Nothing is lost by excluding it. The body is what drifted (live
+            # timestamps, a growing recall block); the identity line is stable
+            # by construction once the id is, so re-rendering it yields the
+            # same bytes and the cache prefix still holds.
+            self._adopted_prompt_body = self._heal_legacy_body(
+                self._strip_identity_prompt(prior)
+            )
+
+    @staticmethod
+    def _heal_legacy_body(body: str) -> str:
+        """``body`` without a scoped addition an older build froze into it.
+
+        Earlier builds appended runtime additions BEFORE the identity line, so in a session saved by one of those the autonomy instruction
+        sits inside the durable body and the ordering fix cannot reach it.
+        Adopting it verbatim re-applies it to every later turn -- including
+        interactive ones, which would tell a user's own session never to ask
+        them for confirmation, with ``/clear`` as the only escape.
+
+        Measured on a session written in the legacy layout: present on turns
+        2, 3, 4 and 5 of an interactive resume.
+
+        Removing the exact known string is deliberately narrow. Anything
+        looser -- a heuristic, a marker, a regex over prompt prose -- would
+        risk eating authored text that merely resembles it, and the whole
+        design already refuses to make user-facing wording load-bearing. A
+        prompt that never contained it is returned unchanged, so this costs
+        nothing once the old sessions age out.
+        """
+        return body.replace("\n" + HEADLESS_AUTONOMY_PROMPT, "").replace(
+            HEADLESS_AUTONOMY_PROMPT, ""
+        )
+
+    def _strip_identity_prompt(self, prompt: str) -> str:
+        """``prompt`` without the trailing identity line this class appends.
+
+        Splits on the marker rather than recomputing the suffix for THIS
+        agent: the stored prompt carries the id of the conversation, which is
+        not necessarily the uuid this process minted, so
+        ``removesuffix(self.get_identity_prompt())`` would silently fail to
+        strip and re-introduce the duplication this avoids.
+
+        A prompt with no identity line -- from another tool, or an older
+        version -- is returned unchanged.
+        """
+        marker = "\n\nYour ID is `"
+        head, sep, _ = prompt.rpartition(marker)
+        return head if sep else prompt
+
+    @staticmethod
+    def _opening_instructions(history: List[Any]) -> Optional[str]:
+        """The system prompt the first request in ``history`` was sent with.
+
+        Reads the FIRST request rather than the last: the opener is the
+        prefix every later message was cached against, and a later message
+        may carry a prompt that had already drifted. Tolerant of shape --
+        histories arrive as pydantic-ai objects or as plain dicts depending
+        on the caller, and a resume must not fail over an attribute.
+        """
+        for message in history:
+            if isinstance(message, dict):
+                instructions = message.get("instructions")
+            else:
+                instructions = getattr(message, "instructions", None)
+            if isinstance(instructions, str) and instructions:
+                return instructions
+        return None
 
     def clear_message_history(self) -> None:
         self._message_history = []
+        # A new conversation gets fresh fragments and drops any prompt
+        # adopted from the old one: this is the single moment the cache
+        # prefix is meant to change.
+        self._standing_prompt_additions = None
+        self._adopted_prompt_body = None
         self._compacted_message_hashes.clear()
 
     def append_to_message_history(self, message: Any) -> None:

--- a/code_puppy/cli_runner.py
+++ b/code_puppy/cli_runner.py
@@ -22,6 +22,7 @@ from rich.console import Console
 
 from code_puppy import __version__, callbacks, get_core_plugins_version, plugins
 from code_puppy.agents import get_current_agent
+from code_puppy.agents.base_agent import HEADLESS_AUTONOMY_PROMPT
 from code_puppy.i18n import t, use_detected_locale
 from code_puppy.command_line.attachments import (
     parse_prompt_attachments,
@@ -54,12 +55,11 @@ from code_puppy.version_checker import default_version_mismatch_behavior
 
 plugins.load_plugin_callbacks()
 
-_HEADLESS_AUTONOMY_PROMPT = """\
-This is an unattended, non-interactive run. Never ask for confirmation, approval,
-clarification, or manual verification, including through tools or MCP servers. Use
-reasonable defaults, proceed autonomously, and validate with the tools available to
-you. State any assumptions or optional manual checks only in the final response.\
-"""
+# Re-exported from base_agent, which owns the text because the prompt
+# assembler has to recognise it to heal sessions written by builds that
+# stored it inside the durable prompt. Kept under the old private name so
+# existing callers and tests are unaffected.
+_HEADLESS_AUTONOMY_PROMPT = HEADLESS_AUTONOMY_PROMPT
 
 
 def _render_turn_exception(exc: Exception) -> None:

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -2375,6 +2375,16 @@ def auto_save_session_if_enabled(*, force: bool = False) -> bool:
             token_estimator=current_agent.estimate_tokens_for_message,
             auto_saved=True,
             scope_key=compute_scope_key(pathlib.Path.cwd()),
+            # Autosave is the path quick-resume actually reads, so identity
+            # has to ride here too or the common resume still loses it.
+            # Type-checked for the same reason as in persist_named_session:
+            # the sidecar is JSON written after the history, so an id that
+            # cannot be serialised must not turn a save into a half-write.
+            agent_id=(
+                current_agent.id
+                if isinstance(getattr(current_agent, "id", None), str)
+                else None
+            ),
         )
 
         # Point quick-resume at this save; every turn/exit/finalize routes through

--- a/code_puppy/session_lifecycle.py
+++ b/code_puppy/session_lifecycle.py
@@ -19,11 +19,19 @@ from __future__ import annotations
 
 import concurrent.futures
 import re
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
-from code_puppy.session_storage import SessionMetadata, compute_scope_key, save_session
+from code_puppy.session_storage import (
+    SessionHistory,
+    SessionMetadata,
+    compute_scope_key,
+    load_session,
+    load_session_agent_id,
+    save_session,
+)
 
 if TYPE_CHECKING:
     from code_puppy.agents.base_agent import BaseAgent
@@ -43,6 +51,18 @@ _RESERVED_PREFIX = "auto_session_"
 # Matches the headroom used by ``config.auto_save_session_if_enabled`` so
 # plugin authors only have to honour one budget.
 _POST_AUTOSAVE_TIMEOUT_S = 4.0
+
+
+@dataclass(frozen=True)
+class RestoredSession:
+    """What a resume produced, for the caller's own reporting.
+
+    ``total_tokens`` rides along because every caller announced it and would
+    otherwise recompute the same sum over the same history.
+    """
+
+    history: SessionHistory
+    total_tokens: int
 
 
 def is_valid_session_name(name: str, *, allow_reserved_prefix: bool = False) -> bool:
@@ -111,6 +131,15 @@ def persist_named_session(
         token_estimator=agent.estimate_tokens_for_message,
         auto_saved=auto_saved,
         scope_key=compute_scope_key(Path.cwd()),
+        # Identity belongs to the conversation, not to the process serving it.
+        # Written here so ``restore_named_session`` has something to put back.
+        #
+        # Type-checked rather than passed through: the metadata sidecar is
+        # JSON, so a non-string ``id`` would raise inside ``json.dump`` AFTER
+        # the history was already written -- turning a save into a half-write
+        # and losing the user's work to a cosmetic field. An id we cannot
+        # serialise is simply not recorded.
+        agent_id=agent.id if isinstance(getattr(agent, "id", None), str) else None,
     )
     if success_message_key is not None:
         # t() interpolates via hardened {identifier} grammar: a missing
@@ -132,6 +161,39 @@ def persist_named_session(
     # NOTE: deliberately skips ``fire_post_autosave_callback`` — that hook is
     # reserved for the periodic auto-save path only (pre-unification semantics).
     return metadata
+
+
+def restore_named_session(
+    agent: "BaseAgent",
+    session_name: str,
+    *,
+    base_dir: Path,
+) -> RestoredSession:
+    """Load ``session_name`` onto ``agent``. Mirror of :func:`persist_named_session`.
+
+    Every resume does the same three things — read the envelope, put the
+    history on the agent, total the tokens for the line it prints — so they
+    live here once rather than in each caller. What the callers do *around*
+    that differs (pin vs rotate the autosave singleton, which success message
+    to emit, whether to preview) and stays with them: that is policy, this is
+    mechanism.
+
+    Raises whatever :func:`load_session` raises — ``FileNotFoundError`` for a
+    missing session, ``ValueError`` for one that cannot be decoded. Callers
+    already handle both and word the failure for their own surface.
+    """
+    history = load_session(session_name, base_dir)
+    # Identity comes from the sidecar; the prompt comes from the history and
+    # is adopted by ``set_message_history`` itself. Resume behaviour lives
+    # there rather than here because every front door goes through it --
+    # an embedding runner can call it directly and never reach this function.
+    # Sessions written before identity was recorded return None and the
+    # agent keeps its own; see ``load_session_agent_id``.
+    agent.set_message_history(
+        history, agent_id=load_session_agent_id(session_name, base_dir)
+    )
+    total_tokens = sum(agent.estimate_tokens_for_message(m) for m in history)
+    return RestoredSession(history=history, total_tokens=total_tokens)
 
 
 class ResumeTargetError(Exception):

--- a/code_puppy/session_storage.py
+++ b/code_puppy/session_storage.py
@@ -57,6 +57,12 @@ class SessionMetadata:
     json_path: Path
     auto_saved: bool = False
     scope_key: str | None = None
+    # The agent identity this session belongs to. Travels with the session
+    # because it is the CONVERSATION's identity, not the process's: a resumed
+    # session that reintroduces itself under a new name breaks both agent
+    # coordination and the provider's prompt cache. Optional so sessions
+    # written before this existed still load.
+    agent_id: str | None = None
 
     def as_serialisable(self) -> dict[str, Any]:
         data = {
@@ -69,6 +75,8 @@ class SessionMetadata:
         }
         if self.scope_key is not None:
             data["scope_key"] = self.scope_key
+        if self.agent_id is not None:
+            data["agent_id"] = self.agent_id
         return data
 
 
@@ -216,6 +224,7 @@ def save_session(
     token_estimator: TokenEstimator,
     auto_saved: bool = False,
     scope_key: str | None = None,
+    agent_id: str | None = None,
 ) -> SessionMetadata:
     ensure_directory(base_dir)
     paths = build_session_paths(base_dir, session_name)
@@ -235,6 +244,7 @@ def save_session(
         json_path=paths.json_path,
         auto_saved=auto_saved,
         scope_key=scope_key,
+        agent_id=agent_id,
     )
 
     tmp_metadata = paths.metadata_path.with_suffix(".tmp")
@@ -243,6 +253,24 @@ def save_session(
     tmp_metadata.replace(paths.metadata_path)
 
     return metadata
+
+
+def load_session_agent_id(session_name: str, base_dir: Path) -> str | None:
+    """The agent identity stored beside ``session_name``, if any.
+
+    Fail-soft by design: a missing, unreadable or pre-``agent_id`` metadata
+    file returns ``None`` and the caller keeps the identity it already has.
+    A resume must not be blocked by an unreadable sidecar -- the history is
+    the thing the user asked for, and losing identity is a degradation, not
+    a reason to refuse.
+    """
+    paths = build_session_paths(base_dir, session_name)
+    try:
+        raw = json.loads(paths.metadata_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    agent_id = raw.get("agent_id")
+    return agent_id if isinstance(agent_id, str) and agent_id else None
 
 
 def load_session(session_name: str, base_dir: Path) -> SessionHistory:

--- a/tests/test_headless_autonomy_prompt.py
+++ b/tests/test_headless_autonomy_prompt.py
@@ -1,5 +1,12 @@
 """Tests for the scoped unattended-run system instruction."""
 
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    UserPromptPart,
+)
+
 from code_puppy.agents.base_agent import BaseAgent
 from code_puppy.cli_runner import _HEADLESS_AUTONOMY_PROMPT
 
@@ -24,6 +31,30 @@ class _TestAgent(BaseAgent):
         return []
 
 
+def _resumed_from(agent: _TestAgent, prompt: str) -> _TestAgent:
+    """A fresh agent resuming the conversation ``agent`` was running.
+
+    Mirrors the headless loop: the history carries the prompt the turn was
+    sent under, and the caller passes the id its own store already holds.
+
+    Real ``ModelRequest``/``ModelResponse`` objects rather than a stand-in
+    with an ``instructions`` attribute. A stand-in cannot drift when
+    pydantic-ai changes shape, which is precisely the blind spot that let an
+    earlier fix pass its tests while every real front end was unchanged.
+    """
+    resumed = _TestAgent()
+    resumed.set_message_history(
+        [
+            ModelRequest(
+                parts=[UserPromptPart(content="continue")], instructions=prompt
+            ),
+            ModelResponse(parts=[TextPart(content="ok")]),
+        ],
+        agent_id=agent.id,
+    )
+    return resumed
+
+
 def test_headless_autonomy_prompt_is_scoped_to_the_run(monkeypatch):
     monkeypatch.setattr("code_puppy.callbacks.on_load_prompt", lambda: [])
     agent = _TestAgent()
@@ -36,8 +67,148 @@ def test_headless_autonomy_prompt_is_scoped_to_the_run(monkeypatch):
         assert full_prompt.index("Authored prompt.") < full_prompt.index(
             _HEADLESS_AUTONOMY_PROMPT
         )
-        assert full_prompt.index(_HEADLESS_AUTONOMY_PROMPT) < full_prompt.index(
-            "Your ID is"
+        # Scoped text sits AFTER the identity line, not before it. That is
+        # what makes it unadoptable on resume: the durable part is everything
+        # up to the identity marker, so an ephemeral addition cannot be
+        # mistaken for part of the conversation's cached prefix.
+        assert full_prompt.index("Your ID is") < full_prompt.index(
+            _HEADLESS_AUTONOMY_PROMPT
         )
 
     assert _HEADLESS_AUTONOMY_PROMPT not in agent.get_full_system_prompt()
+
+
+def test_runtime_addition_applies_to_a_resumed_conversation(monkeypatch):
+    """A resume adopts the cached BODY; it does not opt out of runtime additions.
+
+    ``code-puppy -p`` on an existing session is the live path: the run is
+    wrapped in ``temporary_system_prompt_addition`` but the agent is resuming,
+    so an adopted body that short-circuits the assembly drops the instruction
+    that tells the agent it is unattended.
+    """
+    monkeypatch.setattr("code_puppy.callbacks.on_load_prompt", lambda: [])
+
+    interactive = _TestAgent()
+    turn_one = interactive.get_full_system_prompt()
+    assert _HEADLESS_AUTONOMY_PROMPT not in turn_one
+
+    resumed = _resumed_from(interactive, turn_one)
+    with resumed.temporary_system_prompt_addition(_HEADLESS_AUTONOMY_PROMPT):
+        assert _HEADLESS_AUTONOMY_PROMPT in resumed.get_full_system_prompt()
+
+    assert _HEADLESS_AUTONOMY_PROMPT not in resumed.get_full_system_prompt()
+
+
+def test_runtime_addition_does_not_survive_into_a_resume(monkeypatch):
+    """The scoped addition must not be frozen into the next turn's prefix.
+
+    The headless loop calls ``set_message_history`` AFTER the ``with`` block
+    exits (cli_runner.py), so the addition is already popped from the list --
+    but the history it adopts was sent under a prompt that still contains it.
+    Adopting that verbatim re-introduces the instruction permanently, where no
+    ``finally`` can pop it, and welds it into the provider's cache prefix.
+    """
+    monkeypatch.setattr("code_puppy.callbacks.on_load_prompt", lambda: [])
+
+    headless = _TestAgent()
+    with headless.temporary_system_prompt_addition(_HEADLESS_AUTONOMY_PROMPT):
+        turn_one = headless.get_full_system_prompt()
+    assert _HEADLESS_AUTONOMY_PROMPT in turn_one
+
+    resumed = _resumed_from(headless, turn_one)
+    assert _HEADLESS_AUTONOMY_PROMPT not in resumed.get_full_system_prompt()
+
+
+def test_resume_still_adopts_the_cached_body(monkeypatch):
+    """The fix must not cost the cache prefix it was written to protect.
+
+    Guards the obvious over-correction: refusing to adopt whenever a runtime
+    addition was present would trade a scoping bug for a cache miss on every
+    turn of every headless conversation.
+    """
+    calls = []
+
+    def _drifting():
+        calls.append(len(calls))
+        return [f"RECALL-BLOCK-{len(calls)}"]
+
+    monkeypatch.setattr("code_puppy.callbacks.on_load_prompt", _drifting)
+
+    first = _TestAgent()
+    turn_one = first.get_full_system_prompt()
+    assert "RECALL-BLOCK-1" in turn_one
+
+    resumed = _resumed_from(first, turn_one)
+    turn_two = resumed.get_full_system_prompt()
+
+    assert turn_two == turn_one, "resumed prefix drifted; provider cache misses"
+    assert "RECALL-BLOCK-2" not in turn_two
+
+
+def test_the_cached_prefix_is_stable_across_headless_turns(monkeypatch):
+    """The cache pin for the path this fix actually changed.
+
+    ``test_resume_still_adopts_the_cached_body`` never enters the scoped
+    block, so it cannot see drift on headless turns -- it passes even on the
+    unfixed code. This one resumes WITH the addition applied, which is what
+    ``code-puppy -p`` against an existing session does.
+    """
+    monkeypatch.setattr("code_puppy.callbacks.on_load_prompt", lambda: [])
+
+    first = _TestAgent()
+    with first.temporary_system_prompt_addition(_HEADLESS_AUTONOMY_PROMPT):
+        turn_one = first.get_full_system_prompt()
+
+    resumed = _resumed_from(first, turn_one)
+    with resumed.temporary_system_prompt_addition(_HEADLESS_AUTONOMY_PROMPT):
+        turn_two = resumed.get_full_system_prompt()
+
+    assert turn_two == turn_one, "headless prefix drifted between turns"
+
+
+def test_a_session_from_an_older_build_is_healed(monkeypatch):
+    """Earlier builds stored the addition inside the durable body.
+
+    The ordering fix cannot reach it there, so without healing the
+    instruction is re-applied to every later turn of a resumed session --
+    including interactive ones, telling a user's own session never to ask
+    them for confirmation. ``/clear`` was the only escape.
+    """
+    monkeypatch.setattr("code_puppy.callbacks.on_load_prompt", lambda: [])
+
+    original = _TestAgent()
+    legacy_prompt = (
+        "Authored prompt.\n"
+        + _HEADLESS_AUTONOMY_PROMPT
+        + original.get_identity_prompt()
+    )
+
+    resumed = _resumed_from(original, legacy_prompt)
+    healed = resumed.get_full_system_prompt()
+
+    assert _HEADLESS_AUTONOMY_PROMPT not in healed
+    assert "Authored prompt." in healed
+    assert "Your ID is" in healed
+
+    # And it stays healed: the poison must not creep back turn over turn.
+    again = _resumed_from(resumed, healed)
+    assert _HEADLESS_AUTONOMY_PROMPT not in again.get_full_system_prompt()
+
+
+def test_identity_is_split_on_the_last_marker(monkeypatch):
+    """``_strip_identity_prompt`` uses ``rpartition``, and that is load-bearing.
+
+    Downstream code appends after the identity line (``_builder`` adds
+    AGENTS.md rules and model guards), so the LAST marker is the correct
+    split point. A refactor to ``partition`` or ``split`` would silently
+    adopt a truncated body and drift the prefix; nothing pinned that before.
+    """
+    monkeypatch.setattr("code_puppy.callbacks.on_load_prompt", lambda: [])
+
+    agent = _TestAgent()
+    body = "Authored prompt."
+    # A prompt that mentions the marker text before the real identity line.
+    prior = body + "\n\nYour ID is `quoted-elsewhere`." + agent.get_identity_prompt()
+
+    resumed = _resumed_from(agent, prior)
+    assert resumed._adopted_prompt_body == body + "\n\nYour ID is `quoted-elsewhere`."

--- a/tests/test_one_identity.py
+++ b/tests/test_one_identity.py
@@ -1,0 +1,141 @@
+"""One identity, held as a field rather than recovered from prose.
+
+Freezing the WHOLE prompt on resume put the identity inside the frozen
+string, which left two representations of one fact: the id rendered into
+that text, and ``self.id``. They could disagree, and nothing noticed.
+
+Recovering the id by regexing the rendered sentence would close the gap and
+create worse problems: the round trip is lossy (the line shows six
+characters of a uuid), and the wording of an English sentence becomes
+load-bearing, so translating or rewording it silently breaks identity.
+
+The fix is to not put it there. ``get_identity_prompt`` is appended LAST and
+is a pure function of ``self.id``, so the cached part is the prompt BODY and
+the identity line is rendered fresh each turn from the one field that holds
+it. Same bytes when the id is the same, and no parsing anywhere.
+
+The body is what actually needs freezing: it carries the timestamps and the
+growing recall block that made the prefix drift. The identity line is stable
+by construction once the id is.
+"""
+
+from __future__ import annotations
+
+import re
+
+from code_puppy.agents.base_agent import BaseAgent
+
+
+class _Agent(BaseAgent):
+    @property
+    def name(self) -> str:
+        return "test-agent"
+
+    @property
+    def display_name(self) -> str:
+        return "Test Agent"
+
+    @property
+    def description(self) -> str:
+        return "fixture"
+
+    def get_system_prompt(self) -> str:
+        return "SYSTEM"
+
+    def get_available_tools(self):
+        return []
+
+
+class _Request:
+    def __init__(self, instructions: str | None) -> None:
+        self.instructions = instructions
+        self.kind = "request"
+
+
+def _rendered_id(prompt: str) -> str | None:
+    found = re.search(r"test-agent-[0-9a-f]+", prompt)
+    return found.group() if found else None
+
+
+def test_an_agent_always_reports_the_identity_it_is_sending():
+    # The invariant, stated once: whoever asks, one answer. It holds because
+    # both sides read `self.id`, not because two copies were kept in step.
+    agent = _Agent()
+    assert agent.get_identity() == _rendered_id(agent.get_full_system_prompt())
+
+
+def test_that_invariant_survives_a_resume():
+    first = _Agent()
+    opening = first.get_full_system_prompt()
+
+    resumed = _Agent()
+    resumed.set_message_history([_Request(opening)], agent_id=first.id)
+
+    assert resumed.get_identity() == _rendered_id(resumed.get_full_system_prompt())
+    assert resumed.get_full_system_prompt() == opening
+
+
+def test_the_full_uuid_survives_not_just_its_first_six_characters():
+    # What a lossy round trip through the rendered line would have cost.
+    first = _Agent()
+    resumed = _Agent()
+    resumed.set_message_history(
+        [_Request(first.get_full_system_prompt())], agent_id=first.id
+    )
+    assert resumed.id == first.id
+
+
+def test_resuming_without_an_id_keeps_the_prompt_and_stays_consistent():
+    # Any caller that does not pass an id -- an older front end, or one
+    # whose store has none yet. The
+    # agent introduces itself under its own name -- what it must NOT do is
+    # send one name and report another.
+    first = _Agent()
+    opening = first.get_full_system_prompt()
+
+    resumed = _Agent()
+    resumed.set_message_history([_Request(opening)])
+
+    assert resumed.get_identity() == _rendered_id(resumed.get_full_system_prompt())
+
+
+def test_the_cached_body_is_reused_across_turns():
+    # The reason any of this is frozen: the body drifts, and drift costs a
+    # cache miss on every turn of a long conversation.
+    calls: list[int] = []
+
+    class _Drifting(_Agent):
+        def get_system_prompt(self) -> str:
+            calls.append(len(calls))
+            return f"SYSTEM v{len(calls)}"
+
+    first = _Drifting()
+    opening = first.get_full_system_prompt()
+
+    resumed = _Drifting()
+    resumed.set_message_history([_Request(opening)], agent_id=first.id)
+
+    assert resumed.get_full_system_prompt() == opening
+    assert resumed.get_full_system_prompt() == opening
+
+
+def test_the_identity_sentence_can_be_reworded_without_breaking_identity():
+    # The property lost by parsing prose: this text is presentation, and
+    # editing it must not corrupt a field.
+    class _Reworded(_Agent):
+        def get_identity_prompt(self) -> str:
+            return f"\n\n[[agent={self.get_identity()}]]"
+
+    agent = _Reworded()
+    assert agent.get_identity() in agent.get_full_system_prompt()
+
+    resumed = _Reworded()
+    resumed.set_message_history(
+        [_Request(agent.get_full_system_prompt())], agent_id=agent.id
+    )
+    assert resumed.id == agent.id
+    assert resumed.get_identity() in resumed.get_full_system_prompt()
+
+
+def test_two_fresh_agents_still_differ():
+    assert _Agent().id != _Agent().id

--- a/tests/test_resume_adopts_prior_prompt.py
+++ b/tests/test_resume_adopts_prior_prompt.py
@@ -1,0 +1,150 @@
+"""A resume adopts the prompt and identity the conversation already had.
+
+``set_message_history`` is the real resume door. Every front door that
+continues a conversation goes through it -- the CLI via
+``restore_named_session``, an embedding runner by calling it directly, a
+headless loop rebuilding an agent per turn. Hanging resume behaviour off
+``restore_named_session`` alone fixes exactly one of those callers, which is
+how a previous attempt at this passed its tests while every other front end
+was unchanged.
+
+Two things must survive, and the history already carries both:
+
+``instructions``
+    pydantic-ai stamps the system prompt onto every request message, so a
+    restored history knows the prompt it was built with. That string is the
+    provider's cache prefix. Recomputing it in a fresh process yields a
+    different one -- a live timestamp, a grown recall block -- and the cache
+    misses on every turn of a long conversation, which is precisely when it
+    was worth having.
+
+``agent_id``
+    ...is not in the history, so it is passed in. The prompt tells the agent
+    to use its id "for claiming task ownership or coordination with other
+    agents"; an id minted per process cannot own anything.
+
+The conversation is the authority here, not the process. Measured on a real
+thread before this: three turns, three identities, and the instructions
+block moving 5571 -> 6175 characters.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from code_puppy.agents.base_agent import BaseAgent
+
+
+class _Agent(BaseAgent):
+    @property
+    def name(self) -> str:
+        return "test-agent"
+
+    @property
+    def display_name(self) -> str:
+        return "Test Agent"
+
+    @property
+    def description(self) -> str:
+        return "fixture"
+
+    def get_system_prompt(self) -> str:
+        return "SYSTEM"
+
+    def get_available_tools(self):
+        return []
+
+
+def _request(instructions: str | None) -> Dict[str, Any]:
+    """A restored request message, shaped like pydantic-ai's wire format."""
+    return {"kind": "request", "instructions": instructions, "parts": []}
+
+
+@pytest.fixture
+def drifting(monkeypatch):
+    """A load_prompt fragment that differs every call, like kennel recall."""
+    calls: List[int] = []
+
+    def fake_on_load_prompt():
+        calls.append(len(calls))
+        return [f"MEMORY{'!' * len(calls)}"]
+
+    monkeypatch.setattr("code_puppy.callbacks.on_load_prompt", fake_on_load_prompt)
+    return calls
+
+
+def test_a_resumed_agent_keeps_the_prompt_the_history_was_built_with(drifting):
+    # The whole point: a fresh process resuming a conversation must present
+    # the SAME prefix, not a freshly computed one.
+    #
+    # The id is passed because identity is NOT part of the frozen body -- it
+    # is rendered each turn from `self.id`, so that there is one
+    # representation of it rather than a field and a copy inside a string.
+    # A caller that wants the identical prefix therefore has to supply the
+    # conversation's id, which every real resume path already stores.
+    first = _Agent()
+    opening = first.get_full_system_prompt()
+
+    resumed = _Agent()  # new process, new uuid, fragments would differ
+    resumed.set_message_history([_request(opening)], agent_id=first.id)
+
+    assert resumed.get_full_system_prompt() == opening
+
+
+def test_identity_is_restored_when_the_caller_knows_it(drifting):
+    # An embedding runner stores the id beside its thread; the CLI reads it
+    # from the session sidecar. Either way the caller passes it in, because
+    # the history does not carry it.
+    original = _Agent()
+    resumed = _Agent()
+    assert resumed.id != original.id
+
+    resumed.set_message_history([_request(None)], agent_id=original.id)
+    assert resumed.id == original.id
+
+
+def test_a_fresh_conversation_is_unaffected(drifting):
+    # Setting an EMPTY history is not a resume. Nothing to adopt, so the
+    # agent keeps its own identity and computes its own prompt.
+    agent = _Agent()
+    before = agent.id
+    agent.set_message_history([])
+
+    assert agent.id == before
+    assert "MEMORY" in agent.get_full_system_prompt()
+
+
+def test_history_without_instructions_falls_back_to_computing_one(drifting):
+    # Histories written before instructions were recorded, or by a caller
+    # that strips them. A resume must still work; it just cannot inherit a
+    # prefix that was never stored.
+    agent = _Agent()
+    agent.set_message_history([_request(None)])
+    assert "MEMORY" in agent.get_full_system_prompt()
+
+
+def test_the_adopted_prompt_does_not_drift_across_later_turns(drifting):
+    # Adopting once is not enough if the next call recomputes.
+    first = _Agent()
+    opening = first.get_full_system_prompt()
+    resumed = _Agent()
+    resumed.set_message_history([_request(opening)], agent_id=first.id)
+
+    assert resumed.get_full_system_prompt() == opening
+    assert resumed.get_full_system_prompt() == opening
+
+
+def test_clearing_history_starts_over(drifting):
+    # /clear ends the conversation, so its prompt and cached fragments go
+    # with it: the prefix is allowed to change exactly when the conversation
+    # does.
+    first = _Agent()
+    opening = first.get_full_system_prompt()
+    agent = _Agent()
+    agent.set_message_history([_request(opening)], agent_id=first.id)
+    assert agent.get_full_system_prompt() == opening
+
+    agent.clear_message_history()
+    assert agent.get_full_system_prompt() != opening

--- a/tests/test_session_identity_persistence.py
+++ b/tests/test_session_identity_persistence.py
@@ -1,0 +1,181 @@
+"""An agent's identity must survive a resume.
+
+``BaseAgent.__init__`` mints ``self.id`` as a fresh uuid4, and
+``get_identity()`` renders it into the system prompt via
+``get_identity_prompt()``. Every process therefore introduces itself under a
+different name, and any front door that runs one turn per process -- an
+embedding runner, a headless ``-p`` loop -- changes identity
+mid-conversation.
+
+Two things break, and the second is the expensive one:
+
+1. The prompt tells the agent to use that id "for claiming task ownership or
+   coordination with other agents". An id that does not outlive the turn
+   cannot own anything.
+2. The identity line lives INSIDE the instructions block, which is the
+   provider's cache prefix. A new id per turn rewrites the prefix, so a
+   resumed conversation misses the prompt cache on every turn -- paying full
+   uncached input for context that never changed.
+
+``persist_named_session`` / ``restore_named_session`` are the one true path
+for a session round trip, so identity travels with the session envelope: it
+is state belonging to the conversation, not to the process that happens to
+be serving it.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from code_puppy.agents.base_agent import BaseAgent
+from code_puppy.session_lifecycle import persist_named_session, restore_named_session
+
+
+class _Agent(BaseAgent):
+    """Smallest concrete agent: identity lives on the base class."""
+
+    @property
+    def name(self) -> str:
+        return "test-agent"
+
+    @property
+    def display_name(self) -> str:
+        return "Test Agent"
+
+    @property
+    def description(self) -> str:
+        return "fixture"
+
+    def get_system_prompt(self) -> str:
+        return "SYSTEM"
+
+    def get_available_tools(self):
+        return []
+
+    def estimate_tokens_for_message(self, message) -> int:
+        return 1
+
+
+def _round_trip(tmp: Path) -> tuple[_Agent, _Agent]:
+    """Save from one agent, restore onto a second: the resume, in miniature."""
+    saved = _Agent()
+    saved.set_message_history([{"role": "user", "content": "hello"}])
+    persist_named_session(saved, "s1", base_dir=tmp)
+
+    resumed = _Agent()
+    restore_named_session(resumed, "s1", base_dir=tmp)
+    return saved, resumed
+
+
+def test_identity_survives_a_resume():
+    with tempfile.TemporaryDirectory() as d:
+        saved, resumed = _round_trip(Path(d))
+        assert resumed.id == saved.id
+        assert resumed.get_identity() == saved.get_identity()
+
+
+def test_identity_prompt_is_byte_identical_after_a_resume():
+    # The actual cache-prefix guarantee. Comparing the rendered line rather
+    # than the raw id is deliberate: the id could match while the rendering
+    # drifted, and it is the rendered bytes the provider hashes.
+    with tempfile.TemporaryDirectory() as d:
+        saved, resumed = _round_trip(Path(d))
+        assert resumed.get_identity_prompt() == saved.get_identity_prompt()
+
+
+def test_identity_is_written_into_the_metadata_sidecar():
+    # Persisted with the SESSION, not a process-local cache: a resume in a
+    # brand new process has nothing else to read. Named for the sidecar it
+    # asserts on: the history envelope is a separate file, and a failure
+    # here should point at the right one.
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        agent = _Agent()
+        agent.set_message_history([{"role": "user", "content": "hello"}])
+        metadata = persist_named_session(agent, "s1", base_dir=tmp)
+
+        on_disk = json.loads(Path(metadata.metadata_path).read_text())
+        assert on_disk["agent_id"] == agent.id
+
+
+def test_two_fresh_agents_still_differ():
+    # The guard against over-correcting into a constant. Identity must be
+    # stable ACROSS A RESUME, not shared by every agent ever constructed.
+    assert _Agent().id != _Agent().id
+
+
+def test_autosave_records_the_identity_too():
+    # The path that MATTERS most, and the one a lifecycle-only fix misses.
+    # `auto_save_session_if_enabled` calls `save_session` directly rather than
+    # going through `persist_named_session`, and quick-resume reads what it
+    # writes -- so identity has to ride on this path or the common resume
+    # still loses it. Reported by Copilot on this PR.
+    from unittest import mock
+
+    import code_puppy.config as cp_config
+
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        agent = _Agent()
+        agent.set_message_history([{"role": "user", "content": "hello"}])
+
+        with (
+            mock.patch.object(cp_config, "AUTOSAVE_DIR", str(tmp)),
+            mock.patch(
+                "code_puppy.agents.agent_manager.get_current_agent",
+                return_value=agent,
+            ),
+            mock.patch.object(
+                cp_config, "get_current_session_name", return_value="auto1"
+            ),
+            mock.patch.object(cp_config, "record_quick_resume_sessions"),
+        ):
+            assert cp_config.auto_save_session_if_enabled(force=True) is True
+
+        resumed = _Agent()
+        restore_named_session(resumed, "auto1", base_dir=tmp)
+        assert resumed.id == agent.id
+
+
+def test_an_unserialisable_id_does_not_break_the_save():
+    # The metadata sidecar is JSON and is written AFTER the history. An id
+    # that cannot be serialised must not turn a successful save into a
+    # half-write: the user's conversation matters, the identity field does
+    # not. Caught by a MagicMock agent in the headless save-back tests, where
+    # `agent.id` is a Mock rather than a string.
+    class _Odd(_Agent):
+        def __init__(self) -> None:
+            super().__init__()
+            self.id = object()  # type: ignore[assignment]
+
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        agent = _Odd()
+        agent.set_message_history([{"role": "user", "content": "hello"}])
+        metadata = persist_named_session(agent, "s1", base_dir=tmp)
+
+        on_disk = json.loads(Path(metadata.metadata_path).read_text())
+        assert "agent_id" not in on_disk
+        assert Path(metadata.json_path).exists()
+
+
+def test_restoring_a_session_without_an_id_keeps_the_agents_own():
+    # Sessions written before this existed have no agent_id. Restoring one
+    # must leave the fresh uuid alone rather than blanking the identity.
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        saved = _Agent()
+        saved.set_message_history([{"role": "user", "content": "hello"}])
+        metadata = persist_named_session(saved, "s1", base_dir=tmp)
+
+        path = Path(metadata.metadata_path)
+        stripped = json.loads(path.read_text())
+        stripped.pop("agent_id", None)
+        path.write_text(json.dumps(stripped))
+
+        resumed = _Agent()
+        before = resumed.id
+        restore_named_session(resumed, "s1", base_dir=tmp)
+        assert resumed.id == before

--- a/tests/test_system_prompt_stable_on_resume.py
+++ b/tests/test_system_prompt_stable_on_resume.py
@@ -1,0 +1,134 @@
+"""The system prompt must not drift between turns of one conversation.
+
+``get_full_system_prompt`` appends every ``load_prompt`` plugin fragment on
+every call, and pydantic-ai puts the result in ``instructions`` on EVERY
+request message -- verified on a real thread, where messages 0/2 carried
+5571 chars and 4/6 carried 6129.
+
+``instructions`` is the provider's cache prefix. A fragment that grows as the
+conversation proceeds -- a memory/recall plugin is the live example, since
+it recalls what earlier turns just wrote -- therefore invalidates the prefix on
+every turn. The user pays full uncached input for context that has not
+changed, and pays more of it the longer they talk.
+
+The fix is not to disable recall. It is that recall is CONTEXT, which belongs
+in the conversation, and the system prompt is the CONTRACT, which does not
+change mid-conversation. So volatile fragments are gathered once, when the
+conversation begins, and a resumed turn keeps the prefix it already has.
+
+"Begins" is read from the message history rather than a flag: an agent with
+no history has nothing to resume, and an agent with history does. That needs
+no new hook signature, no per-turn config, and cannot get out of sync with
+the thing it describes.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from code_puppy.agents.base_agent import BaseAgent
+
+
+class _Agent(BaseAgent):
+    @property
+    def name(self) -> str:
+        return "test-agent"
+
+    @property
+    def display_name(self) -> str:
+        return "Test Agent"
+
+    @property
+    def description(self) -> str:
+        return "fixture"
+
+    def get_system_prompt(self) -> str:
+        return "SYSTEM"
+
+    def get_available_tools(self):
+        return []
+
+
+@pytest.fixture
+def growing_fragment(monkeypatch):
+    """A plugin whose fragment grows every call, like kennel recall."""
+    calls: List[int] = []
+
+    def fake_on_load_prompt():
+        calls.append(len(calls))
+        return [f"MEMORY{'!' * len(calls)}"]
+
+    monkeypatch.setattr("code_puppy.callbacks.on_load_prompt", fake_on_load_prompt)
+    return calls
+
+
+def test_first_turn_still_gets_its_fragments(growing_fragment):
+    # The fix must not amount to switching recall off.
+    agent = _Agent()
+    assert "MEMORY" in agent.get_full_system_prompt()
+
+
+def test_prompt_does_not_drift_before_the_first_turn(growing_fragment):
+    # Setup calls this more than once before any history exists --
+    # `_estimate_context_overhead` is one such caller -- so keying the cache
+    # on "history is empty" would still re-poll and still drift, just
+    # earlier. Reported by Copilot; measured at 2 polls and a changed prompt
+    # before turn one had run.
+    agent = _Agent()
+    first = agent.get_full_system_prompt()
+    second = agent.get_full_system_prompt()
+
+    assert second == first
+    assert len(growing_fragment) == 1
+
+
+def test_prompt_is_byte_identical_once_the_conversation_has_started(
+    growing_fragment,
+):
+    agent = _Agent()
+    first = agent.get_full_system_prompt()
+
+    # A turn happened: there is now history to resume from.
+    agent.set_message_history([{"role": "user", "content": "hi"}])
+    second = agent.get_full_system_prompt()
+    third = agent.get_full_system_prompt()
+
+    assert second == first, "the cache prefix changed on the second turn"
+    assert third == first, "the cache prefix kept drifting"
+
+
+def test_volatile_plugins_are_not_polled_once_started(growing_fragment):
+    # Not just the same answer -- the fragments are not gathered at all.
+    # A plugin that reaches a database or a network on every turn is latency
+    # on the critical path of a turn that cannot use the result.
+    agent = _Agent()
+    agent.get_full_system_prompt()
+    polls_after_first = len(growing_fragment)
+
+    agent.set_message_history([{"role": "user", "content": "hi"}])
+    agent.get_full_system_prompt()
+    agent.get_full_system_prompt()
+
+    assert len(growing_fragment) == polls_after_first
+
+
+def test_clearing_history_starts_a_new_conversation(growing_fragment):
+    # /clear means a new conversation, so recall is gathered afresh: the
+    # prefix is allowed to change exactly when the conversation does.
+    agent = _Agent()
+    agent.get_full_system_prompt()
+    agent.set_message_history([{"role": "user", "content": "hi"}])
+    agent.get_full_system_prompt()
+
+    before = len(growing_fragment)
+    agent.clear_message_history()
+    agent.get_full_system_prompt()
+    assert len(growing_fragment) == before + 1
+
+
+def test_identity_still_rides_at_the_end(growing_fragment):
+    agent = _Agent()
+    agent.set_message_history([{"role": "user", "content": "hi"}])
+    assert agent.get_full_system_prompt().endswith(agent.get_identity_prompt())


### PR DESCRIPTION
## The problem

pydantic-ai stamps the assembled system prompt into `instructions` on **every** request message, and `instructions` is the provider's cache prefix. Two things in the current assembly change between turns, so a long conversation misses that cache on every turn — precisely when it's worth having.

Measured on one long-running thread before this change: three turns under three different identities, with the instructions block moving **5571 → 6129 → 6175** characters. Every turn re-sent, and re-paid for, context that hadn't changed.

## Three changes

**1. `load_prompt` fragments are gathered once per conversation.**

A fragment that grows between turns invalidates the prefix every turn. A memory/recall plugin is the worst case — it recalls what the previous turn wrote, so it grows exactly as the conversation gets long. The system prompt is the CONTRACT and shouldn't change mid-conversation; recall is CONTEXT and belongs in the message stream. Turn one still gets it.

Gathered on the *first call* rather than keyed on "is the history empty": the setup path calls the assembly more than once before any history exists (`_estimate_context_overhead` is one such caller), so a history-keyed cache would still re-poll and still drift, only earlier. `None` means "not gathered yet"; `[]` is a real answer meaning no plugin contributed. `clear_message_history` is the single reset.

**2. Identity belongs to the conversation, not the process.**

`__init__` mints `self.id` as a fresh uuid4 and renders it into the prompt, so any front door running one turn per process changes identity mid-conversation. Besides rewriting the cache prefix, the prompt tells the agent to use that id *"for claiming task ownership or coordination with other agents"* — and an id that doesn't outlive the turn can't own anything.

It now travels in the session metadata, on both the lifecycle and autosave paths (quick-resume reads what autosave writes). Backward compatible both ways: a session written before this has no `agent_id` and the resuming agent keeps its own. The id is type-checked before being recorded, because the sidecar is JSON written *after* the history — an unserialisable id must not turn a save into a half-write and lose the user's conversation to a cosmetic field.

**3. `set_message_history` is the one resume door.**

Every front end that continues a conversation arrives there, so the behaviour lives there rather than in `restore_named_session`. Hanging it off one caller fixes exactly that caller — an earlier attempt did precisely that, passed its own tests, and left every other front end unchanged.

The prompt is **inherited**, not recomputed: the restored history already knows what it was built with, and that string is what the provider cached. Identity is passed in rather than parsed back out of the prompt text, so there's one representation instead of two that can drift — the rendered line shows only six characters of a uuid, so the round trip is lossy, and recovering it would make user-facing wording load-bearing.

## Ordering of scoped additions

`temporary_system_prompt_addition` text is appended **after** the identity line, where the strip that produces the adoptable body already discards it. Ephemeral text is unadoptable by construction, and body + identity stay a maximal stable prefix.

This matters because the headless loop calls `set_message_history` *after* the scoped block exits — the list is empty by then, so nothing on the object can say which bytes were ephemeral. Position is the only signal that survives the trip through storage into another process. Without it, the headless autonomy instruction was dropped on a resumed `-p` run and frozen permanently into the prefix in the opposite order.

Additions are also stripped from an adopted body on the way *in*, not only kept out on the way out: the prompt is persisted, so a session written by an older build would otherwise re-apply the instruction to every later turn — including interactive ones, telling a user's own session never to ask them for confirmation. The exact known string is removed and nothing looser.

`_strip_identity_prompt` uses `rpartition` deliberately: `_builder` and subagent invocation both append after the identity line, so the **last** marker is the correct split point. A test pins that, since swapping it for `partition` otherwise passes the whole suite.

## Verification

- **7720 passed**, 33 skipped
- `tests/command_line/test_autosave_menu.py::TestDisplayResumedHistory::test_displays_last_n_messages` fails on a clean checkout of `main` too — pre-existing, unrelated, untouched here
- `ruff check` + `ruff format --check` clean
- Regression tests verified to fail without the fix; the `rpartition` test verified to fail under exactly that mutation
- Exercised against real `ModelRequest`/`ModelResponse` objects rather than stand-ins

Happy to split this into smaller PRs if you'd prefer to take the pieces separately.