### PR TITLE
fix(session): preserve agent identity across headless resume

### DIFF
--- a/code_puppy/agents/_compaction.py
+++ b/code_puppy/agents/_compaction.py
@@ -388,6 +388,9 @@ def make_history_processor(agent: Any) -> Callable[..., Any]:
         # Claude. Cheap no-op when all IDs already conform.
         cleaned = sanitize_tool_call_ids(cleaned)
 
+        from code_puppy.agents._session_state import stamp_session_state
+
+        cleaned = stamp_session_state(agent, cleaned)
         agent._message_history = cleaned
 
         on_message_history_processor_end(

--- a/code_puppy/agents/_compaction.py
+++ b/code_puppy/agents/_compaction.py
@@ -150,7 +150,11 @@ def run_compaction_sync(strategy: Any, messages: List[ModelMessage], *, model: M
     from concurrent.futures import ThreadPoolExecutor
 
     def _run():
-        return asyncio.run(compact_now(strategy, list(messages), model=model))
+        from code_puppy.agents._session_state import read_session_state, stamp_state
+
+        state = read_session_state(messages)
+        result = asyncio.run(compact_now(strategy, list(messages), model=model))
+        return stamp_state(state, result) if state is not None else result
 
     try:
         asyncio.get_running_loop()

--- a/code_puppy/agents/_session_state.py
+++ b/code_puppy/agents/_session_state.py
@@ -36,7 +36,10 @@ def stamp_session_state(agent: Any, messages: list[Any]) -> list[Any]:
     export = getattr(agent, "get_session_state", None)
     if not callable(export):
         return messages
-    state = export()
+    return stamp_state(export(), messages)
+
+
+def stamp_state(state: dict[str, Any], messages: list[Any]) -> list[Any]:
     for index in range(len(messages) - 1, -1, -1):
         message = messages[index]
         if isinstance(message, ModelRequest):

--- a/code_puppy/agents/_session_state.py
+++ b/code_puppy/agents/_session_state.py
@@ -1,0 +1,48 @@
+"""Conversation state carried by real message metadata, never parsed from prose."""
+
+import re
+from dataclasses import replace
+from typing import Any
+
+from pydantic_ai.messages import ModelRequest
+
+SESSION_KEY = "code_puppy_session_v1"
+_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}\Z")
+
+
+def validate_agent_id(value: str) -> str:
+    if not isinstance(value, str) or not _ID.fullmatch(value):
+        raise ValueError(
+            "agent_id must be 1-128 letters, digits, dots, colons, underscores or hyphens"
+        )
+    return value
+
+
+def read_session_state(history: list[Any]) -> dict[str, Any] | None:
+    for message in reversed(history):
+        if isinstance(message, ModelRequest) and SESSION_KEY in (
+            message.metadata or {}
+        ):
+            state = message.metadata[SESSION_KEY]
+            if not isinstance(state, dict):
+                raise ValueError("Invalid conversation metadata")
+            validate_agent_id(state.get("agent_id"))
+            return dict(state)
+    return None
+
+
+def stamp_session_state(agent: Any, messages: list[Any]) -> list[Any]:
+    """Checkpoint state on the newest request after compaction; preserve other metadata."""
+    export = getattr(agent, "get_session_state", None)
+    if not callable(export):
+        return messages
+    state = export()
+    for index in range(len(messages) - 1, -1, -1):
+        message = messages[index]
+        if isinstance(message, ModelRequest):
+            result = list(messages)
+            result[index] = replace(
+                message, metadata={**(message.metadata or {}), SESSION_KEY: state}
+            )
+            return result
+    return messages

--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -64,8 +64,13 @@ def _extract_pydantic_agent_tools(pyd_agent: Any) -> Optional[Dict[str, Any]]:
 class BaseAgent(ABC):
     """Abstract base for all Code Puppy agents."""
 
-    def __init__(self) -> None:
-        self.id: str = str(uuid.uuid4())
+    def __init__(self, *, agent_id: Optional[str] = None) -> None:
+        from code_puppy.agents._session_state import validate_agent_id
+
+        self.id: str = (
+            validate_agent_id(agent_id) if agent_id is not None else str(uuid.uuid4())
+        )
+        self._explicit_agent_id = agent_id
         self._message_history: List[Any] = []
         self._compacted_message_hashes: Set[str] = set()
         self._code_generation_agent: Any = None
@@ -219,8 +224,43 @@ class BaseAgent(ABC):
     def get_message_history(self) -> List[Any]:
         return self._message_history
 
-    def set_message_history(self, history: List[Any]) -> None:
+    def initialize_session(self, *, agent_id: str) -> None:
+        """Set runner-owned identity before the first turn; conflicting resumes fail."""
+        from code_puppy.agents._session_state import validate_agent_id
+
+        agent_id = validate_agent_id(agent_id)
+        if self._message_history and agent_id != self.id:
+            raise ValueError("Cannot change agent_id during a conversation")
+        self.id = agent_id
+        self._explicit_agent_id = agent_id
+        self._code_generation_agent = None
+
+    def get_session_state(self) -> Dict[str, Any]:
+        return {"agent_id": self.id}
+
+    def set_message_history(
+        self, history: List[Any], *, agent_id: Optional[str] = None
+    ) -> None:
+        """Restore identity through the common resume door, including raw history runners."""
+        from code_puppy.agents._session_state import (
+            read_session_state,
+            validate_agent_id,
+        )
+
+        state = read_session_state(history)
+        saved_id = state["agent_id"] if state else None
+        requested_id = (
+            validate_agent_id(agent_id)
+            if agent_id is not None
+            else self._explicit_agent_id
+        )
+        if saved_id and requested_id and saved_id != requested_id:
+            raise ValueError("Requested agent_id conflicts with saved conversation")
+        restored_id = saved_id or requested_id
+        if restored_id is not None:
+            self.id = restored_id
         self._message_history = history
+        self._code_generation_agent = None
 
     def clear_message_history(self) -> None:
         self._message_history = []

--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -248,6 +248,12 @@ class BaseAgent(ABC):
         )
 
         state = read_session_state(history)
