### PR TITLE
Fix streamed Markdown cleanup at EOF

### DIFF
--- a/code_puppy/agents/event_stream_handler.py
+++ b/code_puppy/agents/event_stream_handler.py
@@ -251,6 +251,20 @@ async def event_stream_handler(
         else:
             console.print(f"[dim]{escape(text)}[/dim]", end="")
 
+    async def _finish_text_part(index: int) -> None:
+        """Flush one text part, including streams missing ``PartEndEvent``."""
+        parser = termflow_parsers.pop(index, None)
+        renderer = termflow_renderers.pop(index, None)
+        if parser is not None and renderer is not None:
+            remaining = termflow_line_buffers.pop(index, "")
+            if remaining.strip():
+                renderer.render_all(parser.parse_line(remaining))
+            renderer.render_all(parser.finalize())
+
+        writer = termflow_writers.pop(index, None)
+        if writer is not None:
+            await writer.close()
+
     async def _print_thinking_banner() -> None:
         """Print the THINKING banner on a fresh line."""
         nonlocal did_stream_anything
@@ -481,33 +495,8 @@ async def event_stream_handler(
                 )
 
                 if event.index in streaming_parts:
-                    # For text parts, finalize termflow rendering
                     if event.index in text_parts:
-                        # Render any remaining buffered content
-                        if event.index in termflow_parsers:
-                            parser = termflow_parsers[event.index]
-                            renderer = termflow_renderers[event.index]
-                            remaining = termflow_line_buffers.get(event.index, "")
-
-                            # Parse and render any remaining partial line
-                            if remaining.strip():
-                                events_to_render = parser.parse_line(remaining)
-                                renderer.render_all(events_to_render)
-
-                            # Finalize the parser to close any open blocks
-                            final_events = parser.finalize()
-                            renderer.render_all(final_events)
-
-                            # Clean up termflow state
-                            del termflow_parsers[event.index]
-                            del termflow_renderers[event.index]
-                            del termflow_line_buffers[event.index]
-
-                        # Drain any smooth typewriter writer to completion so the
-                        # full response has finished printing before we move on.
-                        writer = termflow_writers.pop(event.index, None)
-                        if writer is not None:
-                            await writer.close()
+                        await _finish_text_part(event.index)
                     # For tool parts, clear the chunk counter line
                     elif event.index in tool_parts:
                         # Erase the \r-repainted chunk-counter line entirely;
@@ -561,6 +550,11 @@ async def event_stream_handler(
         # background drain tasks that keep typing into the terminal. Abort them.
         _abort_all_drainers()
         raise
+
+    # Providers can end without PartEndEvent. Finalize those parsers too;
+    # otherwise an unterminated fence or partial line disappears.
+    for index in list(text_parts):
+        await _finish_text_part(index)
 
     # Drain any smoothers/writers that didn't see a PartEndEvent (e.g. the
     # stream ended abruptly) so we never lose buffered text or orphan tasks.

--- a/tests/agents/test_event_stream_handler.py
+++ b/tests/agents/test_event_stream_handler.py
@@ -11,7 +11,7 @@ Covers:
 
 import contextlib
 from io import StringIO
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from pydantic_ai import PartDeltaEvent, PartEndEvent, PartStartEvent, RunContext
@@ -435,6 +435,71 @@ class TestEventStreamHandler:
                             await event_stream_handler(mock_ctx, event_stream())
 
         # Handler should process multiple deltas without error
+
+    @pytest.mark.asyncio
+    async def test_finalizes_text_when_stream_ends_without_part_end(self, mock_ctx):
+        """An abrupt provider EOF must not drop buffered Markdown."""
+        start_event = PartStartEvent(index=0, part=TextPart(content=""))
+        delta_event = PartDeltaEvent(
+            index=0, delta=TextPartDelta(content_delta="```python\nprint(1)")
+        )
+
+        async def event_stream():
+            yield start_event
+            yield delta_event
+
+        console = MagicMock(spec=Console, width=80)
+        console.file = StringIO()
+        set_streaming_console(console)
+
+        with (
+            patch(
+                "code_puppy.agents.event_stream_handler.get_banner_color",
+                return_value="blue",
+            ),
+            patch("termflow.Parser") as parser_cls,
+            patch("termflow.Renderer"),
+        ):
+            parser = parser_cls.return_value
+            parser.parse_line.return_value = []
+            parser.finalize.return_value = []
+            await event_stream_handler(mock_ctx, event_stream())
+
+        assert parser.parse_line.call_args_list == [
+            call("```python"),
+            call("print(1)"),
+        ]
+        parser.finalize.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_skips_whitespace_only_text_tail(self, mock_ctx):
+        """Whitespace-only trailing buffers must not create Markdown content."""
+        start_event = PartStartEvent(index=0, part=TextPart(content=""))
+        delta_event = PartDeltaEvent(index=0, delta=TextPartDelta(content_delta="   "))
+
+        async def event_stream():
+            yield start_event
+            yield delta_event
+
+        console = MagicMock(spec=Console, width=80)
+        console.file = StringIO()
+        set_streaming_console(console)
+
+        with (
+            patch(
+                "code_puppy.agents.event_stream_handler.get_banner_color",
+                return_value="blue",
+            ),
+            patch("termflow.Parser") as parser_cls,
+            patch("termflow.Renderer"),
+        ):
+            parser = parser_cls.return_value
+            parser.parse_line.return_value = []
+            parser.finalize.return_value = []
+            await event_stream_handler(mock_ctx, event_stream())
+
+        parser.parse_line.assert_not_called()
+        parser.finalize.assert_called_once_with()
 
     @pytest.mark.asyncio
     async def test_streaming_ignores_delta_for_unknown_part_index(self, mock_ctx):


### PR DESCRIPTION
## Summary

This fixes streamed Markdown responses that can appear to stop unexpectedly and lose their final content when the provider closes the stream without emitting a PartEndEvent.

### What changed

- Centralized streamed text-part cleanup in _finish_text_part().
- Flushes any remaining non-whitespace Markdown buffer.
- Finalizes the Termflow Markdown parser on graceful stream EOF.
- Awaits smooth-writer shutdown so buffered terminal output is not lost.
- Reuses the same cleanup path for normal PartEndEvent handling.
- Preserves the existing behavior for whitespace-only trailing buffers.
- Added regression tests for:
  - Graceful EOF without PartEndEvent.
  - Unterminated fenced Markdown/code blocks.
  - Whitespace-only trailing content.
  - Exact parser call ordering and finalization.

## Problem

The streaming handler incrementally parses complete lines and stores the final partial line in termflow_line_buffers.

Previously, that final buffer was only processed when a PartEndEvent arrived. However, providers can end an otherwise successful stream without sending that event. In that case:

1. The final partial Markdown line remained buffered.
2. Termflow never received finalize().
3. Open Markdown constructs, such as fenced code blocks, were not closed.
4. The smooth output writer could finish without receiving the missing content.
5. The user saw an incomplete response that looked like Markdown rendering had randomly stopped.

## Root cause

Text-part cleanup was tied exclusively to PartEndEvent.

Thinking streams already had post-stream cleanup for parts that remained open after the event iterator ended, but streamed text parts did not have an equivalent fallback. This left a gap specifically for graceful provider EOF without a matching PartEndEvent.

## Implementation details

The new _finish_text_part() helper performs the complete text-part teardown:

1. Removes the parser, renderer, and line buffer from the active state.
2. Parses the remaining non-whitespace partial line, if any.
3. Calls parser.finalize() to close open Markdown state.
4. Awaits the smooth typewriter writer so all rendered output reaches the terminal.

The helper is called from:

- The existing PartEndEvent path.
- A new post-stream cleanup pass for text parts still active when the provider ends the stream.

The cleanup remains safe against duplicate calls because the relevant state is removed with dict.pop().

## Testing

Validated with focused renderer and streaming tests:

`text
140 passed
`

Also verified:

- git diff --check
- Ruff formatting on the changed files
- Exact parser call ordering for complete and buffered lines
- Whitespace-only buffers do not create extra Markdown content

The public checkout's local test environment currently has a pre-existing dependency mismatch during test configuration import:

`text
ModuleNotFoundError: No module named 'pydantic_ai.capabilities'
`

The focused tests passed in the development checkout before the change was ported to this clean upstream-based branch. The dependency mismatch is unrelated to this PR and should be resolved by synchronizing the local environment with the repository's pinned dependencies.