### PR TITLE
fix(mcp): one dead MCP server no longer aborts the whole run

### DIFF
--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -893,6 +893,34 @@ async def _run_with_mcp_impl(
         with executing_agent_context(agent):
             return await _run_agent_task_body()
 
+    def _note_unusable_run_context(cm: Any, exc: BaseException, group_id: str) -> None:
+        """Report a run context that could not be entered, and carry on.
+
+        Named rather than inlined so the message stays one thing: what was
+        lost, and where to look. `/mcp logs` is the only place the real cause
+        lives -- this layer knows a context manager raised, never why.
+
+        The name is best-effort: `run_ctxs` holds whatever plugins returned,
+        so a `toolset` attribute, a `name`, or the repr are all plausible.
+        Reporting `<unknown>` beats hiding the failure over a missing label.
+        """
+        name = (
+            getattr(cm, "name", None)
+            or getattr(getattr(cm, "toolset", None), "name", None)
+            or type(cm).__name__
+        )
+        emit_warning(
+            f"MCP server '{name}' could not start for this run - continuing "
+            f"without its tools. Run [cyan]/mcp logs {name}[/cyan] for the "
+            "reason.",
+            group_id=group_id,
+        )
+        import logging as _logging
+
+        _logging.getLogger(__name__).debug(
+            "run context %r failed to enter: %r", name, exc
+        )
+
     async def _run_agent_task_body() -> Any:
         try:
             agent._message_history = _history.prune_interrupted_tool_calls(
@@ -905,7 +933,21 @@ async def _run_with_mcp_impl(
             )
             async with AsyncExitStack() as stack:
                 for cm in run_ctxs:
-                    await stack.enter_async_context(cm)
+                    # ONE CONTEXT PER TRY, not one try around all of them.
+                    #
+                    # An MCP server whose subprocess never came up raises from
+                    # `__aenter__`. Entered as a single unit, that one failure
+                    # unwinds the whole stack and `_do_run` below is never
+                    # reached -- so a user with six connectors and one broken
+                    # one got no inference at all, only the McpError nudge.
+                    # The nudge reads like the run was rescued; it was not.
+                    #
+                    # A connector is a capability, not a precondition. Losing
+                    # one should cost its tools, not the answer.
+                    try:
+                        await stack.enter_async_context(cm)
+                    except Exception as exc:  # noqa: BLE001
+                        _note_unusable_run_context(cm, exc, group_id)
                 return await _do_run(prompt_payload)
         except* UsageLimitExceeded as ule:
             emit_info(f"Usage limit exceeded: {ule}", group_id=group_id)

--- a/tests/agents/test_run_context_degrades.py
+++ b/tests/agents/test_run_context_degrades.py
@@ -1,0 +1,147 @@
+"""One unusable MCP server must not cost the whole run.
+
+`_run_agent_task_body` composes every `agent_run_context` into an
+`AsyncExitStack`. An MCP server whose subprocess never came up raises from
+`__aenter__`, and entered as a single unit that one failure unwinds the stack
+before `_do_run` is reached — so the model is never called at all.
+
+The `except* McpError` handler downstream makes this look handled: it prints
+"An MCP server failed during this run. Run /mcp logs ..." and returns. A user
+reads that as a warning attached to their answer. There is no answer.
+
+Measured with six connectors and one broken one: no inference, three warnings,
+a thirty-second wait.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import unittest
+from contextlib import AsyncExitStack
+
+
+class _Recorder:
+    """Stands in for the `for cm in run_ctxs` loop under test.
+
+    A copy rather than a call into `_run_agent_task_body`, which needs a live
+    agent, a model and a message bus. The loop is the thing that changed, and
+    a copy of it fails for the same reason the original would.
+    """
+
+    def __init__(self):
+        self.dropped: list[str] = []
+
+    def note(self, cm, exc, group_id):
+        self.dropped.append(getattr(cm, "name", type(cm).__name__))
+
+
+@contextlib.asynccontextmanager
+async def working(name: str, entered: list[str]):
+    entered.append(name)
+    yield
+
+
+class _Dead:
+    """An MCP toolset whose server never came up."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    async def __aenter__(self):
+        raise RuntimeError(f"{self.name}: no solution found when resolving")
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+async def _enter_all(run_ctxs, recorder, *, per_context_try: bool):
+    """The loop, in both shapes, returning whether the run body was reached."""
+    async with AsyncExitStack() as stack:
+        for cm in run_ctxs:
+            if per_context_try:
+                try:
+                    await stack.enter_async_context(cm)
+                except Exception as exc:  # noqa: BLE001
+                    recorder.note(cm, exc, "group")
+            else:
+                await stack.enter_async_context(cm)
+        return "model called"
+
+
+class OneDeadServerDoesNotAbortTheRun(unittest.TestCase):
+    def test_the_old_shape_never_reaches_the_model(self):
+        """THE BUG, stated as a test.
+
+        Without a per-context try, the first failing `__aenter__` propagates
+        and `_do_run` is never evaluated.
+        """
+        entered: list[str] = []
+        ctxs = [
+            working("jira", entered),
+            _Dead("lab-market-mcp"),
+            working("confluence", entered),
+        ]
+        with self.assertRaises(RuntimeError):
+            asyncio.run(_enter_all(ctxs, _Recorder(), per_context_try=False))
+        # And it did not even get as far as the third server.
+        self.assertEqual(entered, ["jira"])
+
+    def test_the_run_proceeds_without_the_dead_server(self):
+        entered: list[str] = []
+        recorder = _Recorder()
+        ctxs = [
+            working("jira", entered),
+            _Dead("lab-market-mcp"),
+            working("confluence", entered),
+        ]
+        result = asyncio.run(_enter_all(ctxs, recorder, per_context_try=True))
+
+        self.assertEqual(result, "model called")
+        # Every healthy connector is still available, including the one AFTER
+        # the failure — an early abort silently loses those too.
+        self.assertEqual(entered, ["jira", "confluence"])
+        self.assertEqual(recorder.dropped, ["lab-market-mcp"])
+
+    def test_every_server_failing_still_reaches_the_model(self):
+        """A connector is a capability, not a precondition.
+
+        With no MCP at all the agent still has its built-in file and shell
+        tools, which is most of what it does.
+        """
+        recorder = _Recorder()
+        ctxs = [_Dead("a"), _Dead("b")]
+        result = asyncio.run(_enter_all(ctxs, recorder, per_context_try=True))
+        self.assertEqual(result, "model called")
+        self.assertEqual(recorder.dropped, ["a", "b"])
+
+    def test_healthy_servers_are_still_unwound(self):
+        """Dropping one must not leak the others.
+
+        The stack still owns every context it did enter, so a failure partway
+        through cannot turn into an unclosed subprocess.
+        """
+        closed: list[str] = []
+
+        @contextlib.asynccontextmanager
+        async def tracked(name: str):
+            try:
+                yield
+            finally:
+                closed.append(name)
+
+        async def scenario():
+            async with AsyncExitStack() as stack:
+                for cm in [tracked("jira"), _Dead("dead"), tracked("confluence")]:
+                    try:
+                        await stack.enter_async_context(cm)
+                    except Exception:  # noqa: BLE001
+                        pass
+                return True
+
+        self.assertTrue(asyncio.run(scenario()))
+        self.assertEqual(sorted(closed), ["confluence", "jira"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
One MCP server that fails to start kills the entire run — no model call, no answer.

`_run_agent_task_body` enters every `agent_run_context` into one shared `AsyncExitStack`. A dead server raises from `__aenter__`, the stack unwinds, and `_do_run` on the next line never executes.

**Fix:** enter each context in its own `try`. A failure is reported by name; the run continues without that server's tools.

```python
 async with AsyncExitStack() as stack:
     for cm in run_ctxs:
-        await stack.enter_async_context(cm)
+        try:
+            await stack.enter_async_context(cm)
+        except Exception as exc:
+            _note_unusable_run_context(cm, exc, group_id)
     return await _do_run(prompt_payload)
```

Full suite: **7680 passed**. `ruff check` + `format --check` clean.

---

<details>
<summary>Why it looks handled but isn't</summary>

The `except* McpError` handler downstream prints:

> An MCP server failed during this run. Run `/mcp logs <name>` for details, or unbind it via `/agents → B`.

That reads like a warning attached to your answer. There is no answer — the coroutine falls off the end and returns `None`. The message makes a total failure look like a partial one, which is why this took a while to spot.

</details>

<details>
<summary>How it was found</summary>

A connector whose `uvx` dependency resolve failed. The process **existed**, so every status flag said RUNNING and pre-run health checks passed cleanly. It only failed at context-entry time — by which point the all-or-nothing stack had already made it fatal.

No amount of pre-run probing catches this; the failure happens after every check has run. That's why the fix has to be at the entry seam rather than in a health filter.

</details>

<details>
<summary>Design note</summary>

A connector is a **capability, not a precondition**. Losing one should cost its tools, not the answer — the agent still has its built-in file and shell tools, which is most of what it does.

Two details worth noting:

- **Servers that did enter are still owned by the stack**, so a partial failure can't leak a subprocess.
- **A server failing early no longer discards the healthy ones after it.** Previously the loop stopped at the first failure, so connectors later in the list were silently never entered either.

</details>

<details>
<summary>Tests</summary>

`tests/agents/test_run_context_degrades.py`:

- the **old shape** raises, never reaches the run body, and stops entering at the first failure
- the **new shape** reaches it, keeps every healthy connector *including those after the failure*, survives all servers failing, and still unwinds what it entered

The single suite failure (`test_copilot_auth_model::test_ghe_host_is_passed_through`) is **pre-existing** — verified to reproduce identically on an unmodified checkout of `main`.

</details>