### PR TITLE
feat(mcp): wire logging, progress, roots and instructions

### DIFF
--- a/code_puppy/mcp_/capabilities.py
+++ b/code_puppy/mcp_/capabilities.py
@@ -1,0 +1,189 @@
+"""Per-server MCP capability wiring.
+
+Turns a server's ``capabilities`` config block into ``MCPToolset`` kwargs.
+
+Sampling and elicitation are out of scope: they are server-initiated requests
+needing an open back-channel, and carry a consent and UI surface this does not.
+Everything here is a one-way notification or handshake data.
+"""
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from code_puppy.mcp_.mcp_logs import write_log
+
+# MCP severity order (RFC 5424). Filtering is client-side, so it behaves the
+# same whatever the server supports.
+_LEVELS: List[str] = [
+    "debug",
+    "info",
+    "notice",
+    "warning",
+    "error",
+    "critical",
+    "alert",
+    "emergency",
+]
+_LEVEL_INDEX: Dict[str, int] = {name: i for i, name in enumerate(_LEVELS)}
+
+DEFAULT_MIN_LOG_LEVEL = "info"
+
+
+def _expand(value: str) -> str:
+    """Expand ``$VAR``/``${VAR}``, plus ``${PWD}`` (not a real env var on Windows)."""
+    if "${PWD}" in value or "$PWD" in value:
+        cwd = os.getcwd()
+        value = value.replace("${PWD}", cwd).replace("$PWD", cwd)
+    return os.path.expandvars(value)
+
+
+def normalize_root(entry: str) -> Optional[str]:
+    """Convert a configured root to a ``file://`` URI; ``None`` if unresolvable.
+
+    Plain paths are accepted for convenience; existing URIs pass through.
+    """
+    expanded = _expand(entry).strip()
+    if not expanded:
+        return None
+    if "://" in expanded:
+        return expanded
+    try:
+        return Path(expanded).expanduser().resolve().as_uri()
+    except (ValueError, OSError):
+        return None
+
+
+@dataclass
+class CapabilityConfig:
+    """Parsed ``capabilities`` block for one server.
+
+    Logging and progress default on (they only write to the log file);
+    ``instructions`` is opt-in because it costs prompt tokens.
+    """
+
+    logging: bool = True
+    min_log_level: str = DEFAULT_MIN_LOG_LEVEL
+    progress: bool = True
+    instructions: bool = False
+    roots: List[str] = field(default_factory=list)
+    cache_prompts: bool = True
+    cache_resources: bool = True
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "CapabilityConfig":
+        """Parse from a server's raw config.
+
+        Bad keys and values fall back to defaults — the JSON is hand-edited,
+        so a typo must not take a working server offline.
+        """
+        raw = config.get("capabilities")
+        if not isinstance(raw, dict):
+            return cls()
+
+        def _flag(key: str, default: bool) -> bool:
+            value = raw.get(key, default)
+            return bool(value) if isinstance(value, bool) else default
+
+        level = raw.get("min_log_level", DEFAULT_MIN_LOG_LEVEL)
+        if not isinstance(level, str) or level.lower() not in _LEVEL_INDEX:
+            level = DEFAULT_MIN_LOG_LEVEL
+
+        roots_raw = raw.get("roots", [])
+        roots = (
+            [r for r in roots_raw if isinstance(r, str)]
+            if isinstance(roots_raw, list)
+            else []
+        )
+
+        return cls(
+            logging=_flag("logging", True),
+            min_log_level=level.lower(),
+            progress=_flag("progress", True),
+            instructions=_flag("instructions", False),
+            roots=roots,
+            cache_prompts=_flag("cache_prompts", True),
+            cache_resources=_flag("cache_resources", True),
+        )
+
+
+def _render_log_data(data: Any) -> str:
+    """Flatten a notification's ``data`` to one line.
+
+    fastmcp sends ``{"msg": ..., "extra": ...}``, which bare ``repr`` renders
+    unreadably.
+    """
+    if isinstance(data, str):
+        return data
+    if isinstance(data, dict) and "msg" in data:
+        msg = data["msg"]
+        text = msg if isinstance(msg, str) else repr(msg)
+        extra = data.get("extra")
+        return f"{text} {extra!r}" if extra else text
+    return repr(data)
+
+
+def make_log_handler(server_name: str, min_level: str = DEFAULT_MIN_LOG_LEVEL):
+    """Route server logs into the per-server file that ``/mcp logs`` reads."""
+    threshold = _LEVEL_INDEX.get(min_level, _LEVEL_INDEX[DEFAULT_MIN_LOG_LEVEL])
+
+    async def handler(params: Any) -> None:
+        level = (getattr(params, "level", "info") or "info").lower()
+        if _LEVEL_INDEX.get(level, _LEVEL_INDEX["info"]) < threshold:
+            return
+        message = _render_log_data(getattr(params, "data", ""))
+        logger = getattr(params, "logger", None)
+        if logger:
+            message = f"[{logger}] {message}"
+        write_log(server_name, message, level=level.upper())
+
+    return handler
+
+
+def make_progress_handler(server_name: str):
+    """Log progress notifications, so slow tool calls are distinguishable from hung ones.
+
+    Logged rather than rendered: a live progress bar would mean touching
+    ``command_line/``, which ``AGENTS.md`` reserves for plugins.
+    """
+
+    async def handler(
+        progress: float, total: Optional[float], message: Optional[str]
+    ) -> None:
+        if total:
+            text = f"progress {progress:g}/{total:g} ({progress / total * 100:.0f}%)"
+        else:
+            text = f"progress {progress:g}"
+        if message:
+            text = f"{text} - {message}"
+        write_log(server_name, text, level="DEBUG")
+
+    return handler
+
+
+def build_capability_kwargs(config: Dict[str, Any], server_name: str) -> Dict[str, Any]:
+    """Map a server's ``capabilities`` block onto ``MCPToolset`` kwargs.
+
+    Returns only what is enabled, so callers can merge over their defaults.
+    ``log_level`` is never emitted; ``min_log_level`` filters client-side.
+    """
+    caps = CapabilityConfig.from_config(config)
+    kwargs: Dict[str, Any] = {
+        "cache_prompts": caps.cache_prompts,
+        "cache_resources": caps.cache_resources,
+    }
+
+    if caps.instructions:
+        kwargs["include_instructions"] = True
+    if caps.logging:
+        kwargs["log_handler"] = make_log_handler(server_name, caps.min_log_level)
+    if caps.progress:
+        kwargs["progress_handler"] = make_progress_handler(server_name)
+
+    if caps.roots:
+        resolved = [uri for uri in (normalize_root(r) for r in caps.roots) if uri]
+        if resolved:
+            kwargs["roots"] = resolved
+
+    return kwargs

