### PR TITLE
fix(completion): apostrophes in prose no longer hide later @file refs

### DIFF
--- a/code_puppy/file_completion_tokens.py
+++ b/code_puppy/file_completion_tokens.py
@@ -3,11 +3,28 @@
 import shlex
 
 
+def _opens_quote(text: str, i: int, symbol: str) -> bool:
+    """Decide whether the quote character at ``text[i]`` starts a quoted span.
+
+    Quotes group characters only when they begin a word (start of input or
+    right after whitespace) or immediately follow the attachment symbol —
+    the two positions a user quotes a filename from. A quote embedded in a
+    word (the apostrophe in ``don't``) is ordinary prose and must never open
+    quote state, or it would swallow later whitespace and hide the active
+    ``@token`` boundary.
+    """
+    if i == 0 or text[i - 1].isspace():
+        return True
+    return i >= len(symbol) and text[i - len(symbol) : i] == symbol
+
+
 def active_reference(text: str, symbol: str = "@"):
     """Return decoded path and raw replacement length, or no active reference.
 
-    Only a token beginning with @ qualifies. Spaces require quotes or escaping;
-    a closed quote ends completion so subsequent prose is never replaced.
+    Only a token beginning with @ qualifies. Within the active token, spaces
+    require quotes or escaping; a closed quote ends completion so subsequent
+    prose is never replaced. Apostrophes in surrounding prose (contractions)
+    are literal characters and never open a quote.
     """
     start = 0
     quote = None
@@ -23,7 +40,8 @@ def active_reference(text: str, symbol: str = "@"):
                 quote = None
                 closed = True
         elif char in "\"'":
-            quote = char
+            if _opens_quote(text, i, symbol):
+                quote = char
         elif char.isspace():
             start = i + 1
             closed = False

--- a/tests/command_line/test_file_completion_regressions.py
+++ b/tests/command_line/test_file_completion_regressions.py
@@ -21,6 +21,45 @@ def test_not_an_active_reference(text):
     assert active_reference(text) is None
 
 
+@pytest.mark.parametrize(
+    "text",
+    [
+        "don't change @target",
+        "it's in @target",
+        "can't @",
+        "they're @a.py",
+        "isn't @~/Documents",
+    ],
+)
+def test_contraction_prose_does_not_hide_active_reference(text):
+    # Issue #915: an apostrophe in preceding prose must not open quote state;
+    # the later @token still completes.
+    token = text[text.rfind("@") :]
+    decoded, raw_len = active_reference(text)
+    assert decoded == token[1:]
+    assert raw_len == len(token) - 1
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ('he said "hi" @target', "target"),
+        ('read @"my file.txt" done', None),
+        ("@'unfinished", "unfinished"),
+        ('@"my file.txt', "my file.txt"),
+    ],
+)
+def test_quotes_still_group_attachment_tokens(text, expected):
+    # Word-boundary quotes keep grouping spaces (filenames with spaces), and
+    # a closed quote still ends completion so later prose is not replaced.
+    result = active_reference(text)
+    if expected is None:
+        assert result is None
+    else:
+        assert result is not None
+        assert result[0] == expected
+
+
 @pytest.mark.parametrize("raw", ['@"space fi', "@'space fi", r"@space\ fi"])
 def test_quoted_completion_replaces_entire_raw_path(raw, monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)

--- a/tests/test_completions_and_small_modules.py
+++ b/tests/test_completions_and_small_modules.py
@@ -12,6 +12,7 @@ Note: mcp_completion.py is covered in tests/command_line/test_mcp_completion.py
 """
 
 import os
+import shlex
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -192,7 +193,11 @@ class TestFilePathCompleterMissedLines:
             doc = Document(f"@~/{basename}/t")
             completions = list(self.completer.get_completions(doc, None))
             for c in completions:
-                assert c.text.startswith("~")
+                # Insertion text is shlex-quoted (see 029ca24); decode it
+                # before asserting the tilde-prefixed absolute path.
+                decoded = shlex.split(c.text)
+                assert len(decoded) == 1
+                assert decoded[0].startswith("~/")
 
     def test_nonexistent_dir_listing(self):
         """Line 41: base_path is not a directory → paths = []."""


### PR DESCRIPTION
Fixes #915

## Summary

Since 029ca24, an apostrophe anywhere in the prompt could disable later `@file` completion: `don't change @target` offered no candidates while `read @target` worked. `active_reference()` treated *every* `'`/`"` in the prompt as a quote delimiter, so the contraction opened quote state, subsequent whitespace stopped advancing the active-token boundary, and the later `@token` was never recognized.

## Fix

A quote character now opens a quoted span only where a filename is legitimately quoted:

- at a word boundary (start of input or right after whitespace), or
- immediately following the attachment symbol (`@"my file`)

A quote embedded inside a word — the apostrophe in `don't`, `it's` — is ordinary prose and never opens quote state.

Quoted/escaped path semantics from 029ca24 are preserved: `@"my file.txt`, `@'my file`, `@my\ file.txt` still complete, and `@"my file.txt" done` still returns no active reference so trailing prose is never replaced.

## Also fixes a failing test on main

`tests/test_completions_and_small_modules.py::TestFilePathCompleterMissedLines::test_tilde_prefix_display` currently fails on `main`: it asserts insertion text starts with `~`, but 029ca24 quotes inserted paths via `shlex.quote` (its own regression test asserts `shlex.split(inserted)` parses back). Updated it to decode via `shlex.split` before asserting the tilde-prefixed path.

## Test plan

- [x] New regression cases in `tests/command_line/test_file_completion_regressions.py`: contractions before `@file` (`don't`, `it's`, `can't`, `they're`, `isn't`), quote grouping, closed-quote suppression
- [x] `uv run pytest tests/command_line/ tests/messaging/test_completion_stable_popup.py tests/messaging/test_editor_completion.py tests/plugins/test_completion_provider.py tests/test_completions_and_small_modules.py` — 1062 passed
- [x] `ruff check` + `ruff format` clean
