### PR TITLE
fix(gemini): remove unsupported propertyNames schemas

### DIFF
--- a/code_puppy/gemini_model.py
+++ b/code_puppy/gemini_model.py
@@ -107,7 +107,7 @@ def _sanitize_schema_for_gemini(schema: dict) -> dict:
 
     Removes/transforms fields that Gemini doesn't support:
     - $defs, definitions, $schema, $id
-    - additionalProperties
+    - additionalProperties, propertyNames
     - $ref (inlined)
     - anyOf/oneOf/allOf (flattened - Gemini doesn't support unions!)
       - For unions of objects: merges into single object with all properties
@@ -213,6 +213,7 @@ def _sanitize_schema_for_gemini(schema: dict) -> dict:
                     "$schema",
                     "$id",
                     "additionalProperties",
+                    "propertyNames",
                     "default",
                     "examples",
                     "const",

--- a/tests/test_gemini_model_full_coverage.py
+++ b/tests/test_gemini_model_full_coverage.py
@@ -88,6 +88,28 @@ class TestSanitizeSchema:
         assert "additionalProperties" not in result
         assert result["properties"]["x"]["type"] == "string"
 
+    def test_removes_property_names_recursively(self):
+        schema = {
+            "type": "object",
+            "propertyNames": {"type": "string"},
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "propertyNames": {"pattern": "^[a-z]+/[a-z]+$"},
+                    "additionalProperties": {"type": "string"},
+                }
+            },
+        }
+
+        result = _sanitize_schema_for_gemini(schema)
+
+        assert "propertyNames" not in result
+        assert "propertyNames" not in result["properties"]["data"]
+        assert result["properties"]["data"]["type"] == "object"
+        assert schema["properties"]["data"]["propertyNames"] == {
+            "pattern": "^[a-z]+/[a-z]+$"
+        }
+
     def test_resolves_ref(self):
         schema = {
             "$defs": {"Foo": {"type": "string", "description": "a foo"}},


### PR DESCRIPTION
## Summary
- remove the JSON Schema `propertyNames` keyword while building Gemini function declarations
- preserve the existing recursive sanitization behavior for nested object schemas
- add a regression test covering nested free-form map parameters, such as Playwright MCP tool data

Gemini rejects `propertyNames` in function-declaration parameters with HTTP 400 (`Unknown name "propertyNames"`).

## Testing
- `uv run pytest tests/test_gemini_model_full_coverage.py`
- `uv run pytest -q`
- `uv run ruff check .`
- `uv run ruff format --check .`