### PR TITLE
fix(subagent): let repeated sub-agent builds share a cacheable prompt prefix

### DIFF
--- a/code_puppy/agents/base_agent.py
+++ b/code_puppy/agents/base_agent.py
@@ -193,17 +193,20 @@ class BaseAgent(ABC):
             "such as claiming task ownership or coordination with other agents."
         )
 
-    def get_full_system_prompt(self) -> str:
-        """Assemble the runtime system prompt.
+    def get_stable_system_prompt(self) -> str:
+        """Assemble the system prompt *without* the per-instance identity block.
 
         Layered as: authored prompt (``get_system_prompt``) + per-turn
-        ``load_prompt`` plugin fragments + this instance's identity.
+        ``load_prompt`` plugin fragments + any scoped runtime additions. This is
+        everything ``get_full_system_prompt`` renders except the trailing
+        ``get_identity_prompt`` block.
 
-        The ``load_prompt`` fragments (live timestamp/CWD, file-permission
-        rules, kennel memory, ...) and the identity ID are *runtime* concerns.
-        They live here — not in ``get_system_prompt`` — so they're recomputed
-        fresh every run and never get persisted into static agent definitions
-        (e.g. when an agent is cloned to JSON). See ``clone_agent``.
+        Kept as its own component so callers that care about which parts of the
+        prompt are stable vs. per-invocation (e.g. sub-agent prompt-cache
+        assembly) can separate them explicitly, without string surgery on the
+        combined prompt. ``load_prompt`` fragments and the identity ID stay
+        *runtime* concerns computed fresh every run — never persisted into
+        static agent definitions (e.g. JSON clones); see ``clone_agent``.
         """
         from code_puppy import callbacks
 
@@ -213,7 +216,15 @@ class BaseAgent(ABC):
             prompt += "\n" + "\n".join(prompt_additions)
         if self._runtime_system_prompt_additions:
             prompt += "\n" + "\n".join(self._runtime_system_prompt_additions)
-        return prompt + self.get_identity_prompt()
+        return prompt
+
+    def get_full_system_prompt(self) -> str:
+        """Assemble the runtime system prompt.
+
+        Exactly ``get_stable_system_prompt`` followed by this instance's
+        identity block; the rendered output is unchanged.
+        """
+        return self.get_stable_system_prompt() + self.get_identity_prompt()
 
     # ---- Message history (plain dict-level access) ------------------------
     def get_message_history(self) -> List[Any]:

--- a/code_puppy/tools/subagent_invocation.py
+++ b/code_puppy/tools/subagent_invocation.py
@@ -180,6 +180,77 @@ above enforces the depth cap automatically, so nesting beyond it is refused
 rather than forbidden by convention."""
 
 
