### PR TITLE
fix(session): preserve identity and stable instructions across headless resume

### DIFF
--- a/code_puppy/agents/_builder.py
+++ b/code_puppy/agents/_builder.py
@@ -585,10 +585,15 @@ def _assemble_instructions(agent: Any, resolved_model_name: str) -> PreparedProm
     standing ``system_prompt`` a plugin wants emitted as its own
     ``SystemPromptPart`` ahead of them.
     """
-    from code_puppy.model_utils import prepare_prompt_for_model
+    from code_puppy.agents._session_prompt import prepare_session_prompt
+    from code_puppy.agents.base_agent import BaseAgent
 
-    instructions = agent.get_full_system_prompt()
-    puppy_rules = load_puppy_rules()
+    if isinstance(agent, BaseAgent):
+        instructions = agent.get_session_prompt_body() + agent.get_identity_prompt()
+        puppy_rules = agent.get_session_rules()
+    else:
+        instructions = agent.get_full_system_prompt()
+        puppy_rules = load_puppy_rules()
     if puppy_rules:
         instructions += f"\n{puppy_rules}"
 
@@ -598,9 +603,7 @@ def _assemble_instructions(agent: Any, resolved_model_name: str) -> PreparedProm
         if _agent_exposes_tool(agent, "agent_run_shell_command"):
             instructions += _GPT_5_6_RUN_SHELL_COMMAND_GUARD_TEXT
 
-    return prepare_prompt_for_model(
-        agent.get_model_name(), instructions, "", prepend_system_to_user=False
-    )
+    return prepare_session_prompt(agent, resolved_model_name, instructions)
 
 
 def build_pydantic_agent(

--- a/code_puppy/agents/_compaction.py
+++ b/code_puppy/agents/_compaction.py
@@ -388,6 +388,9 @@ def make_history_processor(agent: Any) -> Callable[..., Any]:
         # Claude. Cheap no-op when all IDs already conform.
         cleaned = sanitize_tool_call_ids(cleaned)
 
+        from code_puppy.agents._session_state import stamp_session_state
+
+        cleaned = stamp_session_state(agent, cleaned)
         agent._message_history = cleaned
 
         on_message_history_processor_end(

--- a/code_puppy/agents/_compaction.py
+++ b/code_puppy/agents/_compaction.py
@@ -150,7 +150,11 @@ def run_compaction_sync(strategy: Any, messages: List[ModelMessage], *, model: M
     from concurrent.futures import ThreadPoolExecutor
 
     def _run():
-        return asyncio.run(compact_now(strategy, list(messages), model=model))
+        from code_puppy.agents._session_state import read_session_state, stamp_state
+
+        state = read_session_state(messages)
+        result = asyncio.run(compact_now(strategy, list(messages), model=model))
+        return stamp_state(state, result) if state is not None else result
 
     try:
         asyncio.get_running_loop()

--- a/code_puppy/agents/_runtime.py
+++ b/code_puppy/agents/_runtime.py
@@ -571,6 +571,23 @@ def _should_prepend_system_prompt(agent: Any, prompt: str) -> str:
     if agent._message_history:
         return prompt
 
+    from code_puppy.agents.base_agent import BaseAgent
+
+    if isinstance(agent, BaseAgent):
+        from code_puppy.agents._session_prompt import prepare_session_prompt
+
+        saved = agent._session_prepared_prompt
+        # The builder has already resolved any provider fallback. Use that
+        # model and its durable source, never get_full_system_prompt's suffix.
+        model_name = saved["model_name"] if saved else agent.get_model_name()
+        source = agent.get_session_prompt_body() + agent.get_identity_prompt()
+        rules = agent.get_session_rules()
+        if rules:
+            source += f"\n{rules}"
+        return prepare_session_prompt(
+            agent, model_name, source, prompt, prepend_system_to_user=True
+        ).user_prompt
+
     system_prompt = agent.get_full_system_prompt()
     rules = load_puppy_rules()
     if rules:

--- a/code_puppy/agents/_session_prompt.py
+++ b/code_puppy/agents/_session_prompt.py
@@ -1,0 +1,67 @@
+"""Shared durable model preparation for main-agent and subagent conversations."""
+
+from typing import Any
+
+from code_puppy.model_utils import PreparedPrompt
+
+
+def prepare_session_prompt(
+    agent: Any,
+    model_name: str,
+    instructions: str,
+    user_prompt: str = "",
+    *,
+    prepend_system_to_user: bool = False,
+    preparation_scope: str = "main",
+) -> PreparedPrompt:
+    """Freeze system preparation, but keep per-turn user transformations live.
+
+    Callers compose their own durable contract (subagents omit project rules).
+    Temporary policy is appended only after hooks, never supplied to a hook that
+    could copy it into a persisted user prompt. Saved source text keeps first-turn
+    preparation consistent with the builder, including provider fallback models.
+    """
+    from code_puppy.agents.base_agent import BaseAgent
+    from code_puppy.model_utils import prepare_prompt_for_model
+
+    if not isinstance(agent, BaseAgent):
+        return prepare_prompt_for_model(
+            model_name,
+            instructions,
+            user_prompt,
+            prepend_system_to_user=prepend_system_to_user,
+        )
+
+    saved = agent._session_prepared_prompt
+    if saved is not None and (
+        saved["model_name"] != model_name
+        or saved.get("preparation_scope", "main") != preparation_scope
+    ):
+        saved = None
+    source = saved.get("source_prompt", instructions) if saved else instructions
+    # Hooks may transform actual user input; their new system output must not
+    # replace the saved contract on resume. Empty builder probes need no replay.
+    prepared = None
+    if saved is None or user_prompt or prepend_system_to_user:
+        prepared = prepare_prompt_for_model(
+            model_name,
+            source,
+            user_prompt,
+            prepend_system_to_user=prepend_system_to_user,
+        )
+    if saved is None:
+        saved = {
+            "model_name": model_name,
+            "preparation_scope": preparation_scope,
+            "source_prompt": source,
+            "instructions": prepared.instructions,
+            "system_prompt": prepared.system_prompt,
+            "is_claude_code": prepared.is_claude_code,
+        }
+        agent._session_prepared_prompt = saved
+    return PreparedPrompt(
+        instructions=saved["instructions"] + agent.get_runtime_prompt_suffix(),
+        user_prompt=prepared.user_prompt if prepared is not None else user_prompt,
+        is_claude_code=saved["is_claude_code"],
+        system_prompt=saved["system_prompt"],
+    )

--- a/code_puppy/agents/_session_prompt.py
+++ b/code_puppy/agents/_session_prompt.py
@@ -5,6 +5,17 @@ from typing import Any
 from code_puppy.model_utils import PreparedPrompt
 
 
+def saved_system_text(agent: Any) -> str | None:
+    """Read the authoritative prepared system text without replaying live hooks."""
+    from code_puppy.agents.base_agent import BaseAgent
+
+    if not isinstance(agent, BaseAgent) or agent._session_prepared_prompt is None:
+        return None
+    saved = agent._session_prepared_prompt
+    instructions = saved["instructions"] + agent.get_runtime_prompt_suffix()
+    return "\n\n".join(text for text in (saved["system_prompt"], instructions) if text)
+
+
 def prepare_session_prompt(
     agent: Any,
     model_name: str,

--- a/code_puppy/agents/_session_state.py
+++ b/code_puppy/agents/_session_state.py
@@ -27,7 +27,28 @@ def read_session_state(history: list[Any]) -> dict[str, Any] | None:
             if not isinstance(state, dict):
                 raise ValueError("Invalid conversation metadata")
             validate_agent_id(state.get("agent_id"))
-            return dict(state)
+            for key in ("prompt_body", "project_rules"):
+                if key in state and not isinstance(state[key], str):
+                    raise ValueError(f"Invalid conversation {key}")
+            prepared = state.get("prepared_prompt")
+            if prepared is not None:
+                if (
+                    not isinstance(prepared, dict)
+                    or any(
+                        not isinstance(prepared.get(key), str)
+                        for key in ("model_name", "instructions", "system_prompt")
+                    )
+                    or not isinstance(prepared.get("is_claude_code"), bool)
+                    or any(
+                        key in prepared and not isinstance(prepared[key], str)
+                        for key in ("source_prompt", "preparation_scope")
+                    )
+                ):
+                    raise ValueError("Invalid conversation prepared_prompt")
+            return {
+                **state,
+                **({"prepared_prompt": dict(prepared)} if prepared is not None else {}),
+            }
     return None
 
 

--- a/code_puppy/agents/_session_state.py
+++ b/code_puppy/agents/_session_state.py
@@ -36,7 +36,10 @@ def stamp_session_state(agent: Any, messages: list[Any]) -> list[Any]:
     export = getattr(agent, "get_session_state", None)
     if not callable(export):
         return messages
-    state = export()
+    return stamp_state(export(), messages)
+
+
+def stamp_state(state: dict[str, Any], messages: list[Any]) -> list[Any]:
     for index in range(len(messages) - 1, -1, -1):
         message = messages[index]
         if isinstance(message, ModelRequest):

--- a/code_puppy/agents/_session_state.py
+++ b/code_puppy/agents/_session_state.py
@@ -1,0 +1,48 @@
+"""Conversation state carried by real message metadata, never parsed from prose."""
+
+import re
+from dataclasses import replace
+from typing import Any
+
+from pydantic_ai.messages import ModelRequest
+
+SESSION_KEY = "code_puppy_session_v1"
+_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}\Z")
+
+
+def validate_agent_id(value: str) -> str:
+    if not isinstance(value, str) or not _ID.fullmatch(value):
+        raise ValueError(
+            "agent_id must be 1-128 letters, digits, dots, colons, underscores or hyphens"
+        )
+    return value
+
+
+def read_session_state(history: list[Any]) -> dict[str, Any] | None:
+    for message in reversed(history):
+        if isinstance(message, ModelRequest) and SESSION_KEY in (
+            message.metadata or {}
+        ):
+            state = message.metadata[SESSION_KEY]
+            if not isinstance(state, dict):
+                raise ValueError("Invalid conversation metadata")
+            validate_agent_id(state.get("agent_id"))
+            return dict(state)
+    return None
+
+
+def stamp_session_state(agent: Any, messages: list[Any]) -> list[Any]:
+    """Checkpoint state on the newest request after compaction; preserve other metadata."""
+    export = getattr(agent, "get_session_state", None)
+    if not callable(export):
+        return messages
+    state = export()
+    for index in range(len(messages) - 1, -1, -1):
+        message = messages[index]
+        if isinstance(message, ModelRequest):
+            result = list(messages)
+            result[index] = replace(
+                message, metadata={**(message.metadata or {}), SESSION_KEY: state}
+            )
+            return result
+    return messages

--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -71,6 +71,10 @@ class BaseAgent(ABC):
             validate_agent_id(agent_id) if agent_id is not None else str(uuid.uuid4())
         )
         self._explicit_agent_id = agent_id
+        self._session_prompt_body: Optional[str] = None
+        self._session_rules: Optional[str] = None
+        self._session_prepared_prompt: Optional[Dict[str, Any]] = None
+        self._initial_system_prompt: Optional[str] = None
         self._message_history: List[Any] = []
         self._compacted_message_hashes: Set[str] = set()
         self._code_generation_agent: Any = None
@@ -198,48 +202,84 @@ class BaseAgent(ABC):
             "such as claiming task ownership or coordination with other agents."
         )
 
-    def get_full_system_prompt(self) -> str:
-        """Assemble the runtime system prompt.
-
-        Layered as: authored prompt (``get_system_prompt``) + per-turn
-        ``load_prompt`` plugin fragments + this instance's identity.
-
-        The ``load_prompt`` fragments (live timestamp/CWD, file-permission
-        rules, kennel memory, ...) and the identity ID are *runtime* concerns.
-        They live here — not in ``get_system_prompt`` — so they're recomputed
-        fresh every run and never get persisted into static agent definitions
-        (e.g. when an agent is cloned to JSON). See ``clone_agent``.
-        """
+    def get_session_prompt_body(self) -> str:
+        """Freeze authored/plugin instructions once per conversation, not per process turn."""
         from code_puppy import callbacks
 
-        prompt = self.get_system_prompt()
-        prompt_additions = callbacks.on_load_prompt()
-        if prompt_additions:
-            prompt += "\n" + "\n".join(prompt_additions)
-        if self._runtime_system_prompt_additions:
-            prompt += "\n" + "\n".join(self._runtime_system_prompt_additions)
-        return prompt + self.get_identity_prompt()
+        if self._session_prompt_body is None:
+            prompt = self._initial_system_prompt
+            if prompt is None:
+                prompt = self.get_system_prompt()
+            additions = callbacks.on_load_prompt()
+            if additions:
+                prompt += "\n" + "\n".join(additions)
+            self._session_prompt_body = prompt
+        return self._session_prompt_body
+
+    def get_session_rules(self) -> str:
+        if self._session_rules is None:
+            from code_puppy.agents._builder import load_puppy_rules
+
+            self._session_rules = load_puppy_rules() or ""
+        return self._session_rules
+
+    def get_runtime_prompt_suffix(self) -> str:
+        return (
+            "\n" + "\n".join(self._runtime_system_prompt_additions)
+            if self._runtime_system_prompt_additions
+            else ""
+        )
+
+    def get_full_system_prompt(self) -> str:
+        """Stable body/identity followed by this run's temporary instructions."""
+        return (
+            self.get_session_prompt_body()
+            + self.get_identity_prompt()
+            + self.get_runtime_prompt_suffix()
+        )
 
     # ---- Message history (plain dict-level access) ------------------------
     def get_message_history(self) -> List[Any]:
         return self._message_history
 
