### PR TITLE
fix(mcp): make /mcp trust discoverable in tab completion

### DIFF
--- a/code_puppy/command_line/mcp/help_command.py
+++ b/code_puppy/command_line/mcp/help_command.py
@@ -112,7 +112,7 @@ class HelpCommand(MCPCommandBase):
             help_lines.append(
                 Text("/mcp trust", style="cyan")
                 + Text(
-                    " [accept|revoke]  Trust this repo's .code_puppy/mcp_servers.json"
+                    " [accept|revoke|status]  Trust this repo's .code_puppy/mcp_servers.json"
                 )
             )
             help_lines.append(

--- a/code_puppy/command_line/mcp_completion.py
+++ b/code_puppy/command_line/mcp_completion.py
@@ -50,6 +50,7 @@ class MCPCompleter(Completer):
             "search": "Search for available MCP servers",
             "silence-warning": "Silence the 'registered but not bound' MCP warning forever",
             "unsilence-warning": "Restore the 'registered but not bound' MCP warning",
+            "trust": "Manage trust for this repo's .code_puppy/mcp_servers.json",
             "help": "Show help for MCP commands",
         }
 

--- a/tests/command_line/test_mcp_completion.py
+++ b/tests/command_line/test_mcp_completion.py
@@ -54,6 +54,16 @@ class TestMCPCompleter:
         # "list" is intentionally not offered: bare /mcp already does that.
         assert "list" not in names
 
+    def test_trust_is_offered(self):
+        """`/mcp trust` must be discoverable via completion.
+
+        It shipped routable-but-uncompletable, so users concluded it did not
+        exist. Keep this alongside the parity test below: this one pins the
+        specific regression, that one catches the whole class.
+        """
+        names = [c.text for c in self._get_completions("/mcp ")]
+        assert "trust" in names
+
     @patch.object(
         MCPCompleter, "_get_server_names", return_value=["server-a", "server-b"]
     )
@@ -98,3 +108,81 @@ class TestMCPCompleter:
             return_value=None,
         ):
             assert self.completer._get_server_names() == []
+
+
+# Bare `/mcp` already runs the list dashboard, so `list` is deliberately absent
+# from completion. It is the sole sanctioned difference between the two sets.
+COMPLETION_EXEMPT_SUBCOMMANDS = {"list"}
+
+# Subcommands whose next argument is an MCP server name. Bucket membership is
+# behavioural, not cosmetic: it decides whether `/mcp <cmd> <TAB>` offers server
+# names. Putting a non-server command here makes it suggest nonsense.
+SERVER_ARG_SUBCOMMANDS = {
+    "start",
+    "stop",
+    "restart",
+    "status",
+    "logs",
+    "edit",
+    "remove",
+}
+
+
+class TestCompletionMatchesRoutingTable:
+    """The completer must not drift from the handler's routing table.
+
+    `MCPCompleter` hand-maintains its subcommand dicts while
+    `MCPCommandHandler` owns the real routing table. They drifted once already:
+    `trust` was routable and documented in `/mcp help` but never completable,
+    so users concluded it did not exist.
+
+    Production completion code must NOT reach into the handler to fix this --
+    `MCPCommandBase.__init__` calls `get_mcp_manager()`, and coupling passive
+    completion metadata to live MCP runtime infrastructure would drag registry
+    and config work into building the completion stack. So the two lists stay
+    independent and this test enforces the invariant instead, constructing the
+    handler only here with the manager patched out.
+    """
+
+    def _handler_subcommands(self):
+        with patch("code_puppy.command_line.mcp.base.get_mcp_manager"):
+            from code_puppy.command_line.mcp.handler import MCPCommandHandler
+
+            return set(MCPCommandHandler()._commands)
+
+    def test_completion_set_equals_routing_set(self):
+        """Exact equality, deliberately bidirectional.
+
+        Catches BOTH a routed subcommand missing from completion (the `trust`
+        bug) AND a stale completion entry that no longer routes anywhere
+        (which would tab-complete into an 'Unknown MCP subcommand' error).
+        """
+        completion = set(MCPCompleter().all_subcommands)
+        routed = self._handler_subcommands()
+
+        assert completion == routed - COMPLETION_EXEMPT_SUBCOMMANDS
+
+    def test_exempt_subcommands_are_actually_routed(self):
+        """Guard the guard: an exemption for a dead command would hide drift."""
+        assert COMPLETION_EXEMPT_SUBCOMMANDS <= self._handler_subcommands()
+
+    def test_server_bucket_holds_exactly_the_server_arg_commands(self):
+        """Bucket assignment drives behaviour, so pin it.
+
+        `all_subcommands` merges both dicts, so the parity test above cannot
+        see WHICH bucket a name landed in. A non-server command placed in
+        `server_subcommands` still completes at the top level -- but then
+        `/mcp <cmd> <TAB>` offers MCP server names as its argument, which is
+        meaningless for something like `trust` (it takes accept/revoke/status).
+        That is the same catalogue-drift bug one layer down, and it is
+        otherwise invisible to every other test in this file.
+        """
+        assert set(MCPCompleter().server_subcommands) == SERVER_ARG_SUBCOMMANDS
+
+    def test_subcommand_buckets_do_not_overlap(self):
+        """`all_subcommands` merges with `general` last, so an overlap would
+        silently drop the server-argument behaviour for that name."""
+        completer = MCPCompleter()
+        assert not (
+            set(completer.server_subcommands) & set(completer.general_subcommands)
+        )

