### PR TITLE
fix(mcp): preserve live connectors and bound shutdown waiting

### DIFF
--- a/code_puppy/mcp_/async_lifecycle.py
+++ b/code_puppy/mcp_/async_lifecycle.py
@@ -28,6 +28,10 @@ class ManagedServerContext:
     exit_stack: AsyncExitStack
     start_time: datetime
     task: asyncio.Task  # The task that manages this server's lifecycle
+    cleanup_failed: bool = False
+
+
+SERVER_STOP_TIMEOUT = 5.0
 
 
 class AsyncServerLifecycleManager:
@@ -62,18 +66,17 @@ class AsyncServerLifecycleManager:
         Returns:
             True if server started successfully, False otherwise
         """
+        # A stale lifecycle must drain without holding the registry lock.
+        existing = self._servers.get(server_id)
+        if existing is not None:
+            if self.is_running(server_id):
+                return True
+            if not await self.stop_server(server_id):
+                return False
+
         async with self._lock:
-            # Check if already running
             if server_id in self._servers:
-                if toolset_is_running(self._servers[server_id].server):
-                    logger.info(f"Server {server_id} is already running")
-                    return True
-                else:
-                    # Server exists but not running, clean it up
-                    logger.warning(
-                        f"Server {server_id} exists but not running, cleaning up"
-                    )
-                    await self._stop_server_internal(server_id)
+                return self.is_running(server_id)
 
             # Create an event so we know when the server is actually registered
             ready_event = asyncio.Event()
@@ -186,20 +189,15 @@ class AsyncServerLifecycleManager:
                 f"Server {server_id} lifecycle ending, _running_count={running_count}"
             )
 
-            # NOTE: aclose() can raise (cancel scope entered in a different task,
-            # BaseExceptionGroup); harmless at shutdown — swallow the asyncio noise.
+            cleanup_failed = False
             try:
                 await exit_stack.aclose()
-            except (RuntimeError, BaseExceptionGroup) as e:
-                logger.debug(
-                    f"Server {server_id} cleanup raised (suppressed): {e}",
-                    exc_info=True,
+            except (Exception, BaseExceptionGroup, asyncio.CancelledError):
+                cleanup_failed = True
+                logger.warning(
+                    "MCP cleanup failed for %s; retaining lifecycle", server_id
                 )
-            except Exception as e:
-                logger.debug(
-                    f"Server {server_id} cleanup raised (suppressed): {e}",
-                    exc_info=True,
-                )
+                logger.debug("MCP cleanup exception for %s", server_id, exc_info=True)
 
             running_count_after = getattr(leaf, "_running_count", "N/A")
             logger.info(
@@ -209,8 +207,12 @@ class AsyncServerLifecycleManager:
             # Remove from managed servers
             try:
                 async with self._lock:
-                    if server_id in self._servers:
-                        del self._servers[server_id]
+                    context = self._servers.get(server_id)
+                    if context is not None and context.task is asyncio.current_task():
+                        if cleanup_failed:
+                            context.cleanup_failed = True
+                        else:
+                            del self._servers[server_id]
             except Exception as e:
                 logger.debug(f"Error removing {server_id} from registry: {e}")
 
@@ -229,29 +231,30 @@ class AsyncServerLifecycleManager:
             True if server was stopped, False if not found
         """
         async with self._lock:
-            return await self._stop_server_internal(server_id)
+            context = self._servers.get(server_id)
+            if context is None:
+                return False
+            task = context.task
+            if not task.done() and not task.cancelling():
+                task.cancel()
 
-    async def _stop_server_internal(self, server_id: str) -> bool:
-        """
-        Internal method to stop a server (must be called with lock held).
-        """
-        if server_id not in self._servers:
-            logger.warning(f"Server {server_id} not found")
+        # wait() bounds the caller without cancelling the draining task again.
+        # Caller cancellation propagates; cleanup retains its original owner.
+        done, _ = await asyncio.wait({task}, timeout=SERVER_STOP_TIMEOUT)
+        if not done:
+            logger.warning("MCP cleanup deadline exceeded for %s", server_id)
             return False
-
-        context = self._servers[server_id]
-
-        # Cancel the lifecycle task
-        # This will cause the task to exit and clean up properly
-        context.task.cancel()
-
-        try:
-            await context.task
-        except asyncio.CancelledError:
-            pass  # Expected
-
-        logger.info(f"Stopped server {server_id}")
-        return True
+        if not task.cancelled():
+            try:
+                task.result()
+            except (Exception, BaseExceptionGroup):
+                logger.debug(
+                    "MCP lifecycle task failed for %s", server_id, exc_info=True
+                )
+                return False
+        return (
+            not context.cleanup_failed and self._servers.get(server_id) is not context
+        )
 
     def is_running(self, server_id: str) -> bool:
         """
@@ -264,7 +267,12 @@ class AsyncServerLifecycleManager:
             True if server is running, False otherwise
         """
         context = self._servers.get(server_id)
