### PR TITLE
fix(mcp): keep tool schemas available across SDK field names

### DIFF
--- a/code_puppy/mcp_/managed_server.py
+++ b/code_puppy/mcp_/managed_server.py
@@ -21,6 +21,7 @@ from pydantic_ai.toolsets import AbstractToolset
 from code_puppy.http_utils import create_async_client, get_cert_bundle_path
 from code_puppy.mcp_.blocking_startup import BlockingStdioToolset
 from code_puppy.mcp_.tool_arg_coercion import coerce_tool_args
+from code_puppy.mcp_.toolset_utils import tool_input_schema
 
 
 def _expand_env_vars(value: Any) -> Any:
@@ -161,7 +162,7 @@ async def _input_schema_for_tool(
         return None
     for tool in tools:
         if getattr(tool, "name", None) == name:
-            return getattr(tool, "inputSchema", None)
+            return tool_input_schema(tool)
     return None
 
 

--- a/code_puppy/mcp_/toolset_utils.py
+++ b/code_puppy/mcp_/toolset_utils.py
@@ -56,6 +56,14 @@ def toolset_is_running(toolset: Any) -> bool:
     return bool(getattr(unwrap_toolset(toolset), "is_running", False))
 
 
+def tool_input_schema(tool: Any) -> Any:
+    """Prefer SDK v2's spelling without evaluating its deprecated camelCase alias."""
+    schema = getattr(tool, "input_schema", None)
+    if schema is not None:
+        return schema
+    return getattr(tool, "inputSchema", None)
+
+
 def iter_cached_tool_defs(toolset: Any) -> Iterator[Tuple[str, str, Any]]:
     """Yield ``(full_name, description, input_schema)`` for cached MCP tools.
 
@@ -73,5 +81,5 @@ def iter_cached_tool_defs(toolset: Any) -> Iterator[Tuple[str, str, Any]]:
         name = getattr(mcp_tool, "name", "") or ""
         full_name = f"{prefix}_{name}" if prefix and name else name
         description = getattr(mcp_tool, "description", "") or ""
-        schema = getattr(mcp_tool, "inputSchema", None)
+        schema = tool_input_schema(mcp_tool)
         yield full_name, description, schema

--- a/tests/mcp/test_managed_server.py
+++ b/tests/mcp/test_managed_server.py
@@ -270,14 +270,14 @@ class TestProcessToolCall:
     async def test_unwraps_functools_partial_for_schema_lookup(self):
         """Schema lookup unwraps functools.partial (MCPToolset.call_tool shape)."""
         import functools
+        from types import SimpleNamespace
 
         mock_ctx = Mock()
         mock_ctx.deps = None
 
         class FakeToolset:
             async def list_tools(self):
-                tool = Mock()
-                tool.name = "t"
+                tool = SimpleNamespace(name="t")
                 tool.inputSchema = {
                     "type": "object",
                     "properties": {"flag": {"type": "boolean"}},

--- a/tests/mcp/test_schema_field_compatibility.py
+++ b/tests/mcp/test_schema_field_compatibility.py
@@ -1,0 +1,54 @@
+"""Schema access must work without touching a deprecated alias when available."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from code_puppy.mcp_.managed_server import _input_schema_for_tool
+from code_puppy.mcp_.tool_arg_coercion import coerce_tool_args
+from code_puppy.mcp_.toolset_utils import iter_cached_tool_defs
+
+SCHEMA = {"type": "object", "properties": {"items": {"type": "array"}}}
+
+
+class ModernTool:
+    name = "test"
+    description = "test tool"
+    input_schema = SCHEMA
+
+    @property
+    def inputSchema(self):
+        raise AssertionError("deprecated alias accessed")
+
+
+class Server:
+    def __init__(self, tool):
+        self._cached_tools = [tool]
+
+    async def list_tools(self):
+        return self._cached_tools
+
+    async def call_tool(self):
+        pass
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [
+        ModernTool(),
+        SimpleNamespace(name="test", inputSchema=SCHEMA),
+        SimpleNamespace(name="test", input_schema=None, inputSchema=SCHEMA),
+        SimpleNamespace(name="test", input_schema={}),
+        SimpleNamespace(name="test"),
+    ],
+)
+async def test_live_and_cached_schema_reads_agree(tool):
+    server = Server(tool)
+    expected = getattr(tool, "input_schema", None)
+    if expected is None:
+        expected = getattr(tool, "inputSchema", None)
+    schema = await _input_schema_for_tool(server.call_tool, "test")
+    assert schema == expected
+    assert list(iter_cached_tool_defs(server))[0][2] == expected
+    if schema == SCHEMA:
+        assert coerce_tool_args({"items": '["one"]'}, schema) == {"items": ["one"]}