+def build_subagent_instructions(
+    agent_config,
+    agent_name: str,
+    effective_model_name: str,
+    user_prompt: str,
+    is_new_session: bool,
+):
+    """Assemble a sub-agent's instructions as a stable prefix + volatile suffix.
+
+    pydantic-ai marks the *last static* instruction block with Anthropic
+    ``cache_control`` and caches the whole prefix up to it; any *dynamic*
+    instruction part is deliberately ordered after that breakpoint. Two pieces
+    of the sub-agent prompt are per-invocation volatile:
+
+    * the instance identity block (``get_identity_prompt`` embeds a fresh UUID
+      that ``load_agent`` mints on *every* invocation), and
+    * the sub-agent nesting context (depth / invocation chain).
+
+    Baking those into the single static ``instructions`` string — as the old
+    code did — put them inside the cached block, giving *each construction of
+    the same sub-agent* a unique cache key: a cold prefix-sized cache *write*
+    that no later construction of that sub-agent could reuse. Returning them as
+    a pydantic-ai *dynamic* instruction (a callable) keeps the breakpoint after
+    the stable prefix, so repeated constructions of the same sub-agent share an
+    identical cacheable prefix.
+
+    This does NOT make one agent's prefix reusable by a *different* agent: the
+    stable prefix is still the agent's own ``get_stable_system_prompt`` and its
+    own tool set, so genuinely different agents keep distinct prefixes (a first
+    child of a different-agent parent still cold-writes its own prefix). Only
+    the per-invocation volatile tail moves out of the cache boundary; no
+    unauthorized context or tools are shared.
+
+    Returns ``(prepared, instruction_items)`` where ``prepared`` is the
+    ``PreparedPrompt`` (for ``system_prompt_parts`` and the possibly-rewritten
+    user prompt) and ``instruction_items`` is the value for
+    ``Agent(instructions=...)``: the stable literal followed by a callable
+    carrying the volatile suffix.
+    """
+    from code_puppy.model_utils import prepare_prompt_for_model
+
+    # Explicit stable/volatile split via BaseAgent's prompt-component API (no
+    # string surgery): ``get_stable_system_prompt`` is the authored prompt +
+    # load_prompt fragments + scoped runtime additions; ``get_identity_prompt``
+    # is the per-instance identity tail. AGENTS.md is deliberately NOT injected
+    # into sub-agents (main-agent steering only), and load_prompt fragments are
+    # already inside the stable prompt — appending again would double-inject.
+    stable_prompt = agent_config.get_stable_system_prompt()
+    identity = agent_config.get_identity_prompt()
+
+    # Model-family prep (e.g. claude-code): may split off a standing
+    # system_prompt part, or touch the user prompt on the first message.
+    prepared = prepare_prompt_for_model(
+        effective_model_name,
+        stable_prompt,
+        user_prompt,
+        prepend_system_to_user=is_new_session,  # Only prepend on first message
+    )
+
+    # Per-invocation volatile suffix -> dynamic instruction, kept out of the
+    # Anthropic cache breakpoint. ``identity`` already leads with a blank line,
+    # so the rendered order (stable + identity + nesting) is unchanged.
+    volatile_suffix = f"{identity}\n\n{_subagent_identity_prompt(agent_name)}"
+
+    def _volatile_instructions() -> str:
+        return volatile_suffix
+
+    instruction_items = [prepared.instructions, _volatile_instructions]
+    return prepared, instruction_items
+
+
 def _contains_cancellation(exc: BaseException) -> bool:
     """True if ``exc`` is a cancellation, including one nested in a group.
 
@@ -409,27 +480,18 @@ async def _invoke_agent_impl(
                     conversation_scope=get_conversation_root_id(),
                 )
 
-            # Create a temporary agent instance to avoid interfering with current agent state
-            instructions = agent_config.get_full_system_prompt()
-            instructions += f"\n\n{_subagent_identity_prompt(agent_name)}"
-
-            # AGENTS.md deliberately NOT injected into sub-agents: those are
-            # user-facing steering for the MAIN agent and would create recursion
-            # traps (e.g. "always invoke xyz" makes xyz invoke itself).
-
-            # NOTE: load_prompt fragments are already baked into get_full_system_prompt
-            # via BaseAgent — appending again would double-inject them.
-            from code_puppy.model_utils import prepare_prompt_for_model
-
-            # Model-family prep (e.g. claude-code): may split off a standing
-            # system_prompt part, or touch the user prompt on the first message.
-            prepared = prepare_prompt_for_model(
+            # Create a temporary agent instance to avoid interfering with
+            # current agent state. Split the prompt into a cacheable static
+            # prefix and a per-invocation volatile suffix (identity + nesting)
+            # so the Anthropic cache breakpoint stays on the stable prefix
+            # instead of a per-call cache key. See build_subagent_instructions.
+            prepared, instructions = build_subagent_instructions(
+                agent_config,
+                agent_name,
                 effective_model_name,
-                instructions,
                 prompt,
-                prepend_system_to_user=is_new_session,  # Only prepend on first message
+                is_new_session,
             )
-            instructions = prepared.instructions
             prompt = prepared.user_prompt
 
             model_settings = make_model_settings(

--- a/tests/test_subagent_cache_prefix.py
+++ b/tests/test_subagent_cache_prefix.py
@@ -1,0 +1,178 @@
+"""Prompt-cache contracts for sub-agent instruction assembly.
+
+Scope, stated precisely:
+
+* A sub-agent is re-instantiated on every ``invoke_agent`` call (``load_agent``
+  mints a fresh ``BaseAgent.id`` -> a fresh identity UUID). The old code baked
+  that UUID (and the depth/chain nesting text) into the single *static*
+  ``instructions`` block, which is exactly the block pydantic-ai marks with the
+  Anthropic ``cache_control`` breakpoint. So two constructions of the *same*
+  sub-agent produced different cacheable prefixes and could not reuse one
+  another's cache.
+
+* ``build_subagent_instructions`` keeps the stable prompt as a static literal
+  and returns the volatile identity/nesting as a *dynamic* instruction, which
+  the Anthropic mapper orders after the breakpoint.
+
+What this does NOT claim: it does not make one agent's cached prefix reusable by
+a *different* agent (different system prompt and/or tools). A first sub-agent
+whose parent is a different agent still cold-writes its own prefix; that write is
+expected and correct. ``test_distinct_agents_*`` and
+``test_parent_vs_first_child_*`` lock that in.
+
+All tests are offline and metadata-only: no prompt text is logged, no
+credentials, no network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from pydantic_ai.messages import InstructionPart, ModelRequest, UserPromptPart
+from pydantic_ai.models import ModelRequestParameters
+from pydantic_ai.models.anthropic import AnthropicModel, AnthropicModelSettings
+
+from code_puppy.agents.agent_code_puppy import CodePuppyAgent
+from code_puppy.agents.agent_planning import PlanningAgent
+from code_puppy.tools.subagent_invocation import build_subagent_instructions
+
+MODEL = "plain-model"  # no claude-code splitting; static literal == stable prompt
+
+
+def _assemble(agent, agent_name):
+    """Return (static_literal, volatile_text) as build_subagent_instructions does."""
+    _, instruction_items = build_subagent_instructions(
+        agent,
+        agent_name,
+        MODEL,
+        user_prompt="do the thing",
+        is_new_session=True,
+    )
+    static_literal, volatile_callable = instruction_items
+    assert isinstance(static_literal, str)
+    assert callable(volatile_callable)
+    return static_literal, volatile_callable()
+
+
+def test_repeated_constructions_of_same_subagent_share_static_prefix():
+    """Two sequential constructions of the SAME sub-agent produce an identical
+    cacheable static prefix, even though each instance has a distinct UUID."""
+    agent_a = PlanningAgent()
+    agent_b = PlanningAgent()
+    assert agent_a.id != agent_b.id  # distinct instances -> distinct identity UUIDs
+
+    static_a, _ = _assemble(agent_a, "planning-agent")
+    static_b, _ = _assemble(agent_b, "planning-agent")
+
+    assert static_a == static_b
+
+
+def test_identity_and_nesting_delivered_dynamically_not_in_static_prefix():
+    """UUID + depth/chain are still delivered (in the dynamic instruction), but
+    never appear in the cacheable static prefix."""
+    agent = PlanningAgent()
+    static_literal, volatile_text = _assemble(agent, "planning-agent")
+
+    # Identity UUID: present in the volatile suffix, absent from the prefix.
+    assert agent.get_identity() in volatile_text
+    assert agent.get_identity() not in static_literal
+    # Nesting context (depth + invocation chain) is per-invocation too.
+    assert "nesting depth" in volatile_text
+    assert "Invocation chain:" in volatile_text
+    assert "nesting depth" not in static_literal
+    assert "Invocation chain:" not in static_literal
+
+
+def _cached_system_blocks(parts):
+    """Run the real pydantic-ai Anthropic mapper offline; return cached blocks."""
+
+    async def _run():
+        model = AnthropicModel("claude-sonnet-4-5")
+        mrp = ModelRequestParameters()
+        mrp.instruction_parts = parts
+        messages = [ModelRequest(parts=[UserPromptPart(content="hi")])]
+        settings = AnthropicModelSettings(anthropic_cache_instructions="1h")
+        system_prompt, _ = await model._map_message(messages, mrp, settings)
+        blocks = system_prompt if isinstance(system_prompt, list) else []
+        return [dict(b) for b in blocks if dict(b).get("cache_control")]
+
+    return asyncio.run(_run())
+
+
+def test_cache_breakpoint_covers_stable_prefix_and_excludes_volatile_suffix():
+    """End-to-end through the Anthropic mapper: with the fix's static+dynamic
+    parts, the 1h cache_control lands on the stable prefix and no cached block
+    contains the volatile identity."""
+    agent = PlanningAgent()
+    static_literal, volatile_text = _assemble(agent, "planning-agent")
+
+    # Mirror how pydantic-ai classifies Agent(instructions=[literal, callable]):
+    # literals -> static (dynamic=False), callables -> dynamic (dynamic=True).
+    cached = _cached_system_blocks(
+        [
+            InstructionPart(content=static_literal, dynamic=False),
+            InstructionPart(content=volatile_text, dynamic=True),
+        ]
+    )
+    assert cached, "expected at least one cached system block"
+    for block in cached:
+        assert agent.get_identity() not in block.get("text", "")
+    assert cached[-1]["text"] == static_literal
+    assert cached[-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+def test_prefixed_old_style_single_block_would_cache_the_volatile_identity():
+    """Guard: the pre-fix shape (identity inside one static block) puts the UUID
+    inside the cached block. Proves the fix targets a real divergence and that
+    the assertions above are not vacuous."""
+    agent = PlanningAgent()
+    # Reconstruct the exact pre-fix assembly: full prompt + nesting, one block.
+    from code_puppy.tools.subagent_invocation import _subagent_identity_prompt
+
+    old_single = (
+        agent.get_full_system_prompt()
+        + f"\n\n{_subagent_identity_prompt('planning-agent')}"
+    )
+    cached = _cached_system_blocks([InstructionPart(content=old_single, dynamic=False)])
+    assert cached and agent.get_identity() in cached[-1]["text"]
+
+
+def test_distinct_agents_keep_distinct_cacheable_prefixes():
+    """Isolation: genuinely different agents (different system prompt AND tools)
+    are NOT falsely made cache-compatible."""
+    planning = PlanningAgent()
+    main = CodePuppyAgent()
+
+    planning_static, _ = _assemble(planning, "planning-agent")
+    main_static, _ = _assemble(main, "code-puppy")
+
+    assert planning_static != main_static
+    assert set(planning.get_available_tools()) != set(main.get_available_tools())
+
+
+def test_parent_vs_first_child_prefixes_differ_so_first_cold_write_is_expected():
+    """Parent (main ``code-puppy``) vs. its first ``planning`` child: their
+    cacheable system prefixes and tool sets differ, so the child's first request
+    cannot reuse the parent cache. That cold write is expected and correct; the
+    fix does not (and must not) change it. The fix only lets *repeated planning
+    children* share a prefix (see the first test)."""
+    parent = CodePuppyAgent()
+    child = PlanningAgent()
+
+    parent_static, _ = _assemble(parent, "code-puppy")
+    child_static, _ = _assemble(child, "planning-agent")
+
+    # Different system component -> different cacheable prefix.
+    assert parent_static != child_static
+    # Different tool component -> different tool-definitions cache segment.
+    assert set(parent.get_available_tools()) != set(child.get_available_tools())
+
+
+def test_full_system_prompt_is_stable_prefix_plus_identity():
+    """Refactor safety: ``get_full_system_prompt`` output is unchanged \u2014 exactly
+    ``get_stable_system_prompt`` followed by ``get_identity_prompt``."""
+    agent = PlanningAgent()
+    assert (
+        agent.get_full_system_prompt()
+        == agent.get_stable_system_prompt() + agent.get_identity_prompt()
+    )

--- a/tests/test_subagent_invocation_usage.py
+++ b/tests/test_subagent_invocation_usage.py
@@ -99,7 +99,13 @@ def _build_agent_config():
 
     config.temporary_model_name_override.side_effect = temporary_override
     config.get_model_name.return_value = "override-model"
-    config.get_full_system_prompt.return_value = "Test instructions"
+    # Sub-agent prompt assembly reads the stable prefix and the identity tail
+    # as separate components (see build_subagent_instructions); stub both.
+    config.get_stable_system_prompt.return_value = "Test instructions"
+    config.get_identity_prompt.return_value = "\n\nYour ID is `override-agent-abc123`."
+    config.get_full_system_prompt.return_value = (
+        "Test instructions\n\nYour ID is `override-agent-abc123`."
+    )
     config.get_available_tools.return_value = ["list_files"]
     config.get_message_history.return_value = []
     return config


### PR DESCRIPTION
## Problem

Every `invoke_agent` re-instantiates the sub-agent (`load_agent`), minting a fresh identity UUID via `get_identity_prompt`. That UUID (plus the depth/chain nesting text) was concatenated into the single **static** `instructions` string — the exact block pydantic-ai marks with the Anthropic `cache_control` breakpoint (`anthropic_cache_instructions="1h"` for claude-code models). So **two constructions of the same sub-agent produced different cacheable prefixes** and could never reuse one another's cache: a cold prefix-sized write on every construction, zero reads.

## Scope / non-goals (read this first)

This does **not** make a first sub-agent reuse its **parent's** cache. A `planning` child under a `code-puppy` parent has a different system prompt and a different tool set, so their cacheable tools/system prefixes are genuinely different — that first cold write is **expected and correct**, and this patch deliberately preserves it. What the patch fixes is the narrower, real defect: **repeated constructions of the same sub-agent** (across invocations, and across turns/sessions within the 1h TTL) previously received UUID-divergent prefixes and could not share a cache. Only the per-invocation volatile tail moves out of the cache boundary; no unauthorized context or tools are shared, and the main-agent path is unchanged (it's a long-lived instance that already reuses its cache within the TTL).