-        return toolset_is_running(context.server) if context else False
+        return bool(
+            context
+            and not context.task.done()
+            and not context.task.cancelling()
+            and toolset_is_running(context.server)
+        )
 
     def list_servers(self) -> Dict[str, Dict[str, Any]]:
         """
@@ -285,13 +293,11 @@ class AsyncServerLifecycleManager:
         return servers
 
     async def stop_all(self) -> None:
-        """Stop all running servers."""
-        server_ids = list(self._servers.keys())
-
-        for server_id in server_ids:
-            await self.stop_server(server_id)
-
-        logger.info("All MCP servers stopped")
+        """Drain registered lifecycles concurrently, including cancelled ones."""
+        server_ids = list(self._servers)
+        results = await asyncio.gather(*(self.stop_server(key) for key in server_ids))
+        if not all(results):
+            logger.warning("MCP shutdown incomplete; undrained lifecycles retained")
 
 
 # Global singleton instance

--- a/code_puppy/mcp_/manager.py
+++ b/code_puppy/mcp_/manager.py
@@ -30,6 +30,11 @@ logger = logging.getLogger(__name__)
 _WARNED_UNBOUND: set = set()
 
 
+async def _shutdown_mcp() -> None:
+    """Stable callback identity prevents duplicate hooks across managers."""
+    await get_lifecycle_manager().stop_all()
+
+
 def _warn_unbound_servers(server_names: List[str], agent_name: str) -> None:
     """Warn once, in a single consolidated block, about registered-but-unbound MCP servers.
 
@@ -145,6 +150,9 @@ class MCPManager:
         # Load existing servers from registry
         self._initialize_servers()
 
+        from code_puppy.callbacks import register_callback
+
+        register_callback("shutdown", _shutdown_mcp)
         logger.info("MCPManager initialized with core components")
 
     def sync_from_config(self) -> None:
@@ -236,6 +244,10 @@ class MCPManager:
 
         for config in configs:
             try:
+                # External installers refresh this existing manager after sync;
+                # this is not a second __init__. Reload owns config changes.
+                if config.id in self._managed_servers:
+                    continue
                 managed_server = ManagedMCPServer(config)
                 self._managed_servers[config.id] = managed_server
 