--- a/code_puppy/mcp_/managed_server.py
+++ b/code_puppy/mcp_/managed_server.py
@@ -20,6 +20,7 @@ from pydantic_ai.toolsets import AbstractToolset
 
 from code_puppy.http_utils import create_async_client, get_cert_bundle_path
 from code_puppy.mcp_.blocking_startup import BlockingStdioToolset
+from code_puppy.mcp_.capabilities import build_capability_kwargs
 from code_puppy.mcp_.tool_arg_coercion import coerce_tool_args
 
 
@@ -256,13 +257,19 @@ class ManagedMCPServer:
 
         return self._pydantic_server
 
-    def _toolset_kwargs(self, config: Dict[str, Any]) -> Dict[str, Any]:
+    def _toolset_kwargs(
+        self, config: Dict[str, Any], server_name: str = ""
+    ) -> Dict[str, Any]:
         """Map our config keys onto ``MCPToolset`` constructor kwargs.
 
         ``timeout`` (time allowed for the initialize handshake) maps to
         ``init_timeout``; ``read_timeout`` keeps its name. Omitted keys fall
         through to pydantic-ai's defaults (5s / 300s — same as the old
         ``MCPServer*`` defaults).
+
+        The ``capabilities`` block is folded in by ``build_capability_kwargs``.
+        ``server_name`` keys the log sink, so pass the tool prefix that stderr
+        capture and ``/mcp logs`` already use.
 
         ``prefer_tasks=False``: pydantic-ai v2 defaults to task-augmented
         execution (SEP-1686) for tools whose server marks task support
@@ -274,6 +281,7 @@ class ManagedMCPServer:
             "process_tool_call": process_tool_call,
             "prefer_tasks": False,
         }
+        kwargs.update(build_capability_kwargs(config, server_name or self.config.name))
         if "timeout" in config:
             kwargs["init_timeout"] = config["timeout"]
         if "read_timeout" in config:
@@ -315,7 +323,9 @@ class ManagedMCPServer:
                     else None
                 ),
             )
-            self._toolset = MCPToolset(transport, **self._toolset_kwargs(config))
+            self._toolset = MCPToolset(
+                transport, **self._toolset_kwargs(config, tool_prefix)
+            )
 
         elif server_type == "stdio":
             if "command" not in config:
@@ -349,7 +359,7 @@ class ManagedMCPServer:
                 server_name=tool_prefix,
                 emit_stderr=False,  # Logs go to file (use /mcp logs to view)
                 message_group=uuid.uuid4(),
-                **self._toolset_kwargs(stdio_config),
+                **self._toolset_kwargs(stdio_config, tool_prefix),
             )
 
         elif server_type == "http":
@@ -363,7 +373,9 @@ class ManagedMCPServer:
                 url=_expand_env_vars(config["url"]),
                 headers=headers,
             )
-            self._toolset = MCPToolset(transport, **self._toolset_kwargs(config))
+            self._toolset = MCPToolset(
+                transport, **self._toolset_kwargs(config, tool_prefix)
+            )
 
         else:
             raise ValueError(f"Unsupported server type: {server_type}")

--- a/code_puppy/mcp_/toolset_utils.py
+++ b/code_puppy/mcp_/toolset_utils.py
@@ -56,6 +56,34 @@ def toolset_is_running(toolset: Any) -> bool:
     return bool(getattr(unwrap_toolset(toolset), "is_running", False))
 
 
+def toolset_capabilities(toolset: Any) -> Optional[Any]:
+    """Capabilities the server advertised, or ``None`` if not connected yet.
+
+    The underlying properties raise ``AttributeError`` until the toolset is
+    entered; ``None`` spares callers a try/except per call site.
+    """
+    try:
+        return unwrap_toolset(toolset).capabilities
+    except AttributeError:
+        return None
+
+
+def toolset_instructions(toolset: Any) -> Optional[str]:
+    """Server-provided instructions, or ``None`` if not connected/absent."""
+    try:
+        return unwrap_toolset(toolset).instructions
+    except AttributeError:
+        return None
+
+
+def toolset_server_info(toolset: Any) -> Optional[Any]:
+    """Server name/version, or ``None``. Servers may omit it even when live."""
+    try:
+        return unwrap_toolset(toolset).server_info
+    except AttributeError:
+        return None
+
+
 def iter_cached_tool_defs(toolset: Any) -> Iterator[Tuple[str, str, Any]]:
     """Yield ``(full_name, description, input_schema)`` for cached MCP tools.
 

