### PR TITLE
fix(stream): close callback coroutines when task submission fails

### DIFF
--- a/code_puppy/agents/event_stream_handler.py
+++ b/code_puppy/agents/event_stream_handler.py
@@ -51,9 +51,13 @@ def _fire_stream_event(event_type: str, event_data: Any) -> None:
         agent_session_id = get_session_context()
 
         # Use create_task to fire callback without blocking
-        asyncio.create_task(
-            callbacks.on_stream_event(event_type, event_data, agent_session_id)
-        )
+        coroutine = callbacks.on_stream_event(event_type, event_data, agent_session_id)
+        try:
+            asyncio.create_task(coroutine)
+        except BaseException:
+            # Submission failed: no task owns this coroutine. Preserve cancellation.
+            coroutine.close()
+            raise
     except ImportError:
         logger.debug("callbacks or messaging module not available for stream event")
     except Exception as e:

--- a/tests/agents/test_agents_remaining_coverage.py
+++ b/tests/agents/test_agents_remaining_coverage.py
@@ -638,7 +638,9 @@ def test_fire_stream_event_import_error():
     """Cover ImportError branch in _fire_stream_event."""
     from code_puppy.agents.event_stream_handler import _fire_stream_event
 
-    with patch("code_puppy.callbacks.on_stream_event", side_effect=ImportError):
+    with patch(
+        "code_puppy.callbacks.on_stream_event", new=MagicMock(side_effect=ImportError)
+    ):
         _fire_stream_event("test", {})  # Should not raise
 
 
@@ -646,7 +648,10 @@ def test_fire_stream_event_exception():
     """Cover Exception branch in _fire_stream_event."""
     from code_puppy.agents.event_stream_handler import _fire_stream_event
 
-    with patch("code_puppy.callbacks.on_stream_event", side_effect=Exception("boom")):
+    with patch(
+        "code_puppy.callbacks.on_stream_event",
+        new=MagicMock(side_effect=Exception("boom")),
+    ):
         _fire_stream_event("test", {})  # Should not raise
 
 

--- a/tests/agents/test_stream_callback_cleanup.py
+++ b/tests/agents/test_stream_callback_cleanup.py
@@ -1,0 +1,51 @@
+"""A coroutine belongs either to a scheduled task or to the failure cleanup."""
+
+import asyncio
+import inspect
+from unittest.mock import Mock
+
+import pytest
+
+from code_puppy.agents.event_stream_handler import _fire_stream_event
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [RuntimeError("no loop"), ImportError("unavailable"), asyncio.CancelledError()],
+)
+def test_failed_submission_closes_coroutine(monkeypatch, failure):
+    async def callback():
+        pass
+
+    coroutine = callback()
+    monkeypatch.setattr(
+        "code_puppy.callbacks.on_stream_event", Mock(return_value=coroutine)
+    )
+    monkeypatch.setattr(
+        "code_puppy.agents.event_stream_handler.asyncio.create_task",
+        Mock(side_effect=failure),
+    )
+    try:
+        if isinstance(failure, asyncio.CancelledError):
+            with pytest.raises(asyncio.CancelledError):
+                _fire_stream_event("delta", {})
+        else:
+            _fire_stream_event("delta", {})
+        assert inspect.getcoroutinestate(coroutine) == inspect.CORO_CLOSED
+    finally:
+        coroutine.close()  # keep control runs warning-free, after the assertion
+
+
+async def test_successful_submission_runs_callback(monkeypatch):
+    seen = []
+    finished = asyncio.Event()
+
+    async def callback(kind, data, session):
+        seen.append((kind, data, session))
+        finished.set()
+
+    monkeypatch.setattr("code_puppy.callbacks.on_stream_event", callback)
+    monkeypatch.setattr("code_puppy.messaging.get_session_context", lambda: "session")
+    _fire_stream_event("delta", {"text": "hello"})
+    await asyncio.wait_for(finished.wait(), 1)
+    assert seen == [("delta", {"text": "hello"}, "session")]


### PR DESCRIPTION
Stream callback scheduling failures currently leave an unawaited coroutine behind. Close the callback only when task submission fails, avoiding resource warnings while preserving cancellation and normal asynchronous delivery.

## Problem and change

`_fire_stream_event` constructs a callback coroutine before `asyncio.create_task` can accept it. If scheduling raises, no task owns that coroutine. Retain it locally, close it on failed submission, and re-raise into the existing error handling. Successfully scheduled callbacks remain task-owned.

The tests also use synchronous mocks for synchronous import/lookup failures rather than manufacturing unrelated unawaited mock coroutines.

## Related upstream work

- #835 changes stream-rendering delivery through capabilities. This patch addresses callback task ownership in the existing event handler, not rendering architecture; it does not require that proposal.

## Validation

Base: `ce1fe372` (0.0.827). Linux / Python 3.13.13, dedicated environment using PydanticAI 2.35.0 and core plugins 0.0.44. Disposable HOME/XDG; socket connect/DNS/bind blocked.

- Unpatched upstream: three failure-path controls fail, successful-task ownership control passes.
- Candidate focused tests: **44 passed**.
- Agent suite: **468 passed**, no warnings.
- Unpatched existing-handler tests: **40 passed, 2 coroutine warnings**, confirming the warning source.
- Changed-file Ruff lint/format and diff checks pass.

No dependency changes, renderer changes, or live-provider claims. Public CI results will be added after completion.
