### PR TITLE
build: drop re-committed sibling-path core-plugins override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,10 +110,6 @@ omit = ["code_puppy/main.py"]
 [tool.uv]
 python-preference = "only-managed"
 
-[tool.uv.sources]
-# Local development until the post-install MCP binding plugin is released.
-code-puppy-core-plugins = { path = "../code_puppy_core_plugins", editable = true }
-
 [dependency-groups]
 dev = [
     "pytest>=8.3.4",

--- a/uv.lock
+++ b/uv.lock
@@ -466,7 +466,7 @@ requires-dist = [
     { name = "azure-identity", specifier = ">=1.15.0" },
     { name = "boto3", specifier = ">=1.43.9" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.35.0" },
-    { name = "code-puppy-core-plugins", editable = "../code_puppy_core_plugins" },
+    { name = "code-puppy-core-plugins", specifier = ">=0.0.50" },
     { name = "dbos", marker = "extra == 'durable'", specifier = ">=2.11.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.24.1" },
     { name = "httpx2", specifier = ">=2.7" },
@@ -509,26 +509,14 @@ dev = [
 [[package]]
 name = "code-puppy-core-plugins"
 version = "0.0.50"
-source = { editable = "../code_puppy_core_plugins" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic-ai-slim", extra = ["anthropic", "mcp", "openai"] },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "httpx", specifier = ">=0.24.1,<1" },
-    { name = "pydantic-ai-slim", extras = ["openai", "anthropic", "mcp"], specifier = ">=2.35.0,<3" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pexpect", specifier = ">=4.9.0" },
-    { name = "prompt-toolkit", specifier = ">=3.0.0,<4" },
-    { name = "pytest", specifier = ">=8.3.4" },
-    { name = "pytest-asyncio", specifier = ">=0.23.1" },
-    { name = "pytest-cov", specifier = ">=6.1.1" },
-    { name = "ruff", specifier = ">=0.15,<0.16" },
+sdist = { url = "https://files.pythonhosted.org/packages/88/4d/7fd921980ce3376c0c77e8512cc151ac4cd476f0018fb8099a80f85d7e43/code_puppy_core_plugins-0.0.50.tar.gz", hash = "sha256:5cda0d9704b0fea118502eb9ef86b3b5d7fb2353fe51fc2c00398af97f738813", size = 561575, upload-time = "2026-09-11T15:47:06.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/9b/1ded55d07de430c79015fb20e7a78e58b43bd3ce5d675ac5cd7b27e0992f/code_puppy_core_plugins-0.0.50-py3-none-any.whl", hash = "sha256:bf36618042905ead5357a4a6d87d1f3c236423eacf4a7128c19c5612050f450a", size = 760517, upload-time = "2026-09-11T15:47:05.246Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`main` (HEAD `aa4c55d5`) fails **Build and Publish to PyPI** at the `uv pip install -e ".[durable]"` step:

```
error: Distribution not found at: file:///Users/runner/work/code_puppy/code_puppy_core_plugins
```

Commit `aa4c55d5` re-added `[tool.uv.sources]` (and the matching editable `uv.lock` entry) pointing `code-puppy-core-plugins` at `../code_puppy_core_plugins`. That sibling checkout exists only in local dev, never on CI runners. This is a re-commit of the exact block `984f2538` removed for this very reason.

## Fix

- Remove the `[tool.uv.sources]` block from `pyproject.toml`.
- Regenerate `uv.lock` so `code-puppy-core-plugins` resolves from PyPI (`0.0.50`).

Verified locally: `uv pip install --dry-run -e ".[durable]"` resolves without the `Distribution not found` error.

Developers who want the sibling checkout can re-add the source locally.