-    def initialize_session(self, *, agent_id: str) -> None:
+    def initialize_session(
+        self, *, agent_id: Optional[str] = None, system_prompt: Optional[str] = None
+    ) -> None:
         """Set runner-owned identity before the first turn; conflicting resumes fail."""
         from code_puppy.agents._session_state import validate_agent_id
 
-        agent_id = validate_agent_id(agent_id)
-        if (
-            self._message_history or self._explicit_agent_id is not None
-        ) and agent_id != self.id:
-            raise ValueError("Cannot change agent_id during a conversation")
-        if agent_id != self.id:
-            self._code_generation_agent = None
-        self.id = agent_id
-        self._explicit_agent_id = agent_id
+        if agent_id is not None:
+            validate_agent_id(agent_id)
+            if (
+                self._message_history
+                or self._explicit_agent_id is not None
+                or self._session_prompt_body is not None
+            ) and agent_id != self.id:
+                raise ValueError("Cannot change agent_id during a conversation")
+        if system_prompt is not None:
+            if not isinstance(system_prompt, str):
+                raise ValueError("system_prompt must be a string")
+            if self._message_history or self._session_prompt_body is not None:
+                raise ValueError("Set system_prompt before the conversation starts")
+        if agent_id is not None:
+            if agent_id != self.id:
+                self._code_generation_agent = None
+            self.id = agent_id
+            self._explicit_agent_id = agent_id
+        if system_prompt is not None:
+            if system_prompt != self._initial_system_prompt:
+                self._code_generation_agent = None
+            self._initial_system_prompt = system_prompt
 
     def get_session_state(self) -> Dict[str, Any]:
-        return {"agent_id": self.id}
+        state = {"agent_id": self.id}
+        if self._session_prompt_body is not None:
+            state["prompt_body"] = self._session_prompt_body
+        if self._session_rules is not None:
+            state["project_rules"] = self._session_rules
+        if self._session_prepared_prompt is not None:
+            state["prepared_prompt"] = dict(self._session_prepared_prompt)
+        return state
 
     def set_message_history(
         self, history: List[Any], *, agent_id: Optional[str] = None
@@ -265,14 +305,31 @@ class BaseAgent(ABC):
         )
         if saved_id and requested_id and saved_id != requested_id:
             raise ValueError("Requested agent_id conflicts with saved conversation")
+        previous_state = self.get_session_state()
         restored_id = saved_id or requested_id
-        if restored_id is not None and restored_id != self.id:
+        if restored_id is not None:
             self.id = restored_id
-            self._code_generation_agent = None
+        if state is not None:
+            self._session_prompt_body = state.get("prompt_body")
+            self._session_rules = state.get("project_rules")
+            self._session_prepared_prompt = state.get("prepared_prompt")
+        else:
+            # Legacy prompt text has no trustworthy durable/temporary boundary.
+            # Rebuild once rather than parse identity prose or freeze run policy.
+            self._session_prompt_body = None
+            self._session_rules = None
+            self._session_prepared_prompt = None
         self._message_history = history
+        if self.get_session_state() != previous_state:
+            self._code_generation_agent = None
 
     def clear_message_history(self) -> None:
         self._message_history = []
+        self._session_prompt_body = None
+        self._session_rules = None
+        self._session_prepared_prompt = None
+        self._initial_system_prompt = None
+        self._code_generation_agent = None
         self._compacted_message_hashes.clear()
 
     def append_to_message_history(self, message: Any) -> None:

--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -223,6 +223,14 @@ class BaseAgent(ABC):
             self._session_rules = load_puppy_rules() or ""
         return self._session_rules
 
+    def refresh_project_instructions(self) -> None:
+        """Explicit project transition: keep history/identity, rebuild the contract."""
+        self._session_prompt_body = None
+        self._session_rules = None
+        self._session_prepared_prompt = None
+        self._code_generation_agent = None
+        self._tool_probe_agent = None
+
     def get_runtime_prompt_suffix(self) -> str:
         return (
             "\n" + "\n".join(self._runtime_system_prompt_additions)
@@ -353,19 +361,23 @@ class BaseAgent(ABC):
 
     def _estimate_context_overhead(self) -> int:
         """Tokens used by system prompt + registered pydantic tools."""
-        system_prompt = self.get_full_system_prompt()
-        try:
-            from code_puppy.model_utils import prepare_prompt_for_model
+        from code_puppy.agents._session_prompt import saved_system_text
 
-            prepared = prepare_prompt_for_model(
-                model_name=self.get_model_name() or "",
-                system_prompt=system_prompt,
-                user_prompt="",
-                prepend_system_to_user=False,
-            )
-            resolved = prepared.system_text or system_prompt
-        except Exception:
-            resolved = system_prompt
+        resolved = saved_system_text(self)
+        if resolved is None:
+            system_prompt = self.get_full_system_prompt()
+            try:
+                from code_puppy.model_utils import prepare_prompt_for_model
+
+                prepared = prepare_prompt_for_model(
+                    model_name=self.get_model_name() or "",
+                    system_prompt=system_prompt,
+                    user_prompt="",
+                    prepend_system_to_user=False,
+                )
+                resolved = prepared.system_text or system_prompt
+            except Exception:
+                resolved = system_prompt
 
         tools_source = self.pydantic_agent or self._get_tool_probe()
         tools = _extract_pydantic_agent_tools(tools_source) if tools_source else None

--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -64,8 +64,13 @@ def _extract_pydantic_agent_tools(pyd_agent: Any) -> Optional[Dict[str, Any]]:
 class BaseAgent(ABC):
     """Abstract base for all Code Puppy agents."""
 
-    def __init__(self) -> None:
-        self.id: str = str(uuid.uuid4())
+    def __init__(self, *, agent_id: Optional[str] = None) -> None:
+        from code_puppy.agents._session_state import validate_agent_id
+
+        self.id: str = (
+            validate_agent_id(agent_id) if agent_id is not None else str(uuid.uuid4())
+        )
+        self._explicit_agent_id = agent_id
         self._message_history: List[Any] = []
         self._compacted_message_hashes: Set[str] = set()
         self._code_generation_agent: Any = None
@@ -219,8 +224,43 @@ class BaseAgent(ABC):
     def get_message_history(self) -> List[Any]:
         return self._message_history
 
-    def set_message_history(self, history: List[Any]) -> None:
+    def initialize_session(self, *, agent_id: str) -> None:
+        """Set runner-owned identity before the first turn; conflicting resumes fail."""
+        from code_puppy.agents._session_state import validate_agent_id
+
+        agent_id = validate_agent_id(agent_id)
+        if self._message_history and agent_id != self.id:
+            raise ValueError("Cannot change agent_id during a conversation")
+        self.id = agent_id
+        self._explicit_agent_id = agent_id
+        self._code_generation_agent = None
+
+    def get_session_state(self) -> Dict[str, Any]:
+        return {"agent_id": self.id}
+
+    def set_message_history(
+        self, history: List[Any], *, agent_id: Optional[str] = None
+    ) -> None:
+        """Restore identity through the common resume door, including raw history runners."""
+        from code_puppy.agents._session_state import (
+            read_session_state,
+            validate_agent_id,
+        )
+
+        state = read_session_state(history)
+        saved_id = state["agent_id"] if state else None
+        requested_id = (
+            validate_agent_id(agent_id)
+            if agent_id is not None
+            else self._explicit_agent_id
+        )
+        if saved_id and requested_id and saved_id != requested_id:
+            raise ValueError("Requested agent_id conflicts with saved conversation")
+        restored_id = saved_id or requested_id
+        if restored_id is not None:
+            self.id = restored_id
         self._message_history = history
+        self._code_generation_agent = None
 
     def clear_message_history(self) -> None:
         self._message_history = []

--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -248,6 +248,12 @@ class BaseAgent(ABC):
         )
 
         state = read_session_state(history)