--- a/tests/command_line/test_mcp_completion.py
+++ b/tests/command_line/test_mcp_completion.py
@@ -55,12 +55,7 @@ class TestMCPCompleter:
         assert "list" not in names
 
     def test_trust_is_offered(self):
-        """`/mcp trust` must be discoverable via completion.
-
-        It shipped routable-but-uncompletable, so users concluded it did not
-        exist. Keep this alongside the parity test below: this one pins the
-        specific regression, that one catches the whole class.
-        """
+        """Shipped routable but uncompletable, so users concluded it did not exist."""
         names = [c.text for c in self._get_completions("/mcp ")]
         assert "trust" in names
 
@@ -110,13 +105,12 @@ class TestMCPCompleter:
             assert self.completer._get_server_names() == []
 
 
-# Bare `/mcp` already runs the list dashboard, so `list` is deliberately absent
-# from completion. It is the sole sanctioned difference between the two sets.
+# Bare `/mcp` already runs the list dashboard, so `list` is deliberately
+# uncompletable.
 COMPLETION_EXEMPT_SUBCOMMANDS = {"list"}
 
-# Subcommands whose next argument is an MCP server name. Bucket membership is
-# behavioural, not cosmetic: it decides whether `/mcp <cmd> <TAB>` offers server
-# names. Putting a non-server command here makes it suggest nonsense.
+# Hardcoded rather than derived from `server_subcommands` -- deriving it would
+# make the assertion below tautological.
 SERVER_ARG_SUBCOMMANDS = {
     "start",
     "stop",
@@ -129,19 +123,12 @@ SERVER_ARG_SUBCOMMANDS = {
 
 
 class TestCompletionMatchesRoutingTable:
-    """The completer must not drift from the handler's routing table.
+    """Pins the completer to the handler's routing table.
 
-    `MCPCompleter` hand-maintains its subcommand dicts while
-    `MCPCommandHandler` owns the real routing table. They drifted once already:
-    `trust` was routable and documented in `/mcp help` but never completable,
-    so users concluded it did not exist.
-
-    Production completion code must NOT reach into the handler to fix this --
-    `MCPCommandBase.__init__` calls `get_mcp_manager()`, and coupling passive
-    completion metadata to live MCP runtime infrastructure would drag registry
-    and config work into building the completion stack. So the two lists stay
-    independent and this test enforces the invariant instead, constructing the
-    handler only here with the manager patched out.
+    Production code deliberately does not import the handler to stay in sync:
+    `MCPCommandBase.__init__` calls `get_mcp_manager()`, so that would drag MCP
+    runtime into building a passive completion list. The lists stay
+    independent and these tests enforce the invariant instead.
     """
 
     def _handler_subcommands(self):
@@ -151,37 +138,23 @@ class TestCompletionMatchesRoutingTable:
             return set(MCPCommandHandler()._commands)
 
     def test_completion_set_equals_routing_set(self):
-        """Exact equality, deliberately bidirectional.
-
-        Catches BOTH a routed subcommand missing from completion (the `trust`
-        bug) AND a stale completion entry that no longer routes anywhere
-        (which would tab-complete into an 'Unknown MCP subcommand' error).
-        """
         completion = set(MCPCompleter().all_subcommands)
         routed = self._handler_subcommands()
 
         assert completion == routed - COMPLETION_EXEMPT_SUBCOMMANDS
 
     def test_exempt_subcommands_are_actually_routed(self):
-        """Guard the guard: an exemption for a dead command would hide drift."""
+        """Stops drift being silenced by exempting a command that no longer exists."""
         assert COMPLETION_EXEMPT_SUBCOMMANDS <= self._handler_subcommands()
 
     def test_server_bucket_holds_exactly_the_server_arg_commands(self):
-        """Bucket assignment drives behaviour, so pin it.
-
-        `all_subcommands` merges both dicts, so the parity test above cannot
-        see WHICH bucket a name landed in. A non-server command placed in
-        `server_subcommands` still completes at the top level -- but then
-        `/mcp <cmd> <TAB>` offers MCP server names as its argument, which is
-        meaningless for something like `trust` (it takes accept/revoke/status).
-        That is the same catalogue-drift bug one layer down, and it is
-        otherwise invisible to every other test in this file.
-        """
+        """Bucket membership decides whether `/mcp <cmd> <TAB>` offers server
+        names, and the merged-dict check above cannot see it."""
         assert set(MCPCompleter().server_subcommands) == SERVER_ARG_SUBCOMMANDS
 
     def test_subcommand_buckets_do_not_overlap(self):
-        """`all_subcommands` merges with `general` last, so an overlap would
-        silently drop the server-argument behaviour for that name."""
+        """`general` wins the merge, so an overlap would silently drop the
+        server-argument behaviour."""
         completer = MCPCompleter()
         assert not (
             set(completer.server_subcommands) & set(completer.general_subcommands)


### PR DESCRIPTION
## Problem

`/mcp trust` is routed in `MCPCommandHandler._commands` and documented in `/mcp help`, but it never appeared in tab completion. Typing `/mcp ` and pressing Tab listed 14 subcommands — `trust` was not among them.

The practical effect is that the command is undiscoverable. A user hit exactly this and concluded the command did not exist, or that they were using it wrong.

That matters a little more than a typical missing-completion bug: `/mcp trust` is the gate for project-level MCP configs (`<CWD>/.code_puppy/mcp_servers.json`), which can declare `stdio` servers that run arbitrary commands. A user who cannot find the command may never trust a legitimate project config, and will not understand why their project's MCP servers silently fail to load.

## Root cause

`MCPCompleter.__init__` hand-maintains two dicts, `server_subcommands` and `general_subcommands`, that duplicate the handler's routing table. `trust` was added to the handler but never to the completer, so the two catalogues drifted.

There is in fact a third catalogue — `help_command.py` — which had also drifted internally: it advertised `/mcp trust [accept|revoke]` while `TrustCommand.execute` also accepts `status`.

## Changes

- **`mcp_completion.py`** — add `trust` to `general_subcommands`.
- **`mcp/help_command.py`** — correct the usage string to `[accept|revoke|status]`.
- **`tests/command_line/test_mcp_completion.py`** — pin the regression and the class of bug behind it.

Production diff is 2 lines.

## Why a test instead of a shared registry

The obvious refactor is a single declarative subcommand registry imported by both the completer and the handler. That was considered and rejected:

- It would not actually be a single source of truth — routing stays in `handler.py`, help text stays in `help_command.py`.
- `MCPCommandBase.__init__` calls `get_mcp_manager()`. A registry holding command classes would drag the whole command-module graph, and MCP runtime initialisation, into building a passive completion list.

So production completion code deliberately does **not** import the handler. The two lists stay independent, and a test enforces the invariant instead. The parity test constructs the handler only in tests, with `get_mcp_manager` patched out.

The tests assert, against the handler's routing table:

1. **Exact bidirectional set equality**, minus an explicit `{"list"}` exemption (bare `/mcp` already runs the list dashboard). Bidirectional catches both a routed command missing from completion *and* a stale completion entry that no longer routes anywhere.
2. **The exemption is itself still routed** — so drift cannot be silenced by widening the exemption set.
3. **Server-bucket membership.** Bucket assignment is behavioural, not cosmetic: it decides whether `/mcp <cmd> <TAB>` offers server names. `all_subcommands` merges both dicts, so the parity test alone cannot see which bucket a name landed in.
4. **Bucket disjointness** — the merge is `{**server, **general}`, so an overlap would silently drop server-argument behaviour.

## Verification

- Full suite (`tests/command_line/` + `tests/mcp/`): **1462 passed, 6 skipped**.
- Behavioural: `/mcp ` now offers `trust`; `/mcp tr` completes to `trust`; `list` still correctly excluded; `/mcp trust <TAB>` yields `[]`.
- Mutation-tested — each new test was confirmed to actually fail when the defect it guards is reintroduced:

  | Mutation | Result |
  |---|---|
  | Remove `trust` from the completer | 2 tests fail |
  | Move `trust` into the server bucket | bucket test fails |
  | Add a completion entry routing nowhere | parity test fails |
  | Add a bogus exemption for a dead command | exemption guard fails |

- `ruff check` and `ruff format --check` clean.

## Out of scope

- **Second-level completion for `/mcp trust <accept|revoke|status>`.** The reported bug is first-level discoverability, and the completer has no argument-completion path for general subcommands. Worth noting for anyone who picks this up: `/mcp trust <TAB>` currently yields nothing, which means nobody can two-tap their way into `accept`. If arg completion is added later, `accept` should stay non-completable — it authorises arbitrary command execution.
- **Unifying help-text generation.** Help output is richly formatted and categorised; forcing it to share a source with `display_meta` strings would make the abstraction worse. It remains a third uncovered catalogue.
