### PR TITLE
perf: take ~2-4s of code-puppy overhead off the cold TTFT path

### DIFF
--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -21,6 +21,7 @@ import asyncio
 import json
 import re
 import signal
+import sys
 import threading
 import uuid
 from contextlib import AsyncExitStack
@@ -49,17 +50,6 @@ try:  # pragma: no cover - pydantic-ai version dependent
 except ImportError:
     ModelHTTPError = None  # type: ignore[misc,assignment]
 
-try:  # pragma: no cover - optional dependency
-    from openai import APIError as OpenAIAPIError
-except ImportError:
-    OpenAIAPIError = None  # type: ignore[assignment]
-
-try:  # pragma: no cover - optional dependency
-    from anthropic import APIConnectionError as AnthropicAPIConnectionError
-    from anthropic import APIStatusError as AnthropicAPIStatusError
-except ImportError:
-    AnthropicAPIConnectionError = None  # type: ignore[assignment]
-    AnthropicAPIStatusError = None  # type: ignore[assignment]
 
 try:  # pragma: no cover - pydantic-ai version dependent
     from pydantic_ai.exceptions import ModelAPIError
@@ -172,6 +162,18 @@ def _matches_retryable_snippet(msg: str) -> bool:
 _EMBEDDED_HTTP_STATUS_RE = re.compile(r"\[HTTP\s+(\d{3})\]", re.IGNORECASE)
 
 
+def _sdk_exception(module: str, name: str) -> type | None:
+    """Resolve a provider-SDK exception class only if that SDK is loaded.
+
+    An exception raised by a vendor SDK can only exist if the SDK is already
+    in ``sys.modules``, so peeking there (rather than importing) keeps
+    ``openai``/``anthropic`` (~200ms cold apiece) off the startup path for
+    providers this run never touches. ``None`` doubles as "not installed".
+    """
+    loaded = sys.modules.get(module)
+    return getattr(loaded, name, None) if loaded is not None else None
+
+
 def _is_transient_status(status_code: object) -> bool:
     """True for HTTP statuses worth a silent retry: 429 or any 5xx."""
     return status_code == 429 or (isinstance(status_code, int) and status_code >= 500)
@@ -238,7 +240,8 @@ def _is_retryable_one(exc: BaseException) -> bool:
     if isinstance(exc, UnexpectedModelBehavior):
         return _matches_retryable_snippet(msg)
 
-    if OpenAIAPIError is not None and isinstance(exc, OpenAIAPIError):
+    openai_api_error = _sdk_exception("openai", "APIError")
+    if openai_api_error is not None and isinstance(exc, openai_api_error):
         # 5xx and 429 are transient regardless of wording; the SDK exposes the
         # HTTP status on APIStatusError subclasses (connection/timeout errors
         # have none and are covered by the transport branch above). Mirrors the
@@ -260,14 +263,16 @@ def _is_retryable_one(exc: BaseException) -> bool:
                 return _matches_retryable_snippet(body_msg)
 
     # Anthropic SDK: a bare APIConnectionError is, by definition, transient.
-    if AnthropicAPIConnectionError is not None and isinstance(
-        exc, AnthropicAPIConnectionError
+    anthropic_connection_error = _sdk_exception("anthropic", "APIConnectionError")
+    if anthropic_connection_error is not None and isinstance(
+        exc, anthropic_connection_error
     ):
         return True
 
     # Anthropic SDK: status errors are retryable on 5xx (or unset) OR when the
     # message/body matches a gateway-transient snippet (e.g. upstream_idle_timeout).
-    if AnthropicAPIStatusError is not None and isinstance(exc, AnthropicAPIStatusError):
+    anthropic_status_error = _sdk_exception("anthropic", "APIStatusError")
+    if anthropic_status_error is not None and isinstance(exc, anthropic_status_error):
         status_code = getattr(exc, "status_code", None)
         if status_code is None or (isinstance(status_code, int) and status_code >= 500):
             return True

--- a/code_puppy/agents/agent_code_puppy.py
+++ b/code_puppy/agents/agent_code_puppy.py
@@ -132,7 +132,6 @@ When given a coding task:
 {a["task_step"]}
 
 Important rules:
-- You MUST use tools — DO NOT just output code or descriptions
 {r["pre_tool_rule"]}
 - Explore directories before reading/modifying files
 - Read existing files before modifying them

--- a/code_puppy/agents/smooth_stream.py
+++ b/code_puppy/agents/smooth_stream.py
@@ -82,12 +82,26 @@ class SmoothTermflowWriter(SmoothWriter):
         )
 
 
+def _is_interactive_target(target: TextIO) -> bool:
+    """Only a human watching a terminal benefits from typewriter pacing.
+
+    Pipes, files, CI logs and headless ``-p`` captures just pay the drain
+    tail (~1s per text part with the default catch-up window) for nothing.
+    """
+    try:
+        return bool(target.isatty())
+    except Exception:
+        return False
+
+
 def make_thinking_smoother(console: Console) -> Optional[ThinkingStreamSmoother]:
     """Build a thinking smoother honoring the user's config toggle.
 
-    Returns ``None`` when smoothing is disabled, so callers fall back to
-    printing deltas directly.
+    Returns ``None`` when smoothing is disabled or the console isn't a
+    terminal, so callers fall back to printing deltas directly.
     """
+    if not _is_interactive_target(console.file):
+        return None
     try:
         from code_puppy.config import get_smooth_thinking_stream
 
@@ -101,9 +115,11 @@ def make_thinking_smoother(console: Console) -> Optional[ThinkingStreamSmoother]
 def make_smooth_termflow_writer(target: TextIO) -> Optional[SmoothTermflowWriter]:
     """Build a smooth termflow writer honoring the user's config toggle.
 
-    Returns ``None`` when response smoothing is disabled, so callers fall
-    back to writing straight to ``target``.
+    Returns ``None`` when response smoothing is disabled or ``target``
+    isn't a terminal, so callers fall back to writing straight to ``target``.
     """
+    if not _is_interactive_target(target):
+        return None
     try:
         from code_puppy.config import get_smooth_response_stream
 

