### PR TITLE
feat(mcp): support logging, progress, roots, instructions and caching

### DIFF
--- a/code_puppy/mcp_/capabilities.py
+++ b/code_puppy/mcp_/capabilities.py
@@ -1,0 +1,239 @@
+"""Per-server MCP capability wiring (stateless-session subset).
+
+Code Puppy has historically consumed exactly one MCP capability — tools.
+``MCPToolset`` already speaks the rest of the client protocol; this module
+turns the per-server ``capabilities`` config block into the constructor
+kwargs that switch those on.
+
+Deliberately **not** supported: ``sampling`` and ``elicitation``. Those are
+server-initiated *requests*, and SEP-2575 made MCP stateless — a modern
+session holds no connection for the server to issue a request back over, so
+pydantic-ai refuses them and warns ``"will never be called"`` at connect
+time. Logging and progress survive the same negotiation because they are
+one-way *notifications* that ride the response stream. Supporting sampling
+or elicitation would mean pinning the whole connection to the legacy
+protocol era (a pre-built ``fastmcp.Client(mode="legacy")``), which is a
+protocol downgrade rather than a feature flag, so it is out of scope here.
+
+The other consequence of statelessness: ``logging/setLevel`` does not exist
+on a modern session. The server sends **every** level and leaves filtering
+to the client, so ``min_level`` below is applied in ``make_log_handler``
+rather than being negotiated with the server.
+"""
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from code_puppy.mcp_.mcp_logs import write_log
+
+# MCP severity ordering (RFC 5424, as used by the MCP logging capability).
+# Index = severity; higher is more severe. Used for client-side filtering
+# because a stateless session has no `logging/setLevel` to filter server-side.
+_LEVELS: List[str] = [
+    "debug",
+    "info",
+    "notice",
+    "warning",
+    "error",
+    "critical",
+    "alert",
+    "emergency",
+]
+_LEVEL_INDEX: Dict[str, int] = {name: i for i, name in enumerate(_LEVELS)}
+
+DEFAULT_MIN_LOG_LEVEL = "info"
+
+
+def _expand(value: str) -> str:
+    """Expand ``$VAR``/``${VAR}`` plus a synthetic ``${PWD}``.
+
+    ``PWD`` is not a real environment variable on Windows, but it is the
+    obvious way for a user to write "the directory I launched in" in
+    ``servers.json``, so it is resolved explicitly before falling through to
+    the normal environment.
+    """
+    if "${PWD}" in value or "$PWD" in value:
+        cwd = os.getcwd()
+        value = value.replace("${PWD}", cwd).replace("$PWD", cwd)
+    return os.path.expandvars(value)
+
+
+def normalize_root(entry: str) -> Optional[str]:
+    """Turn a configured root into a ``file://`` URI.
+
+    The MCP roots capability is specified in terms of URIs, but writing
+    ``file:///C:/Users/...`` by hand in JSON is miserable, so plain paths are
+    accepted and converted. Entries that are already URIs pass through
+    untouched. Returns ``None`` for entries that cannot be resolved, so a
+    single bad path degrades that root instead of failing server startup.
+    """
+    expanded = _expand(entry).strip()
+    if not expanded:
+        return None
+    if "://" in expanded:
+        return expanded
+    try:
+        return Path(expanded).expanduser().resolve().as_uri()
+    except (ValueError, OSError):
+        return None
+
+
+@dataclass
+class CapabilityConfig:
+    """Parsed ``capabilities`` block for one server.
+
+    Defaults are chosen so that an existing ``servers.json`` with no
+    ``capabilities`` key keeps today's behavior for anything the user can
+    see in the agent's context (``instructions`` stays off, because server
+    instructions are injected into the prompt and cost tokens), while
+    observability that only lands in the existing rotated log file
+    (``logging``, ``progress``) is on — those write through ``write_log``,
+    the same sink ``/mcp logs`` already reads.
+    """
+
+    logging: bool = True
+    min_log_level: str = DEFAULT_MIN_LOG_LEVEL
+    progress: bool = True
+    instructions: bool = False
+    roots: List[str] = field(default_factory=list)
+    cache_prompts: bool = True
+    cache_resources: bool = True
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "CapabilityConfig":
+        """Build from a server's raw config dict.
+
+        Unknown keys are ignored rather than rejected: ``servers.json`` is
+        hand-edited, and a typo should not take a working server offline.
+        An out-of-range ``min_log_level`` falls back to the default for the
+        same reason.
+        """
+        raw = config.get("capabilities")
+        if not isinstance(raw, dict):
+            return cls()
+
+        def _flag(key: str, default: bool) -> bool:
+            value = raw.get(key, default)
+            return bool(value) if isinstance(value, bool) else default
+
+        level = raw.get("min_log_level", DEFAULT_MIN_LOG_LEVEL)
+        if not isinstance(level, str) or level.lower() not in _LEVEL_INDEX:
+            level = DEFAULT_MIN_LOG_LEVEL
+
+        roots_raw = raw.get("roots", [])
+        roots = (
+            [r for r in roots_raw if isinstance(r, str)]
+            if isinstance(roots_raw, list)
+            else []
+        )
+
+        return cls(
+            logging=_flag("logging", True),
+            min_log_level=level.lower(),
+            progress=_flag("progress", True),
+            instructions=_flag("instructions", False),
+            roots=roots,
+            cache_prompts=_flag("cache_prompts", True),
+            cache_resources=_flag("cache_resources", True),
+        )
+
+
+def _render_log_data(data: Any) -> str:
+    """Flatten a log notification's ``data`` into one readable line.
+
+    ``data`` is typed ``Any`` by the protocol. FastMCP's ``ctx.info(...)``
+    helpers send a structured ``{"msg": ..., "extra": ...}`` payload, so a
+    bare ``repr`` renders the useful case as
+    ``{'msg': 'almost done', 'extra': None}``. Unwrap that shape, keeping
+    ``extra`` only when it carries something.
+    """
+    if isinstance(data, str):
+        return data
+    if isinstance(data, dict) and "msg" in data:
+        msg = data["msg"]
+        text = msg if isinstance(msg, str) else repr(msg)
+        extra = data.get("extra")
+        return f"{text} {extra!r}" if extra else text
+    return repr(data)
+
+
+def make_log_handler(server_name: str, min_level: str = DEFAULT_MIN_LOG_LEVEL):
+    """Route MCP ``notifications/message`` into the per-server log file.
+
+    Filtering happens here because a stateless session ignores
+    ``logging/setLevel`` — the server sends everything regardless.
+    """
+    threshold = _LEVEL_INDEX.get(min_level, _LEVEL_INDEX[DEFAULT_MIN_LOG_LEVEL])
+
+    async def handler(params: Any) -> None:
+        level = (getattr(params, "level", "info") or "info").lower()
+        if _LEVEL_INDEX.get(level, _LEVEL_INDEX["info"]) < threshold:
+            return
+        data = getattr(params, "data", "")
+        logger = getattr(params, "logger", None)
+        message = _render_log_data(data)
+        if logger:
+            message = f"[{logger}] {message}"
+        # write_log is sync file I/O; the volume here is a handful of lines
+        # per tool call, so it is not worth a thread hop.
+        write_log(server_name, message, level=level.upper())
+
+    return handler
+
+
+def make_progress_handler(server_name: str):
+    """Record ``notifications/progress`` in the per-server log file.
+
+    No TUI surface: rendering a live progress bar would mean touching
+    ``code_puppy/command_line/``, which ``AGENTS.md`` reserves for plugins.
+    Logging it still answers the question this capability exists to answer —
+    "is this 40-second tool call actually making progress, or is it hung?" —
+    and ``/mcp logs`` already tails the file.
+    """
+
+    async def handler(
+        progress: float, total: Optional[float], message: Optional[str]
+    ) -> None:
+        if total:
+            pct = (progress / total) * 100 if total else 0.0
+            text = f"progress {progress:g}/{total:g} ({pct:.0f}%)"
+        else:
+            text = f"progress {progress:g}"
+        if message:
+            text = f"{text} - {message}"
+        write_log(server_name, text, level="DEBUG")
+
+    return handler
+
+
+def build_capability_kwargs(config: Dict[str, Any], server_name: str) -> Dict[str, Any]:
+    """Map a server's ``capabilities`` block onto ``MCPToolset`` kwargs.
+
+    Returns only the kwargs this config actually enables, so callers can
+    merge the result over their existing defaults without clobbering them.
+
+    ``log_level`` is intentionally never emitted: on a stateless session
+    pydantic-ai warns that it was "not applied", and emitting it would make
+    every enterprise stdio server log a spurious warning at startup.
+    """
+    caps = CapabilityConfig.from_config(config)
+    kwargs: Dict[str, Any] = {
+        "cache_prompts": caps.cache_prompts,
+        "cache_resources": caps.cache_resources,
+    }
+
+    if caps.instructions:
+        kwargs["include_instructions"] = True
+    if caps.logging:
+        kwargs["log_handler"] = make_log_handler(server_name, caps.min_log_level)
+    if caps.progress:
+        kwargs["progress_handler"] = make_progress_handler(server_name)
+
+    if caps.roots:
+        resolved = [uri for uri in (normalize_root(r) for r in caps.roots) if uri]
+        if resolved:
+            kwargs["roots"] = resolved
+
+    return kwargs

