### PR TITLE
fix: align `GeminiModel` and `GeminiCodeAssistModel` response parsers.

### DIFF
--- a/code_puppy/gemini_code_assist.py
+++ b/code_puppy/gemini_code_assist.py
@@ -33,6 +33,8 @@ from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RequestUsage
 
+from code_puppy.gemini_common import _parse_candidate_parts
+
 logger = logging.getLogger(__name__)
 
 
@@ -277,38 +279,14 @@ class GeminiCodeAssistModel(Model):
 
     def _parse_response(self, data: Dict[str, Any]) -> ModelResponse:
         """Parse the Code Assist API response."""
-        # Unwrap the Code Assist response format
+        # Unwrap the Code Assist response format.
         inner_response = data.get("response", data)
 
         candidates = inner_response.get("candidates", [])
         if not candidates:
             raise RuntimeError("No candidates in response")
 
-        candidate = candidates[0]
-        content = candidate.get("content", {})
-        parts = content.get("parts", [])
-
-        response_parts: list[ModelResponsePart] = []
-
-        for part in parts:
-            if "text" in part:
-                response_parts.append(TextPart(content=part["text"]))
-            elif "functionCall" in part:
-                func_call = part["functionCall"]
-                response_parts.append(
-                    ToolCallPart(
-                        tool_name=func_call["name"],
-                        args=func_call.get("args", {}),
-                        tool_call_id=str(uuid.uuid4()),
-                    )
-                )
-
-        # Extract usage metadata
-        usage_meta = inner_response.get("usageMetadata", {})
-        usage = RequestUsage(
-            input_tokens=usage_meta.get("promptTokenCount", 0),
-            output_tokens=usage_meta.get("candidatesTokenCount", 0),
-        )
+        usage, response_parts = _parse_candidate_parts(inner_response, candidates)
 
         return ModelResponse(
             parts=response_parts, model_name=self._model_name, usage=usage

--- a/code_puppy/gemini_common.py
+++ b/code_puppy/gemini_common.py
@@ -1,0 +1,68 @@
+"""Shared Gemini wire-format helpers.
+
+Consolidates logic that was previously duplicated and drifted across
+`gemini_model.py::GeminiModel` and `gemini_code_assist.py::GeminiCodeAssistModel`.
+
+Wire-format knowledge for the Gemini API should live in exactly one place.
+"""
+
+import uuid
+from typing import Any
+
+from pydantic_ai import (
+    ModelResponsePart,
+    ThinkingPart,
+    TextPart,
+    ToolCallPart,
+    RequestUsage,
+)
+
+
+def generate_tool_call_id() -> str:
+    """Generate a unique tool call ID."""
+    return str(uuid.uuid4())
+
+
+def _parse_candidate_parts(
+    data: dict[str, Any], candidates: list[dict[str, Any]]
+) -> tuple[RequestUsage, list[ModelResponsePart]]:
+    """Parse candidate parts from Gemini API response."""
+    # Extract usage.
+    usage_meta = data.get("usageMetadata", {})
+    usage = RequestUsage(
+        input_tokens=usage_meta.get("promptTokenCount", 0),
+        output_tokens=usage_meta.get("candidatesTokenCount", 0),
+    )
+
+    response_parts: list[ModelResponsePart] = []
+
+    if not candidates:
+        return usage, response_parts
+
+    candidate = candidates[0]
+    content = candidate.get("content", {})
+    parts = content.get("parts", [])
+
+    for part in parts:
+        if part.get("thought") and part.get("text") is not None:
+            # Thinking part.
+            signature = part.get("thoughtSignature")
+            response_parts.append(
+                ThinkingPart(content=part["text"], signature=signature)
+            )
+
+        elif "text" in part:
+            response_parts.append(TextPart(content=part["text"]))
+
+        elif "functionCall" in part:
+            fc = part["functionCall"]
+
+            response_parts.append(
+                ToolCallPart(
+                    tool_name=fc["name"],
+                    args=fc.get("args", {}),
+                    tool_call_id=fc.get("id") or generate_tool_call_id(),
+                )
+            )
+
+    return usage, response_parts

--- a/code_puppy/gemini_model.py
+++ b/code_puppy/gemini_model.py
@@ -53,9 +53,6 @@ STEER_PREAMBLE = (
 )
 
 
-
-
-
 def _flatten_union_to_object_gemini(union_items: list, defs: dict, resolve_fn) -> dict:
     """Flatten a union of object types into a single object with all properties.
 

--- a/code_puppy/gemini_model.py
+++ b/code_puppy/gemini_model.py
@@ -23,7 +23,6 @@ from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
     ModelResponse,
-    ModelResponsePart,
     ModelResponseStreamEvent,
     RetryPromptPart,
     SystemPromptPart,
@@ -38,6 +37,7 @@ from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RequestUsage
 
+from code_puppy.gemini_common import _parse_candidate_parts, generate_tool_call_id
 from code_puppy.steer_metadata import is_steer_request
 
 logger = logging.getLogger(__name__)
@@ -53,9 +53,7 @@ STEER_PREAMBLE = (
 )
 
 
-def generate_tool_call_id() -> str:
-    """Generate a unique tool call ID."""
-    return str(uuid.uuid4())
+
 
 
 def _flatten_union_to_object_gemini(union_items: list, defs: dict, resolve_fn) -> dict:
@@ -712,40 +710,7 @@ class GeminiModel(Model):
                 usage=RequestUsage(),
             )
 
-        candidate = candidates[0]
-        content = candidate.get("content", {})
-        parts = content.get("parts", [])
-
-        response_parts: list[ModelResponsePart] = []
-
-        for part in parts:
-            if part.get("thought") and part.get("text") is not None:
-                # Thinking part.
-                signature = part.get("thoughtSignature")
-                response_parts.append(
-                    ThinkingPart(content=part["text"], signature=signature)
-                )
-
-            elif "text" in part:
-                response_parts.append(TextPart(content=part["text"]))
-
-            elif "functionCall" in part:
-                fc = part["functionCall"]
-
-                response_parts.append(
-                    ToolCallPart(
-                        tool_name=fc["name"],
-                        args=fc.get("args", {}),
-                        tool_call_id=fc.get("id") or generate_tool_call_id(),
-                    )
-                )
-
-        # Extract usage.
-        usage_meta = data.get("usageMetadata", {})
-        usage = RequestUsage(
-            input_tokens=usage_meta.get("promptTokenCount", 0),
-            output_tokens=usage_meta.get("candidatesTokenCount", 0),
-        )
+        usage, response_parts = _parse_candidate_parts(data, candidates)
 
         return ModelResponse(
             parts=response_parts,

--- a/tests/test_gemini_common_full_coverage.py
+++ b/tests/test_gemini_common_full_coverage.py
@@ -20,7 +20,6 @@ class TestUtilities:
         assert isinstance(BYPASS_THOUGHT_SIGNATURE, str)
 
 
-
 # --- Parse candidate parts. ---
 
 

--- a/tests/test_gemini_common_full_coverage.py
+++ b/tests/test_gemini_common_full_coverage.py
@@ -1,0 +1,173 @@
+"""Full coverage tests for code_puppy/gemini_common.py."""
+
+import uuid
+
+from pydantic_ai.messages import TextPart, ThinkingPart, ToolCallPart
+
+from code_puppy.gemini_common import generate_tool_call_id, _parse_candidate_parts
+from code_puppy.gemini_model import BYPASS_THOUGHT_SIGNATURE
+
+
+# --- Utility functions. ---
+
+
+class TestUtilities:
+    def test_generate_tool_call_id(self):
+        result = generate_tool_call_id()
+        uuid.UUID(result)  # should not raise
+
+    def test_bypass_thought_signature(self):
+        assert isinstance(BYPASS_THOUGHT_SIGNATURE, str)
+
+
+
+# --- Parse candidate parts. ---
+
+
+class TestParseCandidateParts:
+    def test_text_part(self):
+        data = {"usageMetadata": {}}
+        candidates = [{"content": {"parts": [{"text": "hello"}]}}]
+        usage, parts = _parse_candidate_parts(data, candidates)
+
+        assert len(parts) == 1
+        assert isinstance(parts[0], TextPart)
+        assert parts[0].content == "hello"
+
+    def test_thinking_part_with_signature(self):
+        data = {"usageMetadata": {}}
+        candidates = [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "thought": True,
+                            "text": "reasoning...",
+                            "thoughtSignature": "sig123",
+                        }
+                    ]
+                }
+            }
+        ]
+        usage, parts = _parse_candidate_parts(data, candidates)
+
+        assert len(parts) == 1
+        assert isinstance(parts[0], ThinkingPart)
+        assert parts[0].content == "reasoning..."
+        assert parts[0].signature == "sig123"
+
+    def test_thinking_part_without_signature(self):
+        data = {"usageMetadata": {}}
+        candidates = [
+            {"content": {"parts": [{"thought": True, "text": "reasoning..."}]}}
+        ]
+
+        usage, parts = _parse_candidate_parts(data, candidates)
+        assert parts[0].signature is None
+
+    def test_function_call_with_api_supplied_id(self):
+        data = {"usageMetadata": {}}
+
+        candidates = [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "name": "my_tool",
+                                "args": {"x": 1},
+                                "id": "call_abc123",
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+
+        usage, parts = _parse_candidate_parts(data, candidates)
+        assert isinstance(parts[0], ToolCallPart)
+        assert parts[0].tool_name == "my_tool"
+        assert parts[0].args == {"x": 1}
+        assert parts[0].tool_call_id == "call_abc123"
+
+    def test_function_call_without_api_supplied_id_generates_one(self):
+        data = {"usageMetadata": {}}
+
+        candidates = [
+            {"content": {"parts": [{"functionCall": {"name": "my_tool", "args": {}}}]}}
+        ]
+        usage, parts = _parse_candidate_parts(data, candidates)
+
+        # Should fall back to generate_tool_call_id(), not crash / not be None.
+        assert parts[0].tool_call_id is not None
+        assert parts[0].tool_call_id != ""
+
+    def test_function_call_without_args_defaults_to_empty_dict(self):
+        data = {"usageMetadata": {}}
+        candidates = [{"content": {"parts": [{"functionCall": {"name": "my_tool"}}]}}]
+
+        usage, parts = _parse_candidate_parts(data, candidates)
+        assert parts[0].args == {}
+
+    def test_mixed_parts_in_order(self):
+        data = {"usageMetadata": {}}
+
+        candidates = [
+            {
+                "content": {
+                    "parts": [
+                        {"thought": True, "text": "thinking"},
+                        {"text": "answer"},
+                        {"functionCall": {"name": "tool", "args": {}}},
+                    ]
+                }
+            }
+        ]
+        usage, parts = _parse_candidate_parts(data, candidates)
+
+        assert len(parts) == 3
+        assert isinstance(parts[0], ThinkingPart)
+        assert isinstance(parts[1], TextPart)
+        assert isinstance(parts[2], ToolCallPart)
+
+    def test_usage_extraction(self):
+        data = {
+            "usageMetadata": {
+                "promptTokenCount": 42,
+                "candidatesTokenCount": 17,
+            }
+        }
+        candidates = [{"content": {"parts": [{"text": "x"}]}}]
+
+        usage, _ = _parse_candidate_parts(data, candidates)
+        assert usage.input_tokens == 42
+        assert usage.output_tokens == 17
+
+    def test_usage_defaults_to_zero_when_missing(self):
+        data = {}
+        candidates = [{"content": {"parts": [{"text": "x"}]}}]
+
+        usage, _ = _parse_candidate_parts(data, candidates)
+        assert usage.input_tokens == 0
+        assert usage.output_tokens == 0
+
+    def test_empty_parts_list(self):
+        data = {"usageMetadata": {}}
+        candidates = [{"content": {"parts": []}}]
+
+        usage, parts = _parse_candidate_parts(data, candidates)
+        assert parts == []
+
+    def test_missing_content_key_defaults_to_empty(self):
+        data = {"usageMetadata": {}}
+        candidates = [{}]  # No "content" key at all.
+
+        usage, parts = _parse_candidate_parts(data, candidates)
+        assert parts == []
+
+    def test_empty_candidates_list_does_not_crash(self):
+        data = {"usageMetadata": {}}
+        candidates = []
+
+        usage, parts = _parse_candidate_parts(data, candidates)
+        assert parts == []

--- a/tests/test_gemini_model_full_coverage.py
+++ b/tests/test_gemini_model_full_coverage.py
@@ -1,6 +1,5 @@
 """Full coverage tests for code_puppy/gemini_model.py."""
 
-import uuid
 from datetime import datetime
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
@@ -27,7 +26,6 @@ from code_puppy.gemini_model import (
     GeminiStreamingResponse,
     _flatten_union_to_object_gemini,
     _sanitize_schema_for_gemini,
-    generate_tool_call_id,
 )
 from code_puppy.steer_metadata import STEER_METADATA, is_steer_request
 
@@ -56,18 +54,6 @@ def default_params():
         function_tools=[],
         allow_text_output=True,
     )
-
-
-# --- Utility functions ---
-
-
-class TestUtilities:
-    def test_generate_tool_call_id(self):
-        result = generate_tool_call_id()
-        uuid.UUID(result)  # should not raise
-
-    def test_bypass_thought_signature(self):
-        assert isinstance(BYPASS_THOUGHT_SIGNATURE, str)
 
 
 # --- Schema sanitization ---


### PR DESCRIPTION
Refs issue #461's 2nd point to consolidate `_parse_response` drifts between `gemini_model.py::GeminiModel` and `gemini_code_assist.py::GeminiCodeAssistModel`.

<img width="800" height="200" alt="image" src="https://github.com/user-attachments/assets/777f0f32-3610-4db5-b1ff-9bc8dc4482bc" />

⬆️Fixing 2nd point's everything by a single PR would cause ~1500 diffs......too many.

So the plan here is to split into 3 PRs to each cover a sub area of #461's 2nd point: `_build_generation_config`, `_parse_response`, `_build_tools`.

This PR #934 only deals with `_parse_response`-related fixes. Diffs are ~330.

---

### Changes

Several functions moved into a new `code_puppy/gemini_common.py`:

#### 1. `generate_tool_call_id`

- Previously only in `gemini_model.py`. Now it is in `gemini_common.py` to get called by methods in either `gemini_model.py` or `gemini_common.py`, **since `gemini_model.py` depends on `gemini_common.py`.**

#### 2. `_parse_candidate_parts`

- Shared by `GeminiModel._parse_response` and `GeminiCodeAssistModel._parse_response`: per-part text/`functionCall`/thought loop + `usageMetadata` extraction, per issue's exact scope.

---

### Tests

New `tests/test_gemini_common_full_coverage.py` covers shared functions directly, like:
- `generate_tool_call_id` — generation of tool call ID.
- `_parse_candidate_parts` — candidate parsing regarding thinking parts, function calls with/without API-supplied ids, empty candidates, usage extraction.

For `test_gemini_model_full_coverage.py`, since `generate_tool_call_id` joined `gemini_common.py`, its corresponding tests has moved into `test_gemini_common_full_coverage.py`.
