### PR TITLE
Fix/termflow table row separators

### DIFF
--- a/code_puppy/pydantic_patches.py
+++ b/code_puppy/pydantic_patches.py
@@ -460,6 +460,76 @@ def patch_termflow_code_padding() -> bool:
         )
 
 
+def _render_table_complete_with_row_rules(header, rows, alignments, width, margin, style):
+    """Drop-in for termflow's ``render_table_complete`` with a rule after every row."""
+    from termflow.ansi import visible_length
+    from termflow.render.table import (
+        TableRenderState,
+        render_table_bottom,
+        render_table_row,
+        render_table_separator,
+        render_table_top,
+    )
+
+    state = TableRenderState()
+    state.update_widths(header)
+    for row in rows:
+        state.update_widths(row)
+    state.set_alignments(alignments)
+
+    margin_width = visible_length(margin)
+    state.cap_widths_to_max(margin_width, available_width=width + margin_width)
+
+    lines = [render_table_top(state, margin, style)]
+    lines.extend(render_table_row(header, state, width, margin, style, is_header=True))
+    lines.append(render_table_separator(state, margin, style))
+    state.end_header()
+
+    last_index = len(rows) - 1
+    for i, row in enumerate(rows):
+        lines.extend(render_table_row(row, state, width, margin, style, is_header=False))
+        if i != last_index:
+            lines.append(render_table_separator(state, margin, style))
+
+    lines.append(render_table_bottom(state, margin, style))
+    return lines
+
+
+def patch_termflow_table_row_separators() -> bool:
+    """Draw a rule between every table row, not just after the header.
+
+    termflow's ``render_table_complete`` draws exactly one horizontal rule --
+    right after the header -- and none between body rows, which makes wide
+    tables hard to scan row-by-row. This replaces it with an otherwise-
+    identical version that also draws a rule between consecutive body rows.
+
+    Must patch both ``termflow.render.table`` (the definition) AND
+    ``termflow.render.renderer`` (did ``from ... import render_table_complete``,
+    so it holds a stale reference) -- same reason as ``patch_termflow_code_padding``.
+    """
+    try:
+        import termflow.render.renderer as _termflow_renderer
+        import termflow.render.table as _termflow_table
+    except ImportError as exc:
+        return _optional_lib_missing("patch_termflow_table_row_separators", exc)
+
+    try:
+        if not hasattr(_termflow_table, "render_table_complete") or not hasattr(
+            _termflow_renderer, "render_table_complete"
+        ):
+            raise AttributeError("termflow render_table_complete not found")
+        _termflow_table.render_table_complete = _render_table_complete_with_row_rules
+        _termflow_renderer.render_table_complete = _render_table_complete_with_row_rules
+        return True
+    except Exception as exc:
+        return _patch_failed(
+            "patch_termflow_table_row_separators",
+            exc,
+            "table rows render without separators between them (header rule only).",
+            target="termflow",
+        )
+
+
 def patch_silence_anthropic_sampling_warnings() -> bool:
     """Silence pydantic-ai's unsupported-sampling-parameter UserWarning.
 
@@ -493,6 +563,7 @@ _ALL_PATCHES = (
     patch_tool_call_callbacks,
     patch_termflow_clipboard,
     patch_termflow_code_padding,
+    patch_termflow_table_row_separators,
 )
 
 

--- a/code_puppy/pydantic_patches.py
+++ b/code_puppy/pydantic_patches.py
@@ -460,8 +460,28 @@ def patch_termflow_code_padding() -> bool:
         )
 
 
+def _render_table_header_rule(state, margin, style) -> str:
+    """Header/body divider using double-line chars (╞═╪═╡), mirroring
+    ``termflow.render.table.render_table_separator`` but visually heavier.
+
+    Once every body row also gets a rule (see below), a single-weight rule
+    after the header is no longer enough to mark it as different from a body
+    row -- bold text alone is an easy-to-miss signal. Same convention as
+    Rich's ``box.SQUARE_DOUBLE_HEAD``: double line under the header, single
+    lines everywhere else.
+    """
+    from termflow.ansi import RESET, fg_color
+
+    fg = fg_color(style.symbol)
+    parts = ["═" * (w + 2) for w in state.column_widths]
+    sep = "╪".join(parts)
+    return f"{margin}{fg}╞{sep}╡{RESET}"
+
+
 def _render_table_complete_with_row_rules(header, rows, alignments, width, margin, style):
-    """Drop-in for termflow's ``render_table_complete`` with a rule after every row."""
+    """Drop-in for termflow's ``render_table_complete`` with a rule after every
+    row, and a heavier double-line rule marking the header/body boundary.
+    """
     from termflow.ansi import visible_length
     from termflow.render.table import (
         TableRenderState,
@@ -482,7 +502,7 @@ def _render_table_complete_with_row_rules(header, rows, alignments, width, margi
 
     lines = [render_table_top(state, margin, style)]
     lines.extend(render_table_row(header, state, width, margin, style, is_header=True))
-    lines.append(render_table_separator(state, margin, style))
+    lines.append(_render_table_header_rule(state, margin, style))
     state.end_header()
 
     last_index = len(rows) - 1
@@ -501,7 +521,9 @@ def patch_termflow_table_row_separators() -> bool:
     termflow's ``render_table_complete`` draws exactly one horizontal rule --
     right after the header -- and none between body rows, which makes wide
     tables hard to scan row-by-row. This replaces it with an otherwise-
-    identical version that also draws a rule between consecutive body rows.
+    identical version that also draws a rule between consecutive body rows,
+    using a double-line rule under the header specifically so it stays
+    visually distinct from body-to-body rules.
 
     Must patch both ``termflow.render.table`` (the definition) AND
     ``termflow.render.renderer`` (did ``from ... import render_table_complete``,

--- a/code_puppy/pydantic_patches.py
+++ b/code_puppy/pydantic_patches.py
@@ -478,7 +478,9 @@ def _render_table_header_rule(state, margin, style) -> str:
     return f"{margin}{fg}╞{sep}╡{RESET}"
 
 
-def _render_table_complete_with_row_rules(header, rows, alignments, width, margin, style):
+def _render_table_complete_with_row_rules(
+    header, rows, alignments, width, margin, style
+):
     """Drop-in for termflow's ``render_table_complete`` with a rule after every
     row, and a heavier double-line rule marking the header/body boundary.
     """
@@ -507,7 +509,9 @@ def _render_table_complete_with_row_rules(header, rows, alignments, width, margi
 
     last_index = len(rows) - 1
     for i, row in enumerate(rows):
-        lines.extend(render_table_row(row, state, width, margin, style, is_header=False))
+        lines.extend(
+            render_table_row(row, state, width, margin, style, is_header=False)
+        )
         if i != last_index:
             lines.append(render_table_separator(state, margin, style))
 


### PR DESCRIPTION
termflow's `render_table_complete` draws one horizontal rule (after the header) but nothing between body rows, so wide/dense tables are hard to scan row-by-row.

Adds `patch_termflow_table_row_separators()` to `code_puppy/pydantic_patches.py`, alongside the existing `patch_termflow_clipboard` / `patch_termflow_code_padding`, using the same pattern: swap in an otherwise-identical `render_table_complete` that also draws a separator between consecutive body rows (not redundantly before the bottom border). Registered in `_ALL_PATCHES`.

No termflow files are modified — this only replaces the function reference at runtime, same technique as its two sibling patches.