--- a/tests/mcp/test_schema_field_compatibility.py
+++ b/tests/mcp/test_schema_field_compatibility.py
@@ -3,6 +3,7 @@
 from types import SimpleNamespace
 
 import pytest
+from mcp.types import Tool
 
 from code_puppy.mcp_.managed_server import _input_schema_for_tool
 from code_puppy.mcp_.tool_arg_coercion import coerce_tool_args
@@ -33,20 +34,22 @@ class Server:
 
 
 @pytest.mark.parametrize(
-    "tool",
+    ("tool", "expected"),
     [
-        ModernTool(),
-        SimpleNamespace(name="test", inputSchema=SCHEMA),
-        SimpleNamespace(name="test", input_schema=None, inputSchema=SCHEMA),
-        SimpleNamespace(name="test", input_schema={}),
-        SimpleNamespace(name="test"),
+        (ModernTool(), SCHEMA),
+        (SimpleNamespace(name="test", input_schema=SCHEMA), SCHEMA),
+        (SimpleNamespace(name="test", inputSchema=SCHEMA), SCHEMA),
+        (SimpleNamespace(name="test", input_schema=None, inputSchema=SCHEMA), SCHEMA),
+        (SimpleNamespace(name="test", input_schema=SCHEMA, inputSchema={}), SCHEMA),
+        (SimpleNamespace(name="test", input_schema={}, inputSchema=SCHEMA), {}),
+        (SimpleNamespace(name="test", input_schema={}), {}),
+        (SimpleNamespace(name="test"), None),
+        (Tool(name="test", inputSchema=SCHEMA), SCHEMA),
+        (Tool(name="test", inputSchema={}), {}),
     ],
 )
-async def test_live_and_cached_schema_reads_agree(tool):
+async def test_live_and_cached_schema_reads_agree(tool, expected):
     server = Server(tool)
-    expected = getattr(tool, "input_schema", None)
-    if expected is None:
-        expected = getattr(tool, "inputSchema", None)
     schema = await _input_schema_for_tool(server.call_tool, "test")
     assert schema == expected
     assert list(iter_cached_tool_defs(server))[0][2] == expected


### PR DESCRIPTION
MCP tools can lose schema-based argument conversion when a tool definition exposes `input_schema` instead of `inputSchema`. Support both field names so tool calls keep their expected argument types without requiring an SDK upgrade.

## Problem

Live schema lookup and cached introspection currently read only the camelCase field. Snake-case-only definitions lose their schema, and definitions with a deprecated camelCase alias still access that alias even when the preferred field exists.

## Change

- Share a snake-case-first accessor between live argument-coercion lookup and cached tool introspection.
- Read `inputSchema` only when `input_schema` is absent or `None`.
- Preserve an explicitly empty modern schema instead of substituting a conflicting legacy schema.
- Replace an auto-vivifying mock in the existing partial-call fixture with explicit attributes.

The accessor does not change connector entry, tool execution policy, or lifecycle behavior. It does not depend on the open MCP capability refactor (#834); that refactor also touches `managed_server.py` and should retain the shared accessor.

## Validation

Tested on Linux / Python 3.13.13 using the unchanged upstream lock, based on `1d25d696`. The installed MCP SDK is **1.27.1**; its real `Tool` objects verify legacy compatibility. Modern-field shapes use explicit test doubles, including a deprecated alias that raises if touched.

- New regression file on unpatched base: **5 failed, 5 passed**.
- Coverage includes modern-only, legacy-only, `None` fallback, conflicting fields, empty schemas, absent schemas and real SDK `Tool` instances. Expectations are explicit rather than calculated using the production fallback algorithm.
- `python -m pytest -q -o addopts= tests/mcp/test_schema_field_compatibility.py tests/mcp/test_managed_server.py tests/mcp/test_tool_arg_coercion.py`: **106 passed**.
- `python -m pytest -q -o addopts= tests/mcp`: **483 passed, 6 skipped**, no warnings.
- Ruff lint, format check and `git diff --check` pass for the changed files.

Tests ran with disposable HOME/XDG directories, no inherited credentials, and socket connect/DNS/bind blocked. All six skips explicitly cover search functionality that is not implemented; none hides a schema regression.

## Compatibility and limits

No dependency, package-version or public configuration changes. No live connector or installed SDK-v2 qualification is claimed; this patch tests the two field contracts and the currently pinned SDK.