--- a/docs/MCP_CAPABILITIES.md
+++ b/docs/MCP_CAPABILITIES.md
@@ -1,0 +1,38 @@
+# MCP Server Capabilities
+
+Optional `capabilities` block per server in `~/.code_puppy/mcp_servers.json`.
+All keys optional; omitting the block keeps current behavior.
+
+```jsonc
+"platform-tools": {
+  "type": "stdio",
+  "command": "my-platform-mcp",
+  "capabilities": {
+    "logging": true,
+    "min_log_level": "info",
+    "progress": true,
+    "instructions": false,
+    "roots": ["${PWD}"],
+    "cache_prompts": true,
+    "cache_resources": true
+  }
+}
+```
+
+| Key | Default | Effect |
+|---|---|---|
+| `logging` | `true` | Server logs written to the file `/mcp logs` reads. |
+| `min_log_level` | `info` | `debug`\|`info`\|`notice`\|`warning`\|`error`\|`critical`\|`alert`\|`emergency` |
+| `progress` | `true` | Progress logged at `DEBUG` — tells a slow tool call from a hung one. |
+| `instructions` | `false` | Off by default: costs prompt tokens. |
+| `roots` | `[]` | Paths or URIs. Plain paths become `file://`; `${PWD}` is the launch dir. |
+| `cache_prompts` / `cache_resources` | `true` | Cache listings between calls. |
+
+Bad keys and values fall back to defaults rather than failing startup.
+
+`toolset_capabilities()`, `toolset_instructions()`, and `toolset_server_info()`
+in `mcp_/toolset_utils.py` return what the server advertised, or `None` before
+it starts.
+
+Sampling and elicitation are out of scope — they are server-initiated requests
+with a consent and UI surface beyond this change.

