### PR TITLE
fix: resolve macOS screenshot paths with narrow no-break space in load_image

### DIFF
--- a/code_puppy/tools/image_tools.py
+++ b/code_puppy/tools/image_tools.py
@@ -13,6 +13,7 @@ import io
 import logging
 import mimetypes
 import time
+import unicodedata
 from pathlib import Path
 from typing import Any, Dict, Union
 
@@ -27,6 +28,39 @@ logger = logging.getLogger(__name__)
 # Bigger than this on either edge and we resize to save tokens.
 MAX_IMAGE_EDGE = 2048
 DEFAULT_MAX_HEIGHT = 768  # kept for backward-compat in tool signature
+
+
+def _normalized_filename(value: str) -> str:
+    """Normalize visually interchangeable filename characters.
+
+    macOS screenshot names can contain a narrow no-break space before AM/PM.
+    That character is visually indistinguishable from an ordinary space when a
+    path is copied into a prompt, but filesystems correctly treat them as
+    different names.
+    """
+    compatible = unicodedata.normalize("NFKC", value)
+    return "".join(
+        " " if character.isspace() else character for character in compatible
+    )
+
+
+def _resolve_image_path(image_path: str) -> Path:
+    """Resolve harmless Unicode filename differences without fuzzy guessing.
+
+    The exact path always wins. A fallback is accepted only when exactly one
+    file in the requested parent has the same normalized filename.
+    """
+    requested = Path(image_path)
+    if requested.exists() or not requested.parent.is_dir():
+        return requested
+
+    normalized_name = _normalized_filename(requested.name)
+    matches = [
+        candidate
+        for candidate in requested.parent.iterdir()
+        if _normalized_filename(candidate.name) == normalized_name
+    ]
+    return matches[0] if len(matches) == 1 else requested
 
 
 def _validate_and_prepare_image(
@@ -106,7 +140,7 @@ async def load_image(
     emit_info(f"LOAD IMAGE {image_path}", message_group=group_id)
 
     try:
-        image_file = Path(image_path)
+        image_file = _resolve_image_path(image_path)
 
         if not image_file.exists():
             error_msg = f"Image file not found: {image_path}"
@@ -125,10 +159,12 @@ async def load_image(
             max_edge=MAX_IMAGE_EDGE,
         )
 
-        emit_success(f"Loaded image: {image_path}", message_group=group_id)
+        resolved_image_path = str(image_file)
+        path_was_resolved = resolved_image_path != image_path
+        emit_success(f"Loaded image: {resolved_image_path}", message_group=group_id)
 
         return ToolReturn(
-            return_value=f"Image loaded from: {image_path}",
+            return_value=f"Image loaded from: {resolved_image_path}",
             content=[
                 f"Here's the image from {image_file.name}:",
                 BinaryContent(
@@ -139,7 +175,9 @@ async def load_image(
             ],
             metadata={
                 "success": True,
-                "image_path": image_path,
+                "image_path": resolved_image_path,
+                "requested_image_path": image_path,
+                "path_was_resolved": path_was_resolved,
                 "media_type": prepared_image["media_type"],
                 "actual_media_type": prepared_image["actual_media_type"],
                 "guessed_media_type": prepared_image["guessed_media_type"],

--- a/tests/tools/test_image_tools.py
+++ b/tests/tools/test_image_tools.py
@@ -1,0 +1,87 @@
+"""Tests for image_tools.py filename resolution.
+
+macOS names screenshots with U+202F (narrow no-break space) before AM/PM. That
+character survives on disk but arrives as an ordinary space when the path is
+copied into a prompt, so ``load_image`` has to bridge the difference without
+guessing.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+from pydantic_ai import ToolReturn
+
+from code_puppy.tools.image_tools import load_image
+
+
+class TestLoadImagePathResolution:
+    """Test Unicode-tolerant path resolution."""
+
+    @pytest.mark.asyncio
+    async def test_load_image_resolves_macos_screenshot_space(self, tmp_path):
+        """A pasted normal space resolves the narrow no-break space on disk."""
+        actual_path = tmp_path / "Screenshot 2026-09-04 at 9.01.58\u202fAM.png"
+        image = Image.new("RGB", (32, 24), color="red")
+        image.save(actual_path, format="PNG")
+        requested_path = tmp_path / "Screenshot 2026-09-04 at 9.01.58 AM.png"
+
+        with (
+            patch("code_puppy.tools.image_tools.emit_info"),
+            patch("code_puppy.tools.image_tools.emit_success"),
+        ):
+            result = await load_image(image_path=str(requested_path))
+
+        assert isinstance(result, ToolReturn)
+        assert result.metadata["image_path"] == str(actual_path)
+        assert result.metadata["requested_image_path"] == str(requested_path)
+        assert result.metadata["path_was_resolved"] is True
+
+    @pytest.mark.asyncio
+    async def test_load_image_prefers_exact_path(self, tmp_path):
+        """An exact match is never re-resolved to a normalized sibling."""
+        exact_path = tmp_path / "Screenshot AM.png"
+        image = Image.new("RGB", (32, 24), color="red")
+        image.save(exact_path, format="PNG")
+        image.save(tmp_path / "Screenshot\u202fAM.png", format="PNG")
+
+        with (
+            patch("code_puppy.tools.image_tools.emit_info"),
+            patch("code_puppy.tools.image_tools.emit_success"),
+        ):
+            result = await load_image(image_path=str(exact_path))
+
+        assert isinstance(result, ToolReturn)
+        assert result.metadata["image_path"] == str(exact_path)
+        assert result.metadata["path_was_resolved"] is False
+
+    @pytest.mark.asyncio
+    async def test_load_image_does_not_choose_ambiguous_unicode_match(self, tmp_path):
+        """Unicode fallback fails closed when multiple filenames normalize alike."""
+        image = Image.new("RGB", (32, 24), color="red")
+        image.save(tmp_path / "Screenshot AM.png", format="PNG")
+        image.save(tmp_path / "Screenshot\u202fAM.png", format="PNG")
+        requested_path = tmp_path / "Screenshot\u2009AM.png"
+
+        with (
+            patch("code_puppy.tools.image_tools.emit_info"),
+            patch("code_puppy.tools.image_tools.emit_error"),
+        ):
+            result = await load_image(image_path=str(requested_path))
+
+        assert result["success"] is False
+        assert "not found" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_load_image_missing_parent_directory(self, tmp_path):
+        """A path whose parent does not exist reports not found, not a crash."""
+        requested_path = tmp_path / "nope" / "Screenshot\u202fAM.png"
+
+        with (
+            patch("code_puppy.tools.image_tools.emit_info"),
+            patch("code_puppy.tools.image_tools.emit_error"),
+        ):
+            result = await load_image(image_path=str(requested_path))
+
+        assert result["success"] is False
+        assert "not found" in result["error"]


### PR DESCRIPTION
## Problem

macOS names screenshots with U+202F (narrow no-break space) before `AM`/`PM`.
That character is visually identical to an ordinary space, and copying such a
path into a prompt typically turns it into U+0020 — a genuinely different
filename on disk. `load_image` did a bare `Path(image_path)`, so those paths
failed the `exists()` check and came back as "Image file not found".

for example: Screenshot 2026-08-28 at 8.55.11 PM

## Fix

- `_normalized_filename()` — NFKC normalize, then collapse every whitespace
  character to a plain space.
- `_resolve_image_path()` — the exact path always wins. A fallback is accepted
  only when exactly one file in the requested parent normalizes to the same
  name, so it fails closed on ambiguity instead of guessing.
- `load_image` now reports the resolved path in the success message and
  `return_value`, and its metadata carries `image_path` (resolved),
  `requested_image_path`, and `path_was_resolved`.

## Tests

New `tests/tools/test_image_tools.py` (there were no `load_image` tests before):
resolves the U+202F screenshot name, prefers an exact path over a normalized
sibling, fails closed on an ambiguous match, and handles a missing parent
directory. Unicode characters are written as `\u202f` / `\u2009` escapes so they
survive copy-paste and stay visible in review.

## Notes

- `read_file` and the other path-taking tools in `file_operations.py` have the
  same class of issue; this change deliberately does not touch them.