## Fix

`build_subagent_instructions` splits the sub-agent prompt into:
- a **stable, cacheable literal** (`get_stable_system_prompt()` — authored prompt + `load_prompt` fragments + scoped runtime additions), and
- a **per-invocation dynamic instruction** (identity + depth/chain), returned as a callable.

pydantic-ai orders dynamic instructions **after** the cache breakpoint (verified against pydantic-ai 2.35.0's Anthropic mapper: with `[static(dynamic=False), volatile(dynamic=True)]` and `anthropic_cache_instructions="1h"`, `cache_control` lands on the static block and the volatile block is uncached). Rendered prompt text delivered to the model is byte-identical to before.

## Refactor

`BaseAgent.get_full_system_prompt()` is now exactly `get_stable_system_prompt() + get_identity_prompt()` (byte-identical output, asserted by a test), replacing earlier string surgery with an explicit prompt-component API. Single definition in `BaseAgent`, inherited by every agent including `JSONAgent`.

## Tests

New offline, metadata-only `tests/test_subagent_cache_prefix.py` (no prompt text, credentials, or network) locks in four contracts:
1. repeated constructions of the same sub-agent share an identical cacheable static prefix;
2. UUID + depth/chain are delivered dynamically and never appear in the cached block (asserted end-to-end through the real Anthropic mapper);
3. genuinely different agents keep distinct cacheable prefixes and tool sets (isolation not falsely broken);
4. parent (`code-puppy`) vs. first `planning` child prefixes differ, documenting that the first cold write remains expected.

The existing `test_subagent_invocation_usage.py` MagicMock fixture is updated to stub the new component method (`get_stable_system_prompt`); no assertion is weakened.

## Verification

- Local `ruff check .` and `ruff format --check .` at the CI-pinned ruff **0.15.22**: both clean.
- Patch-specific tests: green.
- Baseline parity: on pristine `c95dba55`, two same-sub-agent static prefixes are **not** identical and the single static block **carries the UUID into `cache_control`**; with the patch they're identical and the UUID is excluded.

Changed files: `code_puppy/agents/base_agent.py`, `code_puppy/tools/subagent_invocation.py`, `tests/test_subagent_invocation_usage.py`, `tests/test_subagent_cache_prefix.py`.