--- a/code_puppy/config.py
+++ b/code_puppy/config.py
@@ -305,9 +305,31 @@ _default_vision_model_cache = None
 _warned_no_model = False
 
 
+# Parsed-config cache: (path, inode, mtime_ns, size) -> parser. ``get_value``
+# is called hundreds of times per turn (and per streamed chunk), and each
+# call used to re-read and re-parse the INI file. Any write -- ours go through
+# ``mutate_config``'s atomic replace, which changes the inode -- rolls the key.
+_CONFIG_CACHE: tuple[tuple[str, int, int, int], configparser.ConfigParser] | None = None
+
+
 def _load_config() -> configparser.ConfigParser:
-    """Load ``CONFIG_FILE`` through the bounded, recoverable I/O layer."""
-    return load_config(CONFIG_FILE)
+    """Load ``CONFIG_FILE`` through the bounded, recoverable I/O layer.
+
+    Returns a shared, cached parser while the file on disk is unchanged;
+    callers must treat it as read-only (mutations go through ``mutate_config``).
+    """
+    global _CONFIG_CACHE
+    try:
+        st = os.stat(CONFIG_FILE)
+    except OSError:
+        # Missing/unreadable: let the I/O layer decide, nothing to cache.
+        return load_config(CONFIG_FILE)
+    key = (CONFIG_FILE, st.st_ino, st.st_mtime_ns, st.st_size)
+    if _CONFIG_CACHE is not None and _CONFIG_CACHE[0] == key:
+        return _CONFIG_CACHE[1]
+    parser = load_config(CONFIG_FILE)
+    _CONFIG_CACHE = (key, parser)
+    return parser
 
 
 def ensure_config_exists():
@@ -323,7 +345,9 @@ def ensure_config_exists():
     # Skip the read entirely when we already know there's nothing to read --
     # matches configparser's own no-op-on-missing-file behavior and avoids an
     # unnecessary open() attempt during first-run setup.
-    config = _load_config() if exists else configparser.ConfigParser()
+    # Uncached read: this parser is mutated in place below, and the cached
+    # instance from _load_config() is shared with every reader.
+    config = load_config(CONFIG_FILE) if exists else configparser.ConfigParser()
     missing = []
     if DEFAULT_SECTION not in config:
         config[DEFAULT_SECTION] = {}

--- a/code_puppy/model_factory.py
+++ b/code_puppy/model_factory.py
@@ -5,18 +5,11 @@ import pathlib
 from collections.abc import Mapping
 from typing import Any, Dict, Optional
 
-from anthropic import AsyncAnthropic
-from openai import AsyncAzureOpenAI
-from pydantic_ai.models.anthropic import AnthropicModel, AnthropicModelSettings
-from pydantic_ai.models.openai import (
-    OpenAIChatModel,
-    OpenAIChatModelSettings,
-    OpenAIResponsesModel,
-    OpenAIResponsesModelSettings,
-)
+# Provider SDKs are imported inside the branch that needs them, not here:
+# ``openai`` (~200ms cold) and ``anthropic`` (~170ms cold) each drag in
+# their whole surface, and a run only ever talks to one provider family.
+# Cold-start TTFT pays for every eager import in this module.
 from pydantic_ai.profiles.openai import OpenAIModelProfile
-from pydantic_ai.providers.cerebras import CerebrasProvider
-from pydantic_ai.providers.openrouter import OpenRouterProvider
 from pydantic_ai.settings import ModelSettings
 
 from code_puppy.gemini_model import GeminiModel
