### PR TITLE
fix(mcp): accept environment-based endpoints without exposing resolved URLs

### DIFF
--- a/code_puppy/mcp_/registry.py
+++ b/code_puppy/mcp_/registry.py
@@ -14,7 +14,7 @@ from typing import Dict, List, Optional
 
 from code_puppy import config
 
-from .managed_server import ServerConfig
+from .managed_server import ServerConfig, _expand_env_vars
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -262,13 +262,14 @@ class ServerRegistry:
                 errors.append(
                     f"{server_type.upper()} server URL must be a non-empty string"
                 )
-            elif not (
-                server_config["url"].startswith("http://")
-                or server_config["url"].startswith("https://")
-            ):
-                errors.append(
-                    f"{server_type.upper()} server URL must start with http:// or https://"
-                )
+            else:
+                # Match startup's expansion, but retain the template in config.
+                # Expanded values can contain secrets: never echo them in errors.
+                expanded_url = _expand_env_vars(server_config["url"])
+                if not expanded_url.startswith(("http://", "https://")):
+                    errors.append(
+                        f"{server_type.upper()} server URL must start with http:// or https://"
+                    )
 
             # Optional parameter validation
             if "timeout" in server_config:

--- a/tests/mcp/test_expanded_url_validation.py
+++ b/tests/mcp/test_expanded_url_validation.py
@@ -33,3 +33,42 @@ def test_invalid_expansion_is_rejected_without_echoing_it(monkeypatch, value):
     assert errors
     assert "SECRET" not in str(errors)
     assert "MCP_TEST_BASE" not in str(errors)
+
+
+@pytest.mark.parametrize("transport", ["http", "sse"])
+def test_registration_persists_template_not_expanded_endpoint(
+    monkeypatch, tmp_path, transport
+):
+    monkeypatch.setenv("MCP_TEST_BASE", "https://example.invalid/private-marker")
+    path = tmp_path / "registry.json"
+    registry = ServerRegistry(str(path))
+    template = "${MCP_TEST_BASE}/mcp"
+    config = ServerConfig(
+        id="test", name="test", type=transport, config={"url": template}
+    )
+    assert registry.register(config) == "test"
+    persisted = path.read_text()
+    assert "private-marker" not in persisted
+    assert template in persisted
+    restored = ServerRegistry(str(path)).get("test")
+    assert restored is not None
+    assert restored.config["url"] == template
+
+
+@pytest.mark.parametrize("transport", ["http", "sse"])
+def test_registration_error_does_not_disclose_expansion(
+    monkeypatch, tmp_path, caplog, transport
+):
+    monkeypatch.setenv("MCP_TEST_BASE", "file:///private/SECRET")
+    path = tmp_path / "registry.json"
+    registry = ServerRegistry(str(path))
+    config = ServerConfig(
+        id="test", name="test", type=transport, config={"url": "$MCP_TEST_BASE/mcp"}
+    )
+    with pytest.raises(
+        ValueError, match="URL must start with http:// or https://"
+    ) as exc:
+        registry.register(config)
+    assert "SECRET" not in str(exc.value) + caplog.text
+    assert "MCP_TEST_BASE" not in str(exc.value) + caplog.text
+    assert not path.exists()

--- a/tests/mcp/test_expanded_url_validation.py
+++ b/tests/mcp/test_expanded_url_validation.py
@@ -1,0 +1,35 @@
+"""Registry validation and runtime must agree without exposing expanded secrets."""
+
+import pytest
+
+from code_puppy.mcp_.managed_server import ServerConfig, _expand_env_vars
+from code_puppy.mcp_.registry import ServerRegistry
+
+
+@pytest.mark.parametrize("transport", ["http", "sse"])
+@pytest.mark.parametrize(
+    "url", ["$MCP_TEST_BASE/mcp", "${MCP_TEST_BASE}/mcp", "https://example.invalid/mcp"]
+)
+def test_expanded_url_is_accepted_without_mutating_config(monkeypatch, transport, url):
+    monkeypatch.setenv("MCP_TEST_BASE", "https://example.invalid")
+    config = ServerConfig(id="test", name="test", type=transport, config={"url": url})
+    assert _expand_env_vars(url).startswith("https://")
+    assert ServerRegistry.validate_config(object.__new__(ServerRegistry), config) == []
+    assert config.config["url"] == url
+
+
+@pytest.mark.parametrize(
+    "value", [None, "", "file:///private/SECRET", "SECRET-not-a-url"]
+)
+def test_invalid_expansion_is_rejected_without_echoing_it(monkeypatch, value):
+    if value is None:
+        monkeypatch.delenv("MCP_TEST_BASE", raising=False)
+    else:
+        monkeypatch.setenv("MCP_TEST_BASE", value)
+    config = ServerConfig(
+        id="test", name="test", type="http", config={"url": "$MCP_TEST_BASE/mcp"}
+    )
+    errors = ServerRegistry.validate_config(object.__new__(ServerRegistry), config)
+    assert errors
+    assert "SECRET" not in str(errors)
+    assert "MCP_TEST_BASE" not in str(errors)


### PR DESCRIPTION
MCP endpoint templates can fail validation even when their environment variables resolve to valid HTTP URLs. Validate the resolved value so these configurations work, without including the resolved endpoint in validation errors or replacing the stored template.

## Problem

Startup expands environment variables, but registry validation checks the unexpanded URL. A configuration such as `${MCP_BASE}/mcp` is rejected before startup even when `MCP_BASE` contains a valid HTTP(S) base URL.

## Change

- Reuse startup's existing environment expansion before the HTTP/SSE scheme check.
- Preserve the original template in memory and persisted configuration.
- Keep validation errors generic: no resolved endpoints or environment values.
- Cover actual register/persist/reload and invalid-registration error paths, not only the validation helper.

No connector lifecycle or schema changes; this patch is independent of other pending MCP fixes. It does not change configuration file reading/writing policy (#802 addresses separate configuration I/O).

## Validation

Base: `1d25d696`; Linux / Python 3.13.13 with the unchanged upstream lock. Tests use disposable HOME/XDG, no inherited credentials and blocked socket connect/DNS/bind.

- Regression file on unpatched base: **6 failed, 8 passed**. HTTP/SSE template acceptance and actual registration fail before this patch.
- `python -m pytest -q -o addopts= tests/mcp/test_expanded_url_validation.py tests/mcp/test_registry_comprehensive.py tests/mcp/test_registry_coverage.py tests/mcp/test_registry_sync_drops_unconfigured.py`: **82 passed**.
- `python -m pytest -q -o addopts= tests/mcp`: **487 passed, 6 skipped**, no warnings. The skips cover explicitly unimplemented MCP search.
- Ruff lint, formatting and diff checks pass on changed files.

## Compatibility and limits

No dependency or package-version changes. This retains the existing HTTP(S) scheme-prefix policy; it is not full URL validation, SSRF protection, authorization, or a guarantee that unresolved variables elsewhere in an otherwise prefixed URL will be rejected. Environment changes between validation and startup remain possible. No live-connector qualification is claimed.

The base currently fails the unrelated tilde-completion assertion corrected separately in #916. This PR neither incorporates that change nor claims the full upstream suite is green.
