### PR TITLE
fix(images): normalize oversized model payloads independently of byte size

### DIFF
--- a/code_puppy/command_line/clipboard.py
+++ b/code_puppy/command_line/clipboard.py
@@ -246,39 +246,25 @@ def get_clipboard_image() -> Optional[bytes]:
         if image_bytes is None:
             return None
 
-        # Check size and resize if needed
-        if len(image_bytes) > MAX_IMAGE_SIZE_BYTES:
-            if not PIL_AVAILABLE:
-                logger.warning(
-                    f"Image size ({len(image_bytes) / 1024 / 1024:.2f}MB) exceeds limit, "
-                    "but PIL not available for resizing."
-                )
+        if not PIL_AVAILABLE:
+            if len(image_bytes) > MAX_IMAGE_SIZE_BYTES:
+                logger.warning("Clipboard image exceeds byte limit; PIL unavailable")
                 return None
+            return image_bytes
 
-            try:
-                # Use safe image opening with verification
-                image = _safe_open_image(image_bytes)
-                if image is None:
-                    logger.warning(
-                        "Image verification failed for Linux clipboard image"
-                    )
-                    return None
-                image = _resize_image_if_needed(image, MAX_IMAGE_SIZE_BYTES)
-                buffer = io.BytesIO()
-                image.save(buffer, format="PNG", optimize=True)
-                image_bytes = buffer.getvalue()
-            except Exception as e:
-                logger.warning(f"Error resizing Linux clipboard image: {e}")
+        try:
+            image = _safe_open_image(image_bytes)
+            if image is None:
+                logger.warning("Image verification failed for Linux clipboard image")
                 return None
-        else:
-            # Verify even small images for safety
-            if PIL_AVAILABLE:
-                image = _safe_open_image(image_bytes)
-                if image is None:
-                    logger.warning(
-                        "Image verification failed for Linux clipboard image"
-                    )
-                    return None
+            resized = _resize_image_if_needed(image, MAX_IMAGE_SIZE_BYTES)
+            if resized is not image:
+                buffer = io.BytesIO()
+                resized.save(buffer, format="PNG", optimize=True)
+                image_bytes = buffer.getvalue()
+        except Exception as e:
+            logger.warning(f"Error resizing Linux clipboard image: {e}")
+            return None
 
         return image_bytes
 

--- a/code_puppy/command_line/clipboard.py
+++ b/code_puppy/command_line/clipboard.py
@@ -258,7 +258,7 @@ def get_clipboard_image() -> Optional[bytes]:
                 logger.warning("Image verification failed for Linux clipboard image")
                 return None
             resized = _resize_image_if_needed(image, MAX_IMAGE_SIZE_BYTES)
-            if resized is not image:
+            if resized is not image or len(image_bytes) > MAX_IMAGE_SIZE_BYTES:
                 buffer = io.BytesIO()
                 resized.save(buffer, format="PNG", optimize=True)
                 image_bytes = buffer.getvalue()

--- a/code_puppy/command_line/image_utils.py
+++ b/code_puppy/command_line/image_utils.py
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 #: Maximum encoded image size before a resize is triggered.
 MAX_IMAGE_SIZE_BYTES: int = 10 * 1024 * 1024  # 10 MB
 
-#: Hard cap on either dimension after any resize.
-MAX_IMAGE_DIMENSION: int = 4096  # px
+#: Conservative cap compatible with Anthropic's many-image request limit.
+MAX_IMAGE_DIMENSION: int = 2000  # px
 
 
 # ---------------------------------------------------------------------------
@@ -80,56 +80,33 @@ def _resize_image_if_needed(
     image: "Image.Image",
     max_bytes: int,
 ) -> "Image.Image":
-    """Return *image* downscaled so its PNG encoding fits within *max_bytes*.
+    """Downscale for dimension and encoded-size limits independently.
 