@@ -370,6 +363,8 @@ def make_model_settings(
         for key in ("extended_thinking", "budget_tokens", "interleaved_thinking"):
             model_settings_dict.pop(key, None)
 
+        from pydantic_ai.models.openai import OpenAIChatModelSettings
+
         model_settings = OpenAIChatModelSettings(**model_settings_dict)
 
     elif is_copilot and (
@@ -379,6 +374,8 @@ def make_model_settings(
     ):
         # Copilot GPT/O-series: no reasoning_effort support (400 Bad Request).
         # Plain OpenAIChatModelSettings without reasoning params.
+        from pydantic_ai.models.openai import OpenAIChatModelSettings
+
         model_settings = OpenAIChatModelSettings(**model_settings_dict)
 
     elif "gpt-5" in model_name or "gpt-5" in str(model_config.get("name", "")).lower():
@@ -386,6 +383,11 @@ def make_model_settings(
         # custom endpoint entries are often keyed by an alias (e.g.
         # "luna-responses" -> name "gpt-5.6-luna") and would otherwise
         # silently skip all reasoning configuration.
+        from pydantic_ai.models.openai import (
+            OpenAIChatModelSettings,
+            OpenAIResponsesModelSettings,
+        )
+
         # Normalize legacy effort values (minimal->none, ultra->max)
         _EFFORT_ALIAS = {"minimal": "none", "ultra": "max"}
         effort = effective_settings.get("reasoning_effort", "medium")
@@ -510,6 +512,8 @@ def make_model_settings(
                 "anthropic_cache_messages": cache_setting,
             }
         )
+        from pydantic_ai.models.anthropic import AnthropicModelSettings
+
         model_settings = AnthropicModelSettings(**model_settings_dict)
 
     # Apply thinking defaults if the model supports them
@@ -534,12 +538,6 @@ def make_model_settings(
         model_settings["extra_body"] = extra_body
 
     return model_settings
-
-
-class ZaiChatModel(OpenAIChatModel):
-    def _process_response(self, response):
-        response.object = "chat.completion"
-        return super()._process_response(response)
 
 
 def get_custom_config(model_config):
@@ -777,6 +775,11 @@ class ModelFactory:
                 )
                 return None
 
+            from pydantic_ai.models.openai import (
+                OpenAIChatModel,
+                OpenAIResponsesModel,
+            )
+
             provider = make_openai_provider(provider_identity, api_key=api_key)
             model = OpenAIChatModel(
                 model_name=model_config["name"],
@@ -826,6 +829,9 @@ class ModelFactory:
             if beta_header:
                 default_headers["anthropic-beta"] = beta_header
 
+            from anthropic import AsyncAnthropic
+            from pydantic_ai.models.anthropic import AnthropicModel
+
             anthropic_client = AsyncAnthropic(
                 api_key=api_key,
                 http_client=client,
@@ -870,6 +876,9 @@ class ModelFactory:
             default_headers = {}
             if beta_header:
                 default_headers["anthropic-beta"] = beta_header
+
+            from anthropic import AsyncAnthropic
+            from pydantic_ai.models.anthropic import AnthropicModel
 
             anthropic_client = AsyncAnthropic(
                 base_url=url,
@@ -931,6 +940,9 @@ class ModelFactory:
             # Configure max_retries for the Azure client, defaulting if not specified in config
             azure_max_retries = model_config.get("max_retries", 2)
 
+            from openai import AsyncAzureOpenAI
+            from pydantic_ai.models.openai import OpenAIChatModel
+
             azure_client = AsyncAzureOpenAI(
                 azure_endpoint=azure_endpoint,
                 api_version=api_version,
@@ -954,6 +966,11 @@ class ModelFactory:
             if api_key:
                 provider_args["api_key"] = api_key
             provider = make_openai_provider(provider_identity, **provider_args)
+            from pydantic_ai.models.openai import (
+                OpenAIChatModel,
+                OpenAIResponsesModel,
+            )
+
             if _custom_openai_uses_responses_api(model_name, model_config):
                 return OpenAIResponsesModel(
                     model_name=model_config["name"], provider=provider
@@ -975,6 +992,8 @@ class ModelFactory:
                 api_key=api_key,
                 base_url="https://api.z.ai/api/coding/paas/v4",
             )
+            from code_puppy.zai_model import ZaiChatModel
+
             return ZaiChatModel(
                 model_name=model_config["name"],
                 provider=provider,
@@ -992,6 +1011,8 @@ class ModelFactory:
                 api_key=api_key,
                 base_url="https://api.z.ai/api/paas/v4/",
             )
+            from code_puppy.zai_model import ZaiChatModel
+
             return ZaiChatModel(
                 model_name=model_config["name"],
                 provider=provider,
@@ -1047,6 +1068,9 @@ class ModelFactory:
                 model_name="cerebras",
                 timeout=timeout if timeout is not None else 180,
             )
+            from pydantic_ai.models.openai import OpenAIChatModel
+            from pydantic_ai.providers.cerebras import CerebrasProvider
+
             provider = CerebrasProvider(
                 api_key=api_key,
                 http_client=client,
@@ -1096,6 +1120,9 @@ class ModelFactory:
                         f"OPENROUTER_API_KEY is not set (check config or environment); skipping OpenRouter model '{model_config.get('name')}'."
                     )
                     return None
+
+            from pydantic_ai.models.openai import OpenAIChatModel
+            from pydantic_ai.providers.openrouter import OpenRouterProvider
 
             provider = OpenRouterProvider(api_key=api_key)
 

--- a/code_puppy/provider_identity.py
+++ b/code_puppy/provider_identity.py
@@ -8,34 +8,33 @@ so we need stable, distinct runtime identities.
 
 from __future__ import annotations
 
-from typing import Any
+import functools
+from typing import TYPE_CHECKING, Any
 
-from pydantic_ai.providers.anthropic import AnthropicProvider
-from pydantic_ai.providers.openai import OpenAIProvider
-
-
-class AliasedAnthropicProvider(AnthropicProvider):
-    """Anthropic provider with an overridable runtime identity."""
-
-    def __init__(self, *args: Any, provider_name: str = "anthropic", **kwargs: Any):
-        self._provider_name = provider_name
-        super().__init__(*args, **kwargs)
-
-    @property
-    def name(self) -> str:
-        return self._provider_name
+if TYPE_CHECKING:
+    from pydantic_ai.providers.anthropic import AnthropicProvider
+    from pydantic_ai.providers.openai import OpenAIProvider
 
 
-class AliasedOpenAIProvider(OpenAIProvider):
-    """OpenAI provider with an overridable runtime identity."""
+# The aliased subclasses are built on first use rather than at import: each
+# base provider pulls in its vendor SDK (openai / anthropic, ~200ms cold
+# apiece) and this module sits on the import path of every run, whichever
+# provider it ends up talking to. Keyed on the base class so a test that
+# patches the provider gets a subclass of the patch, not a stale cached one.
+@functools.cache
+def _aliased_provider(base: type) -> type:
+    class AliasedProvider(base):  # type: ignore[valid-type,misc]
+        """Provider with an overridable runtime identity."""
 
-    def __init__(self, *args: Any, provider_name: str = "openai", **kwargs: Any):
-        self._provider_name = provider_name
-        super().__init__(*args, **kwargs)
+        def __init__(self, *args: Any, provider_name: str, **kwargs: Any):
+            self._provider_name = provider_name
+            super().__init__(*args, **kwargs)
 
-    @property
-    def name(self) -> str:
-        return self._provider_name
+        @property
+        def name(self) -> str:
+            return self._provider_name
+
+    return AliasedProvider
 
 
 _TYPE_PROVIDER_OVERRIDES = {
@@ -95,13 +94,17 @@ def resolve_provider_identity(model_key: str, model_config: dict[str, Any]) -> s
 
 def make_anthropic_provider(provider_name: str, **kwargs: Any) -> AnthropicProvider:
     """Create an Anthropic-family provider with a stable runtime name."""
+    from pydantic_ai.providers.anthropic import AnthropicProvider
+
     if provider_name == "anthropic":
         return AnthropicProvider(**kwargs)
-    return AliasedAnthropicProvider(provider_name=provider_name, **kwargs)
+    return _aliased_provider(AnthropicProvider)(provider_name=provider_name, **kwargs)
 
 
 def make_openai_provider(provider_name: str, **kwargs: Any) -> OpenAIProvider:
     """Create an OpenAI-family provider with a stable runtime name."""
+    from pydantic_ai.providers.openai import OpenAIProvider
+
     if provider_name == "openai":
         return OpenAIProvider(**kwargs)
-    return AliasedOpenAIProvider(provider_name=provider_name, **kwargs)
+    return _aliased_provider(OpenAIProvider)(provider_name=provider_name, **kwargs)

--- a/code_puppy/terminal_utils.py
+++ b/code_puppy/terminal_utils.py
@@ -264,19 +264,54 @@ def reset_windows_terminal_full() -> None:
     flush_windows_keyboard_buffer()
 
 
-def reset_unix_terminal() -> None:
-    """Reset Unix/Linux/macOS terminal to sane state.
+#: Escape codes undoing every visual mode we could have left enabled:
+#: DECSTR soft reset, attributes off, cursor visible, alternate screen off.
+#: Deliberately NOT the full RIS (``\\x1bc``) that ``reset(1)`` sends -- that
+#: clears the screen, wiping the output the user just asked for.
+_UNIX_TERMINAL_RESET = "\x1b[!p\x1b[0m\x1b[?25h\x1b[?1049l"
 
-    Uses the `reset` command to restore terminal sanity.
-    Silently fails if the command isn't available.
+
+def reset_unix_terminal() -> None:
+    """Restore a sane Unix terminal state on exit.
+
+    Historically shelled out to ``reset(1)``, but ``reset``/``tset`` sleeps a
+    full second by design (a settling delay for hardware terminals), and with
+    output captured its escape sequences never reached the terminal anyway --
+    a one-second no-op on every exit. Instead: ``stty sane`` restores cooked
+    input instantly, and a handful of escape codes undo the visual modes we
+    could have left on. Skipped entirely when not attached to a terminal.
     """
     if platform.system() == "Windows":
         return
 
+    stderr_tty = _is_tty(sys.stderr)
+    if not stderr_tty and not _is_tty(sys.stdout):
+        return  # Piped/redirected: nothing to reset, don't touch anything.
+
     try:
-        subprocess.run(["reset"], check=True, capture_output=True)
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        pass  # Silently fail if reset command isn't available
+        # stty operates on its stdin; inherit ours so it reaches the tty.
+        subprocess.run(["stty", "sane"], check=True, capture_output=True, timeout=2)
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+    ):
+        pass  # Best effort -- stdin may be a pipe, stty may be missing.
+
+    stream = sys.stderr if stderr_tty else sys.stdout
+    try:
+        stream.write(_UNIX_TERMINAL_RESET + _MOUSE_TRACKING_OFF)
+        stream.flush()
+    except Exception:
+        pass  # Never let a cleanup helper crash the exit path.
+
+
+def _is_tty(stream) -> bool:
+    """Best-effort ``isatty`` that treats broken streams as non-terminals."""
+    try:
+        return bool(stream.isatty())
+    except Exception:
+        return False
 
 
 #: Disable all xterm mouse-tracking modes + bracketed paste (1000/1002/1003,

--- a/code_puppy/version_checker.py
+++ b/code_puppy/version_checker.py
@@ -1,5 +1,7 @@
 """Version checking utilities for Code Puppy."""
 
+import threading
+
 import httpx
 
 from code_puppy.i18n import t
@@ -54,14 +56,30 @@ def fetch_latest_version(package_name):
         return None
 
 
-def default_version_mismatch_behavior(current_version):
+def default_version_mismatch_behavior(current_version) -> threading.Thread:
+    """Kick off the PyPI version check without blocking startup.
+
+    The fetch is a blocking HTTPS round-trip (up to ``timeout`` seconds on a
+    bad network) that used to sit on the critical path before the first
+    model request. It now runs on a daemon thread, so the result lands on
+    the message bus whenever it arrives and process exit never waits for
+    it. Returns the thread so callers (tests) can ``join()`` if they must.
+    """
     # Defensive: ensure current_version is never None
     if current_version is None:
         current_version = "0.0.0-unknown"
         emit_warning(t("version.undetected"))
 
-    latest_version = fetch_latest_version("code-puppy")
+    def _check() -> None:
+        report_version_status(current_version, fetch_latest_version("code-puppy"))
 
+    thread = threading.Thread(target=_check, name="version-check", daemon=True)
+    thread.start()
+    return thread
+
+
+def report_version_status(current_version, latest_version) -> None:
+    """Emit the version-check messages for an already-fetched ``latest_version``."""
     update_available = bool(
         latest_version and version_is_newer(latest_version, current_version)
     )

--- a/code_puppy/zai_model.py
+++ b/code_puppy/zai_model.py
@@ -1,0 +1,16 @@
+"""Z.AI (GLM) chat model: an OpenAI-compatible endpoint with one quirk.
+
+Lives in its own module so ``model_factory`` can import it lazily -- the
+``OpenAIChatModel`` base class pulls in the whole ``openai`` SDK, which
+only Z.AI / OpenAI-family runs should pay for.
+"""
+
+from pydantic_ai.models.openai import OpenAIChatModel
+
+
+class ZaiChatModel(OpenAIChatModel):
+    """Z.AI omits ``object: chat.completion``; restore it so the SDK parses."""
+
+    def _process_response(self, response):
+        response.object = "chat.completion"
+        return super()._process_response(response)

--- a/docs/TTFT_PROFILE.md
+++ b/docs/TTFT_PROFILE.md
@@ -30,26 +30,27 @@ The overhead is everything *around* the stream.
 
 | Cost | Cause | Fix |
 |---|---|---|
-| ~1.0s per text part | `SmoothTermflowWriter` drains `ceil(remaining/42)` per 12ms tick (exponential decay: the last ~42 chars always crawl at 1 char/tick). Ran even when stdout was a pipe. | Smoothing is gated on `isatty()` (`agents/smooth_stream.py`). Interactive feel is unchanged. |
+| ~1.0s per text part | `SmoothTermflowWriter` drains `ceil(remaining/42)` per 12ms tick (exponential decay: the last ~42 chars always crawl at 1 char/tick). Ran even when stdout was a pipe. | Smoothing is gated on `isatty()` (`agents/smooth_stream.py`). Upstream, termflow's drain quota is now pinned to the burst's high-water mark, so the drain is linear and really finishes inside `catch_up_seconds` (~0.5s) instead of decaying past it. Still smooth. |
 | 75–170ms good wifi, up to **5s** bad | `httpx.get(pypi.org)` on the startup critical path, 5s timeout, headless too. | Fetch runs on a daemon thread; result lands on the message bus when it arrives (`version_checker.py`). |
+| **~1.2s on every exit** | `reset_unix_terminal()` shelled out to `reset(1)`; `tset` sleeps one second by design (a settling delay for hardware terminals), and with `capture_output=True` its escape codes never reached the terminal anyway — a one-second no-op in `main_entry`'s `finally`. | `stty sane` + targeted escape codes (soft reset, attrs off, cursor visible, alt-screen off, mouse tracking off), skipped entirely off-tty (`terminal_utils.py`). Deliberately not RIS: `reset(1)`'s full init clears the screen. |
 | ~170ms (anthropic) + ~200ms (openai) | `model_factory.py` and `provider_identity.py` imported both vendor SDKs at module scope. `agents/_runtime.py` imported both for `isinstance` checks. | Function-local imports per provider branch; `_sdk_exception()` peeks `sys.modules` (an SDK exception can only exist if the SDK is loaded). `ZaiChatModel` moved to `zai_model.py`. |
 | ~54ms pre-request, then 10–20 reads per streamed chunk | `config.get_value()` re-read and re-parsed `puppy.cfg` on every call — 388 times for one "hi". | Parser cached on `(path, inode, mtime_ns, size)`; `mutate_config`'s atomic replace rolls the key (`config.py`). |
 
+## Result
+
+Cold `-p hi` on a TTY: **~4.5s wall, of which ~3s is Anthropic**
+(TTFB + generation). Code-puppy overhead went from ~3.3s to ~1.1s:
+~0.9s to get the request out, ~0.5s of *intended* typewriter catch-up,
+~0.2s exit. `openai`/`anthropic` no longer load at startup at all
+(fixed in `code_puppy_core_plugins` ollama + here; needs the plugin
+release ≥0.0.40 and a termflow-md release with the linear drain).
+
 ## Still on the table
 
-* **`openai` still loads on Claude runs (~200ms)** — the `ollama` core
-  plugin does `from pydantic_ai.models.openai import OpenAIChatModel` at
-  module scope, and plugins load during `cli_runner` import. One-line lazy
-  import in `code_puppy_core_plugins/ollama/register_callbacks.py`.
 * **Upstream: `pydantic_ai.capabilities.mcp` eagerly imports
   `pydantic_ai.mcp`** → fastmcp → key_value → beartype → `mcp.types`
   (~186ms on every `import pydantic_ai`, MCP servers or not). A lazy import
-  inside the `MCP` capability would fix it. Needs a Notes proposal.
-* **Typewriter tail in interactive mode** — the exponential drain means
-  every text part (including the preamble before each tool call) pays a
-  fixed ~0.5–1s tail regardless of length. A linear drain that actually
-  finishes within `catch_up_seconds` is a termflow change and a UX
-  decision, not made here.
+  inside the `MCP` capability would fix it. Needs an upstream proposal.
 * `anthropic` SDK 1.0 imports every `types.beta.*` module eagerly (~100ms).
   Anthropic's problem.
 * `messaging.rich_renderer` → `tools.common` → `tools` → `browser` →

--- a/docs/TTFT_PROFILE.md
+++ b/docs/TTFT_PROFILE.md
@@ -1,0 +1,67 @@
+# TTFT profile: where a cold `code-puppy -p hi` spends its time
+
+Measured on macOS / Python 3.14 / pydantic-ai 2.35 against
+`claude-code-claude-fable-5-1`, stdout piped. Numbers are typical of ~10
+runs; treat them as ±15%.
+
+## Is the byte stream itself slow?
+
+No. The run goes through `pydantic_agent.run(event_stream_handler=...)`,
+and the hop from the first HTTP body chunk (`httpx2`, via
+`ClaudeCacheAsyncClient`) to the first `stream_event` callback is ~30ms.
+The overhead is everything *around* the stream.
+
+## Timeline before the fixes
+
+```
+ 0.00  process start
+ 1.25  cli_runner imported            <- imports
+ 1.37  startup callback               <- blocking PyPI version check in here
+ 1.48  agent_run_start                <- agent build (tool schemas, config reads)
+ 1.51  POST /v1/messages              <- ~1.5s of our overhead before the request leaves
+ 2.38  response headers               <- Anthropic TTFB (TLS to them is ~23ms; not ours)
+ 3.2   first text delta               <- model-side
+ 4.45  last byte
+ 5.53  agent_run_end                  <- 1.08s typewriter drain, into a pipe
+ 5.7   atexit, then ~0.5s interpreter teardown
+```
+
+## What we owned, and what was done
+
+| Cost | Cause | Fix |
+|---|---|---|
+| ~1.0s per text part | `SmoothTermflowWriter` drains `ceil(remaining/42)` per 12ms tick (exponential decay: the last ~42 chars always crawl at 1 char/tick). Ran even when stdout was a pipe. | Smoothing is gated on `isatty()` (`agents/smooth_stream.py`). Interactive feel is unchanged. |
+| 75–170ms good wifi, up to **5s** bad | `httpx.get(pypi.org)` on the startup critical path, 5s timeout, headless too. | Fetch runs on a daemon thread; result lands on the message bus when it arrives (`version_checker.py`). |
+| ~170ms (anthropic) + ~200ms (openai) | `model_factory.py` and `provider_identity.py` imported both vendor SDKs at module scope. `agents/_runtime.py` imported both for `isinstance` checks. | Function-local imports per provider branch; `_sdk_exception()` peeks `sys.modules` (an SDK exception can only exist if the SDK is loaded). `ZaiChatModel` moved to `zai_model.py`. |
+| ~54ms pre-request, then 10–20 reads per streamed chunk | `config.get_value()` re-read and re-parsed `puppy.cfg` on every call — 388 times for one "hi". | Parser cached on `(path, inode, mtime_ns, size)`; `mutate_config`'s atomic replace rolls the key (`config.py`). |
+
+## Still on the table
+
+* **`openai` still loads on Claude runs (~200ms)** — the `ollama` core
+  plugin does `from pydantic_ai.models.openai import OpenAIChatModel` at
+  module scope, and plugins load during `cli_runner` import. One-line lazy
+  import in `code_puppy_core_plugins/ollama/register_callbacks.py`.
+* **Upstream: `pydantic_ai.capabilities.mcp` eagerly imports
+  `pydantic_ai.mcp`** → fastmcp → key_value → beartype → `mcp.types`
+  (~186ms on every `import pydantic_ai`, MCP servers or not). A lazy import
+  inside the `MCP` capability would fix it. Needs a Notes proposal.
+* **Typewriter tail in interactive mode** — the exponential drain means
+  every text part (including the preamble before each tool call) pays a
+  fixed ~0.5–1s tail regardless of length. A linear drain that actually
+  finishes within `catch_up_seconds` is a termflow change and a UX
+  decision, not made here.
+* `anthropic` SDK 1.0 imports every `types.beta.*` module eagerly (~100ms).
+  Anthropic's problem.
+* `messaging.rich_renderer` → `tools.common` → `tools` → `browser` →
+  playwright at import (~30ms). Layering smell more than a perf bug.
+
+## Reproducing
+
+The throwaway tracer used for this lives outside the repo
+(`/tmp/ttft_trace.py`): it stamps phases from process start via the
+`startup` / `agent_run_start` / `stream_event` / `agent_run_end` hooks,
+wraps `httpx.AsyncClient.send` and `httpx2.AsyncClient.send` to time
+headers and body chunks, and samples the main thread's stack every 10ms
+from a daemon thread (`sys._current_frames()`) — py-spy needs root on
+macOS. Import costs came from `python -X importtime` rolled up by top-level
+package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Code generation agent"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"
 dependencies = [
-    "code-puppy-core-plugins>=0.0.39",
+    "code-puppy-core-plugins>=0.0.40",
     "logfire>=4.0",
     "pydantic-ai-slim[openai,anthropic,mcp]==2.35.0",
     "pydantic-ai-harness==0.23.0",
@@ -29,7 +29,7 @@ dependencies = [
     "openai>=2.45.0",
     "ripgrep==14.1.0; sys_platform != 'android'",
     "playwright>=1.40.0; sys_platform != 'android'",
-    "termflow-md>=0.9.0",
+    "termflow-md>=0.9.1",
     "Pillow>=10.0.0",
     "azure-identity>=1.15.0",
     "anthropic>=1.0.0,<2",

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -465,7 +465,7 @@ def test_custom_anthropic_timeout_config(monkeypatch):
     with (
         patch("code_puppy.model_factory.ClaudeCacheAsyncClient") as mock_client,
         patch("code_puppy.model_factory.make_anthropic_provider") as mock_provider,
-        patch("code_puppy.model_factory.AsyncAnthropic") as mock_anthropic,
+        patch("anthropic.AsyncAnthropic") as mock_anthropic,
         patch("code_puppy.model_factory.get_http2", return_value=False),
     ):
         mock_client.return_value = MagicMock()

--- a/tests/test_smooth_stream.py
+++ b/tests/test_smooth_stream.py
@@ -15,8 +15,15 @@ from code_puppy.agents.smooth_stream import (
 )
 
 
+class _TtyStringIO(io.StringIO):
+    """A capture buffer that claims to be a terminal (smoothing is TTY-gated)."""
+
+    def isatty(self) -> bool:
+        return True
+
+
 def _plain_console() -> tuple[Console, io.StringIO]:
-    buf = io.StringIO()
+    buf = _TtyStringIO()
     console = Console(file=buf, force_terminal=False, width=200, no_color=True)
     return console, buf
 
@@ -192,6 +199,13 @@ def test_make_thinking_smoother_enabled_by_default(monkeypatch):
     assert isinstance(make_thinking_smoother(console), ThinkingStreamSmoother)
 
 
+def test_make_thinking_smoother_skips_non_tty(monkeypatch):
+    """Pipes/CI never see the typewriter, whatever the config toggle says."""
+    monkeypatch.setattr("code_puppy.config.get_smooth_thinking_stream", lambda: True)
+    console = Console(file=io.StringIO(), force_terminal=False, width=200)
+    assert make_thinking_smoother(console) is None
+
+
 # ── SmoothTermflowWriter ────────────────────────────────────────────────
 
 ESC = "\x1b"
@@ -253,4 +267,10 @@ def test_make_smooth_termflow_writer_respects_disabled(monkeypatch):
 
 def test_make_smooth_termflow_writer_enabled_by_default(monkeypatch):
     monkeypatch.setattr("code_puppy.config.get_smooth_response_stream", lambda: True)
-    assert isinstance(make_smooth_termflow_writer(io.StringIO()), SmoothTermflowWriter)
+    assert isinstance(make_smooth_termflow_writer(_TtyStringIO()), SmoothTermflowWriter)
+
+
+def test_make_smooth_termflow_writer_skips_non_tty(monkeypatch):
+    """Pipes/CI never see the typewriter, whatever the config toggle says."""
+    monkeypatch.setattr("code_puppy.config.get_smooth_response_stream", lambda: True)
+    assert make_smooth_termflow_writer(io.StringIO()) is None

--- a/tests/test_terminal_utils.py
+++ b/tests/test_terminal_utils.py
@@ -1,5 +1,6 @@
 """Comprehensive test coverage for terminal_utils.py."""
 
+import io
 import subprocess
 import sys
 from unittest.mock import MagicMock
@@ -112,7 +113,21 @@ class TestResetWindowsTerminalFull:
 # ── reset_unix_terminal ──
 
 
+class _FakeTty(io.StringIO):
+    """A writable stream that claims to be a terminal."""
+
+    def isatty(self):
+        return True
+
+
 class TestResetUnixTerminal:
+    def _on_tty(self, monkeypatch):
+        """Route the reset at a fake tty on stderr; return the stream."""
+        monkeypatch.setattr(terminal_utils.platform, "system", lambda: "Linux")
+        fake = _FakeTty()
+        monkeypatch.setattr(terminal_utils.sys, "stderr", fake)
+        return fake
+
     def test_noop_on_windows(self, monkeypatch):
         monkeypatch.setattr(terminal_utils.platform, "system", lambda: "Windows")
         run = MagicMock()
@@ -120,28 +135,55 @@ class TestResetUnixTerminal:
         terminal_utils.reset_unix_terminal()
         run.assert_not_called()
 
-    def test_runs_reset_on_unix(self, monkeypatch):
+    def test_noop_when_not_a_tty(self, monkeypatch):
+        # Piped stdout/stderr (pytest capture qualifies): touch nothing.
         monkeypatch.setattr(terminal_utils.platform, "system", lambda: "Linux")
         run = MagicMock()
         monkeypatch.setattr(terminal_utils.subprocess, "run", run)
         terminal_utils.reset_unix_terminal()
-        run.assert_called_once_with(["reset"], check=True, capture_output=True)
+        run.assert_not_called()
+
+    def test_stty_sane_and_escapes_on_tty(self, monkeypatch):
+        fake = self._on_tty(monkeypatch)
+        run = MagicMock()
+        monkeypatch.setattr(terminal_utils.subprocess, "run", run)
+        terminal_utils.reset_unix_terminal()
+        run.assert_called_once_with(
+            ["stty", "sane"], check=True, capture_output=True, timeout=2
+        )
+        written = fake.getvalue()
+        assert terminal_utils._UNIX_TERMINAL_RESET in written
+        assert terminal_utils._MOUSE_TRACKING_OFF in written
+        assert "\x1bc" not in written  # never full RIS: it clears the screen
 
     def test_handles_called_process_error(self, monkeypatch):
-        monkeypatch.setattr(terminal_utils.platform, "system", lambda: "Linux")
+        fake = self._on_tty(monkeypatch)
         monkeypatch.setattr(
             terminal_utils.subprocess,
             "run",
-            MagicMock(side_effect=subprocess.CalledProcessError(1, "reset")),
+            MagicMock(side_effect=subprocess.CalledProcessError(1, "stty")),
         )
         terminal_utils.reset_unix_terminal()
+        # Escapes still land even when stty fails.
+        assert terminal_utils._UNIX_TERMINAL_RESET in fake.getvalue()
 
     def test_handles_file_not_found(self, monkeypatch):
-        monkeypatch.setattr(terminal_utils.platform, "system", lambda: "Linux")
+        self._on_tty(monkeypatch)
         monkeypatch.setattr(
             terminal_utils.subprocess, "run", MagicMock(side_effect=FileNotFoundError)
         )
         terminal_utils.reset_unix_terminal()
+
+    def test_broken_isatty_treated_as_non_tty(self, monkeypatch):
+        monkeypatch.setattr(terminal_utils.platform, "system", lambda: "Linux")
+        broken = MagicMock()
+        broken.isatty.side_effect = ValueError("closed")
+        monkeypatch.setattr(terminal_utils.sys, "stderr", broken)
+        monkeypatch.setattr(terminal_utils.sys, "stdout", broken)
+        run = MagicMock()
+        monkeypatch.setattr(terminal_utils.subprocess, "run", run)
+        terminal_utils.reset_unix_terminal()
+        run.assert_not_called()
 
 
 # ── reset_terminal ──

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -124,7 +124,7 @@ class TestDefaultVersionMismatchBehavior:
         """Test that update message is shown when versions differ."""
         mock_fetch.return_value = "2.0.0"
 
-        default_version_mismatch_behavior("1.0.0")
+        default_version_mismatch_behavior("1.0.0").join()
 
         # Should emit current version info
         mock_emit_info.assert_any_call("Current version: 1.0.0")
@@ -146,7 +146,7 @@ class TestDefaultVersionMismatchBehavior:
         """Test that current version is still shown when versions match."""
         mock_fetch.return_value = "1.0.0"
 
-        default_version_mismatch_behavior("1.0.0")
+        default_version_mismatch_behavior("1.0.0").join()
 
         # Should emit current version info
         mock_emit_info.assert_called_once_with("Current version: 1.0.0")
@@ -165,7 +165,7 @@ class TestDefaultVersionMismatchBehavior:
         """Test behavior when fetch_latest_version returns None."""
         mock_fetch.return_value = None
 
-        default_version_mismatch_behavior("1.0.0")
+        default_version_mismatch_behavior("1.0.0").join()
 
         # Should still emit current version info even when fetch fails
         mock_emit_info.assert_called_once_with("Current version: 1.0.0")
@@ -184,7 +184,7 @@ class TestDefaultVersionMismatchBehavior:
         """Test the exact content of update messages."""
         mock_fetch.return_value = "2.5.0"
 
-        default_version_mismatch_behavior("2.0.0")
+        default_version_mismatch_behavior("2.0.0").join()
 
         # Check warning contains new version info
         warning_calls = [str(call) for call in mock_emit_warning.call_args_list]
@@ -202,7 +202,7 @@ class TestDefaultVersionMismatchBehavior:
         mock_fetch.return_value = "1.0.0"
 
         # This should not raise an exception
-        default_version_mismatch_behavior(None)
+        default_version_mismatch_behavior(None).join()
 
         # Should emit warning about unknown version
         mock_emit_warning.assert_any_call(

--- a/uv.lock
+++ b/uv.lock
@@ -465,7 +465,7 @@ requires-dist = [
     { name = "azure-identity", specifier = ">=1.15.0" },
     { name = "boto3", specifier = ">=1.43.9" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.35.0" },
-    { name = "code-puppy-core-plugins", specifier = ">=0.0.39" },
+    { name = "code-puppy-core-plugins", specifier = ">=0.0.40" },
     { name = "dbos", marker = "extra == 'durable'", specifier = ">=2.11.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.24.1" },
     { name = "httpx2", specifier = ">=2.7" },
@@ -489,7 +489,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.28.0" },
     { name = "rich", specifier = ">=13.4.2" },
     { name = "ripgrep", marker = "sys_platform != 'android'", specifier = "==14.1.0" },
-    { name = "termflow-md", specifier = ">=0.9.0" },
+    { name = "termflow-md", specifier = ">=0.9.1" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
 provides-extras = ["bedrock", "durable", "computer-use"]
@@ -506,15 +506,15 @@ dev = [
 
 [[package]]
 name = "code-puppy-core-plugins"
-version = "0.0.39"
+version = "0.0.40"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic-ai-slim", extra = ["anthropic", "mcp", "openai"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/75/b9868bb0490a74fcaa335a3485f540be179da3a4465b21e13cf8130b9a0d/code_puppy_core_plugins-0.0.39.tar.gz", hash = "sha256:3c69bcf31e5c43c1ccd0b721ce7984403992bd37f18b505001f8d772d777f083", size = 537693, upload-time = "2026-09-01T21:48:34.977Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/e3/00b151a1b81c8c7051413b2579b2a869d4320965549684be3608a91e5ac4/code_puppy_core_plugins-0.0.40.tar.gz", hash = "sha256:86b7f6df4bf1a040a47c2bbe3b408ec7b5c62e1d5c396ab4758939e6dcf80760", size = 537831, upload-time = "2026-09-03T10:48:25.488Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/60/518f418e9c1cbbafefefceac204e0c2cb4e0242e6172cce70c521195233c/code_puppy_core_plugins-0.0.39-py3-none-any.whl", hash = "sha256:8a25bdd66fadb598a9952d9b0fd8a02d8f6c323c56407d8cc13c9adbd88841a5", size = 726890, upload-time = "2026-09-01T21:48:33.673Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/26/9c5823ab7ed8bbf4127c7f47f0b6c1f02b8d9439076875c11ef66d7139ed/code_puppy_core_plugins-0.0.40-py3-none-any.whl", hash = "sha256:b95cfcbc6573f431f04adf47e63d67e49752e98a6602a9e0722820c9b5aa173d", size = 727052, upload-time = "2026-09-03T10:48:24.143Z" },
 ]
 
 [[package]]
@@ -2757,15 +2757,15 @@ wheels = [
 
 [[package]]
 name = "termflow-md"
-version = "0.9.0"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pygments" },
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/f3/6135aea241a2f5e33066adf7e7d21bccf4930be6fa4f7f182f742becd970/termflow_md-0.9.0.tar.gz", hash = "sha256:32b70994f3d03a3e9af1479d8d4c3b5fbb0ede35aabe529e437ff6effc9c1d3a", size = 161428, upload-time = "2026-08-24T20:12:57.26Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/f7/c8754f90f13edc4008d16ee3923654520a839ff123f0f054a12f485c2282/termflow_md-0.9.1.tar.gz", hash = "sha256:5c0500a1b7937b1a7ea0eeb205ee8b8739823b44b61201de93b76faf8d04e452", size = 162387, upload-time = "2026-09-03T11:18:38.594Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/2f/f0cfb710bed5c604b937131bb58267aef7002ec88efa0fa377bd183e050c/termflow_md-0.9.0-py3-none-any.whl", hash = "sha256:8bea0e4e21faf54a6af3107546a798f4c0b5c64938640bff4f39f326892c3531", size = 95300, upload-time = "2026-08-24T20:12:56.091Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/55/5973340923f3fbfaaeddc0cb5c19b24aeced2b332937a84729a4a72d4131/termflow_md-0.9.1-py3-none-any.whl", hash = "sha256:22ce1e7d4e14bbe61af7bfc4207a0c9ed057c1cc26951fec83f2b5a9931459cb", size = 95775, upload-time = "2026-09-03T11:18:37.477Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Profiling the cold `code-puppy -p hi` path. The byte stream itself is fine (~30ms from first HTTP chunk to first `stream_event`); the cost was everything wrapped around it. Full write-up with the before/after timeline in `docs/TTFT_PROFILE.md`.

**Cold `-p hi` on a TTY: ~6.4–8.2s → ~4.5s (Claude), ~7.5–8.3s → ~3.9s (codex).** Roughly 3s of what's left is the provider's TTFB + generation.

## What was slow, and what changed

| Cost | Cause | Fix |
|---|---|---|
| ~1.0s per streamed text part | termflow's drain quota re-derived from the shrinking remainder each tick → exponential decay, last 42 chars crawl at 1/tick. Ran even into pipes. | Smoothing gated on `isatty()` here; linear drain upstream in **termflow-md 0.9.1** |
| **~1.2s on every exit** | `reset_unix_terminal()` shelled out to `reset(1)`, which sleeps 1s by design — and with `capture_output=True` its escapes never reached the tty. A one-second no-op in `main_entry`'s `finally`. | `stty sane` + targeted escape codes (soft reset, attrs off, cursor visible, alt-screen off, mouse off). Skipped off-tty. Deliberately not RIS (clears the screen). |
| ~370ms of imports | `openai` + `anthropic` SDKs eagerly imported by `model_factory`, `provider_identity`, `agents/_runtime`, and the ollama core plugin | Per-branch lazy imports; `_sdk_exception()` resolves exception classes via `sys.modules`; `ZaiChatModel` → `zai_model.py`; ollama fix in **core-plugins 0.0.40**. Neither SDK loads at startup now. |
| 75–170ms (up to 5s on bad wifi) | Blocking `httpx.get(pypi.org)` version check before the first request, headless too | Daemon thread; result lands on the message bus when it arrives |
| 388 reads of `puppy.cfg` per "hi" | `get_value()` re-read + re-parsed the INI every call, 10–20× per streamed chunk | Parser cached on `(path, inode, mtime_ns, size)` — 184µs → 1.8µs, always fresh |
| **~4s extra round trip on gpt-5.x** | "You MUST use tools" in the rules list: gpt-5.6 calls `list_agents` before saying hi, answers on request #2 | Line dropped; the intro paragraph already covers real work. Verified a real question still calls tools. |

## Dependencies

Pins bumped to `termflow-md>=0.9.1` and `code-puppy-core-plugins>=0.0.40` (both released) so existing installs pick up the upstream halves.

## Still on the table

- Upstream pydantic-ai: `capabilities/mcp.py` eagerly imports the whole MCP stack (~186ms per `import pydantic_ai`, MCP or not).
- `anthropic` SDK imports every `types.beta.*` eagerly (~100ms) — theirs.

## Test plan

- [x] `uv run pytest tests` — 7682 passed, 32 skipped
- [x] ruff check + format clean
- [x] Before/after traces on a real TTY for both `claude-code-*` and `codex-gpt-5.6-sol`
- [x] `openai`/`anthropic` absent from `sys.modules` after `import code_puppy.cli_runner`
- [x] Re-locked against the published wheels (no editable installs)