--- a/code_puppy/mcp_/managed_server.py
+++ b/code_puppy/mcp_/managed_server.py
@@ -20,6 +20,7 @@ from pydantic_ai.toolsets import AbstractToolset
 
 from code_puppy.http_utils import create_async_client, get_cert_bundle_path
 from code_puppy.mcp_.blocking_startup import BlockingStdioToolset
+from code_puppy.mcp_.capabilities import build_capability_kwargs
 from code_puppy.mcp_.tool_arg_coercion import coerce_tool_args
 
 
@@ -256,13 +257,22 @@ class ManagedMCPServer:
 
         return self._pydantic_server
 
-    def _toolset_kwargs(self, config: Dict[str, Any]) -> Dict[str, Any]:
+    def _toolset_kwargs(
+        self, config: Dict[str, Any], server_name: str = ""
+    ) -> Dict[str, Any]:
         """Map our config keys onto ``MCPToolset`` constructor kwargs.
 
         ``timeout`` (time allowed for the initialize handshake) maps to
         ``init_timeout``; ``read_timeout`` keeps its name. Omitted keys fall
         through to pydantic-ai's defaults (5s / 300s — same as the old
         ``MCPServer*`` defaults).
+
+        The ``capabilities`` block (logging, progress, roots, instructions,
+        prompt/resource caching) is folded in by
+        ``build_capability_kwargs``; see ``code_puppy.mcp_.capabilities`` for
+        why sampling and elicitation are excluded. ``server_name`` keys the
+        log sink, so it should be the tool prefix that stderr capture and
+        ``/mcp logs`` already use.
 
         ``prefer_tasks=False``: pydantic-ai v2 defaults to task-augmented
         execution (SEP-1686) for tools whose server marks task support
@@ -274,6 +284,7 @@ class ManagedMCPServer:
             "process_tool_call": process_tool_call,
             "prefer_tasks": False,
         }
+        kwargs.update(build_capability_kwargs(config, server_name or self.config.name))
         if "timeout" in config:
             kwargs["init_timeout"] = config["timeout"]
         if "read_timeout" in config:
@@ -315,7 +326,9 @@ class ManagedMCPServer:
                     else None
                 ),
             )
-            self._toolset = MCPToolset(transport, **self._toolset_kwargs(config))
+            self._toolset = MCPToolset(
+                transport, **self._toolset_kwargs(config, tool_prefix)
+            )
 
         elif server_type == "stdio":
             if "command" not in config:
@@ -349,7 +362,7 @@ class ManagedMCPServer:
                 server_name=tool_prefix,
                 emit_stderr=False,  # Logs go to file (use /mcp logs to view)
                 message_group=uuid.uuid4(),
-                **self._toolset_kwargs(stdio_config),
+                **self._toolset_kwargs(stdio_config, tool_prefix),
             )
 
         elif server_type == "http":
@@ -363,7 +376,9 @@ class ManagedMCPServer:
                 url=_expand_env_vars(config["url"]),
                 headers=headers,
             )
-            self._toolset = MCPToolset(transport, **self._toolset_kwargs(config))
+            self._toolset = MCPToolset(
+                transport, **self._toolset_kwargs(config, tool_prefix)
+            )
 
         else:
             raise ValueError(f"Unsupported server type: {server_type}")

--- a/code_puppy/mcp_/toolset_utils.py
+++ b/code_puppy/mcp_/toolset_utils.py
@@ -56,6 +56,41 @@ def toolset_is_running(toolset: Any) -> bool:
     return bool(getattr(unwrap_toolset(toolset), "is_running", False))
 
 
+def toolset_capabilities(toolset: Any) -> Optional[Any]:
+    """Server capabilities advertised during the handshake, or ``None``.
+
+    ``MCPToolset.capabilities`` raises ``AttributeError`` ("only available
+    after initialization") until the toolset has been entered, so callers
+    that render status for a mix of running and stopped servers would
+    otherwise need a try/except at every call site. ``None`` means "not
+    connected yet", which is exactly what a status view wants to show.
+    """
+    try:
+        return unwrap_toolset(toolset).capabilities
+    except AttributeError:
+        return None
+
+
+def toolset_instructions(toolset: Any) -> Optional[str]:
+    """Server-provided instructions, or ``None`` if not connected/absent."""
+    try:
+        return unwrap_toolset(toolset).instructions
+    except AttributeError:
+        return None
+
+
+def toolset_server_info(toolset: Any) -> Optional[Any]:
+    """Server name/version stamp, or ``None`` if not connected.
+
+    Optional even on a live connection: on a modern (stateless) session
+    ``serverInfo`` is a display-only field the server may omit entirely.
+    """
+    try:
+        return unwrap_toolset(toolset).server_info
+    except AttributeError:
+        return None
+
+
 def iter_cached_tool_defs(toolset: Any) -> Iterator[Tuple[str, str, Any]]:
     """Yield ``(full_name, description, input_schema)`` for cached MCP tools.
 

--- a/docs/MCP_CAPABILITIES.md
+++ b/docs/MCP_CAPABILITIES.md
@@ -1,0 +1,94 @@
+# MCP Server Capabilities
+
+Code Puppy has historically consumed one MCP capability: **tools**. The MCP
+protocol defines several more, and `MCPToolset` (pydantic-ai) already speaks
+them — they just weren't switched on.
+
+This adds an optional per-server `capabilities` block to each entry in
+`~/.code_puppy/mcp_servers.json`.
+
+## Config
+
+Every key is optional; omitting the block keeps current behavior.
+
+```jsonc
+{
+  "platform-tools": {
+    "type": "stdio",
+    "command": "my-platform-mcp",
+    "args": ["--stdio"],
+
+    "capabilities": {
+      "logging": true,          // route server logs into /mcp logs
+      "min_log_level": "info",  // debug|info|notice|warning|error|critical|alert|emergency
+      "progress": true,         // record progress notifications
+      "instructions": false,    // inject server instructions into the prompt
+      "roots": ["${PWD}"],      // workspace dirs advertised to the server
+      "cache_prompts": true,
+      "cache_resources": true
+    }
+  }
+}
+```
+
+| Key | Default | Effect |
+|---|---|---|
+| `logging` | `true` | Server `notifications/message` are written to the server's log file. |
+| `min_log_level` | `info` | Client-side severity filter (see note below). |
+| `progress` | `true` | Progress notifications logged at `DEBUG` — answers "is this slow tool hung?" |
+| `instructions` | `false` | Off by default: instructions are injected into the prompt and cost tokens. |
+| `roots` | `[]` | Paths or URIs. Plain paths are converted to `file://`; `${PWD}` resolves to the launch directory. |
+| `cache_prompts` / `cache_resources` | `true` | Cache listings between calls. |
+
+Logging and progress default **on** because they only write to the existing
+rotated log file that `/mcp logs` already reads — no new UI, no prompt-token
+cost. Anything that changes what the model sees (`instructions`) is opt-in.
+
+Unknown keys and out-of-range values are ignored rather than rejected;
+`mcp_servers.json` is hand-edited, and a typo shouldn't take a working server
+offline.
+
+## Reading it back
+
+`code_puppy/mcp_/toolset_utils.py` exposes `toolset_capabilities()`,
+`toolset_instructions()`, and `toolset_server_info()`. These read what the
+server advertised during the handshake.
+
+They return `None` before the server has been started — the underlying
+pydantic-ai properties raise `AttributeError` ("only available after
+initialization"), so callers rendering a mix of running and stopped servers
+don't need a `try`/`except` at every site.
+
+## Why no `sampling` or `elicitation`
+
+Both work on the currently pinned stack (`fastmcp` 3.x, `mcp` 1.x), where
+every session is a legacy-protocol session. They are excluded here for
+forward compatibility.
+
+SEP-2575 made MCP stateless. Under `fastmcp` 4 with MCP SDK v2, the client
+probes `server/discover` and may negotiate a **modern session**, which holds
+no connection for the server to issue requests back over. Sampling and
+elicitation are server-initiated *requests*, so pydantic-ai refuses them and
+warns at connect time:
+
+```
+`elicitation_handler` will never be called: ... negotiated a modern MCP
+session, which holds no connection for the server to issue sampling or
+elicitation requests over.
+```
+
+Logging and progress survive that negotiation because they are one-way
+*notifications* that ride the response stream. Every capability documented
+above therefore works on both protocol eras.
+
+Supporting sampling or elicitation on a modern session means pinning the
+connection back to the legacy era via a pre-built
+`fastmcp.Client(mode="legacy")` — a protocol downgrade rather than a feature
+flag, and better handled as an explicit per-server opt-in if it's wanted.
+
+## Why `log_level` is never sent
+
+The modern protocol has no `logging/setLevel`; the server sends every level
+and leaves filtering to the client. Sending it makes pydantic-ai warn that it
+"was not applied". `min_log_level` is therefore applied client-side in the
+log handler, which behaves identically on both eras.

--- a/tests/mcp/test_capabilities.py
+++ b/tests/mcp/test_capabilities.py
@@ -1,0 +1,228 @@
+"""Tests for per-server MCP capability wiring.
+
+Covers the stateless-session subset only. Sampling and elicitation are
+intentionally unsupported — SEP-2575 made MCP stateless, so a modern session
+has no back-channel for server-initiated requests and pydantic-ai warns that
+those handlers "will never be called". The tests below assert that we never
+emit those kwargs (nor ``log_level``, which a modern session ignores).
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from code_puppy.mcp_.capabilities import (
+    CapabilityConfig,
+    build_capability_kwargs,
+    make_log_handler,
+    make_progress_handler,
+    normalize_root,
+)
+
+
+def _log(params_level: str, data: str = "hello", logger: str | None = None):
+    return SimpleNamespace(level=params_level, data=data, logger=logger)
+
+
+class TestCapabilityConfig:
+    def test_absent_block_uses_defaults(self):
+        caps = CapabilityConfig.from_config({})
+        assert caps.logging is True
+        assert caps.progress is True
+        # Instructions cost prompt tokens, so they stay opt-in.
+        assert caps.instructions is False
+        assert caps.roots == []
+
+    def test_non_dict_block_is_ignored(self):
+        assert CapabilityConfig.from_config({"capabilities": "yes"}).logging is True
+
+    def test_flags_round_trip(self):
+        caps = CapabilityConfig.from_config(
+            {
+                "capabilities": {
+                    "logging": False,
+                    "progress": False,
+                    "instructions": True,
+                    "cache_prompts": False,
+                }
+            }
+        )
+        assert caps.logging is False
+        assert caps.progress is False
+        assert caps.instructions is True
+        assert caps.cache_prompts is False
+
+    def test_unknown_keys_ignored(self):
+        """A typo in hand-edited servers.json must not take a server down."""
+        caps = CapabilityConfig.from_config({"capabilities": {"loggin": False}})
+        assert caps.logging is True
+
+    def test_sampling_and_elicitation_keys_are_inert(self):
+        caps = CapabilityConfig.from_config(
+            {"capabilities": {"sampling": True, "elicitation": "ask"}}
+        )
+        assert not hasattr(caps, "sampling")
+        assert not hasattr(caps, "elicitation")
+
+    @pytest.mark.parametrize("bad", ["verbose", 5, None, "TRACE"])
+    def test_invalid_min_log_level_falls_back(self, bad):
+        caps = CapabilityConfig.from_config({"capabilities": {"min_log_level": bad}})
+        assert caps.min_log_level == "info"
+
+    def test_min_log_level_is_case_insensitive(self):
+        caps = CapabilityConfig.from_config(
+            {"capabilities": {"min_log_level": "WARNING"}}
+        )
+        assert caps.min_log_level == "warning"
+
+    def test_non_string_roots_dropped(self):
+        caps = CapabilityConfig.from_config(
+            {"capabilities": {"roots": ["/a", 7, None]}}
+        )
+        assert caps.roots == ["/a"]
+
+
+class TestNormalizeRoot:
+    def test_path_becomes_file_uri(self, tmp_path):
+        assert normalize_root(str(tmp_path)).startswith("file://")
+
+    def test_existing_uri_passes_through(self):
+        assert normalize_root("https://example.com/x") == "https://example.com/x"
+
+    def test_pwd_placeholder_expands(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        got = normalize_root("${PWD}")
+        assert got == Path(tmp_path).resolve().as_uri()
+
+    def test_env_var_expands(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CP_TEST_ROOT", str(tmp_path))
+        assert normalize_root("$CP_TEST_ROOT").startswith("file://")
+
+    def test_blank_returns_none(self):
+        assert normalize_root("   ") is None
+
+
+class TestBuildCapabilityKwargs:
+    def test_never_emits_server_initiated_or_log_level(self):
+        """The whole point of the stateless subset: these must never appear.
+
+        Emitting them makes pydantic-ai warn at every connect, and they are
+        unusable on a modern session regardless.
+        """
+        kwargs = build_capability_kwargs({}, "srv")
+        for dead in (
+            "sampling_handler",
+            "sampling_model",
+            "elicitation_handler",
+            "log_level",
+        ):
+            assert dead not in kwargs
+
+    def test_defaults_enable_logging_and_progress(self):
+        kwargs = build_capability_kwargs({}, "srv")
+        assert callable(kwargs["log_handler"])
+        assert callable(kwargs["progress_handler"])
+        assert "include_instructions" not in kwargs
+
+    def test_disabling_omits_handlers(self):
+        kwargs = build_capability_kwargs(
+            {"capabilities": {"logging": False, "progress": False}}, "srv"
+        )
+        assert "log_handler" not in kwargs
+        assert "progress_handler" not in kwargs
+
+    def test_instructions_opt_in(self):
+        kwargs = build_capability_kwargs({"capabilities": {"instructions": True}}, "s")
+        assert kwargs["include_instructions"] is True
+
+    def test_roots_resolved_to_uris(self, tmp_path):
+        kwargs = build_capability_kwargs(
+            {"capabilities": {"roots": [str(tmp_path)]}}, "srv"
+        )
+        assert all(u.startswith("file://") for u in kwargs["roots"])
+
+    def test_all_unresolvable_roots_omits_key(self):
+        kwargs = build_capability_kwargs({"capabilities": {"roots": ["  "]}}, "srv")
+        assert "roots" not in kwargs
+
+    def test_cache_flags_always_present(self):
+        kwargs = build_capability_kwargs({}, "srv")
+        assert kwargs["cache_prompts"] is True
+        assert kwargs["cache_resources"] is True
+
+
+class TestLogHandler:
+    async def test_filters_below_threshold(self):
+        """Client-side filtering matters: a stateless session ignores
+        logging/setLevel, so the server sends every level regardless."""
+        handler = make_log_handler("srv", min_level="warning")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(_log("debug"))
+            await handler(_log("info"))
+            assert wl.call_count == 0
+            await handler(_log("error"))
+            assert wl.call_count == 1
+
+    async def test_writes_to_named_server_sink(self):
+        handler = make_log_handler("my-server")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(_log("error", data="boom"))
+        assert wl.call_args.args[0] == "my-server"
+        assert "boom" in wl.call_args.args[1]
+        assert wl.call_args.kwargs["level"] == "ERROR"
+
+    async def test_logger_name_prefixed(self):
+        handler = make_log_handler("srv")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(_log("info", data="msg", logger="auth"))
+        assert "[auth] msg" in wl.call_args.args[1]
+
+    async def test_non_string_data_is_repr_not_crash(self):
+        handler = make_log_handler("srv")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(_log("info", data={"k": 1}))
+        assert "k" in wl.call_args.args[1]
+
+    async def test_fastmcp_structured_payload_is_unwrapped(self):
+        """fastmcp's ctx.info() sends {"msg": ..., "extra": ...}; rendering
+        that as a raw dict repr is unreadable in `/mcp logs`."""
+        handler = make_log_handler("srv")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(_log("warning", data={"msg": "almost done", "extra": None}))
+        assert wl.call_args.args[1] == "almost done"
+
+    async def test_structured_payload_keeps_meaningful_extra(self):
+        handler = make_log_handler("srv")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(_log("info", data={"msg": "hi", "extra": {"run": 7}}))
+        text = wl.call_args.args[1]
+        assert "hi" in text and "run" in text
+
+    async def test_unknown_level_treated_as_info(self):
+        handler = make_log_handler("srv", min_level="debug")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(_log("bogus"))
+        assert wl.call_count == 1
+
+
+class TestProgressHandler:
+    async def test_percentage_when_total_known(self):
+        handler = make_progress_handler("srv")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(5.0, 10.0, "halfway")
+        text = wl.call_args.args[1]
+        assert "5/10" in text and "50%" in text and "halfway" in text
+
+    async def test_no_total_does_not_divide_by_zero(self):
+        handler = make_progress_handler("srv")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(3.0, None, None)
+        assert "3" in wl.call_args.args[1]
+
+    async def test_zero_total_is_safe(self):
+        handler = make_progress_handler("srv")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(0.0, 0.0, None)
+        assert wl.call_count == 1


### PR DESCRIPTION
## Summary

Code Puppy consumes one MCP capability: **tools**. `MCPToolset` already speaks the rest — this switches them on via an optional `capabilities` block per server in `mcp_servers.json`.

Adds **logging, progress, roots, server instructions, and prompt/resource caching**, plus safe accessors for handshake metadata.

Motivation: running a platform-curated stdio MCP server, the tools work but nothing else the server offers is reachable. Progress is the sharpest gap — a slow stdio tool call gives no signal whether it's working or hung.

```jsonc
"platform-tools": {
  "type": "stdio",
  "command": "my-platform-mcp",
  "capabilities": {
    "logging": true,
    "min_log_level": "info",
    "progress": true,
    "instructions": false,
    "roots": ["${PWD}"]
  }
}
```

## Notes

- **No new UI, nothing under `command_line/`.** Logs and progress route into the per-server file `/mcp logs` already reads. Per `AGENTS.md` the command surface (`/mcp prompts`, `/mcp resources`) belongs in a plugin; this is the core enablement those build on.
- **Defaults preserve current behavior for anything the model sees.** Logging and progress default on (log file only); `instructions` is opt-in since it costs prompt tokens.
- **Fails soft.** Bad config keys fall back to defaults — the JSON is hand-edited.
- **Safe accessors.** `capabilities`/`instructions`/`server_info` raise `AttributeError` until the toolset is entered; the helpers return `None` so status views can render running and stopped servers alike.
- Sampling and elicitation are out of scope: server-initiated requests with a consent and UI surface beyond this change.

## Testing

33 new tests; 500 pass in `tests/mcp/`. The one failure there (`test_project_config.py`, `WinError 1314` symlink privilege) is pre-existing on Windows and fails identically on a clean tree.

Verified end-to-end against a live stdio server through `ManagedMCPServer` — capabilities, instructions, prompts, resources, tool calls, and captured log/progress lines. That run caught a bug the unit tests missed: fastmcp's `ctx.info()` sends a structured dict that rendered as a raw repr in the logs. Fixed and covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