-    Uses a square-root area estimate with a 10 % safety margin.  Dimensions
-    are capped at :data:`MAX_IMAGE_DIMENSION` and floored at 100 px.
-
-    Returns the **same object** unchanged when no resize is required — callers
-    can use ``result is image`` to detect whether a resize occurred.
+    The dimension cap applies even to highly compressible screenshots. Preserve
+    aspect ratio and never upscale a short edge to satisfy a pixel floor.
     """
     if Image is None:  # pragma: no cover
         return image
 
+    scale = min(1.0, MAX_IMAGE_DIMENSION / max(image.size))
+    resized = image
+    if scale < 1.0:
+        resized = image.resize(
+            tuple(max(1, int(edge * scale)) for edge in image.size),
+            Image.Resampling.LANCZOS,
+        )
+
     buf = io.BytesIO()
-    image.save(buf, format="PNG", optimize=True)
+    resized.save(buf, format="PNG", optimize=True)
     current = buf.tell()
-
-    if current <= max_bytes:
-        return image
-
-    logger.info(
-        "Image size (%.2f MB) exceeds limit (%.2f MB), resizing…",
-        current / 1024 / 1024,
-        max_bytes / 1024 / 1024,
-    )
-
-    scale = (max_bytes / current) ** 0.5 * 0.9  # 10 % safety margin
-    new_w = int(image.width * scale)
-    new_h = int(image.height * scale)
-
-    # Respect aspect ratio when a dimension hits the hard cap
-    if new_w > MAX_IMAGE_DIMENSION:
-        ratio = MAX_IMAGE_DIMENSION / new_w
-        new_w = MAX_IMAGE_DIMENSION
-        new_h = int(new_h * ratio)
-    if new_h > MAX_IMAGE_DIMENSION:
-        ratio = MAX_IMAGE_DIMENSION / new_h
-        new_h = MAX_IMAGE_DIMENSION
-        new_w = int(new_w * ratio)
-
-    # Floor both dimensions
-    new_w = max(new_w, 100)
-    new_h = max(new_h, 100)
-
-    resized = image.resize((new_w, new_h), Image.Resampling.LANCZOS)
-    logger.info(
-        "Resized image from %dx%d to %dx%d",
-        image.width,
-        image.height,
-        new_w,
-        new_h,
-    )
+    if current > max_bytes:
+        # Retain the existing approximate byte-budget policy; the dimension
+        # ceiling above is unconditional, not gated on this estimate.
+        scale = (max_bytes / current) ** 0.5 * 0.9
+        resized = resized.resize(
+            tuple(max(1, int(edge * scale)) for edge in resized.size),
+            Image.Resampling.LANCZOS,
+        )
     return resized
 
 
@@ -158,7 +135,7 @@ def normalize_image_bytes(
 
         - *media_type* does not start with ``"image/"``
         - PIL is unavailable
-        - the image already fits within *max_bytes*
+        - the image already fits the byte and dimension limits
         - any error occurs (always fails gracefully)
     """
     if not media_type.startswith("image/"):

--- a/code_puppy/tools/browser/browser_screenshot.py
+++ b/code_puppy/tools/browser/browser_screenshot.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Optional, Union
 
 from pydantic_ai import BinaryContent, RunContext, ToolReturn
 
+from code_puppy.command_line.image_utils import normalize_image_bytes
 from code_puppy.messaging import emit_error, emit_info, emit_success
 from code_puppy.tools.common import generate_group_id
 