+        if (
+            agent_id is not None
+            and self._explicit_agent_id is not None
+            and agent_id != self._explicit_agent_id
+        ):
+            raise ValueError("Requested agent_id conflicts with initialized identity")
         saved_id = state["agent_id"] if state else None
         requested_id = (
             validate_agent_id(agent_id)

--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -229,11 +229,14 @@ class BaseAgent(ABC):
         from code_puppy.agents._session_state import validate_agent_id
 
         agent_id = validate_agent_id(agent_id)
-        if self._message_history and agent_id != self.id:
+        if (
+            self._message_history or self._explicit_agent_id is not None
+        ) and agent_id != self.id:
             raise ValueError("Cannot change agent_id during a conversation")
+        if agent_id != self.id:
+            self._code_generation_agent = None
         self.id = agent_id
         self._explicit_agent_id = agent_id
-        self._code_generation_agent = None
 
     def get_session_state(self) -> Dict[str, Any]:
         return {"agent_id": self.id}
@@ -263,10 +266,10 @@ class BaseAgent(ABC):
         if saved_id and requested_id and saved_id != requested_id:
             raise ValueError("Requested agent_id conflicts with saved conversation")
         restored_id = saved_id or requested_id
-        if restored_id is not None:
+        if restored_id is not None and restored_id != self.id:
             self.id = restored_id
+            self._code_generation_agent = None
         self._message_history = history
-        self._code_generation_agent = None
 
     def clear_message_history(self) -> None:
         self._message_history = []

--- a/code_puppy/command_line/session_commands.py
+++ b/code_puppy/command_line/session_commands.py
@@ -360,6 +360,8 @@ def handle_quick_resume_command(command: str) -> bool:
 
     try:
         history = load_session(session_name, session_path.parent)
+        agent = get_current_agent()
+        agent.set_message_history(history)
     except FileNotFoundError:
         logger.warning("Quick-resume session file not found: %s", session_path)
         emit_error(t("cmd.quick_resume.file_not_found"))
@@ -369,8 +371,6 @@ def handle_quick_resume_command(command: str) -> bool:
         emit_error(t("cmd.quick_resume.failed"))
         return True
 
-    agent = get_current_agent()
-    agent.set_message_history(history)
     set_current_autosave_from_session_name(session_name)
     total_tokens = sum(agent.estimate_tokens_for_message(m) for m in history)
 
@@ -466,6 +466,8 @@ def handle_load_context_command(command: str) -> bool:
 
     try:
         history = load_session(session_name, sessions_dir)
+        agent = get_current_agent()
+        agent.set_message_history(history)
     except FileNotFoundError:
         emit_error(t("cmd.load_context.not_found", path=session_path))
         scope_key = compute_scope_key(Path.cwd()) if cwd_flag else None
@@ -477,8 +479,6 @@ def handle_load_context_command(command: str) -> bool:
         emit_error(t("cmd.load_context.failed", error=exc))
         return True
 
-    agent = get_current_agent()
-    agent.set_message_history(history)
     total_tokens = sum(agent.estimate_tokens_for_message(m) for m in history)
 
     # Rotate the singleton to a fresh ``auto_session_<TS>`` so autosaves don't

--- a/tests/agents/test_session_identity_processes.py
+++ b/tests/agents/test_session_identity_processes.py
@@ -1,0 +1,121 @@
+"""Resume real message history in fresh processes without caller identity repair."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+CHILD = r"""
+import asyncio
+import json
+import pickle
+import sys
+from pathlib import Path
+
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import ProcessHistory
+from pydantic_ai.messages import ModelResponse, TextPart
+from pydantic_ai.models.function import FunctionModel
+
+from code_puppy.agents._compaction import make_history_processor
+from code_puppy.agents.base_agent import BaseAgent
+from code_puppy.callbacks import clear_callbacks
+from code_puppy.session_storage import load_session, save_session
+
+
+def deny_network(event, args):
+    if event in {"socket.connect", "socket.getaddrinfo", "socket.bind"}:
+        raise RuntimeError("Session fixture forbids network")
+
+
+sys.addaudithook(deny_network)
+clear_callbacks()
+
+
+class Owner(BaseAgent):
+    name = "session-test"
+    display_name = "Session test"
+    description = "Local model fixture"
+
+    def get_system_prompt(self):
+        return "Test instructions"
+
+    def get_available_tools(self):
+        return []
+
+    def _get_model_context_length(self):
+        return 1_000_000
+
+    def _estimate_context_overhead(self):
+        return 0
+
+
+async def main():
+    directory, encoding, turn = Path(sys.argv[1]), sys.argv[2], int(sys.argv[3])
+    owner = Owner()
+    path = directory / "history.pkl"
+    if turn:
+        history = (
+            pickle.loads(path.read_bytes())
+            if encoding == "pickle"
+            else load_session("saved", directory)
+        )
+        owner.set_message_history(history)
+    agent = Agent(
+        FunctionModel(lambda messages, info: ModelResponse(parts=[TextPart("done")])),
+        capabilities=[ProcessHistory(make_history_processor(owner))],
+    )
+    result = await agent.run("next", message_history=owner.get_message_history())
+    owner.set_message_history(result.all_messages())
+    if encoding == "pickle":
+        path.write_bytes(pickle.dumps(owner.get_message_history()))
+    else:
+        save_session(
+            session_name="saved", history=owner.get_message_history(),
+            base_dir=directory, timestamp="2026-01-01T00:00:00",
+            token_estimator=lambda message: 1,
+        )
+    print(json.dumps({"id": owner.id, "messages": len(owner.get_message_history())}))
+
+
+asyncio.run(main())
+"""
+
+
+@pytest.mark.parametrize("encoding", ["pickle", "named"])
+def test_fresh_process_resume_keeps_identity_without_caller_repair(tmp_path, encoding):
+    source = Path(__file__).resolve().parents[2]
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "PYTHONPATH": str(source),
+        "HOME": str(tmp_path),
+        "NO_COLOR": "1",
+        "CODE_PUPPY_NO_TUI": "1",
+        **{
+            key: str(tmp_path / key)
+            for key in (
+                "XDG_CONFIG_HOME",
+                "XDG_DATA_HOME",
+                "XDG_CACHE_HOME",
+                "XDG_STATE_HOME",
+            )
+        },
+    }
+    outputs = []
+    for turn in range(3):
+        result = subprocess.run(
+            [sys.executable, "-c", CHILD, str(tmp_path), encoding, str(turn)],
+            cwd=source,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=30,
+            check=True,
+        )
+        assert not result.stderr
+        outputs.append(json.loads(result.stdout.splitlines()[-1]))
+    assert [item["messages"] for item in outputs] == [2, 4, 6]
+    assert len({item["id"] for item in outputs}) == 1

--- a/tests/agents/test_session_state_identity.py
+++ b/tests/agents/test_session_state_identity.py
@@ -117,6 +117,48 @@ def test_initialized_identity_cannot_be_overridden_by_restore_argument():
     assert owner.get_message_history() == []
 
 
+@pytest.mark.parametrize("constructor", [False, True])
+def test_repeated_initialization_is_atomic_and_idempotent(constructor):
+    owner = SessionAgent(agent_id="initialized") if constructor else SessionAgent()
+    owner.initialize_session(agent_id="initialized")
+    cached = owner._code_generation_agent = object()
+    with pytest.raises(ValueError, match="Cannot change"):
+        owner.initialize_session(agent_id="different")
+    owner.initialize_session(agent_id="initialized")
+    assert owner.id == owner._explicit_agent_id == "initialized"
+    assert owner.get_message_history() == []
+    assert owner._code_generation_agent is cached
+
+
+@pytest.mark.parametrize("source", ["legacy", "saved", "argument"])
+def test_history_checkpoint_keeps_cache_when_identity_is_unchanged(source):
+    owner = SessionAgent()
+    cached = owner._code_generation_agent = object()
+    metadata = {SESSION_KEY: {"agent_id": owner.id}} if source == "saved" else None
+    history = [ModelRequest(parts=[UserPromptPart("hello")], metadata=metadata)]
+    kwargs = {"agent_id": owner.id} if source == "argument" else {}
+    owner.set_message_history(history, **kwargs)
+    assert owner.get_message_history() is history
+    assert owner._code_generation_agent is cached
+
+
+@pytest.mark.parametrize("source", ["saved", "argument", "initialize"])
+def test_changed_identity_invalidates_cache(source):
+    owner = SessionAgent()
+    owner._code_generation_agent = object()
+    if source == "initialize":
+        owner.initialize_session(agent_id="restored")
+    else:
+        metadata = (
+            {SESSION_KEY: {"agent_id": "restored"}} if source == "saved" else None
+        )
+        history = [ModelRequest(parts=[UserPromptPart("hello")], metadata=metadata)]
+        kwargs = {"agent_id": "restored"} if source == "argument" else {}
+        owner.set_message_history(history, **kwargs)
+    assert owner.id == "restored"
+    assert owner._code_generation_agent is None
+
+
 async def test_manual_compaction_preserves_identity(monkeypatch):
     from code_puppy.agents import _compaction
     from pydantic_ai.models.test import TestModel

--- a/tests/agents/test_session_state_identity.py
+++ b/tests/agents/test_session_state_identity.py
@@ -1,0 +1,123 @@
+"""Identity round trips through the same message list consumed by headless runners."""
+
+import pickle
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import ProcessHistory
+from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
+from pydantic_ai.models.function import FunctionModel
+
+from code_puppy.agents._compaction import make_history_processor
+from code_puppy.agents._session_state import SESSION_KEY
+from code_puppy.agents.base_agent import BaseAgent
+from code_puppy.session_storage import load_session, save_session
+
+
+class SessionAgent(BaseAgent):
+    name = "test-agent"
+    display_name = "Test Agent"
+    description = "Synthetic session agent"
+
+    def get_system_prompt(self):
+        return "SYSTEM"
+
+    def get_available_tools(self):
+        return []
+
+    def _get_model_context_length(self):
+        return 1_000_000
+
+    def _estimate_context_overhead(self):
+        return 0
+
+
+async def run_turn(owner, prompt="hello"):
+    agent = Agent(
+        FunctionModel(lambda messages, info: ModelResponse(parts=[TextPart("done")])),
+        instructions=owner.get_full_system_prompt(),
+        capabilities=[ProcessHistory(make_history_processor(owner))],
+    )
+    result = await agent.run(prompt, message_history=owner.get_message_history())
+    owner.set_message_history(result.all_messages())
+    return result.all_messages()
+
+
+@pytest.mark.parametrize("encoding", ["pickle", "named"])
+async def test_runner_initialized_identity_survives_turns(tmp_path, encoding):
+    owner = SessionAgent()
+    owner.initialize_session(agent_id="runner-owned-identity")
+    initial_prompt = owner.get_identity_prompt()
+    for _ in range(3):
+        history = await run_turn(owner)
+        if encoding == "pickle":
+            history = pickle.loads(pickle.dumps(history))
+        else:
+            save_session(
+                session_name="session",
+                history=history,
+                base_dir=tmp_path,
+                timestamp="2026-01-01T00:00:00",
+                token_estimator=lambda m: 1,
+            )
+            history = load_session("session", tmp_path)
+        owner = SessionAgent()
+        owner.set_message_history(history)
+        assert owner.id == "runner-owned-identity"
+        assert owner.get_identity_prompt() == initial_prompt
+
+
+async def test_explicit_matching_id_allowed_but_conflict_is_atomic():
+    owner = SessionAgent(agent_id="original")
+    history = await run_turn(owner)
+    resumed = SessionAgent(agent_id="other")
+    with pytest.raises(ValueError, match="conflicts"):
+        resumed.set_message_history(history)
+    assert resumed.id == "other" and resumed.get_message_history() == []
+    resumed = SessionAgent(agent_id="original")
+    resumed.set_message_history(history)
+    with pytest.raises(ValueError, match="Cannot change"):
+        resumed.initialize_session(agent_id="other")
+
+
+@pytest.mark.parametrize("bad", ["", "new\nrule", "`inject`", "x" * 129, 123])
+def test_invalid_identity_rejected(bad):
+    with pytest.raises(ValueError):
+        SessionAgent(agent_id=bad)
+
+
+async def test_real_quick_resume_restores_identity(tmp_path, monkeypatch):
+    from code_puppy.command_line import session_commands
+    from code_puppy.agents import agent_manager
+
+    owner = SessionAgent(agent_id="from-runner")
+    history = await run_turn(owner)
+    save_session(
+        session_name="saved",
+        history=history,
+        base_dir=tmp_path,
+        timestamp="2026-01-01T00:00:00",
+        token_estimator=lambda m: 1,
+    )
+    resumed = SessionAgent()
+    monkeypatch.setattr(
+        "code_puppy.config.resolve_quick_resume_pickle",
+        lambda *a: tmp_path / "saved.json",
+    )
+    monkeypatch.setattr(agent_manager, "get_current_agent", lambda: resumed)
+    session_commands.handle_quick_resume_command("/quick-resume saved")
+    assert resumed.id == owner.id
+
+
+async def test_existing_metadata_and_legacy_history():
+    owner = SessionAgent(agent_id="explicit")
+    owner.set_message_history(
+        [ModelRequest(parts=[UserPromptPart("old")], metadata={"external": 1})]
+    )
+    history = await run_turn(owner)
+    assert history[0].metadata == {"external": 1}
+    requests = [m for m in history if isinstance(m, ModelRequest)]
+    assert requests[-1].metadata[SESSION_KEY]["agent_id"] == "explicit"
+    resumed = SessionAgent()
+    resumed.set_message_history(history)
+    assert resumed.id == "explicit"

--- a/tests/agents/test_session_state_identity.py
+++ b/tests/agents/test_session_state_identity.py
@@ -109,6 +109,31 @@ async def test_real_quick_resume_restores_identity(tmp_path, monkeypatch):
     assert resumed.id == owner.id
 
 
+def test_initialized_identity_cannot_be_overridden_by_restore_argument():
+    owner = SessionAgent(agent_id="initialized")
+    with pytest.raises(ValueError, match="initialized identity"):
+        owner.set_message_history([], agent_id="different")
+    assert owner.id == "initialized"
+    assert owner.get_message_history() == []
+
+
+async def test_manual_compaction_preserves_identity(monkeypatch):
+    from code_puppy.agents import _compaction
+    from pydantic_ai.models.test import TestModel
+
+    owner = SessionAgent(agent_id="saved-id")
+    history = await run_turn(owner)
+
+    async def replacement(*args, **kwargs):
+        return [ModelRequest(parts=[UserPromptPart("summary")])]
+
+    monkeypatch.setattr(_compaction, "compact_now", replacement)
+    compacted = _compaction.run_compaction_sync(object(), history, model=TestModel())
+    resumed = SessionAgent()
+    resumed.set_message_history(compacted)
+    assert resumed.id == "saved-id"
+
+
 async def test_existing_metadata_and_legacy_history():
     owner = SessionAgent(agent_id="explicit")
     owner.set_message_history(

--- a/tests/command_line/test_session_identity_loading.py
+++ b/tests/command_line/test_session_identity_loading.py
@@ -1,0 +1,131 @@
+"""Invalid persisted identity must fail without replacing the active session."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic_ai.messages import ModelRequest, UserPromptPart
+
+from code_puppy.agents._session_state import SESSION_KEY
+from code_puppy.command_line import session_commands
+from code_puppy.i18n import t
+from code_puppy.session_storage import save_session
+from tests.agents.test_session_state_identity import SessionAgent
+from tests.test_cli_runner_full_coverage import (
+    _interactive_patches,
+    _mock_parse_result,
+    _mock_renderer,
+    _run_interactive,
+    _scripted_input,
+)
+
+
+@pytest.fixture(
+    params=["not-a-dict", {}, {"agent_id": "invalid\nidentity"}, {"agent_id": "other"}]
+)
+def saved_session(request, tmp_path):
+    history = [
+        ModelRequest(
+            parts=[UserPromptPart("saved")], metadata={SESSION_KEY: request.param}
+        )
+    ]
+    save_session(
+        session_name="saved",
+        history=history,
+        base_dir=tmp_path,
+        timestamp="2026-01-01T00:00:00",
+        token_estimator=lambda message: 1,
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def active_session():
+    agent = SessionAgent(agent_id="active")
+    history = [ModelRequest(parts=[UserPromptPart("active conversation")])]
+    agent.set_message_history(history)
+    cached = agent._code_generation_agent = object()
+    return agent, history, cached
+
+
+def assert_unchanged(active_session):
+    agent, history, cached = active_session
+    assert agent.id == "active"
+    assert agent.get_message_history() is history
+    assert agent._code_generation_agent is cached
+
+
+@pytest.mark.parametrize("command", ["quick_resume", "load_context"])
+def test_load_commands_reject_invalid_identity(saved_session, active_session, command):
+    agent, _, _ = active_session
+    with (
+        patch.object(session_commands, "AUTOSAVE_DIR", str(saved_session)),
+        patch("code_puppy.agents.agent_manager.get_current_agent", return_value=agent),
+        patch(
+            "code_puppy.config.resolve_quick_resume_pickle",
+            return_value=saved_session / "saved.json",
+        ),
+        patch(
+            "code_puppy.config.get_quick_resume_location",
+            return_value=(str(saved_session), "test"),
+        ),
+        patch("code_puppy.config.set_current_autosave_from_session_name") as pin,
+        patch("code_puppy.config.rotate_session_name") as rotate,
+        patch("code_puppy.messaging.emit_error") as error,
+        patch("code_puppy.messaging.emit_success") as success,
+        patch("code_puppy.messaging.emit_info"),
+    ):
+        handler = getattr(session_commands, f"handle_{command}_command")
+        assert handler(f"/{command.replace('_', '-')} saved") is True
+    error.assert_called_once()
+    success.assert_not_called()
+    pin.assert_not_called()
+    rotate.assert_not_called()
+    assert_unchanged(active_session)
+
+
+async def test_autosave_picker_rejects_invalid_identity_and_continues(
+    saved_session, active_session, monkeypatch
+):
+    agent, _, _ = active_session
+    error = MagicMock()
+    pin = MagicMock()
+    preview = MagicMock()
+    parse = MagicMock(return_value=_mock_parse_result("/autosave_load"))
+    stdin, stdout = MagicMock(), MagicMock()
+    stdin.isatty.return_value = stdout.isatty.return_value = True
+    monkeypatch.setenv("CODE_PUPPY_NO_TUI", "")
+    monkeypatch.setenv("CODE_PUPPY_CLASSIC_PROMPT", "1")
+    patches = _interactive_patches()
+    patches["code_puppy.cli_runner.COMMAND_HISTORY_FILE"] = str(
+        saved_session / "history"
+    )
+    # A second command proves the loop survives the failed restore, then EOF quits.
+    await _run_interactive(
+        _mock_renderer(),
+        patches,
+        _scripted_input("/autosave_load", "/help"),
+        agent=agent,
+        extra_patches={
+            "code_puppy.cli_runner.AUTOSAVE_DIR": str(saved_session),
+            "code_puppy.command_line.command_handler.handle_command": MagicMock(
+                side_effect=["__AUTOSAVE_LOAD__", True]
+            ),
+            "code_puppy.cli_runner.parse_prompt_attachments": parse,
+            "sys.stdin": stdin,
+            "sys.stdout": stdout,
+            "code_puppy.command_line.autosave_menu.interactive_autosave_picker": AsyncMock(
+                return_value="saved"
+            ),
+            "code_puppy.config.pin_current_session_name": pin,
+            "code_puppy.command_line.autosave_menu.display_resumed_history": preview,
+            "code_puppy.messaging.emit_error": error,
+        },
+    )
+    assert parse.call_count == 2
+    error.assert_called_once()
+    assert str(error.call_args.args[0]).startswith(
+        t("cli.autosave.load_failed", error="")
+    )
+    pin.assert_not_called()
+    preview.assert_not_called()
+    assert_unchanged(active_session)


### PR DESCRIPTION
Resuming a conversation in a fresh process currently gives the agent a new identity, even when its message history is restored. Persist identity with that history so headless runners and CLI resume continue the same agent, and reject conflicting explicit identities instead of silently switching ownership.

## Related upstream work

- Replaces the **identity portion of #907**, which was closed without merging. This uses structured message metadata and the common `set_message_history` resume path—not identity recovery from rendered prompt text or a single frontend.
- #832 (assembled instruction delivery) and #839 (first-turn prompt preparation) overlap the **prefix companion's** preparation/delivery paths. Neither is required for this identity-only patch, and their capability refactors are not bundled here.
- The structural prompt-prefix companion **#926** builds on this identity foundation and is a dependent draft. Identity alone does not freeze the system prompt or guarantee cache-prefix stability.
- #747 propagates session IDs into hooks. That is an adjacent contract: this patch preserves `BaseAgent.id` across persisted histories; it does not equate that ID with every hook run/session ID or implement hook propagation.
- #823 concerns migration/retention of legacy pickle files. This patch leaves migration and file-retention policy unchanged and works through the existing history loaders.

## Change

- Add validated, optional runner-owned identity initialization before the conversation starts.
- Carry versioned identity state on real `ModelRequest.metadata`, preserving unrelated metadata.
- Restore centrally through `set_message_history`; a saved ID wins over a randomly generated process default, while a conflicting explicitly initialized ID fails before replacing active history.
- Preserve identity through automatic history processing and manual compaction.
- Keep the cached model agent when identity is unchanged; invalidate it when identity changes.
- Enclose restoration in the existing `/quick-resume` and `/load_context` error boundaries. The existing interactive picker error boundary is exercised too.

The small `command_line/session_commands.py` change corrects existing load-error handling rather than adding a command. Given the plugin-first guidance, please flag a preferred supported seam before landing if this should be routed differently; the common history restore remains the authoritative identity boundary.

## Validation

Base `ce1fe372` (0.0.827), Linux / Python 3.13.13, unchanged upstream dependency lock in a dedicated environment. Tests use disposable HOME/XDG and no inherited credentials; socket connect/DNS/bind is blocked, including in subprocess fixtures.

- Two new behavioral controls run unchanged on unpatched upstream and **both fail**: named-session and raw-pickle resumes produce three different IDs across three fresh processes. Candidate **2/2 pass**, with message counts increasing 2 → 4 → 6 and no caller-side identity repair.
- Existing identity/loading regression selection: **32 passed**, covering explicit conflicts, invalid IDs, cache preservation/invalidation, manual compaction, real quick-resume and picker failure containment.
- Broad agents/commands/CLI/headless/subagent selection: **1600 passed, 1 failed, 4 warnings**. The sole failure is the unchanged `test_open_project_and_select_session` assertion requiring `TODAY`: the fixture subtracts one/two hours from the wall clock, so immediately after midnight both entries are correctly labeled yesterday. The exact failure reproduces on unpatched upstream. No tests were skipped or rewritten to hide it.
- Changed-file Ruff lint, formatting and diff checks pass.

Two stream-callback coroutine warnings and the CLI test's unawaited `main` coroutine reproduce on base. Quick-resume still invokes the existing deprecated autosave setter; this patch does not suppress its warning. This is scoped evidence, not a green full-suite or live-provider claim.

## Compatibility and boundaries

Existing metadata-free histories keep the current/default identity on first restore; after the next checkpoint, the identity is persisted. This deliberately does not infer an old identity from prose. It does not change session file names, formats, migration policy, retry custody, hooks, MCP behavior, dependencies or package versions. New metadata travels with the existing message-history serialization. No prompt-caching or measured cost-saving claim is made by the identity patch alone.
