### PR TITLE
fix(gemini): split mixed user turns and render multiline initial text

### DIFF
--- a/code_puppy/agents/event_stream_handler.py
+++ b/code_puppy/agents/event_stream_handler.py
@@ -216,6 +216,18 @@ async def event_stream_handler(
             highlighter=on_termflow_highlighter(Highlighter()),
         )
 
+    def _render_text_content(index: int, content: str) -> None:
+        """Feed text through Termflow one complete line at a time."""
+        buffer = termflow_line_buffers[index] + content
+        parser = termflow_parsers[index]
+        renderer = termflow_renderers[index]
+
+        while "\n" in buffer:
+            line, buffer = buffer.split("\n", 1)
+            renderer.render_all(parser.parse_line(line))
+
+        termflow_line_buffers[index] = buffer
+
     # Smooth-stream state per thinking part: index → smoother (steady drain)
     # or ``thinking_direct`` when smoothing is off (print deltas immediately).
     thinking_smoothers: dict[int, ThinkingStreamSmoother] = {}
@@ -368,7 +380,7 @@ async def event_stream_handler(
                     if part.content and part.content.strip():
                         await _print_response_banner()
                         banner_printed.add(event.index)
-                        termflow_line_buffers[event.index] = part.content
+                        _render_text_content(event.index, part.content)
                 elif isinstance(part, ToolCallPart):
                     streaming_parts.add(event.index)
                     tool_parts.add(event.index)
@@ -404,22 +416,7 @@ async def event_stream_handler(
                                     await _print_response_banner()
                                     banner_printed.add(event.index)
 
-                                # Add content to line buffer
-                                termflow_line_buffers[event.index] += (
-                                    delta.content_delta
-                                )
-
-                                # Process complete lines
-                                parser = termflow_parsers[event.index]
-                                renderer = termflow_renderers[event.index]
-                                buffer = termflow_line_buffers[event.index]
-
-                                while "\n" in buffer:
-                                    line, buffer = buffer.split("\n", 1)
-                                    events_to_render = parser.parse_line(line)
-                                    renderer.render_all(events_to_render)
-
-                                termflow_line_buffers[event.index] = buffer
+                                _render_text_content(event.index, delta.content_delta)
                             else:
                                 # Stream thinking parts smoothly (dim) via a
                                 # rate-limited buffer; gate on output level /

--- a/code_puppy/gemini_model.py
+++ b/code_puppy/gemini_model.py
@@ -232,6 +232,31 @@ def _sanitize_schema_for_gemini(schema: dict) -> dict:
     return resolve_refs(schema)
 
 
+def _split_mixed_user_contents(contents: list[dict[str, Any]]) -> None:
+    """Split user turns carrying both function responses and other parts.
+
+    Gemini rejects a user content that mixes ``function_response`` with text.
+    The consecutive-user merge in ``_map_messages`` produces exactly that
+    whenever a tool return is followed by a user prompt with no model turn
+    between them, which ``/steer`` and Ctrl+C-interrupted runs both do.
+    """
+    split: list[dict[str, Any]] = []
+    for content in contents:
+        parts = content.get("parts", [])
+        if content.get("role") != "user":
+            split.append(content)
+            continue
+        response_parts = [part for part in parts if "function_response" in part]
+        other_parts = [part for part in parts if "function_response" not in part]
+        if not response_parts or not other_parts:
+            split.append(content)
+            continue
+        # Tool results first: they answer the model's preceding call.
+        split.append({"role": "user", "parts": response_parts})
+        split.append({"role": "user", "parts": other_parts})
+    contents[:] = split
+
+
 class GeminiModel(Model):
     """Standalone Model implementation for Google's Generative Language API.
 
@@ -394,6 +419,8 @@ class GeminiModel(Model):
         # _compaction.py :: history_processor() does for Anthropic prefill.
         while contents and contents[-1].get("role") == "model":
             contents.pop()
+
+        _split_mixed_user_contents(contents)
 
         # Ensure at least one content
         if not contents:

--- a/tests/agents/test_event_stream_handler.py
+++ b/tests/agents/test_event_stream_handler.py
@@ -11,7 +11,7 @@ Covers:
 
 import contextlib
 from io import StringIO
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from pydantic_ai import PartDeltaEvent, PartEndEvent, PartStartEvent, RunContext
@@ -203,6 +203,39 @@ class TestEventStreamHandler:
                             await event_stream_handler(mock_ctx, event_stream())
 
         assert console.print.called
+
+    @pytest.mark.asyncio
+    async def test_multiline_initial_text_is_parsed_line_by_line(self, mock_ctx):
+        """A complete provider response must not become one Markdown line."""
+        text_part = TextPart(content="### Heading\n\nbody tail")
+        events = (
+            PartStartEvent(index=0, part=text_part),
+            PartEndEvent(index=0, part=text_part, next_part_kind=None),
+        )
+
+        async def event_stream():
+            for event in events:
+                yield event
+
+        console = MagicMock(spec=Console, width=80)
+        console.file = StringIO()
+        set_streaming_console(console)
+
+        with (
+            patch("termflow.Parser") as parser_cls,
+            patch("termflow.Renderer"),
+        ):
+            parser = parser_cls.return_value
+            parser.parse_line.return_value = []
+            parser.finalize.return_value = []
+            await event_stream_handler(mock_ctx, event_stream())
+
+        assert parser.parse_line.call_args_list == [
+            call("### Heading"),
+            call(""),
+            call("body tail"),
+        ]
+        parser.finalize.assert_called_once_with()
 
     @pytest.mark.asyncio
     async def test_handles_thinking_part_delta_event(self, mock_ctx):

--- a/tests/test_gemini_model_full_coverage.py
+++ b/tests/test_gemini_model_full_coverage.py
@@ -514,6 +514,74 @@ class TestMapMessages:
         ]
 
     @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "trailing_parts",
+        (
+            pytest.param(
+                [
+                    ToolReturnPart(
+                        tool_name="shell", content="out", tool_call_id="call-1"
+                    ),
+                    UserPromptPart(content="stop, do this instead"),
+                ],
+                id="same_request",
+            ),
+            pytest.param(None, id="separate_requests"),
+        ),
+    )
+    async def test_tool_return_and_user_text_never_share_a_content(
+        self, model, default_params, trailing_parts
+    ):
+        """Gemini 400s when one user content mixes function_response and text."""
+        msgs = [
+            ModelRequest(parts=[UserPromptPart(content="do the thing")]),
+            ModelResponse(
+                parts=[ToolCallPart(tool_name="shell", args={}, tool_call_id="call-1")],
+                model_name="m",
+            ),
+        ]
+        if trailing_parts is None:
+            msgs.append(
+                ModelRequest(
+                    parts=[
+                        ToolReturnPart(
+                            tool_name="shell", content="out", tool_call_id="call-1"
+                        )
+                    ]
+                )
+            )
+            msgs.append(
+                ModelRequest(parts=[UserPromptPart(content="stop, do this instead")])
+            )
+        else:
+            msgs.append(ModelRequest(parts=trailing_parts))
+
+        _, contents = await model._map_messages(msgs, default_params)
+
+        for content in contents:
+            if content["role"] != "user":
+                continue
+            parts = content["parts"]
+            has_response = any("function_response" in part for part in parts)
+            has_other = any("function_response" not in part for part in parts)
+            assert not (has_response and has_other), content
+
+        # The tool result must still precede the prompt that followed it.
+        response_index = next(
+            i
+            for i, content in enumerate(contents)
+            if any("function_response" in part for part in content["parts"])
+        )
+        text_index = next(
+            i
+            for i, content in enumerate(contents)
+            if any(
+                part.get("text") == "stop, do this instead" for part in content["parts"]
+            )
+        )
+        assert response_index < text_index
+
+    @pytest.mark.anyio
     async def test_instructions_injected(self, model, default_params):
         with patch.object(model, "_get_instructions", return_value="INJECTED"):
             msgs = [ModelRequest(parts=[UserPromptPart(content="hi")])]


### PR DESCRIPTION
> [!IMPORTANT]
> **Related PR — please merge #910 as well: https://github.com/mpfaffenberger/code_puppy/pull/910**
>
> This PR does **not** fix streamed Markdown cleanup at EOF. That fix belongs to
> #910 by @wkramme, which touches the same region of `event_stream_handler.py`.
> Without it, a provider that closes its stream without a final `PartEndEvent`
> still drops the last buffered line and any unclosed code fence.
>
> **This PR is not blocked by #910 and does not need to wait for it** — the two
> are complementary and independently mergeable, in either order. Verified by
> merging #910 into this branch locally: clean auto-merge, no conflicts, and
> 119 tests pass on the combined tree with `_finish_text_part` and the
> end-of-stream flush each appearing exactly once (no double-flush).
>
> Merging only this PR leaves the EOF truncation bug in place, so please land
> both.

## What

Two Gemini fixes that share a file, kept together so the internal Walmart fork and this repo stay byte-identical here.

**1. `/steer` and interrupts no longer trigger HTTP 400s.**
Gemini rejects a single user turn containing both a tool result and text. `_map_messages` merged consecutive user turns unconditionally, so whenever a tool finished and the user typed something before the model replied, the two got fused into one turn Gemini refused. The request failed outright. They are now emitted as two turns, tool result first.

This is not steer-specific and not Walmart-specific — a `ToolReturnPart` followed by a `UserPromptPart` is enough to reproduce it on `main`.

**2. Multiline Markdown renders as Markdown.**
A provider that does not stream can deliver an entire response in one `PartStartEvent`. That content was handed to Termflow as a single line, so headings and horizontal rules stayed on screen as literal `###` and `---`. Initial text now goes through the same per-line path that streamed deltas already used.

## Why

Both are provider-shape mismatches: the request shape Gemini accepts, and the assumption that initial text is one line. Symptoms were user-visible — a hard 400 when steering or interrupting, and raw `###` in the terminal.

## How

- `gemini_model.py`: new `_split_mixed_user_contents()` helper, called at the end of `_map_messages`, splits any user turn holding both a `function_response` and other parts.
- `event_stream_handler.py`: new `_render_text_content()` shared by the initial-text and text-delta paths.

## Testing

- `tests/test_gemini_model_full_coverage.py` and `tests/agents/test_event_stream_handler.py`: **117 passed**
- Full suite on this branch: **7415 passed, 72 failed**
- The same 72 fail identically on unmodified `main` in this environment (missing optional `acp`/`playwright` extras); a sorted diff of the two failure lists is empty, so this branch introduces none of them
- `ruff check` and `ruff format --check` clean on all four files

## Scope

Two production files and two test files. No dependency or lockfile changes.

Deliberately excludes the end-of-stream flush for providers that never emit
`PartEndEvent`; that is #910's fix, and duplicating it here would mean two
copies of the same helper. See the note at the top — #910 and #914 are both
still needed for full Gemini correctness.
