### PR TITLE
fix(compaction): preserve provider reasoning replay state

### DIFF
--- a/code_puppy/agents/_compaction.py
+++ b/code_puppy/agents/_compaction.py
@@ -297,7 +297,7 @@ def make_history_processor(agent: Any) -> Callable[..., Any]:
          (preserving the last-message regardless of compacted-hash collisions).
       3. Runs ``compact(...)`` if we're over threshold (or ``/compact`` forced).
       4. Records dropped-message hashes in ``agent._compacted_message_hashes``.
-      5. Strips empty ThinkingParts that carry no replay signature.
+      5. Strips empty ThinkingParts that carry no provider replay state.
       6. Trims trailing ModelResponse messages so history ends with a ModelRequest.
       7. Fires ``on_message_history_processor_end``.
 

--- a/code_puppy/agents/_compaction.py
+++ b/code_puppy/agents/_compaction.py
@@ -260,41 +260,30 @@ async def compact(
 # ---------------------------------------------------------------------------
 
 
+def _is_empty_thinking_part(part: Any) -> bool:
+    """Visible text may be empty while opaque provider replay state is not."""
+    return (
+        isinstance(part, ThinkingPart)
+        and not part.content
+        and not part.signature
+        and not part.id
+        and not part.provider_details
+    )
+
+
 def _strip_empty_thinking_parts(
     messages: List[ModelMessage],
 ) -> Tuple[List[ModelMessage], int]:
-    """Remove empty ThinkingParts without discarding replay signatures."""
+    """Remove empty ThinkingParts without discarding provider replay state."""
     cleaned: List[ModelMessage] = []
     filtered_count = 0
     for msg in messages:
-        parts = list(msg.parts)
-        if (
-            len(parts) == 1
-            and isinstance(parts[0], ThinkingPart)
-            and not parts[0].content
-            and not parts[0].signature
-        ):
-            filtered_count += 1
-            continue
-        if any(
-            isinstance(p, ThinkingPart) and not p.content and not p.signature
-            for p in parts
-        ):
-            msg = dataclasses.replace(
-                msg,
-                parts=[
-                    p
-                    for p in parts
-                    if not (
-                        isinstance(p, ThinkingPart)
-                        and not p.content
-                        and not p.signature
-                    )
-                ],
-            )
-            if not msg.parts:
+        if any(_is_empty_thinking_part(part) for part in msg.parts):
+            parts = [part for part in msg.parts if not _is_empty_thinking_part(part)]
+            if not parts:
                 filtered_count += 1
                 continue
+            msg = dataclasses.replace(msg, parts=parts)
         cleaned.append(msg)
     return cleaned, filtered_count
 

--- a/tests/agents/test_reasoning_replay_state.py
+++ b/tests/agents/test_reasoning_replay_state.py
@@ -1,0 +1,35 @@
+"""Empty visible reasoning may still carry opaque provider replay state."""
+
+import pytest
+from pydantic_ai.messages import ModelResponse, TextPart, ThinkingPart
+
+from code_puppy.agents._compaction import _strip_empty_thinking_parts
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        {"signature": "opaque"},
+        {"id": "rs_test"},
+        {"provider_details": {"opaque": "state"}},
+        {"content": "visible"},
+    ],
+)
+@pytest.mark.parametrize("mixed", [False, True])
+def test_preserves_each_kind_of_replay_state(state, mixed):
+    thinking = ThinkingPart(**{"content": "", **state})
+    parts = [thinking, TextPart("answer")] if mixed else [thinking]
+    message = ModelResponse(parts=parts)
+    cleaned, removed = _strip_empty_thinking_parts([message])
+    assert cleaned == [message]
+    assert cleaned[0].parts[0] is thinking
+    assert removed == 0
+
+
+@pytest.mark.parametrize("mixed", [False, True])
+def test_still_removes_truly_empty_thinking(mixed):
+    answer = TextPart("answer")
+    parts = [ThinkingPart(content=""), answer] if mixed else [ThinkingPart(content="")]
+    cleaned, removed = _strip_empty_thinking_parts([ModelResponse(parts=parts)])
+    assert [p for m in cleaned for p in m.parts] == ([answer] if mixed else [])
+    assert removed == (0 if mixed else 1)

--- a/tests/test_compaction_reasoning.py
+++ b/tests/test_compaction_reasoning.py
@@ -14,8 +14,8 @@ def test_preserve_empty_signed_thinking_part():
     assert filtered == 0
 
 
-def test_remove_empty_unsigned_thinking_part():
-    message = ModelResponse([ThinkingPart(content="", id="rs_1")])
+def test_remove_empty_thinking_part_without_replay_state():
+    message = ModelResponse([ThinkingPart(content="")])
 
     cleaned, filtered = _strip_empty_thinking_parts([message])
 


### PR DESCRIPTION
Compaction can discard reasoning items that have no visible text but still carry provider replay state. Preserve those items so later requests retain the state they need, while continuing to remove genuinely empty reasoning parts.

## Problem

The history cleanup checks only content and signature. An empty `ThinkingPart` with an `id` or `provider_details` is therefore treated as disposable, including when it is the only part of a response. Visible text is not a reliable test for whether provider replay state is present.

## Change

- Use one emptiness predicate that checks content, signature, ID and provider details.
- Preserve opaque state in both standalone and mixed reasoning/text responses.
- Keep removing truly empty parts and dropping responses left with no parts.
- Correct the existing test that classified an ID-bearing item as empty.

This is a history-cleanup correction, not a new compaction strategy or a change to prompt/retry custody. It does not depend on the open capability refactors; #829 touches the same module and may need to retain this predicate when rebased.

## Validation

Tested on Linux / Python 3.13.13 with the unchanged upstream dependency lock (`pydantic-ai-slim` 2.35.0, harness 0.23.0), based on `1d25d696`.

- New regression file on unpatched base: **4 failed, 6 passed**. Failures demonstrate loss of ID-only and provider-details-only reasoning, both alone and alongside text.
- `python -m pytest -q -o addopts= tests/agents/test_reasoning_replay_state.py tests/agents/test_compaction.py tests/test_compaction_reasoning.py`: **39 passed**.
- `python -m pytest -q -o addopts= tests/agents tests/test_compaction_reasoning.py`: **476 passed, 2 warnings**.
- Ruff lint, format check and `git diff --check` pass for the changed files.

Tests ran with disposable HOME/XDG directories, no inherited credentials, and socket connect/DNS/bind blocked. The two unawaited-coroutine warnings come from `test_fire_stream_event_import_error` and `test_fire_stream_event_exception`; both reproduce on the unpatched base. They were not suppressed.

## Compatibility and limits

No dependency, package-version or public API changes. Tests use actual Pydantic message objects; no live-provider replay or end-to-end provider acceptance claim is made.