--- a/tests/mcp/test_shutdown_preservation.py
+++ b/tests/mcp/test_shutdown_preservation.py
@@ -1,0 +1,197 @@
+"""Narrow contracts: preserve objects, and drain registered contexts safely."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from pydantic_ai.toolsets import FunctionToolset
+
+from code_puppy import callbacks
+from code_puppy.mcp_ import async_lifecycle as lifecycle
+from code_puppy.mcp_.manager import MCPManager
+from code_puppy.mcp_.managed_server import ServerConfig, ServerState
+
+
+class Connector(FunctionToolset):
+    def __init__(self, release=None, failure=None):
+        super().__init__()
+        self.is_running = False
+        self.release, self.failure = release, failure
+        self.cleaning = asyncio.Event()
+        self.closed = 0
+
+    async def __aenter__(self):
+        self.is_running = True
+        return self
+
+    async def __aexit__(self, *args):
+        self.cleaning.set()
+        if self.release:
+            await self.release.wait()
+        if self.failure:
+            raise self.failure
+        self.is_running = False
+        self.closed += 1
+
+
+async def test_healthy_stop_does_not_wait_on_its_own_lock():
+    manager = lifecycle.AsyncServerLifecycleManager()
+    connector = Connector()
+    assert await manager.start_server("a", connector.prefixed("a"))
+    assert await asyncio.wait_for(manager.stop_server("a"), 0.5)
+    assert connector.closed == 1 and "a" not in manager._servers
+
+
+async def test_deadline_retains_owner_and_does_not_double_cancel(monkeypatch):
+    monkeypatch.setattr(lifecycle, "SERVER_STOP_TIMEOUT", 0.02)
+    release = asyncio.Event()
+    connector = Connector(release)
+    manager = lifecycle.AsyncServerLifecycleManager()
+    assert await manager.start_server("a", connector)
+    task = manager._servers["a"].task
+    try:
+        assert not await manager.stop_server("a")
+        assert not await manager.stop_server("a")
+        assert "a" in manager._servers
+        assert not task.done()
+        # A stale restart must not replace cleanup still in progress.
+        assert not await manager.start_server("a", Connector())
+    finally:
+        release.set()
+        await asyncio.gather(task, return_exceptions=True)
+    assert connector.closed == 1
+    assert "a" not in manager._servers
+
+
+async def test_cancelled_caller_preserves_original_cleanup():
+    release = asyncio.Event()
+    connector = Connector(release)
+    manager = lifecycle.AsyncServerLifecycleManager()
+    await manager.start_server("a", connector)
+    task = manager._servers["a"].task
+    stop = asyncio.create_task(manager.stop_server("a"))
+    await connector.cleaning.wait()
+    try:
+        stop.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await stop
+        assert not task.done()
+    finally:
+        release.set()
+        await asyncio.gather(task, return_exceptions=True)
+    assert connector.closed == 1
+
+
+@pytest.mark.parametrize("grouped", [False, True])
+async def test_failed_cleanup_returns_false_and_shutdown_reports_it(grouped, caplog):
+    caplog.set_level("DEBUG", logger="code_puppy.mcp_.async_lifecycle")
+    error = RuntimeError("cleanup failed")
+    if grouped:
+        error = BaseExceptionGroup("cleanup", [error, asyncio.CancelledError()])
+    manager = lifecycle.AsyncServerLifecycleManager()
+    await manager.start_server("a", Connector(failure=error))
+    assert not await manager.stop_server("a")
+    assert manager._servers["a"].cleanup_failed
+    assert not manager.is_running("a")
+    assert any(
+        record.exc_info and record.exc_info[1] is error for record in caplog.records
+    )
+    await manager.stop_all()
+    assert "shutdown incomplete" in caplog.text
+
+
+async def test_stop_all_drains_other_servers_while_one_is_stuck(monkeypatch):
+    monkeypatch.setattr(lifecycle, "SERVER_STOP_TIMEOUT", 0.02)
+    release = asyncio.Event()
+    manager = lifecycle.AsyncServerLifecycleManager()
+    slow, good = Connector(release), Connector()
+    await manager.start_server("slow", slow)
+    await manager.start_server("good", good)
+    task = manager._servers["slow"].task
+    try:
+        await asyncio.wait_for(manager.stop_all(), 0.5)
+        assert good.closed == 1
+        assert "slow" in manager._servers and "good" not in manager._servers
+    finally:
+        release.set()
+        await asyncio.gather(task, return_exceptions=True)
+
+
+def test_reinit_preserves_objects_and_status_while_adding_new_servers(monkeypatch):
+    configs = [
+        ServerConfig(id=x, name=x, type="stdio", config={}) for x in ("old", "new")
+    ]
+    registry = Mock()
+    registry.list_all.return_value = configs[:1]
+    monkeypatch.setattr("code_puppy.mcp_.manager.ServerRegistry", lambda: registry)
+    monkeypatch.setattr(MCPManager, "sync_from_config", lambda self: None)
+    monkeypatch.setattr(
+        "code_puppy.mcp_.manager.ManagedMCPServer", lambda c: SimpleNamespace(config=c)
+    )
+    manager = MCPManager()
+    old = manager._managed_servers["old"]
+    tracker = manager.status_tracker
+    tracker.set_status("old", ServerState.RUNNING)
+    # Refresh the existing manager after configuration discovery, not __init__.
+    registry.list_all.return_value = configs
+    manager.sync_from_config()
+    manager._initialize_servers()
+    assert manager._managed_servers["old"] is old
+    assert manager._managed_servers["new"].config is configs[1]
+    assert manager.status_tracker is tracker
+    assert tracker.get_status("old") == ServerState.RUNNING
+    assert tracker.get_status("new") == ServerState.STOPPED
+
+
+async def test_real_stdio_stop_closes_transport(tmp_path):
+    import sys
+    from fastmcp import Client
+    from fastmcp.client.transports import StdioTransport
+    from pydantic_ai.mcp import MCPToolset
+
+    script = tmp_path / "connector.py"
+    script.write_text(
+        "import json,sys\n"
+        "for line in sys.stdin:\n"
+        " r=json.loads(line)\n"
+        " if 'id' not in r: continue\n"
+        " result={'protocolVersion':r.get('params',{}).get('protocolVersion','2025-03-26'),'capabilities':{},'serverInfo':{'name':'local','version':'1'}} if r['method']=='initialize' else {}\n"
+        " print(json.dumps({'jsonrpc':'2.0','id':r['id'],'result':result}),flush=True)\n"
+    )
+    client = Client(
+        StdioTransport(
+            sys.executable,
+            [str(script)],
+            keep_alive=False,
+            env={"HOME": str(tmp_path)},
+            log_file=tmp_path / "stderr.log",
+        ),
+        timeout=3,
+    )
+    leaf = MCPToolset(client, id="local")
+    manager = lifecycle.AsyncServerLifecycleManager()
+    try:
+        assert await asyncio.wait_for(
+            manager.start_server("a", leaf.prefixed("local")), 5
+        )
+        assert client.is_connected()
+        assert await asyncio.wait_for(manager.stop_server("a"), 5)
+        assert not client.is_connected() and leaf._running_count == 0
+        assert "a" not in manager._servers
+    finally:
+        await manager.stop_all()
+        if client.is_connected():
+            await client.close()
+
+
+def test_one_shutdown_hook_for_multiple_managers():
+    from code_puppy.mcp_.manager import _shutdown_mcp
+
+    with (
+        patch.object(MCPManager, "sync_from_config"),
+        patch.object(MCPManager, "_initialize_servers"),
+    ):
+        MCPManager()
+        MCPManager()
+    assert callbacks._callbacks["shutdown"].count(_shutdown_mcp) == 1


### PR DESCRIPTION
Refreshing MCP configuration can replace live connector objects, and stopping a healthy connector can deadlock while cleanup waits for the same registry lock. Preserve existing connectors during refresh and drain registered lifecycle tasks outside that lock, so shutdown has a bounded wait instead of hanging indefinitely.

## Problem

- `_initialize_servers()` rebuilds already-materialized connectors and resets their status even when only a new configuration needs materializing.
- `stop_server()` holds the registry lock while awaiting a lifecycle task whose cleanup needs that lock to unregister itself.
- Sequential shutdown lets one stuck cleanup delay every other connector.

## Change

- Materialize only previously unseen server IDs; preserve existing object identity and status.
- Cancel a registered lifecycle task under the lock, then wait outside it for up to **five seconds**.
- Do not cancel the cleanup task again on timeout, repeated stop, or cancellation of the caller.
- Retain registration and report unsuccessful cleanup, including grouped cancellation failures, rather than discarding ownership.
- Drain registered contexts concurrently and register one stable, deduplicated shutdown callback.
- Preserve DEBUG exception diagnostics while using generic cleanup warning text.

This is one bounded preservation/shutdown correction in two runtime files. It changes no CLI commands, dependencies, package version, or sync API signatures. The open MCP capability refactor (#834) touches manager documentation, not these lifecycle decisions.

## Validation

Base `ce1fe372` (v0.0.827), Linux / Python 3.13.13, current upstream lock installed in a dedicated environment: core plugins 0.0.44, Pydantic AI 2.35.0, MCP 1.27.1 and `fastmcp-slim` 3.4.7 (which supplies the `fastmcp` client import). The patch adds or changes no dependencies relative to that base. The patch was applied independently to current upstream and requalified; it carries no other pending fixes or integration history.

- Two behavioral tests on unpatched upstream both fail: healthy stop reaches the cancellation deadline, then old code swallows cancellation and reports success with stale registration; refresh also replaces the existing connector.
- `python -m pytest -q -o addopts= tests/mcp/test_shutdown_preservation.py`: **9 passed**.
- Coverage includes healthy and stuck cleanup, caller cancellation, grouped failures, concurrent draining, preserved object/status, hook deduplication and a real local MCP stdio transport closing cleanly.
- `python -m pytest -q -o addopts= tests/mcp tests/agents tests/tools tests/command_line/mcp tests/test_completions_and_small_modules.py tests/test_claude_refresh_review.py`: **1886 passed, 7 skipped, 3 warnings**, including the newer upstream completion and OAuth regression tests.
- A separate local combination with optional connector-entry containment passed **1905 tests, 7 skips, 3 warnings**. That containment code is not included or required by this PR. Its test helper was imported from the custody suite without collecting unrelated custody tests.
- Changed-file Ruff lint/format and diff checks pass.

Tests ran with disposable HOME/XDG, no inherited credentials, and blocked socket connect/DNS/bind. The local stdio child uses only the Python standard library; it is not a remote connector or a managed service. Six skips cover unimplemented MCP search; one requires a case-insensitive filesystem. All three coroutine warnings reproduce on the unpatched base, and none was suppressed.

## Boundaries

This deliberately does **not** fix restart/reload/remove ordering, pending startup ownership, late startup registration, manager/CLI completion reporting, or completion-time agent rebinding. Those require separate changes. The deadline bounds how long callers wait; it does not force-terminate a process or prove failed cleanup eventually succeeds. Concurrent stop-all snapshots registered contexts rather than closing a global startup gate. Operations must remain on the owning event loop.

Connector-entry containment is also separate: this patch does not swallow startup failures or replay tool calls. Preserving existing objects during refresh is not an implicit hot-reload of their configuration.

The earlier base's tilde-completion assertion was corrected upstream in `612de2b1`; its tests pass in the updated candidate. No release-readiness claim is made here.