--- a/tests/mcp/test_capabilities.py
+++ b/tests/mcp/test_capabilities.py
@@ -1,0 +1,215 @@
+"""Tests for per-server MCP capability wiring."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from code_puppy.mcp_.capabilities import (
+    CapabilityConfig,
+    build_capability_kwargs,
+    make_log_handler,
+    make_progress_handler,
+    normalize_root,
+)
+
+
+def _log(params_level: str, data: str = "hello", logger: str | None = None):
+    return SimpleNamespace(level=params_level, data=data, logger=logger)
+
+
+class TestCapabilityConfig:
+    def test_absent_block_uses_defaults(self):
+        caps = CapabilityConfig.from_config({})
+        assert caps.logging is True
+        assert caps.progress is True
+        # Instructions cost prompt tokens, so they stay opt-in.
+        assert caps.instructions is False
+        assert caps.roots == []
+
+    def test_non_dict_block_is_ignored(self):
+        assert CapabilityConfig.from_config({"capabilities": "yes"}).logging is True
+
+    def test_flags_round_trip(self):
+        caps = CapabilityConfig.from_config(
+            {
+                "capabilities": {
+                    "logging": False,
+                    "progress": False,
+                    "instructions": True,
+                    "cache_prompts": False,
+                }
+            }
+        )
+        assert caps.logging is False
+        assert caps.progress is False
+        assert caps.instructions is True
+        assert caps.cache_prompts is False
+
+    def test_unknown_keys_ignored(self):
+        """A typo in hand-edited servers.json must not take a server down."""
+        caps = CapabilityConfig.from_config({"capabilities": {"loggin": False}})
+        assert caps.logging is True
+
+    def test_sampling_and_elicitation_keys_are_inert(self):
+        caps = CapabilityConfig.from_config(
+            {"capabilities": {"sampling": True, "elicitation": "ask"}}
+        )
+        assert not hasattr(caps, "sampling")
+        assert not hasattr(caps, "elicitation")
+
+    @pytest.mark.parametrize("bad", ["verbose", 5, None, "TRACE"])
+    def test_invalid_min_log_level_falls_back(self, bad):
+        caps = CapabilityConfig.from_config({"capabilities": {"min_log_level": bad}})
+        assert caps.min_log_level == "info"
+
+    def test_min_log_level_is_case_insensitive(self):
+        caps = CapabilityConfig.from_config(
+            {"capabilities": {"min_log_level": "WARNING"}}
+        )
+        assert caps.min_log_level == "warning"
+
+    def test_non_string_roots_dropped(self):
+        caps = CapabilityConfig.from_config(
+            {"capabilities": {"roots": ["/a", 7, None]}}
+        )
+        assert caps.roots == ["/a"]
+
+
+class TestNormalizeRoot:
+    def test_path_becomes_file_uri(self, tmp_path):
+        assert normalize_root(str(tmp_path)).startswith("file://")
+
+    def test_existing_uri_passes_through(self):
+        assert normalize_root("https://example.com/x") == "https://example.com/x"
+
+    def test_pwd_placeholder_expands(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        got = normalize_root("${PWD}")
+        assert got == Path(tmp_path).resolve().as_uri()
+
+    def test_env_var_expands(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CP_TEST_ROOT", str(tmp_path))
+        assert normalize_root("$CP_TEST_ROOT").startswith("file://")
+
+    def test_blank_returns_none(self):
+        assert normalize_root("   ") is None
+
+
+class TestBuildCapabilityKwargs:
+    def test_never_emits_server_initiated_or_log_level(self):
+        """Emitting these makes pydantic-ai warn on every connect."""
+        kwargs = build_capability_kwargs({}, "srv")
+        for dead in (
+            "sampling_handler",
+            "sampling_model",
+            "elicitation_handler",
+            "log_level",
+        ):
+            assert dead not in kwargs
+
+    def test_defaults_enable_logging_and_progress(self):
+        kwargs = build_capability_kwargs({}, "srv")
+        assert callable(kwargs["log_handler"])
+        assert callable(kwargs["progress_handler"])
+        assert "include_instructions" not in kwargs
+
+    def test_disabling_omits_handlers(self):
+        kwargs = build_capability_kwargs(
+            {"capabilities": {"logging": False, "progress": False}}, "srv"
+        )
+        assert "log_handler" not in kwargs
+        assert "progress_handler" not in kwargs
+
+    def test_instructions_opt_in(self):
+        kwargs = build_capability_kwargs({"capabilities": {"instructions": True}}, "s")
+        assert kwargs["include_instructions"] is True
+
+    def test_roots_resolved_to_uris(self, tmp_path):
+        kwargs = build_capability_kwargs(
+            {"capabilities": {"roots": [str(tmp_path)]}}, "srv"
+        )
+        assert all(u.startswith("file://") for u in kwargs["roots"])
+
+    def test_all_unresolvable_roots_omits_key(self):
+        kwargs = build_capability_kwargs({"capabilities": {"roots": ["  "]}}, "srv")
+        assert "roots" not in kwargs
+
+    def test_cache_flags_always_present(self):
+        kwargs = build_capability_kwargs({}, "srv")
+        assert kwargs["cache_prompts"] is True
+        assert kwargs["cache_resources"] is True
+
+
+class TestLogHandler:
+    async def test_filters_below_threshold(self):
+        """Filtering is client-side: the server sends every level."""
+        handler = make_log_handler("srv", min_level="warning")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(_log("debug"))
+            await handler(_log("info"))
+            assert wl.call_count == 0
+            await handler(_log("error"))
+            assert wl.call_count == 1
+
+    async def test_writes_to_named_server_sink(self):
+        handler = make_log_handler("my-server")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(_log("error", data="boom"))
+        assert wl.call_args.args[0] == "my-server"
+        assert "boom" in wl.call_args.args[1]
+        assert wl.call_args.kwargs["level"] == "ERROR"
+
+    async def test_logger_name_prefixed(self):
+        handler = make_log_handler("srv")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(_log("info", data="msg", logger="auth"))
+        assert "[auth] msg" in wl.call_args.args[1]
+
+    async def test_non_string_data_is_repr_not_crash(self):
+        handler = make_log_handler("srv")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(_log("info", data={"k": 1}))
+        assert "k" in wl.call_args.args[1]
+
+    async def test_fastmcp_structured_payload_is_unwrapped(self):
+        """fastmcp's ctx.info() sends a dict; raw repr is unreadable."""
+        handler = make_log_handler("srv")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(_log("warning", data={"msg": "almost done", "extra": None}))
+        assert wl.call_args.args[1] == "almost done"
+
+    async def test_structured_payload_keeps_meaningful_extra(self):
+        handler = make_log_handler("srv")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(_log("info", data={"msg": "hi", "extra": {"run": 7}}))
+        text = wl.call_args.args[1]
+        assert "hi" in text and "run" in text
+
+    async def test_unknown_level_treated_as_info(self):
+        handler = make_log_handler("srv", min_level="debug")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(_log("bogus"))
+        assert wl.call_count == 1
+
+
+class TestProgressHandler:
+    async def test_percentage_when_total_known(self):
+        handler = make_progress_handler("srv")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(5.0, 10.0, "halfway")
+        text = wl.call_args.args[1]
+        assert "5/10" in text and "50%" in text and "halfway" in text
+
+    async def test_no_total_does_not_divide_by_zero(self):
+        handler = make_progress_handler("srv")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(3.0, None, None)
+        assert "3" in wl.call_args.args[1]
+
+    async def test_zero_total_is_safe(self):
+        handler = make_progress_handler("srv")
+        with patch("code_puppy.mcp_.capabilities.write_log") as wl:
+            await handler(0.0, 0.0, None)
+        assert wl.call_count == 1


### PR DESCRIPTION
Code Puppy consumes MCP tools only. MCPToolset already supports these, so they are enabled by an optional per-server `capabilities` block in mcp_servers.json.

Logs and progress route into the existing per-server file that `/mcp logs` reads, so there is no new UI and nothing under command_line/. Progress answers "is this slow tool call hung?", which stdio servers give no signal for today.

Logging and progress default on since they only touch the log file; `instructions` is opt-in because it costs prompt tokens. Bad config keys fall back to defaults rather than failing startup.

Also adds safe accessors for handshake metadata, which otherwise raise AttributeError until the toolset is entered.