@@ -124,14 +125,18 @@ async def take_screenshot(
 
         screenshot_path = result.get("screenshot_path", "(not saved)")
 
+        # Preserve the full-resolution file; normalize only the model payload.
+        image_bytes, media_type = normalize_image_bytes(
+            result["screenshot_bytes"], "image/png"
+        )
         # Return as ToolReturn with BinaryContent so the model can SEE the image!
         return ToolReturn(
             return_value=f"Screenshot captured successfully. Saved to: {screenshot_path}",
             content=[
                 f"Here's the browser screenshot ({target}):",
                 BinaryContent(
-                    data=result["screenshot_bytes"],
-                    media_type="image/png",
+                    data=image_bytes,
+                    media_type=media_type,
                 ),
                 "Please analyze what you see and describe any relevant details.",
             ],

--- a/code_puppy/tools/image_tools.py
+++ b/code_puppy/tools/image_tools.py
@@ -76,6 +76,8 @@ def _validate_and_prepare_image(
             resized = image.resize(
                 (output_width, output_height), Image.Resampling.LANCZOS
             )
+            if resized.mode not in ("RGB", "RGBA", "L", "LA", "P"):
+                resized = resized.convert("RGB")
             output = io.BytesIO()
             resized.save(output, format="PNG", optimize=True)
             output.seek(0)

--- a/code_puppy/tools/image_tools.py
+++ b/code_puppy/tools/image_tools.py
@@ -19,13 +19,14 @@ from typing import Any, Dict, Union
 from PIL import Image, UnidentifiedImageError
 from pydantic_ai import BinaryContent, RunContext, ToolReturn
 
+from code_puppy.command_line.image_utils import MAX_IMAGE_DIMENSION
 from code_puppy.messaging import emit_error, emit_info, emit_success
 from code_puppy.tools.common import generate_group_id
 
 logger = logging.getLogger(__name__)
 
 # Bigger than this on either edge and we resize to save tokens.
-MAX_IMAGE_EDGE = 2048
+MAX_IMAGE_EDGE = MAX_IMAGE_DIMENSION
 DEFAULT_MAX_HEIGHT = 768  # kept for backward-compat in tool signature
 
 

--- a/tests/command_line/test_clipboard.py
+++ b/tests/command_line/test_clipboard.py
@@ -194,6 +194,7 @@ class TestGetClipboardImage:
         mock_image.mode = "RGB"
         mock_image.width = 100
         mock_image.height = 100
+        mock_image.size = (100, 100)
         mock_image.info = {}
 
         def save_as_png(buffer, format, **kwargs):
@@ -379,6 +380,7 @@ class TestGetClipboardImageLinux:
 
         small_bytes = b"pngdata" * 10
         mock_img = MagicMock()
+        mock_img.size = (100, 100)
         with (
             patch("code_puppy.command_line.clipboard.sys.platform", "linux"),
             patch(

--- a/tests/command_line/test_clipboard_linux.py
+++ b/tests/command_line/test_clipboard_linux.py
@@ -188,6 +188,7 @@ class TestImageResizing:
         mock_image = MagicMock()
         mock_image.width = width
         mock_image.height = height
+        mock_image.size = (width, height)
 
         call_count = [0]
 

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -90,8 +90,8 @@ class TestResizeImageIfNeeded:
         assert result.width < 500
         assert result.height < 500
 
-    def test_dimensions_floored_at_100(self) -> None:
-        """Even a huge budget-to-size ratio should not drop below 100 px."""
+    def test_dimensions_remain_positive_under_tiny_budget(self) -> None:
+        """Tiny budgets must not upscale short edges or create zero-sized images."""
         try:
             from PIL import Image
         except ImportError:  # pragma: no cover
@@ -99,8 +99,8 @@ class TestResizeImageIfNeeded:
 
         img = Image.new("RGB", (200, 200))
         result = _resize_image_if_needed(img, 1)
-        assert result.width >= 100
-        assert result.height >= 100
+        assert 1 <= result.width < img.width
+        assert 1 <= result.height < img.height
 
     def test_dimensions_capped_at_max(self) -> None:
         """Resizing a huge image should not exceed MAX_IMAGE_DIMENSION."""

--- a/tests/test_model_image_dimensions.py
+++ b/tests/test_model_image_dimensions.py
@@ -70,3 +70,30 @@ def test_linux_clipboard_normalizes_small_byte_capture(monkeypatch):
     result = clipboard.get_clipboard_image()
     with Image.open(io.BytesIO(result)) as image:
         assert image.size == (2000, 1118)
+
+
+def test_linux_clipboard_reencodes_oversized_encoding(monkeypatch):
+    from code_puppy.command_line import clipboard
+
+    buf = io.BytesIO()
+    Image.new("RGB", (2000, 2000), "white").save(buf, format="PNG", compress_level=0)
+    data = buf.getvalue()
+    assert len(data) > clipboard.MAX_IMAGE_SIZE_BYTES
+    monkeypatch.setattr(clipboard.sys, "platform", "linux")
+    monkeypatch.setattr(clipboard, "_get_linux_clipboard_image", lambda: data)
+    result = clipboard.get_clipboard_image()
+    assert len(result) < clipboard.MAX_IMAGE_SIZE_BYTES
+    with Image.open(io.BytesIO(result)) as image:
+        assert image.size == (2000, 2000)
+
+
+def test_file_loader_normalizes_cmyk_when_new_limit_requires_resize():
+    from code_puppy.tools.image_tools import MAX_IMAGE_EDGE, _validate_and_prepare_image
+
+    buf = io.BytesIO()
+    Image.new("CMYK", (2048, 1024)).save(buf, format="JPEG")
+    result = _validate_and_prepare_image(buf.getvalue(), max_edge=MAX_IMAGE_EDGE)
+    assert result["media_type"] == "image/png"
+    with Image.open(io.BytesIO(result["image_bytes"])) as image:
+        assert image.size == (2000, 1000)
+        assert image.mode == "RGB"

--- a/tests/test_model_image_dimensions.py
+++ b/tests/test_model_image_dimensions.py
@@ -55,10 +55,16 @@ async def test_browser_normalizes_payload_but_preserves_saved_capture(
         assert image.size == (2000, 1125)
 
 
-def test_file_loader_uses_shared_limit():
-    from code_puppy.tools.image_tools import MAX_IMAGE_EDGE
+async def test_file_loader_caps_actual_payload_and_preserves_file(tmp_path):
+    from code_puppy.tools.image_tools import load_image
 
-    assert MAX_IMAGE_EDGE == 2000
+    data = png((2048, 1024))
+    path = tmp_path / "capture.png"
+    path.write_bytes(data)
+    result = await load_image(str(path))
+    assert path.read_bytes() == data
+    with Image.open(io.BytesIO(result.content[1].data)) as image:
+        assert image.size == (2000, 1000)
 
 
 def test_linux_clipboard_normalizes_small_byte_capture(monkeypatch):

--- a/tests/test_model_image_dimensions.py
+++ b/tests/test_model_image_dimensions.py
@@ -1,0 +1,72 @@
+"""Dimension limits apply even when screenshots compress to only a few KB."""
+
+import io
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from PIL import Image
+
+from code_puppy.command_line.image_utils import normalize_image_bytes
+
+
+def png(size):
+    buf = io.BytesIO()
+    Image.new("RGB", size, "white").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.mark.parametrize("size", [(2002, 1120), (3840, 2160), (6000, 40), (40, 6000)])
+def test_small_byte_images_obey_dimension_limit_and_aspect_ratio(size):
+    data = png(size)
+    assert len(data) < 100_000
+    normalized, mime = normalize_image_bytes(data, "image/png")
+    with Image.open(io.BytesIO(normalized)) as image:
+        assert max(image.size) <= 2000
+        scale = 2000 / max(size)
+        assert image.size == tuple(max(1, int(edge * scale)) for edge in size)
+    assert mime == "image/png"
+
+
+@pytest.mark.parametrize("size", [(1920, 1080), (2000, 2000)])
+def test_in_bounds_bytes_unchanged(size):
+    data = png(size)
+    assert normalize_image_bytes(data, "image/png") == (data, "image/png")
+
+
+async def test_browser_normalizes_payload_but_preserves_saved_capture(
+    monkeypatch, tmp_path
+):
+    from code_puppy.tools.browser import browser_screenshot
+
+    data = png((3840, 2160))
+    page = SimpleNamespace(screenshot=AsyncMock(return_value=data))
+    manager = SimpleNamespace(get_current_page=AsyncMock(return_value=page))
+    monkeypatch.setattr(
+        browser_screenshot, "get_session_browser_manager", lambda: manager
+    )
+    path = tmp_path / "capture.png"
+    monkeypatch.setattr(
+        browser_screenshot, "_build_screenshot_path", lambda stamp: path
+    )
+    result = await browser_screenshot.take_screenshot()
+    assert path.read_bytes() == data
+    with Image.open(io.BytesIO(result.content[1].data)) as image:
+        assert image.size == (2000, 1125)
+
+
+def test_file_loader_uses_shared_limit():
+    from code_puppy.tools.image_tools import MAX_IMAGE_EDGE
+
+    assert MAX_IMAGE_EDGE == 2000
+
+
+def test_linux_clipboard_normalizes_small_byte_capture(monkeypatch):
+    from code_puppy.command_line import clipboard
+
+    data = png((2002, 1120))
+    monkeypatch.setattr(clipboard.sys, "platform", "linux")
+    monkeypatch.setattr(clipboard, "_get_linux_clipboard_image", lambda: data)
+    result = clipboard.get_clipboard_image()
+    with Image.open(io.BytesIO(result)) as image:
+        assert image.size == (2000, 1118)


### PR DESCRIPTION
Images can be small in bytes but still exceed a model's dimension limit. Normalize dimensions across attachment, clipboard and browser-screenshot payloads so compressible screenshots no longer bypass resizing, while keeping saved screenshot files at full resolution.

## Problem

The shared image helper gates resizing on encoded byte size. A large, mostly blank screenshot can therefore pass through unchanged. Browser screenshots also bypass that helper, and the file loader uses a different edge limit.

## Change

- Apply a shared **2000px maximum edge** independently of encoded byte size.
- Preserve aspect ratio, keep dimensions positive, and never upscale a short edge to satisfy the old 100px floor.
- Normalize browser model payloads after preserving the original screenshot file.
- Process small-byte Linux clipboard captures too; retain re-encoding when the original encoding exceeds the byte budget.
- Align file loading with the shared cap and convert resized CMYK images to a PNG-compatible mode.
- Leave in-bounds original payload bytes unchanged when no resize is needed.

### Core scope and overlap

This corrects existing image producers and their shared utility, rather than adding a command or parallel plugin policy. It necessarily touches existing `command_line/image_utils.py` and `clipboard.py`; given the plugin-first contribution guidance, please flag a preferred supported seam before landing if this belongs elsewhere. The goal is one shared policy, not another frontend-specific workaround.

#911 fixes image-path resolution in the same file-loading module; this patch changes its dimension limit/encoding path, not path lookup. It does not depend on that PR or any MCP lifecycle work.

## Validation

Base: `1d25d696`; Linux / Python 3.13.13 with the unchanged upstream lock. Tests use actual Pillow-generated images, disposable HOME/XDG, no inherited credentials and blocked socket connect/DNS/bind. Browser capture and clipboard acquisition are mocked; payload processing and file-loader calls are real.

- New regression file on unpatched base: **8 failed, 3 passed**.
- Focused image/clipboard/attachment/screenshot selection: **169 passed**.
- `python -m pytest -q -o addopts= tests/test_model_image_dimensions.py tests/test_image_utils.py tests/command_line tests/test_command_line_attachments.py tests/tools`: **1654 passed, 1 skipped, 1 warning**.
- Regressions cover thin images, low-byte oversized images, untouched in-bounds bytes, full-resolution saved captures, actual file-loader output, oversized clipboard encoding and CMYK resizing.
- Ruff lint, formatting and diff checks pass on changed files.

The skip requires a case-insensitive filesystem. The browser-control unawaited-coroutine warning reproduces on the unpatched base; it was not suppressed.

## Compatibility and limits

The conservative 2000px policy reduces detail for images previously allowed above that size. Saved files are not resized, and this does not rewrite images already persisted in conversation history. The existing byte-budget estimate is not a hard encoded-byte guarantee. No universal provider acceptance, live browser/clipboard capture, or live-provider qualification is claimed. No dependency or package-version changes.

The base currently fails the unrelated tilde-completion assertion corrected separately in #916. This PR does not bundle that change or claim full upstream CI is green.