+        if (
+            agent_id is not None
+            and self._explicit_agent_id is not None
+            and agent_id != self._explicit_agent_id
+        ):
+            raise ValueError("Requested agent_id conflicts with initialized identity")
         saved_id = state["agent_id"] if state else None
         requested_id = (
             validate_agent_id(agent_id)

--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -229,11 +229,14 @@ class BaseAgent(ABC):
         from code_puppy.agents._session_state import validate_agent_id
 
         agent_id = validate_agent_id(agent_id)
-        if self._message_history and agent_id != self.id:
+        if (
+            self._message_history or self._explicit_agent_id is not None
+        ) and agent_id != self.id:
             raise ValueError("Cannot change agent_id during a conversation")
+        if agent_id != self.id:
+            self._code_generation_agent = None
         self.id = agent_id
         self._explicit_agent_id = agent_id
-        self._code_generation_agent = None
 
     def get_session_state(self) -> Dict[str, Any]:
         return {"agent_id": self.id}
@@ -263,10 +266,10 @@ class BaseAgent(ABC):
         if saved_id and requested_id and saved_id != requested_id:
             raise ValueError("Requested agent_id conflicts with saved conversation")
         restored_id = saved_id or requested_id
-        if restored_id is not None:
+        if restored_id is not None and restored_id != self.id:
             self.id = restored_id
+            self._code_generation_agent = None
         self._message_history = history
-        self._code_generation_agent = None
 
     def clear_message_history(self) -> None:
         self._message_history = []

--- a/code_puppy/command_line/core_commands.py
+++ b/code_puppy/command_line/core_commands.py
@@ -106,9 +106,13 @@ def handle_cd_command(command: str) -> bool:
             try:
                 from code_puppy.agents.agent_manager import get_current_agent
 
-                # reload_code_generation_agent() invalidates cached rules
-                # and rebuilds prompt/context from the new cwd
-                get_current_agent().reload_code_generation_agent()
+                # /cd is an explicit contract transition, unlike ordinary resume.
+                from code_puppy.agents.base_agent import BaseAgent
+
+                agent = get_current_agent()
+                if isinstance(agent, BaseAgent):
+                    agent.refresh_project_instructions()
+                agent.reload_code_generation_agent()
                 emit_info(t("cmd.cd.agent_updated"))
             except Exception as e:
                 # Non-fatal: directory change succeeded even if reload failed

--- a/code_puppy/command_line/session_commands.py
+++ b/code_puppy/command_line/session_commands.py
@@ -360,6 +360,8 @@ def handle_quick_resume_command(command: str) -> bool:
 
     try:
         history = load_session(session_name, session_path.parent)
+        agent = get_current_agent()
+        agent.set_message_history(history)
     except FileNotFoundError:
         logger.warning("Quick-resume session file not found: %s", session_path)
         emit_error(t("cmd.quick_resume.file_not_found"))
@@ -369,8 +371,6 @@ def handle_quick_resume_command(command: str) -> bool:
         emit_error(t("cmd.quick_resume.failed"))
         return True
 
-    agent = get_current_agent()
-    agent.set_message_history(history)
     set_current_autosave_from_session_name(session_name)
     total_tokens = sum(agent.estimate_tokens_for_message(m) for m in history)
 
@@ -466,6 +466,8 @@ def handle_load_context_command(command: str) -> bool:
 
     try:
         history = load_session(session_name, sessions_dir)
+        agent = get_current_agent()
+        agent.set_message_history(history)
     except FileNotFoundError:
         emit_error(t("cmd.load_context.not_found", path=session_path))
         scope_key = compute_scope_key(Path.cwd()) if cwd_flag else None
@@ -477,8 +479,6 @@ def handle_load_context_command(command: str) -> bool:
         emit_error(t("cmd.load_context.failed", error=exc))
         return True
 
-    agent = get_current_agent()
-    agent.set_message_history(history)
     total_tokens = sum(agent.estimate_tokens_for_message(m) for m in history)
 
     # Rotate the singleton to a fresh ``auto_session_<TS>`` so autosaves don't

--- a/code_puppy/token_usage.py
+++ b/code_puppy/token_usage.py
@@ -227,6 +227,11 @@ def _resolved_system_prompt(agent) -> str:
     Mirrors what ``_estimate_context_overhead`` does, so the bucket counts
     line up with what actually gets shipped to the model.
     """
+    from code_puppy.agents._session_prompt import saved_system_text
+
+    saved = saved_system_text(agent)
+    if saved is not None:
+        return saved
     system_prompt = agent.get_full_system_prompt()
     try:
         from code_puppy.model_utils import prepare_prompt_for_model
@@ -317,6 +322,12 @@ def compute_overhead_breakdown(agent) -> OverheadBreakdown:
     when switching between models.
     """
     from code_puppy.agents._builder import load_puppy_rules
+    from code_puppy.agents._session_prompt import saved_system_text
+
+    # Frozen preparation already includes project rules and plugin fragments.
+    # Their original contribution cannot be recovered after arbitrary hooks;
+    # keep one truthful system bucket rather than add live inputs a second time.
+    frozen = saved_system_text(agent) is not None
 
     # Resolved system prompt already includes load_prompt plugin fragments
     # (notably kennel memory) — carve those out below to avoid double-counting.
@@ -329,7 +340,7 @@ def compute_overhead_breakdown(agent) -> OverheadBreakdown:
     # Carve kennel memory out of the system prompt (own line in /context),
     # clamped to zero if the resolved prompt lacks it (get_system_prompt override).
     try:
-        kennel_tokens = _raw_estimate_tokens(_kennel_memory_block())
+        kennel_tokens = 0 if frozen else _raw_estimate_tokens(_kennel_memory_block())
     except Exception:
         kennel_tokens = 0
     system_tokens = max(0, system_tokens - kennel_tokens)
@@ -337,7 +348,7 @@ def compute_overhead_breakdown(agent) -> OverheadBreakdown:
     # AGENTS.md / puppy rules — separate bucket so users can see how much of
     # their context budget is being eaten by project rules.
     try:
-        rules = load_puppy_rules() or ""
+        rules = "" if frozen else (load_puppy_rules() or "")
         agents_md_tokens = _raw_estimate_tokens(rules) if rules else 0
     except Exception:
         agents_md_tokens = 0

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -404,8 +404,15 @@ async def _invoke_agent_impl(
                 )
 
             # Create a temporary agent instance to avoid interfering with current agent state
-            instructions = agent_config.get_full_system_prompt()
-            instructions += f"\n\n{_subagent_identity_prompt(agent_name)}"
+            from code_puppy.agents.base_agent import BaseAgent
+
+            if isinstance(agent_config, BaseAgent):
+                instructions = (
+                    agent_config.get_session_prompt_body()
+                    + agent_config.get_identity_prompt()
+                )
+            else:
+                instructions = agent_config.get_full_system_prompt()
 
             # AGENTS.md deliberately NOT injected into sub-agents: those are
             # user-facing steering for the MAIN agent and would create recursion
@@ -413,17 +420,23 @@ async def _invoke_agent_impl(
 
             # NOTE: load_prompt fragments are already baked into get_full_system_prompt
             # via BaseAgent — appending again would double-inject them.
-            from code_puppy.model_utils import prepare_prompt_for_model
+            from code_puppy.agents._session_prompt import prepare_session_prompt
 
-            # Model-family prep (e.g. claude-code): may split off a standing
-            # system_prompt part, or touch the user prompt on the first message.
-            prepared = prepare_prompt_for_model(
+            # Share durable preparation with main agents without importing their
+            # project rules. User-prompt hooks still run for each actual turn.
+            prepared = prepare_session_prompt(
+                agent_config,
                 effective_model_name,
                 instructions,
                 prompt,
                 prepend_system_to_user=is_new_session,  # Only prepend on first message
+                preparation_scope=f"subagent:{agent_name}",
             )
-            instructions = prepared.instructions
+            # Parent chain/depth can change on resume: keep invocation context
+            # live and outside hooks that could copy it into persisted user text.
+            instructions = (
+                prepared.instructions + f"\n\n{_subagent_identity_prompt(agent_name)}"
+            )
             prompt = prepared.user_prompt
 
             model_settings = make_model_settings(

--- a/tests/agents/test_session_identity_processes.py
+++ b/tests/agents/test_session_identity_processes.py
@@ -1,0 +1,121 @@
+"""Resume real message history in fresh processes without caller identity repair."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+CHILD = r"""
+import asyncio
+import json
+import pickle
+import sys
+from pathlib import Path
+
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import ProcessHistory
+from pydantic_ai.messages import ModelResponse, TextPart
+from pydantic_ai.models.function import FunctionModel
+
+from code_puppy.agents._compaction import make_history_processor
+from code_puppy.agents.base_agent import BaseAgent
+from code_puppy.callbacks import clear_callbacks
+from code_puppy.session_storage import load_session, save_session
+
+
+def deny_network(event, args):
+    if event in {"socket.connect", "socket.getaddrinfo", "socket.bind"}:
+        raise RuntimeError("Session fixture forbids network")
+
+
+sys.addaudithook(deny_network)
+clear_callbacks()
+
+
+class Owner(BaseAgent):
+    name = "session-test"
+    display_name = "Session test"
+    description = "Local model fixture"
+
+    def get_system_prompt(self):
+        return "Test instructions"
+
+    def get_available_tools(self):
+        return []
+
+    def _get_model_context_length(self):
+        return 1_000_000
+
+    def _estimate_context_overhead(self):
+        return 0
+
+
+async def main():
+    directory, encoding, turn = Path(sys.argv[1]), sys.argv[2], int(sys.argv[3])
+    owner = Owner()
+    path = directory / "history.pkl"
+    if turn:
+        history = (
+            pickle.loads(path.read_bytes())
+            if encoding == "pickle"
+            else load_session("saved", directory)
+        )
+        owner.set_message_history(history)
+    agent = Agent(
+        FunctionModel(lambda messages, info: ModelResponse(parts=[TextPart("done")])),
+        capabilities=[ProcessHistory(make_history_processor(owner))],
+    )
+    result = await agent.run("next", message_history=owner.get_message_history())
+    owner.set_message_history(result.all_messages())
+    if encoding == "pickle":
+        path.write_bytes(pickle.dumps(owner.get_message_history()))
+    else:
+        save_session(
+            session_name="saved", history=owner.get_message_history(),
+            base_dir=directory, timestamp="2026-01-01T00:00:00",
+            token_estimator=lambda message: 1,
+        )
+    print(json.dumps({"id": owner.id, "messages": len(owner.get_message_history())}))
+
+
+asyncio.run(main())
+"""
+
+
+@pytest.mark.parametrize("encoding", ["pickle", "named"])
+def test_fresh_process_resume_keeps_identity_without_caller_repair(tmp_path, encoding):
+    source = Path(__file__).resolve().parents[2]
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "PYTHONPATH": str(source),
+        "HOME": str(tmp_path),
+        "NO_COLOR": "1",
+        "CODE_PUPPY_NO_TUI": "1",
+        **{
+            key: str(tmp_path / key)
+            for key in (
+                "XDG_CONFIG_HOME",
+                "XDG_DATA_HOME",
+                "XDG_CACHE_HOME",
+                "XDG_STATE_HOME",
+            )
+        },
+    }
+    outputs = []
+    for turn in range(3):
+        result = subprocess.run(
+            [sys.executable, "-c", CHILD, str(tmp_path), encoding, str(turn)],
+            cwd=source,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=30,
+            check=True,
+        )
+        assert not result.stderr
+        outputs.append(json.loads(result.stdout.splitlines()[-1]))
+    assert [item["messages"] for item in outputs] == [2, 4, 6]
+    assert len({item["id"] for item in outputs}) == 1

--- a/tests/agents/test_session_preparation_paths.py
+++ b/tests/agents/test_session_preparation_paths.py
@@ -1,0 +1,230 @@
+"""Real provider-hook and subagent persistence regressions for prepared prompts."""
+
+import pickle
+from unittest.mock import MagicMock
+
+import pytest
+
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import ProcessHistory
+from pydantic_ai.messages import ModelResponse, TextPart, UserPromptPart
+from pydantic_ai.models.function import FunctionModel
+
+from code_puppy.agents import _builder, _runtime
+from code_puppy.agents._compaction import make_history_processor
+from code_puppy.model_utils import PreparedPrompt
+from tests.agents.test_session_state_identity import SessionAgent
+
+
+async def test_first_turn_hook_never_persists_temporary_policy(monkeypatch):
+    def hook(model, system, prompt, prepend):
+        return [
+            {
+                "handled": True,
+                "instructions": system,
+                "user_prompt": system + "\n" + prompt if prepend else prompt,
+            }
+        ]
+
+    monkeypatch.setattr("code_puppy.callbacks.on_prepare_model_prompt", hook)
+    monkeypatch.setattr("code_puppy.callbacks.on_load_prompt", lambda: [])
+    monkeypatch.setattr(_builder, "load_puppy_rules", lambda: "RULES")
+    owner = SessionAgent(agent_id="fixed")
+    owner.get_model_name = lambda: "test"
+    with owner.temporary_system_prompt_addition("TEMPORARY POLICY"):
+        prepared = _builder._assemble_instructions(owner, "test")
+        prompt = _runtime._should_prepend_system_prompt(owner, "hello")
+        agent = Agent(
+            FunctionModel(
+                lambda messages, info: ModelResponse(parts=[TextPart("done")])
+            ),
+            instructions=prepared.instructions,
+            capabilities=[ProcessHistory(make_history_processor(owner))],
+        )
+        result = await agent.run(prompt)
+    history = pickle.loads(pickle.dumps(result.all_messages()))
+    resumed = SessionAgent()
+    resumed.set_message_history(history)
+    assert "TEMPORARY POLICY" in prepared.instructions
+    user_parts = [
+        p.content for m in history for p in m.parts if isinstance(p, UserPromptPart)
+    ]
+    assert all("TEMPORARY POLICY" not in text for text in user_parts)
+    assert "RULES" in user_parts[0]
+    assert "TEMPORARY POLICY" not in str(resumed.get_session_state())
+    assert (
+        "TEMPORARY POLICY"
+        not in _builder._assemble_instructions(resumed, "test").instructions
+    )
+
+
+@pytest.mark.parametrize("fork_main", [False, True])
+async def test_subagent_resume_freezes_preparation_but_model_change_reprepares(
+    monkeypatch,
+    fork_main,
+):
+    from code_puppy.tools import subagent_invocation as invocation
+    from tests.test_subagent_invocation_usage import _capture_invoke_with_model
+
+    saved = {}
+    seen = []
+    user_inputs = []
+    generation = [0]
+
+    async def model(messages, info):
+        seen.append(messages[-1].instructions)
+        user_inputs.append(
+            [p.content for p in messages[-1].parts if isinstance(p, UserPromptPart)]
+        )
+        yield "done"
+
+    def prepare(model, system, prompt, prepend_system_to_user=True):
+        return PreparedPrompt(
+            system + f"\nprovider-{generation[0]}",
+            f"user-{generation[0]}:{prompt}",
+            False,
+            f"standing-{generation[0]}",
+        )
+
+    monkeypatch.setattr(
+        "code_puppy.agents.agent_manager.load_agent", lambda name: SessionAgent()
+    )
+    monkeypatch.setattr(
+        "code_puppy.model_factory.ModelFactory.load_config",
+        lambda: {"test": {}, "other": {}},
+    )
+    monkeypatch.setattr(
+        "code_puppy.model_factory.ModelFactory.get_model",
+        lambda *a: FunctionModel(stream_function=model),
+    )
+    monkeypatch.setattr(
+        "code_puppy.model_factory.make_model_settings", lambda *a, **kw: {}
+    )
+    monkeypatch.setattr("code_puppy.callbacks.on_load_prompt", lambda: [])
+    monkeypatch.setattr("code_puppy.model_utils.prepare_prompt_for_model", prepare)
+    monkeypatch.setattr(_builder, "load_puppy_rules", lambda: "MAIN-ONLY-RULES")
+    monkeypatch.setattr(
+        "code_puppy.config.get_value",
+        lambda key, *a, **kw: "true" if key == "disable_mcp_servers" else None,
+    )
+    monkeypatch.setattr("code_puppy.config.get_output_level", lambda: "medium")
+    monkeypatch.setattr(
+        "code_puppy.tools.register_tools_for_agent", lambda *a, **kw: None
+    )
+    monkeypatch.setattr(
+        invocation, "on_wrap_pydantic_agent", lambda cfg, agent, **kw: agent
+    )
+    monkeypatch.setattr(invocation, "on_agent_run_context", lambda *a: [])
+    monkeypatch.setattr(
+        invocation,
+        "_load_session_history",
+        lambda sid: pickle.loads(saved[sid]) if sid in saved else [],
+    )
+    monkeypatch.setattr(
+        invocation,
+        "_save_session_history",
+        lambda session_id, message_history, **kw: saved.update(
+            {session_id: pickle.dumps(message_history)}
+        ),
+    )
+    monkeypatch.setattr(
+        invocation, "get_subagent_chain", lambda: (f"parent-{generation[0]}",)
+    )
+    invoke = _capture_invoke_with_model()
+    session = "prepared-resume"
+    if fork_main:
+        from code_puppy.agents._session_state import stamp_session_state
+        from pydantic_ai.messages import ModelRequest
+
+        main = SessionAgent()
+        _builder._assemble_instructions(main, "test")
+        saved[session] = pickle.dumps(
+            stamp_session_state(
+                main,
+                [
+                    ModelRequest(parts=[UserPromptPart("main task")]),
+                    ModelResponse(parts=[TextPart("main answer")]),
+                ],
+            )
+        )
+    for index, model_name in enumerate(["test", "test", "other"]):
+        generation[0] = index
+        result = await invoke(
+            MagicMock(),
+            agent_name="test-agent",
+            prompt="hello",
+            model_name=model_name,
+            session_id=session,
+        )
+        assert not result.error, result.error
+        session = result.session_id
+        checkpoint = SessionAgent()
+        checkpoint.set_message_history(pickle.loads(saved[session]))
+        snapshot = checkpoint.get_session_state()["prepared_prompt"]
+        assert snapshot["system_prompt"] == (
+            "standing-0" if index < 2 else "standing-2"
+        )
+    assert user_inputs == [["user-0:hello"], ["user-1:hello"], ["user-2:hello"]]
+    durable = [text.split("\n\n## Sub-agent execution context")[0] for text in seen]
+    assert durable[0] == durable[1]
+    for index, text in enumerate(seen):
+        assert f"parent-{index}" in text
+    assert "Sub-agent execution context" not in str(snapshot)
+    assert "provider-2" in seen[2]
+    assert all("MAIN-ONLY-RULES" not in text for text in seen)
+    resumed = SessionAgent()
+    resumed.set_message_history(pickle.loads(saved[session]))
+    assert resumed.get_session_state()["prepared_prompt"]["model_name"] == "other"
+
+
+def test_first_turn_uses_builder_resolved_model_and_frozen_source(monkeypatch):
+    calls = []
+
+    def prepare(model_name, system_prompt, user_prompt, prepend_system_to_user=True):
+        calls.append((model_name, system_prompt, prepend_system_to_user))
+        return PreparedPrompt(
+            system_prompt,
+            system_prompt + user_prompt if prepend_system_to_user else user_prompt,
+            False,
+        )
+
+    monkeypatch.setattr("code_puppy.model_utils.prepare_prompt_for_model", prepare)
+    monkeypatch.setattr("code_puppy.callbacks.on_load_prompt", lambda: [])
+    monkeypatch.setattr(_builder, "load_puppy_rules", lambda: "ORIGINAL RULES")
+    owner = SessionAgent()
+    owner.get_model_name = lambda: "unavailable-requested-model"
+    _builder._assemble_instructions(owner, "resolved-fallback")
+    monkeypatch.setattr(_builder, "load_puppy_rules", lambda: "CHANGED RULES")
+    _runtime._should_prepend_system_prompt(owner, "hello")
+    assert calls[0][:2] == calls[1][:2]
+    assert calls[1][0] == "resolved-fallback"
+    assert calls[1][2] is True
+
+
+@pytest.mark.parametrize("source", [None, "valid source", 123])
+def test_preparation_source_metadata_compatibility(source):
+    from code_puppy.agents._session_state import SESSION_KEY
+    from pydantic_ai.messages import ModelRequest
+
+    prepared = {
+        "model_name": "test",
+        "instructions": "saved",
+        "system_prompt": "",
+        "is_claude_code": False,
+    }
+    if source is not None:
+        prepared["source_prompt"] = source
+    history = [
+        ModelRequest(
+            parts=[UserPromptPart("hello")],
+            metadata={SESSION_KEY: {"agent_id": "fixed", "prepared_prompt": prepared}},
+        )
+    ]
+    owner = SessionAgent()
+    if source == 123:
+        with pytest.raises(ValueError, match="prepared_prompt"):
+            owner.set_message_history(history)
+        assert owner.get_message_history() == []
+    else:
+        owner.set_message_history(history)
+        assert _builder._assemble_instructions(owner, "test").instructions == "saved"

--- a/tests/agents/test_session_prompt_cache.py
+++ b/tests/agents/test_session_prompt_cache.py
@@ -1,0 +1,59 @@
+"""Cache reuse follows the complete durable prompt contract, not identity alone."""
+
+from copy import deepcopy
+
+import pytest
+from pydantic_ai.messages import ModelRequest, UserPromptPart
+
+from code_puppy.agents import _builder
+from code_puppy.agents._session_state import SESSION_KEY
+from tests.agents.test_session_state_identity import SessionAgent
+
+
+@pytest.mark.parametrize(
+    "change", [None, "prompt_body", "project_rules", "prepared_prompt", "legacy"]
+)
+def test_restore_invalidates_only_when_durable_state_changes(monkeypatch, change):
+    monkeypatch.setattr("code_puppy.callbacks.on_load_prompt", lambda: [])
+    monkeypatch.setattr(_builder, "load_puppy_rules", lambda: "RULES")
+    owner = SessionAgent(agent_id="same-id")
+    owner.initialize_session(system_prompt="CONTRACT")
+    _builder._assemble_instructions(owner, "test")
+    state = deepcopy(owner.get_session_state())
+    if change == "prepared_prompt":
+        state[change]["instructions"] += " changed"
+    elif change in ("prompt_body", "project_rules"):
+        state[change] += " changed"
+    metadata = None if change == "legacy" else {SESSION_KEY: state}
+    history = [ModelRequest(parts=[UserPromptPart("restored")], metadata=metadata)]
+    cached = owner._code_generation_agent = object()
+    owner.set_message_history(history)
+    assert owner.id == "same-id"
+    assert owner.get_message_history() is history
+    if change is None:
+        assert owner._code_generation_agent is cached
+    else:
+        assert owner._code_generation_agent is None
+
+
+def test_initialization_validates_all_inputs_before_mutating(monkeypatch):
+    monkeypatch.setattr("code_puppy.callbacks.on_load_prompt", lambda: [])
+    owner = SessionAgent()
+    original_id = owner.id
+    owner.get_session_prompt_body()
+    cached = owner._code_generation_agent = object()
+    with pytest.raises(ValueError, match="Set system_prompt before"):
+        owner.initialize_session(agent_id=original_id, system_prompt="replacement")
+    assert owner._explicit_agent_id is None
+    assert owner.id == original_id
+    assert owner._initial_system_prompt is None
+    assert owner._code_generation_agent is cached
+
+
+def test_prompt_initialization_invalidates_cache_but_noop_does_not():
+    owner = SessionAgent(agent_id="same-id")
+    cached = owner._code_generation_agent = object()
+    owner.initialize_session()
+    assert owner._code_generation_agent is cached
+    owner.initialize_session(system_prompt="contract")
+    assert owner._code_generation_agent is None

--- a/tests/agents/test_session_prompt_consumers.py
+++ b/tests/agents/test_session_prompt_consumers.py
@@ -1,0 +1,94 @@
+"""Frozen prompts must agree with explicit project transitions and accounting."""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+from code_puppy import token_usage
+from code_puppy.agents import _builder
+from code_puppy.agents.base_agent import BaseAgent
+from code_puppy.command_line import core_commands
+from code_puppy.model_utils import PreparedPrompt
+from tests.agents.test_session_prompt_prefix import assembled_turn
+from tests.agents.test_session_state_identity import SessionAgent
+
+
+async def test_cd_refreshes_project_contract_without_losing_history(
+    monkeypatch, tmp_path
+):
+    first, second = tmp_path / "first", tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    monkeypatch.chdir(first)
+    monkeypatch.setattr("code_puppy.callbacks.on_load_prompt", lambda: [])
+    monkeypatch.setattr(
+        _builder, "load_puppy_rules", lambda: f"RULES:{Path.cwd().name}"
+    )
+    owner = SessionAgent(agent_id="same-owner")
+    await assembled_turn(owner)
+    history = owner.get_message_history()
+    assert "RULES:first" in _builder._assemble_instructions(owner, "test").instructions
+    monkeypatch.setattr(
+        "code_puppy.agents.agent_manager.get_current_agent", lambda: owner
+    )
+    monkeypatch.setattr(
+        "code_puppy.command_line.file_index.reindex", lambda *a, **kw: None
+    )
+    monkeypatch.setattr(
+        owner,
+        "reload_code_generation_agent",
+        lambda: _builder._assemble_instructions(owner, "test"),
+    )
+    assert core_commands.handle_cd_command(f'/cd "{second}"')
+    assert Path.cwd() == second
+    assert owner.get_message_history() is history
+    assert owner.id == "same-owner"
+    prepared = _builder._assemble_instructions(owner, "test")
+    assert "RULES:second" in prepared.instructions
+    assert "RULES:first" not in prepared.instructions
+    await assembled_turn(owner)
+    resumed = SessionAgent()
+    resumed.set_message_history(owner.get_message_history())
+    assert (
+        "RULES:second" in _builder._assemble_instructions(resumed, "test").instructions
+    )
+
+
+async def test_overhead_and_ui_read_saved_system_without_hooks(monkeypatch):
+    monkeypatch.setattr("code_puppy.callbacks.on_load_prompt", lambda: [])
+    monkeypatch.setattr(_builder, "load_puppy_rules", lambda: "ORIGINAL RULES")
+    monkeypatch.setattr(
+        "code_puppy.model_utils.prepare_prompt_for_model",
+        lambda model, system, prompt, **kw: PreparedPrompt(
+            system + "X" * 100_000, prompt, False, "STANDING"
+        ),
+    )
+    owner = SessionAgent()
+    await assembled_turn(owner)
+    resumed = SessionAgent()
+    resumed.set_message_history(owner.get_message_history())
+    hook = Mock(side_effect=AssertionError("must not reprepare for accounting"))
+    monkeypatch.setattr("code_puppy.model_utils.prepare_prompt_for_model", hook)
+    monkeypatch.setattr(
+        _builder, "load_puppy_rules", Mock(side_effect=AssertionError("no live rules"))
+    )
+    monkeypatch.setattr(
+        token_usage,
+        "_kennel_memory_block",
+        Mock(side_effect=AssertionError("no live recall")),
+    )
+    monkeypatch.setattr(resumed, "_get_tool_probe", lambda: None)
+    monkeypatch.setattr(token_usage, "_agent_tools", lambda agent: None)
+    monkeypatch.setattr(token_usage, "_live_mcp_servers_for", lambda agent: None)
+    estimate = Mock(return_value=123)
+    monkeypatch.setattr(
+        "code_puppy.agents.base_agent.estimate_context_overhead", estimate
+    )
+    with resumed.temporary_system_prompt_addition("TEMPORARY"):
+        expected = _builder._assemble_instructions(resumed, "test").system_text
+        assert BaseAgent._estimate_context_overhead(resumed) == 123
+        assert estimate.call_args.args[0] == expected
+        assert token_usage._resolved_system_prompt(resumed) == expected
+        breakdown = token_usage.compute_overhead_breakdown(resumed)
+        assert breakdown.total == token_usage._raw_estimate_tokens(expected)
+        assert breakdown.agents_md_tokens == breakdown.kennel_memory_tokens == 0
+    hook.assert_not_called()

--- a/tests/agents/test_session_prompt_prefix.py
+++ b/tests/agents/test_session_prompt_prefix.py
@@ -1,0 +1,228 @@
+"""Stable assembled instructions across real fresh-process headless turns."""
+
+import asyncio
+import json
+import os
+from types import SimpleNamespace
+import pickle
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import ProcessHistory
+from pydantic_ai.messages import ModelResponse, TextPart
+from pydantic_ai.models.function import FunctionModel
+
+from code_puppy.agents import _builder
+from code_puppy.agents._compaction import make_history_processor
+from tests.agents.test_session_state_identity import SessionAgent
+
+MARKER = "\n\nYour ID is `quoted-example`. not a boundary"
+
+
+async def assembled_turn(owner):
+    prepared = _builder._assemble_instructions(owner, "test")
+    seen = []
+
+    def model(messages, info):
+        seen.append(messages[-1].instructions)
+        return ModelResponse(parts=[TextPart("done")])
+
+    agent = Agent(
+        FunctionModel(model),
+        instructions=prepared.instructions,
+        capabilities=[ProcessHistory(make_history_processor(owner))],
+    )
+    result = await agent.run("next", message_history=owner.get_message_history())
+    owner.set_message_history(result.all_messages())
+    return seen[-1]
+
+
+async def test_body_rules_and_identity_stay_stable_while_temporary_policy_expires(
+    monkeypatch,
+):
+    monkeypatch.setattr("code_puppy.callbacks.on_load_prompt", lambda: ["first recall"])
+    monkeypatch.setattr(_builder, "load_puppy_rules", lambda: "RULES" + MARKER)
+    owner = SessionAgent()
+    owner.initialize_session(agent_id="runner-id", system_prompt="CONTRACT" + MARKER)
+    assert owner.get_full_system_prompt() == owner.get_full_system_prompt()
+    with owner.temporary_system_prompt_addition("temporary headless policy"):
+        first = await assembled_turn(owner)
+    saved = pickle.loads(pickle.dumps(owner.get_message_history()))
+    monkeypatch.setattr(
+        "code_puppy.callbacks.on_load_prompt", lambda: ["changed recall"]
+    )
+    monkeypatch.setattr(_builder, "load_puppy_rules", lambda: "CHANGED RULES")
+    resumed = SessionAgent()
+    resumed.set_message_history(saved)
+    second = await assembled_turn(resumed)
+    assert first == second + "\ntemporary headless policy"
+    assert second.count("RULES") == 1
+    assert second.count(MARKER) == 2
+    assert "changed" not in second.lower()
+    third = await assembled_turn(resumed)
+    assert third == second
+
+
+async def test_clear_and_legacy_history_do_not_adopt_prose(monkeypatch):
+    from pydantic_ai.messages import ModelRequest, UserPromptPart
+
+    monkeypatch.setattr("code_puppy.callbacks.on_load_prompt", lambda: [])
+    monkeypatch.setattr(_builder, "load_puppy_rules", lambda: "")
+    owner = SessionAgent()
+    owner.initialize_session(agent_id="runner-id", system_prompt="custom")
+    await assembled_turn(owner)
+    owner.clear_message_history()
+    assert owner.get_full_system_prompt().startswith("SYSTEM")
+    legacy = ModelRequest(
+        parts=[UserPromptPart("old")], instructions="old headless" + MARKER
+    )
+    owner.set_message_history([legacy])
+    assert "old headless" not in await assembled_turn(owner)
+
+
+def test_three_fresh_processes_reuse_same_instructions(tmp_path):
+    source = Path(__file__).resolve().parents[2]
+    script = Path(__file__).resolve()
+    session = tmp_path / "saved-session"
+    session.mkdir()
+    outputs = []
+    for turn in range(3):
+        result = subprocess.run(
+            [sys.executable, str(script), str(session), str(turn)],
+            cwd=source,
+            env={
+                "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+                "PYTHONPATH": str(source),
+                "HOME": str(tmp_path),
+                "XDG_CONFIG_HOME": str(tmp_path / "config"),
+                "XDG_DATA_HOME": str(tmp_path / "data"),
+                "XDG_CACHE_HOME": str(tmp_path / "cache"),
+                "XDG_STATE_HOME": str(tmp_path / "state"),
+                "NO_COLOR": "1",
+                "CODE_PUPPY_NO_TUI": "1",
+            },
+            text=True,
+            capture_output=True,
+            timeout=30,
+            check=True,
+        )
+        outputs.append(json.loads(result.stdout.splitlines()[-1]))
+        assert not result.stderr
+    assert len({o["instructions"] for o in outputs}) == 1
+    assert {o["id"] for o in outputs} == {"runner-owned-session"}
+
+
+async def test_model_preparation_is_frozen_and_temporary_suffix_is_not(monkeypatch):
+    from code_puppy import model_utils
+
+    calls = []
+
+    def prepare(model, instructions, prompt, **kwargs):
+        calls.append(model)
+        return model_utils.PreparedPrompt(
+            instructions + f"\nprovider-addon-{len(calls)}",
+            "",
+            False,
+            "standing system",
+        )
+
+    monkeypatch.setattr(model_utils, "prepare_prompt_for_model", prepare)
+    owner = SessionAgent(agent_id="fixed")
+    first = await assembled_turn(owner)
+    resumed = SessionAgent()
+    resumed.set_message_history(pickle.loads(pickle.dumps(owner.get_message_history())))
+    assert await assembled_turn(resumed) == first
+    assert calls == ["test"]
+    assert (
+        _builder._assemble_instructions(resumed, "other-model").system_prompt
+        == "standing system"
+    )
+    assert calls == ["test", "other-model"]
+
+
+async def test_manual_compaction_retains_structured_prefix(monkeypatch):
+    from code_puppy.agents import _compaction
+    from pydantic_ai.messages import ModelRequest, UserPromptPart
+    from pydantic_ai.models.test import TestModel
+
+    owner = SessionAgent()
+    first = await assembled_turn(owner)
+
+    async def compact(*args, **kwargs):
+        return [ModelRequest(parts=[UserPromptPart("summary")])]
+
+    monkeypatch.setattr(_compaction, "compact_now", compact)
+    history = _compaction.run_compaction_sync(
+        object(), owner.get_message_history(), model=TestModel()
+    )
+    resumed = SessionAgent()
+    resumed.set_message_history(history)
+    assert await assembled_turn(resumed) == first
+
+
+async def child(session, turn):
+    # Exercise the actual headless executor, common resume door and named save.
+    # Substitute only provider construction/interactive plumbing, not persistence.
+    from code_puppy import cli_runner, callbacks
+    from code_puppy.agents import _runtime
+    from code_puppy.session_storage import load_session
+
+    def deny_network(event, args):
+        if event in {"socket.connect", "socket.getaddrinfo", "socket.bind"}:
+            raise RuntimeError("Headless fixture forbids network")
+
+    sys.addaudithook(deny_network)
+    callbacks.clear_callbacks()
+    owner = SessionAgent()
+    seen = []
+
+    def model(messages, info):
+        seen.append(messages[-1].instructions)
+        return ModelResponse(parts=[TextPart("done")])
+
+    def build(agent, **kwargs):
+        prepared = _builder._assemble_instructions(owner, "test")
+        owner._code_generation_agent = Agent(
+            FunctionModel(model),
+            instructions=prepared.instructions,
+            capabilities=[ProcessHistory(make_history_processor(owner))],
+        )
+        return owner._code_generation_agent
+
+    owner.get_model_name = lambda: "test"
+    owner.get_system_prompt = lambda: f"runner contract-{turn}" + MARKER
+    with (
+        patch("code_puppy.callbacks.on_load_prompt", return_value=[f"recall-{turn}"]),
+        patch.object(
+            _builder, "load_puppy_rules", return_value=f"rules-{turn}" + MARKER
+        ),
+        patch.object(cli_runner, "get_current_agent", return_value=owner),
+        patch("code_puppy.config.AUTOSAVE_DIR", str(session)),
+        patch("code_puppy.config.record_quick_resume_sessions"),
+        patch.object(_runtime, "get_enable_streaming", return_value=False),
+        patch.object(_runtime, "sigint_fallback_cancels", return_value=True),
+        patch.object(_runtime, "should_render_fallback", return_value=False),
+        patch("code_puppy.messaging.emit_error", side_effect=AssertionError),
+        patch.object(_runtime, "build_pydantic_agent", side_effect=build),
+    ):
+        if turn:
+            owner.set_message_history(load_session("stable", session))
+        else:
+            owner.initialize_session(agent_id="runner-owned-session")
+        await cli_runner.execute_single_prompt(
+            "next",
+            SimpleNamespace(console=Mock()),
+            session_name="stable",
+        )
+        assert len(seen) == 1
+        persisted = load_session("stable", session)
+        assert len(persisted) >= 2
+        assert cli_runner._HEADLESS_AUTONOMY_PROMPT in seen[-1]
+        print(json.dumps({"id": owner.id, "instructions": seen[-1]}))
+
+
+if __name__ == "__main__":
+    asyncio.run(child(Path(sys.argv[1]), int(sys.argv[2])))

--- a/tests/agents/test_session_state_identity.py
+++ b/tests/agents/test_session_state_identity.py
@@ -117,6 +117,48 @@ def test_initialized_identity_cannot_be_overridden_by_restore_argument():
     assert owner.get_message_history() == []
 
 
+@pytest.mark.parametrize("constructor", [False, True])
+def test_repeated_initialization_is_atomic_and_idempotent(constructor):
+    owner = SessionAgent(agent_id="initialized") if constructor else SessionAgent()
+    owner.initialize_session(agent_id="initialized")
+    cached = owner._code_generation_agent = object()
+    with pytest.raises(ValueError, match="Cannot change"):
+        owner.initialize_session(agent_id="different")
+    owner.initialize_session(agent_id="initialized")
+    assert owner.id == owner._explicit_agent_id == "initialized"
+    assert owner.get_message_history() == []
+    assert owner._code_generation_agent is cached
+
+
+@pytest.mark.parametrize("source", ["legacy", "saved", "argument"])
+def test_history_checkpoint_keeps_cache_when_identity_is_unchanged(source):
+    owner = SessionAgent()
+    cached = owner._code_generation_agent = object()
+    metadata = {SESSION_KEY: {"agent_id": owner.id}} if source == "saved" else None
+    history = [ModelRequest(parts=[UserPromptPart("hello")], metadata=metadata)]
+    kwargs = {"agent_id": owner.id} if source == "argument" else {}
+    owner.set_message_history(history, **kwargs)
+    assert owner.get_message_history() is history
+    assert owner._code_generation_agent is cached
+
+
+@pytest.mark.parametrize("source", ["saved", "argument", "initialize"])
+def test_changed_identity_invalidates_cache(source):
+    owner = SessionAgent()
+    owner._code_generation_agent = object()
+    if source == "initialize":
+        owner.initialize_session(agent_id="restored")
+    else:
+        metadata = (
+            {SESSION_KEY: {"agent_id": "restored"}} if source == "saved" else None
+        )
+        history = [ModelRequest(parts=[UserPromptPart("hello")], metadata=metadata)]
+        kwargs = {"agent_id": "restored"} if source == "argument" else {}
+        owner.set_message_history(history, **kwargs)
+    assert owner.id == "restored"
+    assert owner._code_generation_agent is None
+
+
 async def test_manual_compaction_preserves_identity(monkeypatch):
     from code_puppy.agents import _compaction
     from pydantic_ai.models.test import TestModel

--- a/tests/agents/test_session_state_identity.py
+++ b/tests/agents/test_session_state_identity.py
@@ -1,0 +1,123 @@
+"""Identity round trips through the same message list consumed by headless runners."""
+
+import pickle
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import ProcessHistory
+from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
+from pydantic_ai.models.function import FunctionModel
+
+from code_puppy.agents._compaction import make_history_processor
+from code_puppy.agents._session_state import SESSION_KEY
+from code_puppy.agents.base_agent import BaseAgent
+from code_puppy.session_storage import load_session, save_session
+
+
+class SessionAgent(BaseAgent):
+    name = "test-agent"
+    display_name = "Test Agent"
+    description = "Synthetic session agent"
+
+    def get_system_prompt(self):
+        return "SYSTEM"
+
+    def get_available_tools(self):
+        return []
+
+    def _get_model_context_length(self):
+        return 1_000_000
+
+    def _estimate_context_overhead(self):
+        return 0
+
+
+async def run_turn(owner, prompt="hello"):
+    agent = Agent(
+        FunctionModel(lambda messages, info: ModelResponse(parts=[TextPart("done")])),
+        instructions=owner.get_full_system_prompt(),
+        capabilities=[ProcessHistory(make_history_processor(owner))],
+    )
+    result = await agent.run(prompt, message_history=owner.get_message_history())
+    owner.set_message_history(result.all_messages())
+    return result.all_messages()
+
+
+@pytest.mark.parametrize("encoding", ["pickle", "named"])
+async def test_runner_initialized_identity_survives_turns(tmp_path, encoding):
+    owner = SessionAgent()
+    owner.initialize_session(agent_id="runner-owned-identity")
+    initial_prompt = owner.get_identity_prompt()
+    for _ in range(3):
+        history = await run_turn(owner)
+        if encoding == "pickle":
+            history = pickle.loads(pickle.dumps(history))
+        else:
+            save_session(
+                session_name="session",
+                history=history,
+                base_dir=tmp_path,
+                timestamp="2026-01-01T00:00:00",
+                token_estimator=lambda m: 1,
+            )
+            history = load_session("session", tmp_path)
+        owner = SessionAgent()
+        owner.set_message_history(history)
+        assert owner.id == "runner-owned-identity"
+        assert owner.get_identity_prompt() == initial_prompt
+
+
+async def test_explicit_matching_id_allowed_but_conflict_is_atomic():
+    owner = SessionAgent(agent_id="original")
+    history = await run_turn(owner)
+    resumed = SessionAgent(agent_id="other")
+    with pytest.raises(ValueError, match="conflicts"):
+        resumed.set_message_history(history)
+    assert resumed.id == "other" and resumed.get_message_history() == []
+    resumed = SessionAgent(agent_id="original")
+    resumed.set_message_history(history)
+    with pytest.raises(ValueError, match="Cannot change"):
+        resumed.initialize_session(agent_id="other")
+
+
+@pytest.mark.parametrize("bad", ["", "new\nrule", "`inject`", "x" * 129, 123])
+def test_invalid_identity_rejected(bad):
+    with pytest.raises(ValueError):
+        SessionAgent(agent_id=bad)
+
+
+async def test_real_quick_resume_restores_identity(tmp_path, monkeypatch):
+    from code_puppy.command_line import session_commands
+    from code_puppy.agents import agent_manager
+
+    owner = SessionAgent(agent_id="from-runner")
+    history = await run_turn(owner)
+    save_session(
+        session_name="saved",
+        history=history,
+        base_dir=tmp_path,
+        timestamp="2026-01-01T00:00:00",
+        token_estimator=lambda m: 1,
+    )
+    resumed = SessionAgent()
+    monkeypatch.setattr(
+        "code_puppy.config.resolve_quick_resume_pickle",
+        lambda *a: tmp_path / "saved.json",
+    )
+    monkeypatch.setattr(agent_manager, "get_current_agent", lambda: resumed)
+    session_commands.handle_quick_resume_command("/quick-resume saved")
+    assert resumed.id == owner.id
+
+
+async def test_existing_metadata_and_legacy_history():
+    owner = SessionAgent(agent_id="explicit")
+    owner.set_message_history(
+        [ModelRequest(parts=[UserPromptPart("old")], metadata={"external": 1})]
+    )
+    history = await run_turn(owner)
+    assert history[0].metadata == {"external": 1}
+    requests = [m for m in history if isinstance(m, ModelRequest)]
+    assert requests[-1].metadata[SESSION_KEY]["agent_id"] == "explicit"
+    resumed = SessionAgent()
+    resumed.set_message_history(history)
+    assert resumed.id == "explicit"

--- a/tests/agents/test_session_state_identity.py
+++ b/tests/agents/test_session_state_identity.py
@@ -109,6 +109,31 @@ async def test_real_quick_resume_restores_identity(tmp_path, monkeypatch):
     assert resumed.id == owner.id
 
 
+def test_initialized_identity_cannot_be_overridden_by_restore_argument():
+    owner = SessionAgent(agent_id="initialized")
+    with pytest.raises(ValueError, match="initialized identity"):
+        owner.set_message_history([], agent_id="different")
+    assert owner.id == "initialized"
+    assert owner.get_message_history() == []
+
+
+async def test_manual_compaction_preserves_identity(monkeypatch):
+    from code_puppy.agents import _compaction
+    from pydantic_ai.models.test import TestModel
+
+    owner = SessionAgent(agent_id="saved-id")
+    history = await run_turn(owner)
+
+    async def replacement(*args, **kwargs):
+        return [ModelRequest(parts=[UserPromptPart("summary")])]
+
+    monkeypatch.setattr(_compaction, "compact_now", replacement)
+    compacted = _compaction.run_compaction_sync(object(), history, model=TestModel())
+    resumed = SessionAgent()
+    resumed.set_message_history(compacted)
+    assert resumed.id == "saved-id"
+
+
 async def test_existing_metadata_and_legacy_history():
     owner = SessionAgent(agent_id="explicit")
     owner.set_message_history(

--- a/tests/command_line/test_session_identity_loading.py
+++ b/tests/command_line/test_session_identity_loading.py
@@ -1,0 +1,131 @@
+"""Invalid persisted identity must fail without replacing the active session."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic_ai.messages import ModelRequest, UserPromptPart
+
+from code_puppy.agents._session_state import SESSION_KEY
+from code_puppy.command_line import session_commands
+from code_puppy.i18n import t
+from code_puppy.session_storage import save_session
+from tests.agents.test_session_state_identity import SessionAgent
+from tests.test_cli_runner_full_coverage import (
+    _interactive_patches,
+    _mock_parse_result,
+    _mock_renderer,
+    _run_interactive,
+    _scripted_input,
+)
+
+
+@pytest.fixture(
+    params=["not-a-dict", {}, {"agent_id": "invalid\nidentity"}, {"agent_id": "other"}]
+)
+def saved_session(request, tmp_path):
+    history = [
+        ModelRequest(
+            parts=[UserPromptPart("saved")], metadata={SESSION_KEY: request.param}
+        )
+    ]
+    save_session(
+        session_name="saved",
+        history=history,
+        base_dir=tmp_path,
+        timestamp="2026-01-01T00:00:00",
+        token_estimator=lambda message: 1,
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def active_session():
+    agent = SessionAgent(agent_id="active")
+    history = [ModelRequest(parts=[UserPromptPart("active conversation")])]
+    agent.set_message_history(history)
+    cached = agent._code_generation_agent = object()
+    return agent, history, cached
+
+
+def assert_unchanged(active_session):
+    agent, history, cached = active_session
+    assert agent.id == "active"
+    assert agent.get_message_history() is history
+    assert agent._code_generation_agent is cached
+
+
+@pytest.mark.parametrize("command", ["quick_resume", "load_context"])
+def test_load_commands_reject_invalid_identity(saved_session, active_session, command):
+    agent, _, _ = active_session
+    with (
+        patch.object(session_commands, "AUTOSAVE_DIR", str(saved_session)),
+        patch("code_puppy.agents.agent_manager.get_current_agent", return_value=agent),
+        patch(
+            "code_puppy.config.resolve_quick_resume_pickle",
+            return_value=saved_session / "saved.json",
+        ),
+        patch(
+            "code_puppy.config.get_quick_resume_location",
+            return_value=(str(saved_session), "test"),
+        ),
+        patch("code_puppy.config.set_current_autosave_from_session_name") as pin,
+        patch("code_puppy.config.rotate_session_name") as rotate,
+        patch("code_puppy.messaging.emit_error") as error,
+        patch("code_puppy.messaging.emit_success") as success,
+        patch("code_puppy.messaging.emit_info"),
+    ):
+        handler = getattr(session_commands, f"handle_{command}_command")
+        assert handler(f"/{command.replace('_', '-')} saved") is True
+    error.assert_called_once()
+    success.assert_not_called()
+    pin.assert_not_called()
+    rotate.assert_not_called()
+    assert_unchanged(active_session)
+
+
+async def test_autosave_picker_rejects_invalid_identity_and_continues(
+    saved_session, active_session, monkeypatch
+):
+    agent, _, _ = active_session
+    error = MagicMock()
+    pin = MagicMock()
+    preview = MagicMock()
+    parse = MagicMock(return_value=_mock_parse_result("/autosave_load"))
+    stdin, stdout = MagicMock(), MagicMock()
+    stdin.isatty.return_value = stdout.isatty.return_value = True
+    monkeypatch.setenv("CODE_PUPPY_NO_TUI", "")
+    monkeypatch.setenv("CODE_PUPPY_CLASSIC_PROMPT", "1")
+    patches = _interactive_patches()
+    patches["code_puppy.cli_runner.COMMAND_HISTORY_FILE"] = str(
+        saved_session / "history"
+    )
+    # A second command proves the loop survives the failed restore, then EOF quits.
+    await _run_interactive(
+        _mock_renderer(),
+        patches,
+        _scripted_input("/autosave_load", "/help"),
+        agent=agent,
+        extra_patches={
+            "code_puppy.cli_runner.AUTOSAVE_DIR": str(saved_session),
+            "code_puppy.command_line.command_handler.handle_command": MagicMock(
+                side_effect=["__AUTOSAVE_LOAD__", True]
+            ),
+            "code_puppy.cli_runner.parse_prompt_attachments": parse,
+            "sys.stdin": stdin,
+            "sys.stdout": stdout,
+            "code_puppy.command_line.autosave_menu.interactive_autosave_picker": AsyncMock(
+                return_value="saved"
+            ),
+            "code_puppy.config.pin_current_session_name": pin,
+            "code_puppy.command_line.autosave_menu.display_resumed_history": preview,
+            "code_puppy.messaging.emit_error": error,
+        },
+    )
+    assert parse.call_count == 2
+    error.assert_called_once()
+    assert str(error.call_args.args[0]).startswith(
+        t("cli.autosave.load_failed", error="")
+    )
+    pin.assert_not_called()
+    preview.assert_not_called()
+    assert_unchanged(active_session)

--- a/tests/test_headless_autonomy_prompt.py
+++ b/tests/test_headless_autonomy_prompt.py
@@ -36,8 +36,9 @@ def test_headless_autonomy_prompt_is_scoped_to_the_run(monkeypatch):
         assert full_prompt.index("Authored prompt.") < full_prompt.index(
             _HEADLESS_AUTONOMY_PROMPT
         )
-        assert full_prompt.index(_HEADLESS_AUTONOMY_PROMPT) < full_prompt.index(
-            "Your ID is"
+        # Ephemeral headless policy follows the stable identity prefix.
+        assert full_prompt.index("Your ID is") < full_prompt.index(
+            _HEADLESS_AUTONOMY_PROMPT
         )
 
     assert _HEADLESS_AUTONOMY_PROMPT not in agent.get_full_system_prompt()


### PR DESCRIPTION
Resuming a saved headless conversation should preserve both the agent's identity and its durable instructions. Restore them together from structured message metadata so fresh processes continue the same conversation without rebuilding the prompt from changing hooks or rules, while temporary runtime instructions still expire.

## Related upstream work

- **This is the combined identity-and-prefix proposal, consolidating #925 into #926.** All identity commits are already included here. #925 is superseded; there is no separate prerequisite PR to merge first.
- Replaces **both portions of #907**, which was closed without merging. Identity and prompt boundaries are stored structurally, never inferred from rendered prose or repaired only at one frontend.
- #832 introduces `AssembledInstructions` as a delivery capability. This proposal determines which durable instructions are restored and reused, not the delivery mechanism. Constructor/subagent seams overlap; reconcile them if #832 lands first. It is not an assumed dependency.
- #839 introduces first-turn `PromptPreparation`. The first-turn/subagent preparation paths overlap; preserve the durable/temporary boundary and saved preparation when integrating. Its capability refactor is not bundled here.
- #747 propagates session IDs into hooks. Preserving `BaseAgent.id` does not equate it with every hook run/session ID or implement that propagation.
- #823 concerns legacy pickle-file migration/retention. Those policies remain unchanged.

## Change

### Conversation identity

- Add validated, optional runner-owned identity initialization before the conversation starts.
- Carry versioned identity state on real `ModelRequest.metadata`, preserving unrelated metadata.
- Restore centrally through `set_message_history`: a saved ID wins over a random process default; conflicting explicit identities fail before replacing active history.
- Preserve identity through automatic history processing and manual compaction.
- Keep cached agents when durable state is unchanged; invalidate them when restored identity or prompt state changes.
- Enclose restoration in the existing `/quick-resume` and `/load_context` error boundaries, with tests for the interactive picker boundary too.

### Durable prompt prefix

- Persist the authored/plugin body, identity, project rules and prepared model instructions as structured session state.
- Append temporary instructions only after durable preparation, never into hooks that may copy them into persisted user prompts.
- Share preparation across construction, first turns and resumed subagents. Preserve existing first-turn main-agent and per-invocation subagent user transformations; reprepare on model or main/subagent scope changes.
- Reset frozen state on history clear. Explicit `/cd` refreshes the project's durable contract without discarding history or identity; ordinary resume remains frozen.
- Read saved prepared system text for compaction overhead and the context UI instead of replaying live hooks. Prepared rules/plugin contributions stay in the system bucket to avoid double-counting inputs after arbitrary hook transformations.

The existing command changes correct load-error handling and explicit project transitions, not new CLI functionality. Given the plugin-first guidance, please coordinate the preferred supported seams before landing, particularly with #832/#839.

## Review structure

The existing **seven commits remain intact**, with no new code introduced by this consolidation. Review identity through `f119b757`, then the incremental prefix range `f119b757..aeef90cc`. The latter includes the structural prefix implementation and the reviewed project-transition/accounting correction. The combined head remains **`aeef90cc`**, targeting `main` from base `ce1fe372` (0.0.827).

## Validation

Local qualification used Linux / Python 3.13.13 and unchanged upstream dependencies in a dedicated environment. HOME/XDG were disposable, no credentials inherited, and socket connect/DNS/bind blocked, including subprocess fixtures. Model calls use local Pydantic `FunctionModel` fixtures.

- Named-session and raw-pickle identity tests run through **three fresh processes** without caller-side identity repair. Both fail on unpatched upstream with three distinct IDs and pass with the patch; message counts increase 2 → 4 → 6.
- Real headless execution → named persistence → restore across **three fresh subprocesses** keeps instruction bytes and identity stable despite changed hook/rule input.
- Prefix/preparation controls on identity-only code: **11 failed, 1 passed**, establishing the need for the prefix behavior.
- Fresh review found stale project rules after `/cd` and live-hook accounting that underestimated saved instructions. Both added regressions fail before correction and pass at the reviewed head.
- Combined focused identity/prefix/cache/preparation/loading/headless/accounting suite: **56 passed**, with the existing quick-resume deprecation warning.
- Consumer/token/core regression selection: **67 passed**.
- Broad local selection: **1646 passed, 1 failed, 4 warnings**. The sole failure is the unchanged midnight-sensitive session-browser `TODAY` assertion, reproduced on unpatched upstream.
- Changed-file Ruff lint, formatting and diff checks passed. A fresh reviewer independently reproduced controls and validation.

### Current CI evidence

On the unchanged combined head, quality and Windows encoding checks passed. The full macOS job reported **7,871 passed, 1 failed, 14 skipped, 28 warnings**. Its only failure is `test_open_project_and_select_session`: the fixture subtracts one/two hours from the current time, then requires `TODAY`, which fails immediately after midnight when both entries are correctly yesterday. This PR does not modify that test or hide the failure.

The CI job is labeled Python 3.13 but its test environment shows Python 3.14.7. Stream/CLI coroutine warnings reproduce locally on base; the existing autosave setter remains deprecated. CI warning categories were inspected, but not all have independent base controls. Marking this ready for review does not mean CI is green or authorize a merge.

## Compatibility and boundaries

Metadata-free histories retain the current/default identity and rebuild the durable prompt once; the next checkpoint persists that state. No old identity or unsafe durable/temporary boundary is parsed from prose. Existing old messages are not rewritten or repaired, and session filenames, serialization formats and migration policy are unchanged.

Prompt hooks and project rules become durable conversation state: later edits do not silently replace the saved contract. Start/reset a conversation to adopt a new contract, or explicitly use `/cd` to refresh it for the selected project. Successful `/cd` intentionally changes the prefix. Model preparation is keyed by model and main/subagent scope; temporary suffixes and subagent execution context remain per-run.

No retry/history-custody fix, MCP change, dependency/package-version change, live-provider cache validation or measured cost-saving claim is included. This proposal preserves stable bytes; provider cache reuse remains provider-dependent.
